### PR TITLE
Self-hosted deployments get no usage quotas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,3 +142,6 @@ SESSION_SECRET_KEY=
 # CELERY_WORKER_CONCURRENCY=8
 # CELERY_WORKER_PREFETCH_MULTIPLIER=4
 # CELERY_WORKER_LOGLEVEL=       # defaults to LOG_LEVEL
+# USAGE_QUOTAS_ENABLED=false   # cloud-only; enables per-org usage quota enforcement.
+#                               # Self-hosted deployments leave this unset (default false)
+#                               # so no usage limits apply.

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -201,10 +201,11 @@ not supposed to require thinking about billing.
 - **Who to bill**: read at emission time from `app/usage_attribution.py`'s ContextVar, bound by
   the `bind_usage_attribution` async dependency (pulled in by `get_tenant_db_session`) and by the
   Celery `task_prerun` handler.
-- **Whether to bill**: `BaseLLM.usage_metered`, stamped by the model-resolution layer via
-  `stamp_usage_provenance`. This cannot move to the provider — an org's own OpenAI key means they
-  pay OpenAI directly, while the deployment default runs on our credentials, and that is the same
-  provider class with opposite answers.
+- **Whether to skip**: `BaseLLM.usage_metered`, stamped by the model-resolution layer via
+  `stamp_usage_provenance`. When `USAGE_QUOTAS_ENABLED` is true (Rhesis cloud), a `metered=False`
+  model is skipped: the org supplied its own API key and pays the provider directly. When quotas
+  are off (self-hosted, the default), every model accrues regardless so the usage page shows the
+  full picture of what the instance spent.
 
 Two rules for new code:
 

--- a/apps/backend/src/rhesis/backend/app/config/settings.py
+++ b/apps/backend/src/rhesis/backend/app/config/settings.py
@@ -87,6 +87,7 @@ class ApplicationSettings(BaseSettings):
 
     quick_start: bool = Field(default=False, alias="QUICK_START")
     dev_mode: bool = Field(default=False, alias="DEV_MODE")
+    usage_quotas_enabled: bool = Field(default=False, alias="USAGE_QUOTAS_ENABLED")
     backend_env: Literal["production", "development", "staging", "local"] = Field(
         default="development", alias="BACKEND_ENV"
     )

--- a/apps/backend/src/rhesis/backend/app/ee_bootstrap.py
+++ b/apps/backend/src/rhesis/backend/app/ee_bootstrap.py
@@ -29,6 +29,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def bootstrap_ee_providers() -> None:
+    """Install the EE license and quota providers without the full app bootstrap.
+
+    Called from the Celery worker init signal so workers resolve licensed
+    quota limits instead of falling back to free-tier defaults. No-op when
+    the EE package is not installed.
+    """
+    try:
+        from rhesis.backend.ee import bootstrap_providers  # type: ignore[import-untyped]
+    except ImportError:
+        return
+
+    bootstrap_providers()
+
+
 def bootstrap_ee(app: "FastAPI") -> None:
     """Conditionally load and initialise the EE package.
 

--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -321,6 +321,9 @@ async def lifespan(app: FastAPI):
     """
     set_logger()
 
+    _quotas = get_application_settings().usage_quotas_enabled
+    logger.info("Usage quota enforcement: %s", "enabled" if _quotas else "disabled (self-hosted)")
+
     # Apply fail-fast Celery broker settings for the web process.
     # Must happen before any Celery task is published from an HTTP handler.
     from rhesis.backend.celery.core import apply_web_context_overrides

--- a/apps/backend/src/rhesis/backend/app/quota/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/quota/__init__.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional, Protocol, Union
 
+from rhesis.backend.app.config.settings import get_application_settings
 from rhesis.backend.app.models.organization import Organization
 
 
@@ -90,6 +91,11 @@ FREE_TIER_LIMITS: dict[QuotaResource, int | None] = {
     QuotaResource.PROJECTS: 1,
     QuotaResource.ENDPOINTS: 1,
 }
