### PR TITLE
Add ENABLE_RHESIS_KEY config to control platform key feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,8 @@ SESSION_SECRET_KEY=
 # Rhesis-hosted by default; get a key at https://app.rhesis.ai/.
 
 # RHESIS_API_KEY=
+# ENABLE_RHESIS_KEY=true    # Lets org owners configure a Rhesis platform key from the
+#                           # UI (Models page) instead of only this env var.
 # DEFAULT_GENERATION_MODEL=rhesis/rhesis
 # DEFAULT_EVALUATION_MODEL=rhesis/rhesis
 # DEFAULT_EXECUTION_MODEL=rhesis/rhesis
@@ -136,7 +138,8 @@ SESSION_SECRET_KEY=
 # ADVANCED TUNING
 # =============================================================================
 # BACKEND_ENV=local        # set to "local" by docker-compose.yml for self-hosting;
-#                          # enables the local-only /platform/rhesis-key endpoints.
+#                          # enables local-only model providers (Ollama, etc.) and
+#                          # skips the SaaS Polyphemus access-request email flow.
 # LOG_LEVEL=INFO
 # QUICK_START=false
 # CELERY_WORKER_CONCURRENCY=8

--- a/apps/backend/src/rhesis/backend/app/auth/feature_gates.py
+++ b/apps/backend/src/rhesis/backend/app/auth/feature_gates.py
@@ -78,18 +78,17 @@ def has_feature(name: FeatureNameLike):
     return _dep
 
 
-def require_local_mode() -> None:
-    """Dependency: raise 404 unless the deployment runs in local mode.
+def require_rhesis_key_enabled() -> None:
+    """Dependency: raise 404 unless ENABLE_RHESIS_KEY is set.
 
-    Local-only endpoints (e.g. the org-scoped Rhesis platform API key
-    management under ``/platform``) mount unconditionally but must be
-    invisible on non-local deployments. Returning 404 (not 403) means an
-    unavailable local endpoint is indistinguishable from a non-existent
+    Rhesis platform API key endpoints (``/platform``) mount unconditionally
+    but must be invisible when the feature is disabled. Returning 404 (not
+    403) makes a disabled endpoint indistinguishable from a non-existent
     route from the outside, preventing enumeration -- the same rationale as
     :func:`require_feature`. Unlike ``require_feature`` this gate needs no
     organization, so it is a plain dependency rather than a factory.
     """
-    if not get_application_settings().is_local:
+    if not get_application_settings().enable_rhesis_key:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Not available",
@@ -97,4 +96,4 @@ def require_local_mode() -> None:
     return None
 
 
-__all__ = ["has_feature", "require_feature", "require_local_mode"]
+__all__ = ["has_feature", "require_feature", "require_rhesis_key_enabled"]

--- a/apps/backend/src/rhesis/backend/app/auth/public_routes.py
+++ b/apps/backend/src/rhesis/backend/app/auth/public_routes.py
@@ -107,8 +107,8 @@ AUTHZ_EXEMPT_ROUTES: frozenset[tuple[str, str]] = frozenset(
         # single PEP capability would exclude telemetry-only (or result-only)
         # users. Authentication still runs; authorize() is enforced in-handler.
         ("GET", "/annotations/"),
-        # Local-mode platform key status: gated by require_local_mode (404s off
-        # local) plus require_current_user_or_token, and always scoped to the
+        # Platform key status: gated by require_rhesis_key_enabled (404s when
+        # ENABLE_RHESIS_KEY is unset) plus require_current_user_or_token, scoped to the
         # caller's own organization. Read-only, never exposes the raw key (only
         # a masked suffix), so any authenticated org member may read it — unlike
         # PUT/DELETE below, which mutate the org-wide key and are gated by

--- a/apps/backend/src/rhesis/backend/app/config/settings.py
+++ b/apps/backend/src/rhesis/backend/app/config/settings.py
@@ -97,6 +97,7 @@ class ApplicationSettings(BaseSettings):
     cloud_run_revision: str | None = Field(default=None, alias="K_REVISION")
     json_logger_enabled: bool = Field(default=False, alias="JSON_LOGGER_ENABLED")
     api_base_url: str = Field(default="http://localhost:8080", alias="API_BASE_URL")
+    enable_rhesis_key: bool = Field(default=False, alias="ENABLE_RHESIS_KEY")
 
     @field_validator("api_base_url")
     @classmethod

--- a/apps/backend/src/rhesis/backend/app/routers/features.py
+++ b/apps/backend/src/rhesis/backend/app/routers/features.py
@@ -41,6 +41,9 @@ class FeaturesResponse(BaseModel):
     #: the frontend derives this from here instead of its own env var so the two
     #: can never drift apart.
     is_local: bool = False
+    #: Whether the Rhesis platform API key option is enabled (ENABLE_RHESIS_KEY=true).
+    #: Controls the platform key UI and endpoints independently of deployment type.
+    rhesis_key_enabled: bool = False
 
 
 @router.get("", response_model=FeaturesResponse)
@@ -61,4 +64,5 @@ def list_features(
         warnings=warnings,
         limits=limits,
         is_local=get_application_settings().is_local,
+        rhesis_key_enabled=get_application_settings().enable_rhesis_key,
     )

--- a/apps/backend/src/rhesis/backend/app/routers/platform.py
+++ b/apps/backend/src/rhesis/backend/app/routers/platform.py
@@ -1,7 +1,7 @@
-"""Local-mode Rhesis platform API key management.
+"""Rhesis platform API key management.
 
-All endpoints are gated by :func:`require_local_mode` (they 404 on non-local
-deployments, preventing enumeration) and by ``require_current_user_or_token``.
+All endpoints are gated by :func:`require_rhesis_key_enabled` (they 404 when
+ENABLE_RHESIS_KEY is not set, preventing enumeration) and by ``require_current_user_or_token``.
 The organization is always resolved from the authenticated user, so a caller
 can only read or write their own organization's platform key. The raw key is
 never returned by any response.
@@ -19,7 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app.auth.capabilities import Permission, capability
-from rhesis.backend.app.auth.feature_gates import require_local_mode
+from rhesis.backend.app.auth.feature_gates import require_rhesis_key_enabled
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import get_db_session
 from rhesis.backend.app.models.user import User
@@ -31,11 +31,10 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     prefix="/platform",
     tags=["platform"],
-    dependencies=[Depends(require_local_mode)],
+    dependencies=[Depends(require_rhesis_key_enabled)],
     responses={404: {"description": "Not found"}},
-    # Local-only endpoints: keep them out of the OpenAPI schema so they are not
-    # enumerable on non-local (SaaS) deployments. require_local_mode still
-    # enforces the 404 behavior regardless.
+    # Keep these out of the OpenAPI schema when the feature is disabled so they
+    # are not enumerable. require_rhesis_key_enabled enforces 404 regardless.
     include_in_schema=False,
 )
 

--- a/apps/backend/src/rhesis/backend/app/services/platform_key.py
+++ b/apps/backend/src/rhesis/backend/app/services/platform_key.py
@@ -141,7 +141,7 @@ def annotate_model_availability(db: Session, organization_id, models_list) -> No
     Reason slugs are a frozen contract: ``"rhesis_key_missing"``,
     ``"rhesis_key_invalid"`` and ``"polyphemus_not_authorized"``.
     """
