### PR TITLE
fix(backend): re-parent metric_scope migration on release branch

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/40a5b6b88a52_require_metric_scope.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/40a5b6b88a52_require_metric_scope.py
@@ -9,7 +9,7 @@ practice hold JSONB ``'null'`` (a JSON null value), which NOT NULL does not
 reject. It also rejects an empty array and any non-array value.
 
 Revision ID: 40a5b6b88a52
-Revises: a1927b321511
+Revises: e90c29496562
 Create Date: 2026-08-10
 
 """
@@ -20,7 +20,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "40a5b6b88a52"
-down_revision: Union[str, None] = "a1927b321511"
+down_revision: Union[str, None] = "e90c29496562"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Purpose

Staging (`rhesis` namespace) has had the `backend` pod stuck in `CrashLoopBackOff` for ~8 days on the current `release/v0.12.0` deploy. The container fails at startup during `alembic upgrade head` with `KeyError: 'a1927b321511'`, because migration `40a5b6b88a52` (require_metric_scope) declares a parent revision that does not exist on this branch, so Alembic cannot build the revision map.

## What Changed

- `40a5b6b88a52_require_metric_scope.py`: changed `down_revision` (and the `Revises:` docstring line) from `a1927b321511` to `e90c29496562`.

## Additional Context

`release/v0.12.0` was cut from `main` on 2026-08-06 at migration head `e90c29496562`. On 2026-08-10, PR #2419 was cherry-picked onto the release branch, bringing migration `40a5b6b88a52`. On `main`, that migration's actual parent is `a1927b321511`, added by an unrelated PR (#2377, "platform key support for local-mode hosted models") that was intentionally never backported to this release branch. That left `40a5b6b88a52` pointing at a revision that only exists on `main`, breaking the chain on `release/v0.12.0`.

Confirmed no other migration on `release/v0.12.0` already chains off `e90c29496562`, so this re-parent does not fork the history.

## Testing

Verified locally with Alembic's `ScriptDirectory.get_heads()` against this branch's `alembic/versions/` directory: before the fix it raises `KeyError: 'a1927b321511'`; after the fix it resolves to a single head, `40a5b6b88a52`.

Once merged, the backend image needs to be rebuilt from this branch and redeployed to staging (ArgoCD sync or `kubectl rollout restart deployment/backend -n rhesis`) to replace the stuck ReplicaSet.