+
+# Every resource explicitly set to None (unlimited). Explicit keys rather than
+# an empty dict so the /features wire shape stays stable: callers always see
+# all seven resource names, whether the deployment enforces quotas or not.
+UNLIMITED_LIMITS: dict[QuotaResource, int | None] = {r: None for r in QuotaResource}
 
 
 @dataclass(frozen=True)
@@ -213,6 +219,8 @@ class QuotaRegistry:
     @classmethod
     def get_policy(cls, org: Optional[Organization] = None) -> QuotaPolicy:
         """Return the resolved limits and overage policy for *org*."""
+        if not get_application_settings().usage_quotas_enabled:
+            return QuotaPolicy(limits=dict(UNLIMITED_LIMITS))
         return cls._provider.get_policy(org)
 
     @classmethod
@@ -253,5 +261,6 @@ __all__ = [
     "QuotaRegistry",
     "QuotaResource",
     "QuotaResourceLike",
+    "UNLIMITED_LIMITS",
     "limits_to_wire",
 ]

--- a/apps/backend/src/rhesis/backend/app/utils/usage_tracking.py
+++ b/apps/backend/src/rhesis/backend/app/utils/usage_tracking.py
@@ -13,25 +13,13 @@ cannot be forgotten because there is nothing to remember.
 
 Two inputs decide what happens to an emission:
 
-**Who pays** -- ``BaseLLM.usage_metered``, stamped by the model-resolution
-layer (``user_model_utils``, and ``metrics.strategies.local`` for per-metric
-judge overrides). This cannot move to the SDK or to the provider: the same
-provider class is billable or not depending on where its API key came from.
-An org running ``openai`` on its own key pays OpenAI directly and must not
-also pay us; the deployment's default model runs on our credentials and
-must. Same class, opposite answer, decided by how the model was selected.
-
-``None`` -- nobody stamped it -- is treated as a bug, not as a third
-category, and billed. That is safe because an org's own API key can only
-enter through a Model row (``_fetch_and_configure_model``,
-``_resolve_metric_model``) or the connection-test form
-(``model_connection``), and all of those stamp; a model that reached an LLM
-call unstamped is therefore running on this deployment's credentials.
-``tests/backend/app/test_language_model_construction_boundary.py`` keeps it
-that way, and the two Penelope construction sites (``batch/runner.py``,
-``output_providers.py``) stamp across that package boundary since Penelope
-cannot stamp itself. :func:`_warn_unstamped` fires once per provider/model
-so a path that slips through all of that is findable rather than silent.
+**Whether to skip** -- ``BaseLLM.usage_metered``, stamped by the
+model-resolution layer. When ``USAGE_QUOTAS_ENABLED`` is true (Rhesis
+cloud), a ``metered=False`` model is skipped: the org supplied its own API
+key and pays the provider directly. When quotas are off (self-hosted), every
+model accrues regardless of ``usage_metered`` so the usage page shows total
+instance spend. ``None`` (unstamped) always warns via :func:`_warn_unstamped`
+-- it is a construction-boundary defect in either deployment mode.
 
 **Who to bill** -- the ambient organization from
 :mod:`rhesis.backend.app.usage_attribution`, read at emission time rather
@@ -46,6 +34,7 @@ from __future__ import annotations
 import logging
 from typing import Optional, Set, Tuple
 
+from rhesis.backend.app.config.settings import get_application_settings
 from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.services.usage import dispatch_accrual
 from rhesis.backend.app.usage_attribution import current_usage_org