-    if not get_application_settings().is_local:
+    if not get_application_settings().enable_rhesis_key:
         for model in models_list:
             model.available = True
             model.availability_reason = None

--- a/apps/backend/src/rhesis/backend/app/services/platform_key.py
+++ b/apps/backend/src/rhesis/backend/app/services/platform_key.py
@@ -1,4 +1,4 @@
-"""Org-scoped Rhesis platform API key management (local/self-hosted mode).
+"""Org-scoped Rhesis platform API key management.
 
 Stores an encrypted Rhesis platform API key on the organization row so
 self-hosted deployments can configure the hosted-model key per organization
@@ -22,7 +22,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app.config.settings import get_application_settings, get_rhesis_settings
 from rhesis.backend.app.models.organization import Organization
 
-#: Providers whose models depend on the Rhesis platform key in local mode.
+#: Providers whose models depend on the Rhesis platform key when ENABLE_RHESIS_KEY is set.
 _PLATFORM_PROVIDERS = ("rhesis", "polyphemus")
 
 logger = logging.getLogger(__name__)
@@ -122,9 +122,9 @@ def annotate_model_availability(db: Session, organization_id, models_list) -> No
     performs ZERO network calls and ZERO commits (safe on the GET /models hot
     path):
 
-    - Outside local/self-hosted mode every model is available (no requirement
-      change on hosted deployments).
-    - In local mode, presence is the cheap ``get_availability_signals`` check
+    - With ENABLE_RHESIS_KEY unset every model is available (no requirement
+      change on deployments that don't use the platform key).
+    - When enabled, presence is the cheap ``get_availability_signals`` check
       (DB-stored key OR the ``RHESIS_API_KEY`` env var -- same source the model
       resolver authenticates with), which loads the organization row once and
       returns presence plus the cached ``rhesis_key_valid`` /

--- a/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
@@ -705,7 +705,7 @@ def _try_platform_key_model(
     ``False`` for embedders, which have no usage-emission path at all, so the
     stamp is a no-op on them.
     """
-    if not get_application_settings().is_local:
+    if not get_application_settings().enable_rhesis_key:
         return None
     key = get_platform_api_key(db, organization_id)
     if not key:

--- a/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
@@ -692,18 +692,19 @@ def _try_platform_key_model(
     *,
     metered: bool = False,
 ) -> Optional[Union[BaseLLM, BaseEmbedder]]:
-    """Authenticate a Rhesis-hosted model with the org's platform key, in local mode only.
+    """Authenticate a Rhesis-hosted model with the org's platform key, when
+    ENABLE_RHESIS_KEY is set.
 
-    Returns a configured instance when local mode is active and a platform key
-    resolves; ``None`` otherwise, so callers fall through to their own
-    non-local default/delegation logic unchanged.
+    Returns a configured instance when the feature is enabled and a platform
+    key resolves; ``None`` otherwise, so callers fall through to their own
+    default/delegation logic unchanged.
 
     ``metered`` records that we pay for these tokens, and must be passed
     explicitly here rather than derived from :func:`_is_hosted_model`: that
     helper reads any API key as the org's own, and the platform key looks like
-    one while actually being Rhesis-issued credentials for local mode. Left
-    ``False`` for embedders, which have no usage-emission path at all, so the
-    stamp is a no-op on them.
+    one while actually being Rhesis-issued credentials. Left ``False`` for
+    embedders, which have no usage-emission path at all, so the stamp is a
+    no-op on them.
     """
     if not get_application_settings().enable_rhesis_key:
         return None
@@ -773,10 +774,10 @@ def _fetch_and_configure_model(
 
     # Special handling for Rhesis system models
     if _is_rhesis_system_model(provider, api_key):
-        # Local/self-hosted mode: authenticate the prepopulated Rhesis-hosted
+        # When ENABLE_RHESIS_KEY is set: authenticate the prepopulated Rhesis-hosted
         # system models with the org-scoped platform key when one is configured,
-        # accruing usage like any other hosted call. Non-local (SaaS) behavior
-        # is unchanged: fall back to the stamped default.
+        # accruing usage like any other hosted call. Otherwise behavior is
+        # unchanged: fall back to the stamped default.
         hosted = _try_platform_key_model(
             db,
             organization_id,
@@ -800,9 +801,9 @@ def _fetch_and_configure_model(
     #   be meaningless to the externally-hosted Polyphemus service, so a
     #   configured RHESIS_API_KEY always takes precedence when present.
     if provider == "polyphemus" and not api_key:
-        # Local/self-hosted mode: authenticate with the org-scoped platform
+        # When ENABLE_RHESIS_KEY is set: authenticate with the org-scoped platform
         # key when configured, accruing usage like any other hosted call.
-        # Non-local (SaaS) behavior is unchanged: existing env-precedence and
+        # Otherwise behavior is unchanged: existing env-precedence and
         # delegation logic runs when no per-org key resolves.
         hosted = _try_platform_key_model(
             db, organization_id, "polyphemus", model_name, "language", metered=True
@@ -943,9 +944,9 @@ def _fetch_and_configure_embedder(
 
     # Special handling for Rhesis system models
     if _is_rhesis_system_model(provider, api_key):
-        # Local/self-hosted mode: authenticate the prepopulated Rhesis-hosted
+        # When ENABLE_RHESIS_KEY is set: authenticate the prepopulated Rhesis-hosted
         # embedding models with the org-scoped platform key when configured.
-        # Non-local (SaaS) behavior is unchanged: fall back to default_model.
+        # Otherwise behavior is unchanged: fall back to default_model.
         hosted = _try_platform_key_model(
             db, organization_id, "rhesis", model_name or "default", "embedding"
         )

--- a/apps/frontend/src/app/(protected)/models/components/PlatformKeyDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/models/components/PlatformKeyDrawer.tsx
@@ -191,7 +191,7 @@ export function PlatformKeyDrawer({
   };
 
   const intro =
-    'Rhesis-hosted models (Rhesis, Rhesis Embedding, and Rhesis Polyphemus) require a platform API key on self-hosted deployments.';
+    'Rhesis-hosted models (Rhesis, Rhesis Embedding, and Rhesis Polyphemus) require a platform API key.';
 
   const loadingSection = (
     <Box sx={drawerSectionSx}>

--- a/apps/frontend/src/app/(protected)/models/page.tsx
+++ b/apps/frontend/src/app/(protected)/models/page.tsx
@@ -39,14 +39,14 @@ import type { ValidationStatus } from './types';
 
 export type { ValidationStatus } from './types';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
-import { useIsLocalMode } from '@/contexts/FeaturesContext';
+import { useRhesisKeyEnabled } from '@/contexts/FeaturesContext';
 
 type ModelTypeFilter = 'all' | 'language' | 'embedding';
 
 export default function ModelsPage() {
   const { data: session, status } = useSession();
   const queryClient = useQueryClient();
-  const isLocalMode = useIsLocalMode();
+  const rhesisKeyEnabled = useRhesisKeyEnabled();
   const userScope = session?.user?.id ?? '';
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
     Capability.Model.READ
@@ -385,7 +385,7 @@ export default function ModelsPage() {
       breadcrumbs={[]}
       actions={
         <FabGroup>
-          {isLocalMode && (
+          {rhesisKeyEnabled && (
             <Fab
               icon={<VpnKeyIcon />}
               tooltip="Rhesis Platform API Key"
@@ -519,7 +519,7 @@ export default function ModelsPage() {
         title="Delete Model Connection"
       />
 
-      {isLocalMode && (
+      {rhesisKeyEnabled && (
         <PlatformKeyDrawer
           open={platformKeyDrawerOpen}
           onClose={() => setPlatformKeyDrawerOpen(false)}

--- a/apps/frontend/src/app/api/platform/rhesis-key/route.ts
+++ b/apps/frontend/src/app/api/platform/rhesis-key/route.ts
@@ -7,9 +7,9 @@ export const dynamic = 'force-dynamic';
 /**
  * BFF proxy for the deployment-wide Rhesis platform API key.
  *
- * These endpoints only exist when the backend runs in local/self-hosted mode;
+ * These endpoints only exist when ENABLE_RHESIS_KEY is set on the backend;
  * otherwise the backend returns 404, which we pass through cleanly so the
- * frontend can hide the local-only key-settings UI. Mirrors the
+ * frontend can hide the key-settings UI. Mirrors the
  * `users/request-polyphemus-access` BFF pattern: inject `Authorization`
  * server-side from the httpOnly session cookie, never exposing the access
  * token to the browser.

--- a/apps/frontend/src/contexts/FeaturesContext.tsx
+++ b/apps/frontend/src/contexts/FeaturesContext.tsx
@@ -34,6 +34,7 @@ interface FeaturesState {
   enabled: ReadonlySet<string>;
   warnings: Readonly<Record<string, string>>;
   isLocalMode: boolean;
+  rhesisKeyEnabled: boolean;
   loading: boolean;
   error: Error | null;
 }
@@ -43,6 +44,7 @@ const DEFAULT_STATE: FeaturesState = {
   enabled: new Set<string>(),
   warnings: {},
   isLocalMode: false,
+  rhesisKeyEnabled: false,
   loading: true,
   error: null,
 };
@@ -90,6 +92,7 @@ export function FeaturesProvider({
         enabled: new Set<string>(),
         warnings: {},
         isLocalMode: false,
+        rhesisKeyEnabled: false,
         loading: false,
         error: error instanceof Error ? error : new Error(String(error)),
       };
@@ -99,6 +102,7 @@ export function FeaturesProvider({
       enabled: new Set<string>(data.enabled),
       warnings: data.warnings ?? {},
       isLocalMode: data.is_local ?? false,
+      rhesisKeyEnabled: data.rhesis_key_enabled ?? false,
       loading: false,
       error: null,
     };
@@ -143,14 +147,22 @@ export function useFeaturesState(): FeaturesState {
 /**
  * Whether this deployment runs in local/self-hosted mode.
  *
- * Single source of truth for local-only UI (e.g. the Rhesis platform key
- * card, greying Polyphemus in the provider picker) -- derived from the
- * backend's `BACKEND_ENV` via `GET /features` instead of a separate
- * frontend-only env var, so the two can never disagree. Fail-closed like
- * every other flag on this context: `false` while loading or on error.
+ * Single source of truth for local-only UI (e.g. greying Polyphemus in the
+ * provider picker) -- derived from the backend's `BACKEND_ENV` via
+ * `GET /features`. Fail-closed: `false` while loading or on error.
  */
 export function useIsLocalMode(): boolean {
   return useContext(FeaturesContext).isLocalMode;
+}
+
+/**
+ * Whether the Rhesis platform API key option is enabled (ENABLE_RHESIS_KEY).
+ *
+ * Controls the platform key UI and endpoints independently of deployment type.
+ * Fail-closed: `false` while loading or on error.
+ */
+export function useRhesisKeyEnabled(): boolean {
+  return useContext(FeaturesContext).rhesisKeyEnabled;
 }
 
 /**

--- a/apps/frontend/src/contexts/__tests__/FeaturesContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/FeaturesContext.test.tsx
@@ -294,7 +294,9 @@ describe('useRhesisKeyEnabled', () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByTestId('rhesis-key-enabled')).toHaveTextContent('false')
+      expect(screen.getByTestId('rhesis-key-enabled')).toHaveTextContent(
+        'false'
+      )
     );
   });
 
@@ -308,7 +310,9 @@ describe('useRhesisKeyEnabled', () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByTestId('rhesis-key-enabled')).toHaveTextContent('false')
+      expect(screen.getByTestId('rhesis-key-enabled')).toHaveTextContent(
+        'false'
+      )
     );
   });
 });

--- a/apps/frontend/src/contexts/__tests__/FeaturesContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/FeaturesContext.test.tsx
@@ -9,6 +9,7 @@ import {
   useFeature,
   useFeaturesState,
   useIsLocalMode,
+  useRhesisKeyEnabled,
 } from '../FeaturesContext';
 
 const mockGetFeatures = jest.fn();
@@ -255,6 +256,59 @@ describe('useIsLocalMode', () => {
 
     await waitFor(() =>
       expect(screen.getByTestId('local-mode')).toHaveTextContent('false')
+    );
+  });
+});
+
+function RhesisKeyEnabledProbe() {
+  const rhesisKeyEnabled = useRhesisKeyEnabled();
+  return <div data-testid="rhesis-key-enabled">{String(rhesisKeyEnabled)}</div>;
+}
+
+describe('useRhesisKeyEnabled', () => {
+  it('returns true when the backend reports rhesis_key_enabled', async () => {
+    mockGetFeatures.mockResolvedValue({
+      license: LICENSE,
+      enabled: [],
+      rhesis_key_enabled: true,
+    });
+
+    render(
+      <FeaturesProvider>
+        <RhesisKeyEnabledProbe />
+      </FeaturesProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('rhesis-key-enabled')).toHaveTextContent('true')
+    );
+  });
+
+  it('defaults to false when rhesis_key_enabled is absent (older backend)', async () => {
+    mockGetFeatures.mockResolvedValue({ license: LICENSE, enabled: [] });
+
+    render(
+      <FeaturesProvider>
+        <RhesisKeyEnabledProbe />
+      </FeaturesProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('rhesis-key-enabled')).toHaveTextContent('false')
+    );
+  });
+
+  it('fails closed (false) while loading and on fetch error', async () => {
+    mockGetFeatures.mockRejectedValue(new Error('boom'));
+
+    render(
+      <FeaturesProvider>
+        <RhesisKeyEnabledProbe />
+      </FeaturesProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('rhesis-key-enabled')).toHaveTextContent('false')
     );
   });
 });

--- a/apps/frontend/src/hooks/usePlatformKey.ts
+++ b/apps/frontend/src/hooks/usePlatformKey.ts
@@ -9,24 +9,24 @@ import {
 } from '@/utils/api-client/platform-client';
 import type { PlatformKeyStatus } from '@/utils/api-client/interfaces/platform';
 import { useIsAuthenticated } from '@/hooks/useIsAuthenticated';
-import { useIsLocalMode } from '@/contexts/FeaturesContext';
+import { useRhesisKeyEnabled } from '@/contexts/FeaturesContext';
 
 /**
  * Status of, and mutations for, the deployment-wide Rhesis platform API key.
  *
- * Only fetches in local mode (the backend endpoints 404 otherwise). On a
- * successful set/clear the models query is invalidated so any grid greying that
- * depends on model availability re-resolves.
+ * Only fetches when ENABLE_RHESIS_KEY is set (the backend endpoints 404
+ * otherwise). On a successful set/clear the models query is invalidated so
+ * any grid greying that depends on model availability re-resolves.
  */
 export function usePlatformKey(enabled = true) {
   const isAuthenticated = useIsAuthenticated();
-  const isLocalMode = useIsLocalMode();
+  const rhesisKeyEnabled = useRhesisKeyEnabled();
   const queryClient = useQueryClient();
 
   const query = useQuery<PlatformKeyStatus>({
     queryKey: platformKeyKeys.all(),
     queryFn: getRhesisPlatformKeyStatus,
-    enabled: enabled && isAuthenticated && isLocalMode,
+    enabled: enabled && isAuthenticated && rhesisKeyEnabled,
     staleTime: 60_000,
   });
 
@@ -50,5 +50,5 @@ export function usePlatformKey(enabled = true) {
     },
   });
 
-  return { query, setKey, clearKey, isLocalMode };
+  return { query, setKey, clearKey, rhesisKeyEnabled };
 }

--- a/apps/frontend/src/utils/api-client/features-client.ts
+++ b/apps/frontend/src/utils/api-client/features-client.ts
@@ -17,6 +17,11 @@ export interface FeaturesResponse {
    * predates this field.
    */
   is_local?: boolean;
+  /**
+   * Whether the Rhesis platform API key option is enabled (ENABLE_RHESIS_KEY).
+   * Optional to tolerate older backends that predate this field.
+   */
+  rhesis_key_enabled?: boolean;
 }
 
 /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ x-rhesis-config: &rhesis-config
   API_BASE_URL: *api_base_url
   RHESIS_BASE_URL: ${RHESIS_BASE_URL:-}
   RHESIS_API_KEY: ${RHESIS_API_KEY:-}
+  ENABLE_RHESIS_KEY: ${ENABLE_RHESIS_KEY:-true}  # Self-hosted: opt-out via env var
   RHESIS_CONNECTOR_DISABLED: true
   FRONTEND_URL: *frontend_url
   BACKEND_URL: http://backend:8080

--- a/docs/content/docs/deployment/environment-variables.mdx
+++ b/docs/content/docs/deployment/environment-variables.mdx
@@ -103,6 +103,7 @@ provider's key **and** point the matching `DEFAULT_*_MODEL` at it.
 | Variable | Description | Default |
 |---|---|---|
 | `RHESIS_API_KEY` | API key for Rhesis-hosted models | *(unset)* |
+| `ENABLE_RHESIS_KEY` | Lets org owners configure a Rhesis platform key from the Models page instead of only `RHESIS_API_KEY` | `true` |
 | `DEFAULT_GENERATION_MODEL` | Model for test generation | `rhesis/rhesis-default` |
 | `DEFAULT_EVALUATION_MODEL` | Model for evaluation / judging | `rhesis/rhesis-default` |
 | `DEFAULT_EXECUTION_MODEL` | Model for multi-turn execution | `rhesis/rhesis-default` |

--- a/infrastructure/k8s/manifests/configmaps/rhesis-config.yaml.example
+++ b/infrastructure/k8s/manifests/configmaps/rhesis-config.yaml.example
@@ -86,6 +86,8 @@ data:
   BACKEND_ENV: "local"
   WORKER_ENV: "local"
   LOG_LEVEL: "INFO"
+  # Enables the org-scoped Rhesis platform API key UI/endpoints (/platform/rhesis-key).
+  ENABLE_RHESIS_KEY: "true"
 
   # =============================================================================
   # 🔗 INTERNAL URLS

--- a/scripts/rh/dev.sh
+++ b/scripts/rh/dev.sh
@@ -122,6 +122,7 @@ CELERY_RESULT_BACKEND=redis://:rhesis-redis-pass@localhost:${DEV_REDIS_PORT}/1
 
 # Environment
 BACKEND_ENV=local
+ENABLE_RHESIS_KEY=true
 DEV_MODE=true
 LOG_LEVEL=DEBUG
 OTEL_RHESIS_TELEMETRY_ENABLED=false

--- a/tests/backend/app/test_usage_tracking.py
+++ b/tests/backend/app/test_usage_tracking.py
@@ -438,23 +438,23 @@ class TestConfiguredModelProvenance:
 
 
 class TestPlatformKeyModelProvenance:
-    """A local-mode platform-key model is ours to bill.
+    """A platform-key model is ours to bill.
 
     The one place where ``_is_hosted_model`` cannot be used to derive the
     stamp. It reads *any* API key as the org's own, and the Rhesis platform
     key looks exactly like one while actually being Rhesis-issued credentials
-    for local/self-hosted mode -- so ``_try_platform_key_model`` has to pass
-    ``metered`` explicitly. Pinned because it is a merge-time judgement call
-    (#2377 landed on main wiring the old per-call-site accrual callback here,
-    which this branch replaced with the stamp) and getting it backwards would
-    either bill an org for its own spend or stop billing ours, silently.
+    -- so ``_try_platform_key_model`` has to pass ``metered`` explicitly.
+    Pinned because it is a merge-time judgement call (#2377 landed on main
+    wiring the old per-call-site accrual callback here, which this branch
+    replaced with the stamp) and getting it backwards would either bill an
+    org for its own spend or stop billing ours, silently.
     """
 
     @pytest.fixture
-    def in_local_mode_with_a_platform_key(self, monkeypatch):
+    def rhesis_key_enabled_with_a_platform_key(self, monkeypatch):
         monkeypatch.setattr(
             "rhesis.backend.app.utils.user_model_utils.get_application_settings",
-            lambda: SimpleNamespace(is_local=True),
+            lambda: SimpleNamespace(enable_rhesis_key=True),
         )
         monkeypatch.setattr(
             "rhesis.backend.app.utils.user_model_utils.get_platform_api_key",
@@ -465,7 +465,7 @@ class TestPlatformKeyModelProvenance:
             lambda **kwargs: _StubLLM(kwargs.get("model_name", "default")),
         )
 
-    def test_language_model_is_stamped_metered(self, in_local_mode_with_a_platform_key):
+    def test_language_model_is_stamped_metered(self, rhesis_key_enabled_with_a_platform_key):
         from rhesis.backend.app.utils.user_model_utils import _try_platform_key_model
 
         model = _try_platform_key_model(
@@ -474,11 +474,11 @@ class TestPlatformKeyModelProvenance:
 
         assert model.usage_metered is True
 
-    def test_returns_none_outside_local_mode(self, monkeypatch):
+    def test_returns_none_when_rhesis_key_disabled(self, monkeypatch):
         """So callers fall through to their own delegation/default logic."""
         monkeypatch.setattr(
             "rhesis.backend.app.utils.user_model_utils.get_application_settings",
-            lambda: SimpleNamespace(is_local=False),
+            lambda: SimpleNamespace(enable_rhesis_key=False),
         )
         from rhesis.backend.app.utils.user_model_utils import _try_platform_key_model
 

--- a/tests/backend/routes/test_features.py
+++ b/tests/backend/routes/test_features.py
@@ -143,13 +143,21 @@ class TestFeaturesEndpoint:
     def test_response_shape_is_stable(self, client: TestClient, registered_sso, mock_current_user):
         response = client.get("/features")
         body = response.json()
-        assert set(body.keys()) == {"license", "enabled", "warnings", "limits", "is_local"}
+        assert set(body.keys()) == {
+            "license",
+            "enabled",
+            "warnings",
+            "limits",
+            "is_local",
+            "rhesis_key_enabled",
+        }
         assert set(body["license"].keys()) == {"edition", "licensed"}
         assert isinstance(body["enabled"], list)
         assert all(isinstance(name, str) for name in body["enabled"])
         assert isinstance(body["warnings"], dict)
         assert isinstance(body["limits"], dict)
         assert isinstance(body["is_local"], bool)
+        assert isinstance(body["rhesis_key_enabled"], bool)
 
     def test_license_info_reflects_org(self, client: TestClient, registered_sso, mock_current_user):
         """license_info() must always receive the org object, never None.

--- a/tests/backend/routes/test_platform_authz.py
+++ b/tests/backend/routes/test_platform_authz.py
@@ -33,9 +33,9 @@ def _auth(token) -> dict:
     return {"Authorization": f"Bearer {token.token}"}
 
 
-def _local_mode():
-    """Patch require_local_mode's settings check so the routes don't 404."""
-    settings = type("_Settings", (), {"is_local": True})()
+def _rhesis_key_enabled():
+    """Patch require_rhesis_key_enabled's settings check so the routes don't 404."""
+    settings = type("_Settings", (), {"enable_rhesis_key": True})()
     return patch(
         "rhesis.backend.app.auth.feature_gates.get_application_settings",
         return_value=settings,
@@ -83,20 +83,20 @@ class TestPlatformKeyAdminDeniedForNonOwner:
 
     def test_set_key_denied(self, client: TestClient, test_db):
         _org, _user, token = _context(test_db, "Member")
-        with _ee_provider_active(), _local_mode():
+        with _ee_provider_active(), _rhesis_key_enabled():
             resp = client.put("/platform/rhesis-key", json={"key": "rh-test"}, headers=_auth(token))
         assert resp.status_code == 403, resp.text
 
     def test_clear_key_denied(self, client: TestClient, test_db):
         _org, _user, token = _context(test_db, "Member")
-        with _ee_provider_active(), _local_mode():
+        with _ee_provider_active(), _rhesis_key_enabled():
             resp = client.delete("/platform/rhesis-key", headers=_auth(token))
         assert resp.status_code == 403, resp.text
 
     def test_read_key_status_still_allowed(self, client: TestClient, test_db):
         """GET is read-only (masked key only) and stays open to any member."""
         _org, _user, token = _context(test_db, "Member")
-        with _ee_provider_active(), _local_mode():
+        with _ee_provider_active(), _rhesis_key_enabled():
             resp = client.get("/platform/rhesis-key", headers=_auth(token))
         assert resp.status_code != 403, resp.text
 
@@ -108,12 +108,12 @@ class TestPlatformKeyAdminAllowedForOwner:
 
     def test_set_key_allowed(self, client: TestClient, test_db):
         _org, _user, token = _context(test_db, "Owner")
-        with _ee_provider_active(), _local_mode(), _no_op_validation():
+        with _ee_provider_active(), _rhesis_key_enabled(), _no_op_validation():
             resp = client.put("/platform/rhesis-key", json={"key": "rh-test"}, headers=_auth(token))
         assert resp.status_code != 403, resp.text
 
     def test_clear_key_allowed(self, client: TestClient, test_db):
         _org, _user, token = _context(test_db, "Owner")
-        with _ee_provider_active(), _local_mode():
+        with _ee_provider_active(), _rhesis_key_enabled():
             resp = client.delete("/platform/rhesis-key", headers=_auth(token))
         assert resp.status_code != 403, resp.text

--- a/tests/backend/services/test_platform_key.py
+++ b/tests/backend/services/test_platform_key.py
@@ -122,15 +122,15 @@ def test_availability_signals_missing_org_fails_open():
 # --------------------------------------------------------------------------- #
 # annotate_model_availability
 # --------------------------------------------------------------------------- #
-def test_annotate_availability_outside_local_mode_everything_available():
+def test_annotate_availability_rhesis_key_disabled_everything_available():
     db = Mock(spec=Session)
     models = [_model("rhesis"), _model("openai")]
-    with patch(f"{_MODULE}.get_application_settings", return_value=Mock(is_local=False)):
+    with patch(f"{_MODULE}.get_application_settings", return_value=Mock(enable_rhesis_key=False)):
         pk.annotate_model_availability(db, "org-1", models)
     assert all(m.available is True and m.availability_reason is None for m in models)
 
 
-def test_annotate_availability_local_mode_key_missing_greys_platform_providers():
+def test_annotate_availability_rhesis_key_enabled_missing_key_greys_platform_providers():
     db = Mock(spec=Session)
     rhesis_model, poly_model, openai_model = (
         _model("rhesis"),
@@ -138,7 +138,7 @@ def test_annotate_availability_local_mode_key_missing_greys_platform_providers()
         _model("openai"),
     )
     with (
-        patch(f"{_MODULE}.get_application_settings", return_value=Mock(is_local=True)),
+        patch(f"{_MODULE}.get_application_settings", return_value=Mock(enable_rhesis_key=True)),
         patch(f"{_MODULE}._load_org", return_value=_org(None)),
         patch(f"{_MODULE}.get_rhesis_settings", return_value=Mock(api_key=None)),
     ):
@@ -152,13 +152,13 @@ def test_annotate_availability_local_mode_key_missing_greys_platform_providers()
     assert openai_model.availability_reason is None
 
 
-def test_annotate_availability_local_mode_invalid_key_greys_platform_providers():
+def test_annotate_availability_rhesis_key_enabled_invalid_key_greys_platform_providers():
     db = Mock(spec=Session)
     org = _org("rh-stored")
     org.rhesis_key_valid = False
     rhesis_model = _model("rhesis")
     with (
-        patch(f"{_MODULE}.get_application_settings", return_value=Mock(is_local=True)),
+        patch(f"{_MODULE}.get_application_settings", return_value=Mock(enable_rhesis_key=True)),
         patch(f"{_MODULE}._load_org", return_value=org),
     ):
         pk.annotate_model_availability(db, "org-1", [rhesis_model])
@@ -167,14 +167,14 @@ def test_annotate_availability_local_mode_invalid_key_greys_platform_providers()
     assert rhesis_model.availability_reason == "rhesis_key_invalid"
 
 
-def test_annotate_availability_local_mode_unauthorized_polyphemus_only():
+def test_annotate_availability_rhesis_key_enabled_unauthorized_polyphemus_only():
     db = Mock(spec=Session)
     org = _org("rh-stored")
     org.rhesis_key_valid = True
     org.rhesis_key_polyphemus_authorized = False
     rhesis_model, poly_model = _model("rhesis"), _model("polyphemus")
     with (
-        patch(f"{_MODULE}.get_application_settings", return_value=Mock(is_local=True)),
+        patch(f"{_MODULE}.get_application_settings", return_value=Mock(enable_rhesis_key=True)),
         patch(f"{_MODULE}._load_org", return_value=org),
     ):
         pk.annotate_model_availability(db, "org-1", [rhesis_model, poly_model])
@@ -185,14 +185,14 @@ def test_annotate_availability_local_mode_unauthorized_polyphemus_only():
     assert poly_model.availability_reason == "polyphemus_not_authorized"
 
 
-def test_annotate_availability_local_mode_valid_key_everything_available():
+def test_annotate_availability_rhesis_key_enabled_valid_key_everything_available():
     db = Mock(spec=Session)
     org = _org("rh-stored")
     org.rhesis_key_valid = True
     org.rhesis_key_polyphemus_authorized = True
     models = [_model("rhesis"), _model("polyphemus"), _model("openai")]
     with (
-        patch(f"{_MODULE}.get_application_settings", return_value=Mock(is_local=True)),
+        patch(f"{_MODULE}.get_application_settings", return_value=Mock(enable_rhesis_key=True)),
         patch(f"{_MODULE}._load_org", return_value=org),
     ):
         pk.annotate_model_availability(db, "org-1", models)
@@ -205,7 +205,7 @@ def test_annotate_availability_unknown_validity_fails_open():
     db = Mock(spec=Session)
     rhesis_model = _model("rhesis")
     with (
-        patch(f"{_MODULE}.get_application_settings", return_value=Mock(is_local=True)),
+        patch(f"{_MODULE}.get_application_settings", return_value=Mock(enable_rhesis_key=True)),
         patch(f"{_MODULE}._load_org", return_value=_org(None)),
         patch(f"{_MODULE}.get_rhesis_settings", return_value=Mock(api_key="rh-env")),
     ):

--- a/tests/backend/utils/test_llm_delegation.py
+++ b/tests/backend/utils/test_llm_delegation.py
@@ -152,14 +152,14 @@ class TestPolyphemusModelConfiguration:
         get_rhesis_settings.cache_clear()
 
     @pytest.fixture(autouse=True)
-    def not_local_mode(self):
+    def rhesis_key_disabled(self):
         """These tests cover SaaS delegation and self-hosted-via-env-var-only
-        requirement, not the per-org platform key (local-mode-only) path -- force
-        ``is_local=False`` so a developer's own ``BACKEND_ENV=local`` .env
-        doesn't change which branch runs."""
+        requirement, not the per-org platform key (ENABLE_RHESIS_KEY-gated) path
+        -- force ``enable_rhesis_key=False`` so a developer's own
+        ``ENABLE_RHESIS_KEY=true`` .env doesn't change which branch runs."""
         with patch(
             "rhesis.backend.app.utils.user_model_utils.get_application_settings",
-            return_value=Mock(is_local=False),
+            return_value=Mock(enable_rhesis_key=False),
         ):
             yield
 


### PR DESCRIPTION
## Purpose

The Rhesis platform API key UI and endpoints used to be gated on deployment type (`BACKEND_ENV=local`), which meant the only way to turn the feature on or off was to run a different deployment mode entirely. This branch introduces an explicit `ENABLE_RHESIS_KEY` setting so the feature can be toggled independently of deployment type, then completes the migration end to end: fixing stale references, stale tests, and the self-hosted deployment configs that relied on the old implicit behavior.

## What Changed

- Added `ApplicationSettings.enable_rhesis_key` (`ENABLE_RHESIS_KEY` env var, default `false`) and renamed `require_local_mode` to `require_rhesis_key_enabled`, switching `/platform/rhesis-key`, `annotate_model_availability`, and `_try_platform_key_model` to check it instead of `is_local`.
- Exposed `rhesis_key_enabled` on `GET /features` and added a `useRhesisKeyEnabled` hook on the frontend; `usePlatformKey` and the Models page now gate on it instead of `useIsLocalMode`.
- Corrected stale "local mode" wording left in `platform_key.py`/`user_model_utils.py` docstrings and comments after the gate moved to `ENABLE_RHESIS_KEY`.
- Fixed test mocks across `test_platform_authz.py`, `test_usage_tracking.py`, `test_llm_delegation.py`, `test_features.py`, and `test_platform_key.py` that still stubbed `is_local` — some raised `AttributeError` once the code moved to `enable_rhesis_key`, others (plain `Mock()`) silently auto-generated a truthy attribute and passed while exercising the wrong branch.
- Added `useRhesisKeyEnabled` test coverage mirroring the existing `useIsLocalMode` tests, which had none.
- Defaulted `ENABLE_RHESIS_KEY` on for self-hosted deployments in `docker-compose.yml`, `./rh dev`'s generated `.env`, and the Kubernetes config example, since none of them previously set it and the setting has no fallback to `is_local` — without this, every self-hosted or local-dev deployment would have silently lost the platform key UI on upgrade.
- Documented `ENABLE_RHESIS_KEY` in `.env.example` and `docs/deployment/environment-variables.mdx`, and fixed a stale `.env.example` comment that still attributed the gating to `BACKEND_ENV=local`.

## Additional Context

`ProviderSelectionPanel.tsx` (local-only model providers like Ollama) and `ModelCard.tsx` (suppressing the Polyphemus access-request email flow) still use `useIsLocalMode` deliberately — those are genuinely tied to deployment type, not the platform key feature, and were left unchanged.

## Testing

- `uv run pytest tests/backend/routes/test_platform_authz.py tests/backend/app/test_usage_tracking.py tests/backend/utils/test_llm_delegation.py tests/backend/routes/test_features.py tests/backend/services/test_platform_key.py` — 99 passed
- `npx jest src/contexts/__tests__/FeaturesContext.test.tsx` (frontend) — 19 passed
- `ruff check` / `ruff format --check` on touched backend files — clean
- `eslint` on touched frontend files — clean
- `docker compose config` with dummy secrets — confirmed `ENABLE_RHESIS_KEY` resolves to `true` by default and is overridable via env