@@ -138,26 +127,10 @@ def accrue_model_tokens(usage: TokenUsage, model: BaseLLM) -> None:
     unlike the Celery call sites, this runs during interactive requests a
     user is waiting on.
     """
-    if model.usage_metered is False:
-        # The org supplied its own API key, so it already pays the provider.
-        return
     if model.usage_metered is None:
-        # Nobody stamped it, which is a bug rather than a category, so bill it
-        # and say so once. Billing (rather than skipping) is safe only because
-        # an org's own key cannot reach an unstamped model: it enters via a
-        # Model row or the connection-test form, and every one of those paths
-        # stamps. The invariant is enforced, not assumed --
-        # tests/backend/app/test_language_model_construction_boundary.py fails
-        # on any new construction site, and its allowlist documents the
-        # exceptions.
-        #
-        # Revisit if Rhesis stops offering hosted models: once every model
-        # carries an org's key, "unstamped" flips from "ours" to "theirs" and
-        # billing on it would charge orgs for their own spend. Skipping would
-        # be the safer default then. Today nothing is enforced against these
-        # numbers (limits are display-only), so the blast radius is a wrong
-        # figure on a dashboard, not a blocked user.
         _warn_unstamped(model)
+    if get_application_settings().usage_quotas_enabled and model.usage_metered is False:
+        return
 
     organization_id = current_usage_org()
     if not organization_id:

--- a/apps/backend/src/rhesis/backend/celery/signals.py
+++ b/apps/backend/src/rhesis/backend/celery/signals.py
@@ -66,7 +66,7 @@ def _update_test_run_status(task_id: str, new_status: RunStatus, error_message: 
 @celeryd_init.connect
 @worker_process_init.connect
 def install_worker_usage_sink(**kwargs):
-    """Register the process-wide token-usage sink in the worker.
+    """Register the process-wide token-usage sink and EE providers in the worker.
 
     Connected to both signals on purpose, and ``celeryd_init`` is the
     load-bearing one. ``worker_process_init`` is sent only by the prefork and
@@ -79,9 +79,16 @@ def install_worker_usage_sink(**kwargs):
     installing after the fork keeps the sink independent of whatever the
     parent had imported at fork time. Installation is idempotent, so being
     called by both costs nothing.
+
+    ``bootstrap_ee_providers`` installs the EE license and quota providers so
+    workers resolve licensed quota limits instead of falling back to free-tier
+    defaults. It registers no features, so no feature gate can flip in a
+    worker. No-op when the EE package is not installed.
     """
+    from rhesis.backend.app.ee_bootstrap import bootstrap_ee_providers
     from rhesis.backend.app.utils.usage_tracking import install_usage_sink
 
+    bootstrap_ee_providers()
     install_usage_sink()
 
 

--- a/charts/rhesis/templates/configmap.yaml
+++ b/charts/rhesis/templates/configmap.yaml
@@ -55,6 +55,7 @@ data:
   FRONTEND_URL: {{ .Values.config.frontendUrl | quote }}
   BACKEND_URL: {{ .Values.config.backendUrl | quote }}
   QUICK_START: {{ .Values.config.quickStart | quote }}
+  USAGE_QUOTAS_ENABLED: {{ .Values.config.usageQuotasEnabled | quote }}
 
   # -------------------------------------------------------------------------
   # Auth

--- a/charts/rhesis/values-dev.yaml
+++ b/charts/rhesis/values-dev.yaml
@@ -20,6 +20,7 @@ config:
   # INFO reduces API log I/O under load; use DEBUG only when actively tracing.
   logLevel: "INFO"
   jsonLoggerEnabled: true
+  usageQuotasEnabled: true
 
   # App DB name (ConfigMap DB_NAME) and Bitnami PostgreSQL bootstrap database.
   dbName: &rhesis_db_name "rhesis-dev-db"

--- a/charts/rhesis/values-prd.yaml
+++ b/charts/rhesis/values-prd.yaml
@@ -30,6 +30,7 @@ config:
   environment: "production"
   logLevel: "INFO"
   jsonLoggerEnabled: true
+  usageQuotasEnabled: true
 
   # Must match kubernetes/clusters/prd/cnpg-cluster/cnpg-cluster.yaml bootstrap.initdb.database
   dbName: "rhesis-prd-db"

--- a/charts/rhesis/values-stg.yaml
+++ b/charts/rhesis/values-stg.yaml
@@ -26,6 +26,7 @@ config:
   environment: "staging"
   logLevel: "INFO"
   jsonLoggerEnabled: true
+  usageQuotasEnabled: true
 
   # Must match kubernetes/clusters/stg/cnpg-cluster/cnpg-cluster.yaml bootstrap.initdb.database
   dbName: "rhesis-stg-db"

--- a/charts/rhesis/values.yaml
+++ b/charts/rhesis/values.yaml
@@ -98,6 +98,10 @@ config:
   authBlockDisposableEmails: "log"
   authDisposableEmailExtraDomains: ""
 
+  # Usage quota enforcement. Off by default so self-hosted deployments have no
+  # limits; Rhesis cloud overrides this to true in its per-env values files.
+  usageQuotasEnabled: false
+
   # AI model configuration
   azureOpenAiDeploymentName: "gpt-4o"
   azureOpenAiApiVersion: ""

--- a/docs/content/docs/deployment/environment-variables.mdx
+++ b/docs/content/docs/deployment/environment-variables.mdx
@@ -201,7 +201,13 @@ Rarely changed; the defaults are correct for most deployments.
 for reference only — a self-hosted deployment does not need any of them.
 </Callout>
 
-**Onboarding and lifecycle emails** — the hosted SendGrid drip campaign and welcome flow.
+**Usage quota enforcement** -- per-organization resource limits (test executions, tracing spans, model tokens, etc.). Self-hosted deployments have no usage limits; the usage page still shows what the instance spent.
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `USAGE_QUOTAS_ENABLED` | Enable per-org usage quota enforcement | `false` |
+
+**Onboarding and lifecycle emails** -- the hosted SendGrid drip campaign and welcome flow.
 
 | Variable | Purpose |
 |---|---|

--- a/docs/content/docs/deployment/index.mdx
+++ b/docs/content/docs/deployment/index.mdx
@@ -79,3 +79,10 @@ graph LR
     Worker --> Redis
 ```
 
+## Usage Limits
+
+A self-hosted deployment has no usage limits. All seven metered resources (test executions, tracing
+spans, test generation, model tokens, seats, projects, endpoints) are unlimited. The usage page
+reports what the instance spent so you have visibility into resource consumption without any
+enforcement or blocking.
+

--- a/ee/backend/src/rhesis/backend/ee/__init__.py
+++ b/ee/backend/src/rhesis/backend/ee/__init__.py
@@ -43,6 +43,23 @@ except PackageNotFoundError:
     __version__ = "0+unknown"
 
 
+def bootstrap_providers() -> None:
+    """Install the EE license and quota providers.
+
+    Idempotent. Called from :func:`bootstrap` (API process) and from
+    :func:`~rhesis.backend.app.ee_bootstrap.bootstrap_ee_providers`
+    (Celery workers), so every process resolves licensed quota limits
+    rather than falling back to free-tier defaults.
+    """
+    from rhesis.backend.app.features import FeatureRegistry
+    from rhesis.backend.app.quota import QuotaRegistry
+    from rhesis.backend.ee.licensing.provider import SignedTokenLicenseProvider
+    from rhesis.backend.ee.licensing.quota_provider import ConfigQuotaProvider
+
+    FeatureRegistry.set_license_provider(SignedTokenLicenseProvider())
+    QuotaRegistry.set_quota_provider(ConfigQuotaProvider())
+
+
 def bootstrap(app: "FastAPI") -> None:
     """Register EE features and routers with the FastAPI *app*.
 
@@ -86,7 +103,6 @@ def bootstrap(app: "FastAPI") -> None:
         mint_for_client_bound_refresh,
     )
     from rhesis.backend.ee.api_clients.router import router as api_clients_router
-    from rhesis.backend.ee.licensing.provider import SignedTokenLicenseProvider
     from rhesis.backend.ee.rbac.provider import PermissionAuthorizationProvider
     from rhesis.backend.ee.rbac.router import router as rbac_router
     from rhesis.backend.ee.sso.provider_enricher import sso_provider_enricher
@@ -109,16 +125,11 @@ def bootstrap(app: "FastAPI") -> None:
                 "the API Clients audit log relies on it for hashed_email"
             )
 
-    from rhesis.backend.app.quota import QuotaRegistry
-    from rhesis.backend.ee.licensing.quota_provider import ConfigQuotaProvider
+    # ---- License + quota providers ----------------------------------------
+    # Extracted into bootstrap_providers() so Celery workers can install them
+    # without running the full feature/router bootstrap.
+    bootstrap_providers()
 
-    # ---- License provider -----------------------------------------------
-    # Install before feature registration so any is_available() call that
-    # races during bootstrap already sees the correct provider.
-    FeatureRegistry.set_license_provider(SignedTokenLicenseProvider())
-
-    # ---- Quota provider -------------------------------------------------
-    QuotaRegistry.set_quota_provider(ConfigQuotaProvider())
 
     # ---- Feature registry -----------------------------------------------
     FeatureRegistry.register(

--- a/tests/backend/app/test_quota_deployment_mode.py
+++ b/tests/backend/app/test_quota_deployment_mode.py
@@ -1,0 +1,108 @@
+"""Tests for self-hosted deployment mode (USAGE_QUOTAS_ENABLED=false).
+
+With quotas off, every resource is unlimited, nothing enforces, and
+everything still counts. These tests use the ``quotas_disabled`` fixture
+to opt out of the suite-wide quotas-enabled patch from conftest.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rhesis.backend.app.quota import (
+    QuotaPolicy,
+    QuotaRegistry,
+    QuotaResource,
+    UNLIMITED_LIMITS,
+)
+from rhesis.backend.app.quota.enforcement import (
+    QuotaExceededError,
+    check_quota,
+    enforce_quota,
+)
+from rhesis.backend.app.services.usage import increment_usage
+
+
+class _FixedPolicyProvider:
+    """Always returns a limited policy, to prove the flag overrides it."""
+
+    def __init__(self, policy: QuotaPolicy):
+        self._policy = policy
+
+    def get_policy(self, org=None) -> QuotaPolicy:
+        return self._policy
+
+
+@pytest.fixture
+def limited_registry(quotas_disabled):
+    """Install a provider with tight limits, but quotas are off."""
+    saved = QuotaRegistry._provider
+    QuotaRegistry.set_quota_provider(
+        _FixedPolicyProvider(
+            QuotaPolicy(
+                limits={
+                    QuotaResource.TEST_EXECUTIONS: 10,
+                    QuotaResource.MODEL_TOKENS: 100,
+                    QuotaResource.TRACING_SPANS: 5,
+                    QuotaResource.TEST_GENERATION: 5,
+                    QuotaResource.SEATS: 1,
+                    QuotaResource.PROJECTS: 1,
+                    QuotaResource.ENDPOINTS: 1,
+                }
+            )
+        )
+    )
+    yield
+    QuotaRegistry._provider = saved
+
+
+class TestGetPolicyWithQuotasOff:
+    def test_returns_unlimited_for_all_resources(self, limited_registry):
+        policy = QuotaRegistry.get_policy()
+        for r in QuotaResource:
+            assert policy.limits[r] is None, f"{r} should be unlimited"
+
+    def test_keys_match_all_quota_resources(self, limited_registry):
+        policy = QuotaRegistry.get_policy()
+        assert set(policy.limits.keys()) == set(QuotaResource)
+
+
+class TestCheckQuotaWithQuotasOff:
+    def test_allows_usage_far_past_the_former_limit(
+        self, test_db, test_org_id, limited_registry
+    ):
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 1_000_000)
+
+        verdict = check_quota(
+            test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS
+        )
+
+        assert verdict.allowed is True
+        assert verdict.limit is None
+
+    def test_used_still_reflects_real_usage(
+        self, test_db, test_org_id, limited_registry
+    ):
+        increment_usage(test_db, test_org_id, QuotaResource.MODEL_TOKENS, 42)
+
+        verdict = check_quota(
+            test_db, test_org_id, None, QuotaResource.MODEL_TOKENS
+        )
+
+        assert verdict.used == 42
+        assert verdict.limit is None
+
+
+class TestEnforceQuotaWithQuotasOff:
+    def test_does_not_raise(self, test_db, test_org_id, limited_registry):
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 1_000_000)
+
+        enforce_quota(test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS)
+
+
+class TestUnlimitedLimitsConstant:
+    def test_covers_all_resources(self):
+        assert set(UNLIMITED_LIMITS.keys()) == set(QuotaResource)
+
+    def test_all_values_are_none(self):
+        assert all(v is None for v in UNLIMITED_LIMITS.values())

--- a/tests/backend/app/test_usage_tracking.py
+++ b/tests/backend/app/test_usage_tracking.py
@@ -575,3 +575,28 @@ class TestResolveDefaultHostedModel:
             model.emit(30)
 
         assert fake_delay == [("org-42", QuotaResource.MODEL_TOKENS.value, 30)]
+
+
+class TestAccrueModelTokensQuotasOff:
+    """With quotas disabled, metered=False models still accrue (counting
+    instance spend) and unstamped models still warn."""
+
+    def test_metered_false_accrues_when_quotas_off(self, fake_delay, quotas_disabled):
+        with usage_attribution("org-1"):
+            accrue_model_tokens(_usage(500), _model(False))
+
+        assert fake_delay == [("org-1", QuotaResource.MODEL_TOKENS.value, 500)]
+
+    def test_unstamped_model_still_warns_when_quotas_off(self, fake_delay, caplog, quotas_disabled):
+        _warned_unstamped.clear()
+        with caplog.at_level("WARNING"), usage_attribution("org-1"):
+            accrue_model_tokens(_usage(7), _StubLLM("stub/unstamped"))
+
+        assert fake_delay == [("org-1", QuotaResource.MODEL_TOKENS.value, 7)]
+        assert UNSTAMPED_MARKER in caplog.text
+
+    def test_metered_true_still_accrues_when_quotas_off(self, fake_delay, quotas_disabled):
+        with usage_attribution("org-1"):
+            accrue_model_tokens(_usage(100), _model(True))
+
+        assert fake_delay == [("org-1", QuotaResource.MODEL_TOKENS.value, 100)]

--- a/tests/backend/app/test_worker_bootstrap.py
+++ b/tests/backend/app/test_worker_bootstrap.py
@@ -1,0 +1,46 @@
+"""Tests for the Celery worker bootstrap path.
+
+The signal handler ``install_worker_usage_sink`` must install EE providers
+(when the EE package is importable) **and** the usage sink. These tests
+verify both halves without needing a live Celery worker.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from rhesis.backend.app.ee_bootstrap import bootstrap_ee_providers
+
+
+class TestBootstrapEeProviders:
+    def test_installs_providers_when_ee_importable(self):
+        mock_providers = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {"rhesis.backend.ee": MagicMock(bootstrap_providers=mock_providers)},
+        ):
+            bootstrap_ee_providers()
+
+        mock_providers.assert_called_once()
+
+    def test_noop_when_ee_not_importable(self):
+        with patch.dict("sys.modules", {"rhesis.backend.ee": None}):
+            bootstrap_ee_providers()
+
+
+class TestInstallWorkerUsageSink:
+    def test_signal_handler_calls_both_bootstrap_and_sink(self):
+        with (
+            patch(
+                "rhesis.backend.app.ee_bootstrap.bootstrap_ee_providers"
+            ) as mock_providers,
+            patch(
+                "rhesis.backend.app.utils.usage_tracking.install_usage_sink"
+            ) as mock_sink,
+        ):
+            from rhesis.backend.celery.signals import install_worker_usage_sink
+
+            install_worker_usage_sink(sender=None)
+
+        mock_providers.assert_called_once()
+        mock_sink.assert_called_once()

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -127,6 +127,47 @@ _apply_test_env()
 
 
 @pytest.fixture(autouse=True)
+def _enable_usage_quotas(monkeypatch):
+    """Run the entire test suite with USAGE_QUOTAS_ENABLED=true.
+
+    Without this, QuotaRegistry.get_policy short-circuits to unlimited
+    limits for every org (the self-hosted default), so the existing 1,600+
+    lines of quota tests all pass vacuously. The patch targets the name
+    where quota/__init__.py imports the function.
+
+    Tests that exercise the quotas-off path opt out via the
+    ``quotas_disabled`` fixture (see test_quota_deployment_mode.py).
+    """
+    from types import SimpleNamespace
+
+    from rhesis.backend.app.config.settings import get_application_settings
+
+    real = get_application_settings()
+
+    def _with_quotas_on():
+        ns = SimpleNamespace(**{k: getattr(real, k) for k in real.model_fields})
+        ns.usage_quotas_enabled = True
+        return ns
+
+    monkeypatch.setattr("rhesis.backend.app.quota.get_application_settings", _with_quotas_on)
+    monkeypatch.setattr(
+        "rhesis.backend.app.utils.usage_tracking.get_application_settings", _with_quotas_on
+    )
+
+
+@pytest.fixture
+def quotas_disabled(monkeypatch):
+    """Opt out of the suite-wide quotas-enabled patch for one test."""
+    from rhesis.backend.app.config.settings import get_application_settings
+
+    monkeypatch.setattr("rhesis.backend.app.quota.get_application_settings", get_application_settings)
+    monkeypatch.setattr(
+        "rhesis.backend.app.utils.usage_tracking.get_application_settings",
+        get_application_settings,
+    )
+
+
+@pytest.fixture(autouse=True)
 def isolate_storage_settings_cache():
     """Ensure tests that patch storage env vars do not reuse cached settings."""
     from importlib import import_module

--- a/tests/backend/routes/test_features.py
+++ b/tests/backend/routes/test_features.py
@@ -21,6 +21,7 @@ from rhesis.backend.app.features import (
 )
 from rhesis.backend.app.main import app
 from rhesis.backend.app.models.organization import Organization
+from rhesis.backend.app.quota import QuotaResource
 
 _TEST_ORG_ID = UUID("00000000-0000-0000-0000-000000000000")
 
@@ -222,3 +223,17 @@ class TestFeaturesEndpointWithSignedProvider:
         assert body["license"]["edition"] == "community"
         assert body["license"]["licensed"] is False
         assert body["enabled"] == []
+
+
+class TestFeaturesEndpointQuotasOff:
+    """With quotas disabled, GET /features returns all-null limits with stable keys."""
+
+    def test_all_limits_null_with_quotas_off(
+        self, client: TestClient, registered_sso, mock_current_user, quotas_disabled
+    ):
+        response = client.get("/features")
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        limits = body["limits"]
+        assert set(limits.keys()) == {str(r) for r in QuotaResource}
+        assert all(v is None for v in limits.values())


### PR DESCRIPTION
## Summary

- Adds `USAGE_QUOTAS_ENABLED` setting (default `false`) so self-hosted deployments are correct out of the box with no usage limits on any of the seven metered resources.
- Gates `QuotaRegistry.get_policy` on the flag. When off, returns `UNLIMITED_LIMITS` (all-null dict with stable keys so the `/features` wire shape stays the same). When on (Rhesis cloud), existing behavior is unchanged.
- Accrual still counts everything when quotas are off so the usage page shows what the instance spent. Only the `metered=False` skip (org's own API key) is gated on quotas being enabled.
- Extracts `bootstrap_providers()` from the EE package and calls it from the Celery worker init signal so workers resolve licensed quota limits instead of falling back to free-tier defaults.
- Helm values default to `false`; dev/stg/prd override to `true`. Configmap, `.env.example`, and docs updated.

## Test plan

- [x] New `test_quota_deployment_mode.py`: policy returns unlimited, check allows past limits, enforce does not raise, constant covers all resources
- [x] New `TestFeaturesEndpointQuotasOff`: `/features` returns all-null limits with stable keys
- [x] New `TestAccrueModelTokensQuotasOff`: metered=False model accrues when quotas off, unstamped model still warns
- [x] New `test_worker_bootstrap.py`: signal handler installs both EE providers and usage sink
- [x] Autouse fixture enables quotas for the whole test suite; `quotas_disabled` fixture for opt-out
- [x] Existing quota tests (enforcement, registry, token gate) pass unchanged
- [x] EE boundary test passes unchanged