### PR TITLE
Add project scoping to token-exchange via RFC 8693 resource

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/a4b5c6d7e8f9_add_refresh_token_project_id.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/a4b5c6d7e8f9_add_refresh_token_project_id.py
@@ -32,6 +32,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
+from rhesis.backend.alembic.utils.idempotency import column_exists, index_exists
+
 revision: str = "a4b5c6d7e8f9"
 down_revision: Union[str, None] = "3f5954f6c374"
 branch_labels: Union[str, Sequence[str], None] = None
@@ -41,26 +43,13 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     conn = op.get_bind()
 
-    project_id_exists = conn.execute(
-        sa.text(
-            "SELECT 1 FROM information_schema.columns "
-            "WHERE table_name='refresh_token' AND column_name='project_id'"
-        )
-    ).fetchone()
-    if not project_id_exists:
+    if not column_exists(conn, "refresh_token", "project_id"):
         op.add_column(
             "refresh_token",
             sa.Column("project_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),
         )
 
-    index_exists = conn.execute(
-        sa.text(
-            "SELECT 1 FROM pg_indexes "
-            "WHERE tablename='refresh_token' "
-            "AND indexname='ix_refresh_token_project_id'"
-        )
-    ).fetchone()
-    if not index_exists:
+    if not index_exists(conn, "ix_refresh_token_project_id"):
         op.create_index(
             "ix_refresh_token_project_id",
             "refresh_token",

--- a/apps/backend/src/rhesis/backend/alembic/versions/a4b5c6d7e8f9_add_refresh_token_project_id.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/a4b5c6d7e8f9_add_refresh_token_project_id.py
@@ -1,0 +1,73 @@
+"""add project_id column to refresh_token
+
+Token-exchange-issued refresh tokens now carry the project resolved
+from the RFC 8693 ``resource`` parameter at exchange time, so that:
+
+1. Rotation (``verify_and_rotate_refresh_token``) preserves the project
+   binding on the successor row, the same way it already preserves
+   ``client_id`` and ``scope`` (see ``d8a5e0f3c4b2``). Without this
+   column the project claim on the access token would silently
+   disappear on the first refresh -- a token that works, then stops,
+   then works again only after a fresh exchange.
+2. ``mint_for_client_bound_refresh`` reads it back to re-mint the
+   access token's ``project`` claim on every rotation.
+
+No FK to ``project.id``: this mirrors ``token.project_id``
+(``a1b2c3d4e5f0``), which is also looked up before tenant context is
+established and therefore left without a FK.
+
+Nullable, no backfill. Existing rows -- all minted before this
+migration ran -- keep ``project_id IS NULL``, which the refresh and
+mint paths treat as "no project scope", the pre-existing behaviour.
+The migration is strictly additive.
+
+Revision ID: a4b5c6d7e8f9
+Revises: 3f5954f6c374
+Create Date: 2026-08-19
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a4b5c6d7e8f9"
+down_revision: Union[str, None] = "3f5954f6c374"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    project_id_exists = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name='refresh_token' AND column_name='project_id'"
+        )
+    ).fetchone()
+    if not project_id_exists:
+        op.add_column(
+            "refresh_token",
+            sa.Column("project_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),
+        )
+
+    index_exists = conn.execute(
+        sa.text(
+            "SELECT 1 FROM pg_indexes "
+            "WHERE tablename='refresh_token' "
+            "AND indexname='ix_refresh_token_project_id'"
+        )
+    ).fetchone()
+    if not index_exists:
+        op.create_index(
+            "ix_refresh_token_project_id",
+            "refresh_token",
+            ["project_id"],
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_refresh_token_project_id", table_name="refresh_token")
+    op.drop_column("refresh_token", "project_id")

--- a/apps/backend/src/rhesis/backend/app/auth/oauth_scope.py
+++ b/apps/backend/src/rhesis/backend/app/auth/oauth_scope.py
@@ -1,0 +1,61 @@
+"""Map RFC 8693 token-exchange OAuth scope claims to capability sets.
+
+Token-exchange-issued JWTs (``ee/backend/.../token_exchange/exchange.py``)
+carry a coarse OAuth ``scope`` claim -- v1 supports ``read`` and ``full``
+(``ee/backend/.../api_clients/schemas.py:V1_SUPPORTED_SCOPES``;
+``offline_access`` never reaches this claim, ``exchange.py`` strips it before
+minting the access token). This module translates that claim into the
+fine-grained capability vocabulary (``"resource:action"``) that
+:class:`~rhesis.backend.app.auth.principal.Principal.scopes` and the EE RBAC
+provider actually consume, so a project-scoped API client requesting ``read``
+is limited to read-only access instead of silently inheriting its owner's
+full access.
+
+Deliberately lives in core, not ``ee.*``: the mapping is generic
+capability-catalog logic, no different from how the ``rh-*`` token path
+already stores its ``scopes`` column directly as capability strings. The
+literal ``"read"`` / ``"full"`` scope names are just strings here, so this
+file creates no community-boundary import.
+
+Enforcement note: :class:`~rhesis.backend.ee.rbac.provider.PermissionAuthorizationProvider`
+only consults ``Principal.scopes`` when RBAC is licensed for the org
+(``rbac_active_for``); otherwise it falls back to
+:class:`~rhesis.backend.app.auth.rbac.DefaultAuthorizationProvider`, which
+never reads ``scopes`` at all. Setting the field here is correct either way
+-- inert where RBAC isn't active, effective where it is -- so this module
+does not need to check RBAC availability itself.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def capabilities_for_oauth_scope(scope_claim: Optional[str]) -> Optional[frozenset[str]]:
+    """Return the capability set an OAuth ``scope`` claim grants.
+
+    Returns ``None`` for ``full`` (checked first, so ``"read full"`` also
+    resolves to unrestricted) -- the same sentinel
+    :class:`~rhesis.backend.app.auth.principal.Principal.scopes` uses for
+    "inherit the owner's full access", matching an unscoped ``rh-*`` token.
+
+    Returns the frozenset of every registered ``*:read`` capability for
+    ``read`` alone.
+
+    Returns an empty frozenset -- not ``None`` -- when *scope_claim* is
+    ``None``, empty, or carries no recognized access-granting scope (e.g. a
+    token minted for ``offline_access`` only, which strips to an empty scope
+    string). Fail-closed: an unrecognized or absent scope grants nothing,
+    never everything.
+    """
+    tokens = set((scope_claim or "").split())
+    if "full" in tokens:
+        return None
+    if "read" in tokens:
+        from rhesis.backend.app.auth.capabilities import get_all_capabilities
+
+        return frozenset(cap for cap in get_all_capabilities() if cap.endswith(":read"))
+    return frozenset()
+
+
+__all__ = ["capabilities_for_oauth_scope"]

--- a/apps/backend/src/rhesis/backend/app/auth/refresh_token_utils.py
+++ b/apps/backend/src/rhesis/backend/app/auth/refresh_token_utils.py
@@ -38,6 +38,7 @@ def create_refresh_token(
     *,
     client_id: str | None = None,
     scope: str | None = None,
+    project_id: str | None = None,
 ) -> str:
     """Create and persist a new refresh token, returning the raw value.
 
@@ -61,6 +62,12 @@ def create_refresh_token(
         preserves the original scope (without this, a ``scope=read``
         token-exchange refresh would silently escalate to full-user
         on its first refresh).
+    project_id:
+        Optional project UUID resolved from the RFC 8693 ``resource``
+        parameter at exchange time. Preserved across rotation for the
+        same reason as ``scope`` -- without it the project claim on
+        the access token would silently disappear on the first
+        refresh.
 
     Returns
     -------
@@ -82,6 +89,7 @@ def create_refresh_token(
         expires_at=expires_at,
         client_id=client_id,
         scope=scope,
+        project_id=project_id,
     )
     db.add(db_token)
     db.flush()  # assign id without committing
@@ -151,16 +159,17 @@ def verify_and_rotate_refresh_token(
     # Revoke the current token (rotation)
     db_token.revoked_at = datetime.now(timezone.utc)
 
-    # Issue a new token in the same family, propagating client_id and
-    # scope so that token-exchange-minted refresh chains keep their
-    # binding across rotation. UI/SSO tokens have both NULL and the
-    # propagation is a no-op.
+    # Issue a new token in the same family, propagating client_id,
+    # scope, and project_id so that token-exchange-minted refresh
+    # chains keep their binding across rotation. UI/SSO tokens have
+    # all three NULL and the propagation is a no-op.
     new_raw_token = create_refresh_token(
         db,
         user_id=str(db_token.user_id),
         family_id=str(db_token.family_id),
         client_id=db_token.client_id,
         scope=db_token.scope,
+        project_id=str(db_token.project_id) if db_token.project_id else None,
     )
 
     return db_token, new_raw_token

--- a/apps/backend/src/rhesis/backend/app/auth/token_utils.py
+++ b/apps/backend/src/rhesis/backend/app/auth/token_utils.py
@@ -59,6 +59,7 @@ def create_session_token(
     scope: Optional[str] = None,
     jti: Optional[str] = None,
     epoch: Optional[Union[datetime, int]] = None,
+    project: Optional[str] = None,
 ) -> str:
     """Create a new session token for a user.
 
@@ -92,6 +93,13 @@ def create_session_token(
       check at verify time is one int comparison with no DB lookup,
       and that is the entire mechanism behind coarse revocation.
       Minting an azp-bearing token without it raises immediately.
+    - ``project`` -- project UUID the exchanged token is scoped to
+      (RFC 8693 ``resource`` parameter on ``/auth/token-exchange``).
+      ``None`` means no project scope (org-level rows only), which is
+      also the default when the caller omits ``resource`` at exchange
+      time. Consumed by ``get_authenticated_user_with_context`` to set
+      ``request.state.api_token_project_id`` the same way a
+      project-scoped ``rh-*`` token does.
     """
     if aud is not None and azp is None:
         # An ``aud`` without ``azp`` is unverifiable: ``verify_jwt_token``
@@ -146,11 +154,13 @@ def create_session_token(
                 to_encode["epoch"] = int(epoch.timestamp())
             else:
                 to_encode["epoch"] = int(epoch)
-    elif scope is not None or jti is not None or epoch is not None:
+        if project is not None:
+            to_encode["project"] = project
+    elif scope is not None or jti is not None or epoch is not None or project is not None:
         # Same reasoning as the aud-without-azp guard: the new claims
         # only have meaning in concert with ``azp``. Smuggling them in
         # alone would produce a token that looks bound but isn't.
-        raise ValueError("scope/jti/epoch require azp to be set")
+        raise ValueError("scope/jti/epoch/project require azp to be set")
 
     encoded_jwt = jwt.encode(to_encode, get_secret_key(), algorithm=get_jwt_algorithm())
     return encoded_jwt

--- a/apps/backend/src/rhesis/backend/app/auth/user_utils.py
+++ b/apps/backend/src/rhesis/backend/app/auth/user_utils.py
@@ -7,6 +7,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app.auth.constants import UNAUTHORIZED_MESSAGE, AuthenticationMethod
+from rhesis.backend.app.auth.oauth_scope import capabilities_for_oauth_scope
 from rhesis.backend.app.auth.principal import (
     REQUEST_STATE_API_TOKEN_PROJECT_ID,
     REQUEST_STATE_API_TOKEN_SCOPES,
@@ -306,16 +307,18 @@ async def get_authenticated_user_with_context(
 
             # ``azp`` marks a token-exchange-issued JWT; UI/SSO JWTs never
             # carry it, so gating on it leaves their AuthKind.SESSION
-            # classification untouched. Storing the ``project`` claim on
-            # request.state is what lets get_project_context treat this
-            # like a project-scoped rh-* token (membership re-checked per
-            # request by assert_project_access). The re-decode is a cheap
+            # classification untouched. Storing the ``project`` and
+            # ``scope`` claims on request.state is what lets
+            # get_project_context and the EE RBAC provider treat this like
+            # a project-scoped, scope-restricted rh-* token (membership and
+            # scope both re-checked per request). The re-decode is a cheap
             # HMAC verify -- get_user_from_jwt discards the payload.
             #
             # Authentication already succeeded above, so this only reads
             # claims for scoping and must not be able to fail the request:
-            # on any decode problem we fall through with no project scope,
-            # which is fail-closed (fewer rows visible, never more).
+            # on any decode problem we fall through with no project/scope
+            # binding, which is fail-closed (fewer rows/permissions visible,
+            # never more).
             try:
                 payload = verify_jwt_token(credentials.credentials, secret_key)
             except Exception:
@@ -326,6 +329,12 @@ async def get_authenticated_user_with_context(
                 project_claim = payload.get("project")
                 if project_claim:
                     setattr(request.state, REQUEST_STATE_API_TOKEN_PROJECT_ID, str(project_claim))
+                # None means "full access" (Principal.scopes' own sentinel);
+                # only set request.state when the claim actually narrows it,
+                # so an unset field keeps meaning "inherit owner's access".
+                scope_capabilities = capabilities_for_oauth_scope(payload.get("scope"))
+                if scope_capabilities is not None:
+                    setattr(request.state, REQUEST_STATE_API_TOKEN_SCOPES, scope_capabilities)
 
             request.state.user = jwt_user
             return jwt_user

--- a/apps/backend/src/rhesis/backend/app/auth/user_utils.py
+++ b/apps/backend/src/rhesis/backend/app/auth/user_utils.py
@@ -311,7 +311,16 @@ async def get_authenticated_user_with_context(
             # like a project-scoped rh-* token (membership re-checked per
             # request by assert_project_access). The re-decode is a cheap
             # HMAC verify -- get_user_from_jwt discards the payload.
-            payload = verify_jwt_token(credentials.credentials, secret_key)
+            #
+            # Authentication already succeeded above, so this only reads
+            # claims for scoping and must not be able to fail the request:
+            # on any decode problem we fall through with no project scope,
+            # which is fail-closed (fewer rows visible, never more).
+            try:
+                payload = verify_jwt_token(credentials.credentials, secret_key)
+            except Exception:
+                logger.debug("Could not re-read JWT claims for project scope", exc_info=True)
+                payload = {}
             if payload.get("azp"):
                 setattr(request.state, REQUEST_STATE_AUTH_KIND, AuthKind.TOKEN)
                 project_claim = payload.get("project")

--- a/apps/backend/src/rhesis/backend/app/auth/user_utils.py
+++ b/apps/backend/src/rhesis/backend/app/auth/user_utils.py
@@ -303,6 +303,21 @@ async def get_authenticated_user_with_context(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="User is not associated with an organization",
                 )
+
+            # ``azp`` marks a token-exchange-issued JWT; UI/SSO JWTs never
+            # carry it, so gating on it leaves their AuthKind.SESSION
+            # classification untouched. Storing the ``project`` claim on
+            # request.state is what lets get_project_context treat this
+            # like a project-scoped rh-* token (membership re-checked per
+            # request by assert_project_access). The re-decode is a cheap
+            # HMAC verify -- get_user_from_jwt discards the payload.
+            payload = verify_jwt_token(credentials.credentials, secret_key)
+            if payload.get("azp"):
+                setattr(request.state, REQUEST_STATE_AUTH_KIND, AuthKind.TOKEN)
+                project_claim = payload.get("project")
+                if project_claim:
+                    setattr(request.state, REQUEST_STATE_API_TOKEN_PROJECT_ID, str(project_claim))
+
             request.state.user = jwt_user
             return jwt_user
 

--- a/apps/backend/src/rhesis/backend/app/database.py
+++ b/apps/backend/src/rhesis/backend/app/database.py
@@ -133,6 +133,25 @@ def scope_project_id(db: Session) -> str:
     return str(project_id) if project_id else ""
 
 
+def no_project_scope_hint(db: Session) -> str:
+    """Return a trailing explanation when *db* has no project in scope, else ``""``.
+
+    For appending to "not found" messages on project-scoped entities. Under
+    fail-closed project isolation a request with no active project sees only
+    org-level (``project_id IS NULL``) rows, so a lookup for a project-scoped
+    row misses no matter what id was passed. Saying so turns "your id is wrong"
+    into "your request has no project scope" -- the distinction that otherwise
+    costs an integrator a debugging session. Safe to expose: it describes the
+    caller's own request scope, not whether any row exists.
+    """
+    if scope_project_id(db):
+        return ""
+    return (
+        " (no project scope on this request -- project-scoped entities are invisible "
+        "without one; set X-Project-Id, or exchange a token with a resource parameter)"
+    )
+
+
 def bind_scope_to_session(
     db: Session,
     organization_id: str = "",

--- a/apps/backend/src/rhesis/backend/app/models/refresh_token.py
+++ b/apps/backend/src/rhesis/backend/app/models/refresh_token.py
@@ -25,6 +25,11 @@ class RefreshToken(Base):
     ``scope=read`` token never silently escalates to full-user access
     on its first refresh. UI/SSO refresh tokens leave both columns
     NULL and behave exactly as before this column was added.
+
+    ``project_id`` is likewise preserved across rotation for
+    token-exchange tokens minted with an RFC 8693 ``resource``
+    parameter -- without it the project claim on the access token
+    would silently disappear on the first refresh.
     """
 
     __tablename__ = "refresh_token"
@@ -68,6 +73,15 @@ class RefreshToken(Base):
         nullable=True,
         comment=(
             "Space-separated scope string preserved across rotation; set when client_id is set."
+        ),
+    )
+    project_id = Column(
+        GUID(),
+        nullable=True,
+        index=True,
+        comment=(
+            "Project UUID from the RFC 8693 resource parameter, preserved across "
+            "rotation. NULL for UI/SSO refresh tokens and exchanges with no resource."
         ),
     )
 

--- a/apps/backend/src/rhesis/backend/app/routers/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/routers/endpoint.py
@@ -11,6 +11,7 @@ from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.quota_gates import require_quota
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
+from rhesis.backend.app.database import no_project_scope_hint
 from rhesis.backend.app.dependencies import (
     get_endpoint_service,
     get_tenant_context,
@@ -48,6 +49,15 @@ router = RhesisRouter(
     dependencies=[Depends(require_current_user_or_token)],
     resource="endpoint",
 )
+
+
+def _endpoint_not_found_detail(db: Session) -> str:
+    """404 detail for a missing endpoint.
+
+    ``endpoint.project_id`` is NOT NULL, so an endpoint is never visible without
+    a project in scope -- the hint says so rather than implying a bad id.
+    """
+    return f"Endpoint not found{no_project_scope_hint(db)}"
 
 
 @router.post("/", response_model=schemas.Endpoint)
@@ -242,7 +252,7 @@ async def test_endpoint_mapping(
         db, endpoint_id=endpoint_id, organization_id=organization_id, user_id=user_id
     )
     if not endpoint:
-        raise HTTPException(status_code=404, detail="Endpoint not found")
+        raise HTTPException(status_code=404, detail=_endpoint_not_found_detail(db))
 
     response_format = test_request.response_format.value if test_request.response_format else None
 
@@ -270,7 +280,7 @@ def read_endpoint(
         db, endpoint_id=endpoint_id, organization_id=organization_id, user_id=user_id
     )
     if db_endpoint is None:
-        raise HTTPException(status_code=404, detail="Endpoint not found")
+        raise HTTPException(status_code=404, detail=_endpoint_not_found_detail(db))
     return db_endpoint
 
 
@@ -286,7 +296,7 @@ def delete_endpoint(
         db, endpoint_id=endpoint_id, organization_id=organization_id, user_id=user_id
     )
     if db_endpoint is None:
-        raise HTTPException(status_code=404, detail="Endpoint not found")
+        raise HTTPException(status_code=404, detail=_endpoint_not_found_detail(db))
     return db_endpoint
 
 
@@ -307,7 +317,7 @@ def update_endpoint(
         user_id=user_id,
     )
     if db_endpoint is None:
-        raise HTTPException(status_code=404, detail="Endpoint not found")
+        raise HTTPException(status_code=404, detail=_endpoint_not_found_detail(db))
     return db_endpoint
 
 
@@ -400,7 +410,7 @@ def explore_endpoint_route(
         db, endpoint_id=endpoint_id, organization_id=organization_id, user_id=user_id
     )
     if db_endpoint is None:
-        raise HTTPException(status_code=404, detail="Endpoint not found")
+        raise HTTPException(status_code=404, detail=_endpoint_not_found_detail(db))
 
     task_result = task_launcher(
         run_exploration_task,

--- a/apps/backend/src/rhesis/backend/app/services/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_set.py
@@ -772,7 +772,9 @@ def execute_test_set_on_endpoint(
         user_id=str(current_user.id),
     )
     if not db_endpoint:
-        raise ValueError(f"Endpoint not found: {endpoint_id}")
+        from rhesis.backend.app.database import no_project_scope_hint
+
+        raise ValueError(f"Endpoint not found: {endpoint_id}{no_project_scope_hint(db)}")
     logger.info(f"Successfully verified endpoint: {db_endpoint.name} (ID: {db_endpoint.id})")
 
     # Check user access permissions

--- a/docs/content/docs/organizations/api-clients.mdx
+++ b/docs/content/docs/organizations/api-clients.mdx
@@ -24,9 +24,17 @@ The exchange audience binds the request to one organization:
 
 The slug after `rhesis:org:` must match the organization's slug.
 
+An exchange can also name the project the resulting token should be scoped to, using the RFC 8693 `resource` parameter:
+
+<CodeBlock filename="resource.txt" language="text">
+{`urn:rhesis:project:<project-uuid>`}
+</CodeBlock>
+
+The requesting user must be a member of that project. Omitting `resource` yields a token that can only see organization-level rows (`project_id IS NULL`); it cannot see anything scoped to a specific project.
+
 ## Create an API Client
 
-Create clients from the organization settings UI or with the API:
+Create clients with the API:
 
 <CodeBlock filename="create_api_client.sh" language="bash">
 {`curl -X POST "https://api.example.com/organizations/<org-id>/auth-clients" \
@@ -71,8 +79,11 @@ curl -X POST "https://api.example.com/auth/token-exchange" \
   --data-urlencode "subject_token=$SUBJECT_TOKEN" \
   --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:access_token" \
   --data-urlencode "audience=rhesis:org:acme" \
+  --data-urlencode "resource=urn:rhesis:project:11111111-2222-3333-4444-555555555555" \
   --data-urlencode "scope=read offline_access"`}
 </CodeBlock>
+
+The resulting access token behaves like a project-scoped `rh-*` API key: every request it authenticates is scoped to that one project, the same way `X-Project-Id` scopes a browser session. There's no per-request override — a service that needs to work across several projects exchanges once per project. Project membership is re-checked on every request, so removing the exchanged user from the project cuts off access immediately, without waiting for the token to expire.
 
 Successful responses follow the OAuth token response shape:
 
@@ -90,6 +101,32 @@ Successful responses follow the OAuth token response shape:
 
 `refresh_token` is present only when the resolved scope includes `offline_access`. Both lifetimes are deployment-configurable (`JWT_ACCESS_TOKEN_EXPIRE_MINUTES` and `JWT_REFRESH_TOKEN_EXPIRE_DAYS`); the values above are the defaults.
 
+## Discover available projects
+
+`resource` needs a project UUID, and project UUIDs are not visible anywhere in the IdP or in the client configuration. To find one, exchange once with no `resource` and use the resulting token to list the projects the subject user belongs to:
+
+<CodeBlock filename="list_projects.sh" language="bash">
+{`SUBJECT_TOKEN="<oidc-access-token-from-your-idp>"
+
+# Step 1: exchange with no resource -- yields an org-scoped token
+ACCESS_TOKEN=$(curl -s -X POST "https://api.example.com/auth/token-exchange" \
+  -u "warehouse-sync:$CLIENT_SECRET" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+  --data-urlencode "subject_token=$SUBJECT_TOKEN" \
+  --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:access_token" \
+  --data-urlencode "audience=rhesis:org:acme" \
+  | jq -r .access_token)
+
+# Step 2: list the projects the subject user is a member of
+curl -s "https://api.example.com/projects/" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" | jq '.[] | {id, name}'`}
+</CodeBlock>
+
+`GET /projects/` returns every project the org member is a member of, org-scoped rather than project-scoped, so the token from step 1 works for it without a `resource`. Pick an `id` from the list and pass it as the `resource` in a second exchange to get a project-scoped token.
+
+The Java SDK exposes the same call as `client.projects().list()` -- point `RhesisClientBuilder.apiKey(...)` at the org-scoped token from step 1, list projects, then re-point it at the project-scoped token from the second exchange.
+
 ## Manage clients
 
 | Endpoint | Purpose |
@@ -106,8 +143,8 @@ Rotating a client secret also advances the client's token epoch. Existing client
 
 ## Common errors
 
-- `invalid_request`: the audience is malformed or multi-valued, client credentials are missing, or a required form field is absent.
-- `invalid_target`: the organization slug does not exist, SSO is not configured, or API Clients are not enabled.
+- `invalid_request`: the audience is malformed or multi-valued, the resource is malformed or multi-valued, client credentials are missing, or a required form field is absent.
+- `invalid_target`: the organization slug does not exist, SSO is not configured, API Clients are not enabled, the resource does not resolve to a project in that organization, the project is inactive or deleted, or the requesting user is not a member of that project.
 - `invalid_client`: the supplied client credentials are wrong.
 - `invalid_grant`: the subject token is invalid, expired, replayed, or does not match the configured `azp` and audience.
 - `invalid_scope`: requested scopes are not allowed for the client.

--- a/ee/backend/src/rhesis/backend/ee/api_clients/audit.py
+++ b/ee/backend/src/rhesis/backend/ee/api_clients/audit.py
@@ -193,6 +193,7 @@ def token_exchange_audit_log(
     subject_token_jti: Optional[str] = None,
     email: Optional[str] = None,
     scope: Optional[str] = None,
+    project_id: Optional[str] = None,
     reason_code: Optional[str] = None,
     ip: Optional[str] = None,
     user_agent: Optional[str] = None,
@@ -224,6 +225,8 @@ def token_exchange_audit_log(
         entry["hashed_email"] = he
     if scope is not None:
         entry["scope"] = scope
+    if project_id is not None:
+        entry["project_id"] = project_id
     if reason_code is not None:
         entry["reason_code"] = reason_code
     if ip is not None:

--- a/ee/backend/src/rhesis/backend/ee/api_clients/clients.py
+++ b/ee/backend/src/rhesis/backend/ee/api_clients/clients.py
@@ -324,17 +324,31 @@ def authenticate_client(
       the refresh path, from the bound user / client row) so this
       function authenticates against the correct row even under
       identifier collision across tenants.
-    """
 
-    row: Optional[AuthClient] = (
-        db.query(AuthClient)
-        .filter(
-            AuthClient.organization_id == organization_id,
-            AuthClient.client_id == client_id,
-            AuthClient.deleted_at.is_(None),
+    Binding org scope for the lookup is not optional. ``auth_client`` is
+    FORCE ROW LEVEL SECURITY with a strict
+    ``organization_id = current_setting('app.current_organization')::uuid``
+    policy and no empty-org passthrough (unlike ``organization``). Both
+    callers reach this function on ``get_db_session``, which binds no
+    tenant GUCs, so querying unscoped casts ``''`` to uuid and raises
+    ``invalid input syntax for type uuid: ""`` for any app role without
+    BYPASSRLS -- which the deployed ``rhesis-user`` is. Scoping here
+    rather than at the call sites means a future third caller cannot
+    reintroduce the failure. Project scope stays empty: ``auth_client``
+    has no ``project_id`` column and is not project-scoped.
+    """
+    from rhesis.backend.app.database import temporary_project_scope
+
+    with temporary_project_scope(db, str(organization_id or ""), "", ""):
+        row: Optional[AuthClient] = (
+            db.query(AuthClient)
+            .filter(
+                AuthClient.organization_id == organization_id,
+                AuthClient.client_id == client_id,
+                AuthClient.deleted_at.is_(None),
+            )
+            .first()
         )
-        .first()
-    )
 
     if row is None:
         # Burn the same CPU we would have burned on a real verify so

--- a/ee/backend/src/rhesis/backend/ee/api_clients/refresh_minter.py
+++ b/ee/backend/src/rhesis/backend/ee/api_clients/refresh_minter.py
@@ -147,11 +147,16 @@ def mint_for_client_bound_refresh(
     # preserves the original intent) and is consulted on the next
     # refresh; only the access token's scope is filtered.
     access_scope = _strip_offline_access(old_token.scope)
+    # ``old_token.project_id`` carries the project resolved from the
+    # RFC 8693 ``resource`` parameter at exchange time. Re-minting it
+    # on every rotation is what keeps the project claim alive past the
+    # first refresh -- without this it would vanish silently.
     return create_session_token(
         user,
         azp=auth_client.client_id,
         scope=access_scope,
         epoch=auth_client.token_epoch,
+        project=str(old_token.project_id) if old_token.project_id else None,
     )
 
 

--- a/ee/backend/src/rhesis/backend/ee/sso/token_exchange/exchange.py
+++ b/ee/backend/src/rhesis/backend/ee/sso/token_exchange/exchange.py
@@ -39,12 +39,19 @@ surface area or skips a security check entirely. The order is:
    fail-closed on confirmed replay).
 8. Resolve the user via the same path as the SSO callback (domain
    allowlist, cross-org collision, auto-provision gate, is_active).
-9. Mint the Rhesis JWT with ``azp`` / ``aud`` / ``scope`` / ``jti`` /
-   ``epoch`` claims via the extended ``create_session_token``.
-10. Conditionally mint a refresh token (only when ``offline_access`` is
-    in the resolved scope), persisting ``client_id`` and ``scope`` so
-    the refresh path can preserve them on rotation.
-11. Emit success audit event and return the RFC 8693 payload.
+9. Optional project binding: when the request carries a ``resource``
+   parameter, resolve it to a project in the resolved org, require it
+   to be active and not soft-deleted, and require the resolved user to
+   have a ``ProjectMembership`` row for it. This runs AFTER user
+   resolution because the membership check needs the resolved user,
+   not the subject-token claims. Omitting ``resource`` keeps the
+   pre-existing behaviour (no project scope, org-level rows only).
+10. Mint the Rhesis JWT with ``azp`` / ``aud`` / ``scope`` / ``jti`` /
+    ``epoch`` / ``project`` claims via the extended ``create_session_token``.
+11. Conditionally mint a refresh token (only when ``offline_access`` is
+    in the resolved scope), persisting ``client_id`` / ``scope`` /
+    ``project_id`` so the refresh path can preserve them on rotation.
+12. Emit success audit event and return the RFC 8693 payload.
 
 Error contract
 --------------
@@ -106,6 +113,17 @@ logger = logging.getLogger(__name__)
 #: the ``Organization.slug`` ``String(50)`` column.
 _AUDIENCE_RE = re.compile(r"^rhesis:org:[a-z0-9-]{1,50}$")
 
+#: Strict regex for the optional ``resource`` form parameter, naming
+#: the project the exchanged token should be scoped to. Case-sensitive
+#: and lowercase-only, matching :data:`_AUDIENCE_RE`: one spelling per
+#: value keeps the parameter unambiguous, and every project UUID we
+#: emit is lowercase (Postgres renders uuid lowercase, as does
+#: ``str(uuid.UUID)``), so callers echoing back an id we gave them
+#: always match.
+_RESOURCE_RE = re.compile(
+    r"^urn:rhesis:project:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
 #: The single permitted scope separator. Tabs and other Unicode
 #: whitespace are rejected because mixed separators are an easy way
 #: to smuggle a forbidden scope past a naive splitter.
@@ -135,6 +153,9 @@ class TokenExchangeRequest:
     scope: Optional[str]
     client_id: str
     client_secret: str
+    # RFC 8693 resource parameter: the project to scope the exchanged
+    # token to. ``None`` means no project scope (org-level rows only).
+    resource: Optional[str] = None
     # Best-effort context for the audit trail; ``None`` is acceptable.
     source_ip: Optional[str] = None
     user_agent: Optional[str] = None
@@ -234,6 +255,7 @@ async def run_token_exchange(
             subject_token_jti=kwargs.get("jti"),
             email=kwargs.get("email"),
             scope=kwargs.get("scope"),
+            project_id=kwargs.get("project_id"),
             reason_code=reason_code,
             ip=audit_ip,
             user_agent=audit_ua,
@@ -457,6 +479,54 @@ async def run_token_exchange(
             email=user.email,
         )
 
+    # ---- Step 9: optional project binding ---------------------------------
+    # Runs AFTER user resolution because the membership check needs the
+    # resolved user, not the subject-token claims. Omitting ``resource``
+    # keeps the pre-existing behaviour: no project scope, org-level rows
+    # only.
+    resolved_project_id: Optional[str] = None
+    if payload.resource is not None:
+        project_id = _resource_to_project_id(payload.resource)
+        # _check_request_shape already validated the shape; this is
+        # only reachable with a well-formed resource.
+        assert project_id is not None
+
+        project, is_member = _resolve_resource_project(db, org, user, project_id)
+
+        if project is None:
+            _deny(
+                "invalid_target",
+                "resource_project_not_found",
+                org_id=str(org.id),
+                iss=sso_config.issuer_url,
+                jti=subject_jti,
+                email=user.email,
+                project_id=project_id,
+            )
+        assert project is not None
+        if not project.is_active or project.deleted_at is not None:
+            _deny(
+                "invalid_target",
+                "resource_project_inactive",
+                org_id=str(org.id),
+                iss=sso_config.issuer_url,
+                jti=subject_jti,
+                email=user.email,
+                project_id=project_id,
+            )
+        if not is_member:
+            _deny(
+                "invalid_target",
+                "resource_project_not_member",
+                org_id=str(org.id),
+                iss=sso_config.issuer_url,
+                jti=subject_jti,
+                email=user.email,
+                project_id=project_id,
+            )
+
+        resolved_project_id = str(project.id)
+
     # ---- Validate scope against client's allowed_scopes (S7) -------------
     allowed = set(auth_client.allowed_scopes or [])
     if requested_scopes is None:
@@ -479,7 +549,7 @@ async def run_token_exchange(
         resolved_scopes = requested_scopes
     resolved_scope_str = " ".join(resolved_scopes)
 
-    # ---- Step 9: mint Rhesis JWT -----------------------------------------
+    # ---- Step 10: mint Rhesis JWT -----------------------------------------
     # ``offline_access`` is an OIDC convention for "I want a refresh
     # token alongside the access token"; it does not grant authority
     # on the access token itself. Stripping it from the JWT scope
@@ -498,9 +568,10 @@ async def run_token_exchange(
         scope=access_scope_str,
         jti=issued_jti,
         epoch=auth_client.token_epoch,
+        project=resolved_project_id,
     )
 
-    # ---- Step 10: refresh token (only when offline_access requested) -----
+    # ---- Step 11: refresh token (only when offline_access requested) -----
     refresh_token: Optional[str] = None
     refresh_expires_in: Optional[int] = None
     if SCOPE_OFFLINE_ACCESS in resolved_scopes:
@@ -509,11 +580,12 @@ async def run_token_exchange(
             user_id=str(user.id),
             client_id=auth_client.client_id,
             scope=resolved_scope_str,
+            project_id=resolved_project_id,
         )
         db.commit()
         refresh_expires_in = REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600
 
-    # ---- Step 11: success audit + return ---------------------------------
+    # ---- Step 12: success audit + return ---------------------------------
     token_exchange_audit_log(
         TokenExchangeEvent.SUCCESS,
         org_id=str(org.id),
@@ -522,6 +594,7 @@ async def run_token_exchange(
         subject_token_jti=subject_jti,
         email=user.email,
         scope=resolved_scope_str,
+        project_id=resolved_project_id,
         ip=audit_ip,
         user_agent=audit_ua,
     )
@@ -563,6 +636,8 @@ def _check_request_shape(payload: TokenExchangeRequest) -> None:
         raise TokenExchangeError("invalid_request", "client_credentials_missing")
     if not _AUDIENCE_RE.match(payload.audience or ""):
         raise TokenExchangeError("invalid_request", "audience_malformed")
+    if payload.resource is not None and not _RESOURCE_RE.match(payload.resource):
+        raise TokenExchangeError("invalid_request", "resource_malformed")
 
 
 def _audience_to_slug(audience: str) -> Optional[str]:
@@ -570,6 +645,54 @@ def _audience_to_slug(audience: str) -> Optional[str]:
     if not _AUDIENCE_RE.match(audience or ""):
         return None
     return audience.split(":", 2)[2]
+
+
+def _resource_to_project_id(resource: str) -> Optional[str]:
+    """Strip the ``urn:rhesis:project:`` prefix; return ``None`` on shape violation."""
+    if not _RESOURCE_RE.match(resource or ""):
+        return None
+    return resource.split(":", 3)[3]
+
+
+def _resolve_resource_project(db: Session, org, user, project_id: str):
+    """Look up *project_id* in *org* and whether *user* is a member of it.
+
+    Returns ``(project_or_None, is_member)``. Deliberately makes no policy
+    decision: the orchestrator owns the deny-and-audit calls, where the audit
+    context lives.
+
+    ``project`` and ``project_membership`` are both FORCE ROW LEVEL SECURITY with
+    a strict ``organization_id = current_setting('app.current_organization')::uuid``
+    policy and no empty-org passthrough. The exchange runs on ``get_db_session``,
+    which binds no tenant GUCs, so querying either table unscoped raises
+    ``invalid input syntax for type uuid: ""`` for any app role without BYPASSRLS
+    -- which the deployed ``rhesis-user`` is. Binding org scope for just these two
+    reads is what ``temporary_project_scope`` is for; it restores the caller's
+    scope on exit. Project scope stays empty: we are resolving which project to
+    grant, not operating inside one, and ``project_membership`` is exempt from the
+    project predicate anyway.
+    """
+    from rhesis.backend.app.database import temporary_project_scope
+    from rhesis.backend.app.models.project import Project
+    from rhesis.backend.app.models.project_membership import ProjectMembership
+
+    with temporary_project_scope(db, str(org.id), str(user.id), ""):
+        project = (
+            db.query(Project)
+            .filter(Project.id == project_id, Project.organization_id == org.id)
+            .first()
+        )
+        is_member = project is not None and (
+            db.query(ProjectMembership)
+            .filter(
+                ProjectMembership.project_id == project.id,
+                ProjectMembership.user_id == user.id,
+                ProjectMembership.organization_id == org.id,
+            )
+            .first()
+            is not None
+        )
+    return project, is_member
 
 
 def _split_scope_string(scope: Optional[str]) -> Optional[List[str]]:

--- a/ee/backend/src/rhesis/backend/ee/sso/token_exchange/router.py
+++ b/ee/backend/src/rhesis/backend/ee/sso/token_exchange/router.py
@@ -219,6 +219,11 @@ async def _parse_form_payload(request: Request) -> TokenExchangeRequest:
       values. We require exactly one because our authorization model
       ties an exchanged token to one organization (the audience). A
       multi-audience exchange would have ambiguous org binding.
+    - **At most one resource.** RFC 8693's ``resource`` parameter
+      names the project the exchanged token should be scoped to. Zero
+      values means no project scope (org-level rows only, the
+      pre-existing behaviour); more than one would leave the binding
+      ambiguous, same rationale as audience.
     - **Single credential mechanism.** RFC 6749 §2.3.1 forbids
       sending client credentials via both Basic ``Authorization`` and
       the request body. Doing so could let two different secrets
@@ -265,6 +270,15 @@ async def _parse_form_payload(request: Request) -> TokenExchangeRequest:
         raise _FormParseError("audience_must_be_single")
     audience = audience_list[0]
 
+    # RFC 8693 resource: optional, at most one. Same ambiguity argument
+    # as audience -- a multi-valued resource would leave the project
+    # binding undefined. Absent means "no project scope" (org-level
+    # rows only), which is the pre-existing behaviour.
+    resource_list = form.get("resource") or []
+    if len(resource_list) > 1:
+        raise _FormParseError("resource_must_be_single")
+    resource = resource_list[0] if resource_list else None
+
     # Basic auth detection. If the header is present and parses
     # successfully, the body MUST NOT also carry credentials.
     auth_header = request.headers.get("authorization")
@@ -285,6 +299,7 @@ async def _parse_form_payload(request: Request) -> TokenExchangeRequest:
         audience=audience or "",
         requested_token_type=_single("requested_token_type") or None,
         scope=_single("scope"),
+        resource=resource,
         client_id=client_id,
         client_secret=client_secret,
         source_ip=get_real_ip(request),

--- a/tests/backend/auth/test_oauth_scope.py
+++ b/tests/backend/auth/test_oauth_scope.py
@@ -1,0 +1,55 @@
+"""Unit tests for capabilities_for_oauth_scope.
+
+This is the mapping peqy flagged as missing on PR #2526: token-exchange JWTs
+carry a coarse OAuth ``scope`` claim (``read``/``full``) but nothing translated
+it into the capability strings Principal.scopes and the EE RBAC provider
+actually consume, so every exchanged token silently inherited full access
+regardless of what scope it requested.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from rhesis.backend.app.auth.oauth_scope import capabilities_for_oauth_scope
+
+_FAKE_CATALOG = [
+    "endpoint:read",
+    "endpoint:create",
+    "endpoint:update",
+    "endpoint:delete",
+    "test_set:read",
+    "test_set:execute",
+    "recycle:view",  # deliberately NOT ":read" -- see test below
+]
+
+
+@pytest.mark.unit
+@patch("rhesis.backend.app.auth.capabilities.get_all_capabilities", return_value=_FAKE_CATALOG)
+class TestCapabilitiesForOAuthScope:
+    def test_full_returns_none_sentinel(self, _mock_catalog):
+        """None means "inherit full access" -- same sentinel as an unscoped rh-* token."""
+        assert capabilities_for_oauth_scope("full") is None
+
+    def test_full_wins_over_read(self, _mock_catalog):
+        assert capabilities_for_oauth_scope("read full") is None
+        assert capabilities_for_oauth_scope("full read") is None
+
+    def test_read_returns_only_read_capabilities(self, _mock_catalog):
+        result = capabilities_for_oauth_scope("read")
+        assert result == frozenset({"endpoint:read", "test_set:read"})
+
+    def test_read_excludes_non_read_suffixed_actions(self, _mock_catalog):
+        """recycle:view is read-like but not literally ':read' -- excluded on purpose."""
+        result = capabilities_for_oauth_scope("read")
+        assert "recycle:view" not in result
+
+    @pytest.mark.parametrize("scope_claim", [None, "", "   ", "offline_access"])
+    def test_no_recognized_scope_grants_nothing(self, _mock_catalog, scope_claim):
+        """Fail-closed: absent/empty/unrecognized scope is zero capabilities, not everything."""
+        assert capabilities_for_oauth_scope(scope_claim) == frozenset()
+
+    def test_unknown_token_alongside_read_still_grants_read(self, _mock_catalog):
+        assert capabilities_for_oauth_scope("read unknown_future_scope") == frozenset(
+            {"endpoint:read", "test_set:read"}
+        )

--- a/tests/backend/auth/test_refresh_token_utils.py
+++ b/tests/backend/auth/test_refresh_token_utils.py
@@ -78,6 +78,44 @@ class TestCreateRefreshToken:
         assert row is not None
         assert str(row.user_id) == str(user.id)
 
+    def test_persists_project_id(self, test_db):
+        """project_id (RFC 8693 resource, resolved at exchange time) is stored."""
+        org = create_test_organization(test_db, "ProjectId Org")
+        user = create_test_user(
+            test_db, org.id, _unique_email("projectid"), "ProjectId User"
+        )
+        test_db.flush()
+        project_id = str(uuid.uuid4())
+
+        raw = create_refresh_token(
+            test_db, str(user.id), client_id="client-abc", project_id=project_id
+        )
+        test_db.commit()
+
+        row = (
+            test_db.query(RefreshToken)
+            .filter(RefreshToken.token_hash == _hash_token(raw))
+            .first()
+        )
+        assert str(row.project_id) == project_id
+
+    def test_project_id_defaults_to_none(self, test_db):
+        org = create_test_organization(test_db, "NoProject Org")
+        user = create_test_user(
+            test_db, org.id, _unique_email("noproject"), "NoProject User"
+        )
+        test_db.flush()
+
+        raw = create_refresh_token(test_db, str(user.id))
+        test_db.commit()
+
+        row = (
+            test_db.query(RefreshToken)
+            .filter(RefreshToken.token_hash == _hash_token(raw))
+            .first()
+        )
+        assert row.project_id is None
+
     def test_assigns_new_family_when_none(self, test_db):
         org = create_test_organization(test_db, "Family Org")
         user = create_test_user(
@@ -469,6 +507,35 @@ class TestVerifyAndRefresh:
 
         assert returned != raw  # rotated
         assert row.is_revoked  # old token revoked
+
+    def test_project_id_preserved_across_rotation(self, test_db):
+        """The successor row keeps project_id -- the regression this exists to catch.
+
+        Without propagating project_id on rotation, a token-exchange-issued
+        access token's ``project`` claim would work until the first refresh
+        and then silently disappear.
+        """
+        org = create_test_organization(test_db, "ProjectRotate Org")
+        user = create_test_user(
+            test_db, org.id, _unique_email("projectrotate"), "ProjectRotate User"
+        )
+        test_db.flush()
+        project_id = str(uuid.uuid4())
+
+        raw = create_refresh_token(
+            test_db, str(user.id), client_id="client-abc", project_id=project_id
+        )
+        test_db.commit()
+
+        _, new_raw = verify_and_rotate_refresh_token(test_db, raw)
+        test_db.commit()
+
+        successor = (
+            test_db.query(RefreshToken)
+            .filter(RefreshToken.token_hash == _hash_token(new_raw))
+            .first()
+        )
+        assert str(successor.project_id) == project_id
 
     def test_token_exchange_reuse_revokes_family(self, test_db):
         """Reusing a rotated token-exchange token revokes the family."""

--- a/tests/backend/auth/test_token_utils_session_claims.py
+++ b/tests/backend/auth/test_token_utils_session_claims.py
@@ -1,0 +1,78 @@
+"""Unit tests for create_session_token's token-exchange-issued claims.
+
+No DB needed -- create_session_token only reads attributes off the
+User it is handed, so a SimpleNamespace stands in for the ORM model,
+mirroring the mocking pattern in test_token_utils_email_flow.py.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import jwt
+import pytest
+
+from rhesis.backend.app.auth.token_utils import create_session_token, get_jwt_algorithm
+
+SECRET = "test-secret-key-for-tests"
+
+
+def _user(**overrides):
+    base = dict(
+        id="11111111-1111-1111-1111-111111111111",
+        organization_id="22222222-2222-2222-2222-222222222222",
+        email="user@example.com",
+        name="Test User",
+        picture=None,
+        is_email_verified=True,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.mark.unit
+@patch("rhesis.backend.app.auth.token_utils.get_secret_key", return_value=SECRET)
+class TestCreateSessionTokenProjectClaim:
+    """Tests for the ``project`` claim added alongside azp/scope/jti/epoch."""
+
+    def test_default_path_has_no_project_claim(self, mock_secret):
+        """No kwargs at all -- byte-identical default payload, no project key."""
+        token = create_session_token(_user())
+        payload = jwt.decode(
+            token, SECRET, algorithms=[get_jwt_algorithm()], options={"verify_exp": False}
+        )
+        assert "project" not in payload
+        assert "azp" not in payload
+
+    def test_project_claim_set_when_azp_present(self, mock_secret):
+        project_id = "33333333-3333-3333-3333-333333333333"
+        token = create_session_token(
+            _user(),
+            azp="warehouse-sync",
+            epoch=0,
+            project=project_id,
+        )
+        # azp implies an aud claim; verify_aud=False because this test only
+        # cares about the project claim, not the audience contract.
+        payload = jwt.decode(
+            token,
+            SECRET,
+            algorithms=[get_jwt_algorithm()],
+            options={"verify_exp": False, "verify_aud": False},
+        )
+        assert payload["project"] == project_id
+
+    def test_no_project_claim_when_resource_omitted(self, mock_secret):
+        """Exchanging with no ``resource`` mints a token with no project claim."""
+        token = create_session_token(_user(), azp="warehouse-sync", epoch=0, project=None)
+        payload = jwt.decode(
+            token,
+            SECRET,
+            algorithms=[get_jwt_algorithm()],
+            options={"verify_exp": False, "verify_aud": False},
+        )
+        assert "project" not in payload
+
+    def test_project_without_azp_raises(self, mock_secret):
+        """project only has meaning alongside azp, same as scope/jti/epoch."""
+        with pytest.raises(ValueError, match="require azp"):
+            create_session_token(_user(), project="33333333-3333-3333-3333-333333333333")

--- a/tests/backend/ee/api_clients/test_clients_rls.py
+++ b/tests/backend/ee/api_clients/test_clients_rls.py
@@ -1,0 +1,82 @@
+"""``authenticate_client`` must work for an app role subject to RLS.
+
+``auth_client`` is FORCE ROW LEVEL SECURITY with a strict
+``organization_id = current_setting('app.current_organization')::uuid`` policy
+and no empty-org passthrough. Both callers (``/auth/token-exchange`` and the
+client-bound ``/auth/refresh`` minter) reach it on ``get_db_session``, which
+binds no tenant GUCs, so the lookup has to bind org scope itself or it raises
+``invalid input syntax for type uuid: ""``.
+
+The test DB role is a superuser and bypasses RLS, so the sibling tests in
+test_clients.py (which mock the session entirely) cannot catch this. These use a
+real row and a real non-BYPASSRLS role -- the same technique as
+``TestResolveUnderEnforcedRLS`` in tests/backend/routes/test_resolve.py.
+"""
+
+import uuid as _uuid
+
+import pytest
+from sqlalchemy import text
+
+from rhesis.backend.ee.api_clients.clients import (
+    AuthClient,
+    authenticate_client,
+    generate_client_secret,
+    hash_client_secret,
+)
+
+
+@pytest.mark.integration
+class TestAuthenticateClientUnderEnforcedRLS:
+    def _make_client(self, test_db, org_id, secret):
+        row = AuthClient(
+            organization_id=org_id,
+            client_id=f"probe-{_uuid.uuid4().hex[:8]}",
+            client_secret_hash=hash_client_secret(secret),
+            expected_subject_azp="probe-azp",
+            expected_subject_audience="account",
+            allowed_scopes=["read"],
+            default_scope="read",
+        )
+        test_db.add(row)
+        test_db.flush()
+        return row
+
+    def test_authenticates_for_a_role_subject_to_rls(self, test_db, test_organization):
+        secret = generate_client_secret()
+        row = self._make_client(test_db, test_organization.id, secret)
+        client_id = row.client_id
+        org_id = test_organization.id
+
+        probe = f"authclient_rls_probe_{_uuid.uuid4().hex[:8]}"
+        test_db.execute(text(f'CREATE ROLE "{probe}" NOLOGIN'))
+        test_db.execute(text(f'GRANT SELECT ON public.auth_client TO "{probe}"'))
+        test_db.execute(text(f'SET LOCAL ROLE "{probe}"'))
+
+        # Blank the org GUC so the session presents what get_db_session gives the
+        # exchange. Without this the fixture's own org scope is still bound and
+        # the lookup would succeed regardless of the fix, making this vacuous.
+        test_db.execute(text("SET LOCAL app.current_organization = ''"))
+
+        # The function binds org scope internally, so it resolves the row even
+        # though the surrounding session has no tenant GUCs bound.
+        result = authenticate_client(test_db, org_id, client_id, secret)
+        assert result is not None, (
+            "authenticate_client could not see auth_client under an RLS-enforced "
+            "role -- the org scope binding regressed"
+        )
+        assert result.client_id == client_id
+
+        # And the raw unscoped query is what would have happened without it.
+        with pytest.raises(Exception) as exc:
+            with test_db.begin_nested():
+                test_db.execute(text("SET LOCAL app.current_organization = ''"))
+                test_db.execute(
+                    text("SELECT id FROM auth_client WHERE client_id = :c"),
+                    {"c": client_id},
+                ).fetchone()
+        assert 'invalid input syntax for type uuid: ""' in str(exc.value), (
+            f"expected the empty-org uuid cast to fail, got: {exc.value}"
+        )
+
+        test_db.execute(text("RESET ROLE"))

--- a/tests/backend/ee/api_clients/test_refresh_minter.py
+++ b/tests/backend/ee/api_clients/test_refresh_minter.py
@@ -7,15 +7,35 @@ access token's ``scope`` claim must NOT carry it (or a future
 per-route scope check might mistakenly grant it as an authority),
 but the persisted refresh row MUST keep it so re-rotation preserves
 the original intent.
+
+``TestMintForClientBoundRefresh`` covers the sibling regression this
+module is exposed to for ``project_id``: without re-minting it from
+``old_token.project_id`` on every rotation, a token-exchange-issued
+access token's ``project`` claim would work until the first refresh
+and vanish silently after.
 """
 
 from __future__ import annotations
 
+import base64
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import jwt
 import pytest
 
+from rhesis.backend.app.auth.token_utils import get_jwt_algorithm
 from rhesis.backend.ee.api_clients.refresh_minter import (
     _strip_offline_access,
+    mint_for_client_bound_refresh,
 )
+
+SECRET = "test-secret-key-for-tests"
+
+
+def _basic_auth_header(client_id: str, client_secret: str = "s3cret") -> str:
+    raw = f"{client_id}:{client_secret}".encode()
+    return "Basic " + base64.b64encode(raw).decode()
 
 
 @pytest.mark.parametrize(
@@ -47,3 +67,88 @@ def test_does_not_strip_substrings() -> None:
     assert _strip_offline_access("full offline_access_v2") == (
         "full offline_access_v2"
     )
+
+
+@pytest.mark.unit
+@patch("rhesis.backend.app.auth.token_utils.get_secret_key", return_value=SECRET)
+class TestMintForClientBoundRefresh:
+    """``db`` is unused when ``authenticate_client`` is mocked, so a bare
+    ``None`` stands in for it -- the function never touches it directly."""
+
+    def _auth_client(self, **overrides):
+        base = dict(
+            client_id="warehouse-sync",
+            organization_id="22222222-2222-2222-2222-222222222222",
+            token_epoch=0,
+            disabled=False,
+        )
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def _old_token(self, **overrides):
+        base = dict(
+            client_id="warehouse-sync",
+            scope="read",
+            project_id="33333333-3333-3333-3333-333333333333",
+        )
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def _user(self, **overrides):
+        base = dict(
+            id="11111111-1111-1111-1111-111111111111",
+            organization_id="22222222-2222-2222-2222-222222222222",
+            email="user@example.com",
+            name="Test User",
+            picture=None,
+            is_email_verified=True,
+        )
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def _request(self, client_id: str = "warehouse-sync") -> SimpleNamespace:
+        return SimpleNamespace(
+            headers=SimpleNamespace(get=lambda name: _basic_auth_header(client_id))
+        )
+
+    def test_project_id_reminted_on_rotation(self, mock_secret) -> None:
+        old_token = self._old_token()
+        with patch(
+            "rhesis.backend.ee.api_clients.refresh_minter.authenticate_client",
+            return_value=self._auth_client(),
+        ):
+            access_token = mint_for_client_bound_refresh(
+                db=None,
+                request=self._request(),
+                old_token=old_token,
+                user=self._user(),
+            )
+
+        payload = jwt.decode(
+            access_token,
+            SECRET,
+            algorithms=[get_jwt_algorithm()],
+            options={"verify_exp": False, "verify_aud": False},
+        )
+        assert payload["project"] == old_token.project_id
+
+    def test_no_project_claim_when_old_token_has_none(self, mock_secret) -> None:
+        old_token = self._old_token(project_id=None)
+        with patch(
+            "rhesis.backend.ee.api_clients.refresh_minter.authenticate_client",
+            return_value=self._auth_client(),
+        ):
+            access_token = mint_for_client_bound_refresh(
+                db=None,
+                request=self._request(),
+                old_token=old_token,
+                user=self._user(),
+            )
+
+        payload = jwt.decode(
+            access_token,
+            SECRET,
+            algorithms=[get_jwt_algorithm()],
+            options={"verify_exp": False, "verify_aud": False},
+        )
+        assert "project" not in payload

--- a/tests/backend/ee/sso/token_exchange/test_exchange_helpers.py
+++ b/tests/backend/ee/sso/token_exchange/test_exchange_helpers.py
@@ -19,6 +19,7 @@ from rhesis.backend.ee.sso.token_exchange.exchange import (
     TokenExchangeRequest,
     _audience_to_slug,
     _check_request_shape,
+    _resource_to_project_id,
     _split_scope_string,
     _ttl_until_expiry,
 )
@@ -93,6 +94,33 @@ class TestCheckRequestShape:
             _check_request_shape(_valid_payload(audience=audience))
         assert exc.value.reason_code == "audience_malformed"
 
+    def test_accepts_missing_resource(self) -> None:
+        # resource is optional -- None means "no project scope".
+        _check_request_shape(_valid_payload(resource=None))
+
+    def test_accepts_well_formed_resource(self) -> None:
+        _check_request_shape(
+            _valid_payload(resource="urn:rhesis:project:11111111-2222-3333-4444-555555555555")
+        )
+
+    @pytest.mark.parametrize(
+        "resource",
+        [
+            "",
+            "11111111-2222-3333-4444-555555555555",  # missing prefix
+            "urn:rhesis:project:",  # missing uuid
+            "urn:rhesis:project:not-a-uuid",
+            "urn:rhesis:org:11111111-2222-3333-4444-555555555555",  # wrong entity
+            # Case-sensitive, matching the audience rule: one spelling per value.
+            "URN:RHESIS:PROJECT:11111111-2222-3333-4444-555555555555",
+            "urn:rhesis:project:AAAAAAAA-2222-3333-4444-555555555555",
+        ],
+    )
+    def test_rejects_malformed_resource(self, resource: str) -> None:
+        with pytest.raises(TokenExchangeError) as exc:
+            _check_request_shape(_valid_payload(resource=resource))
+        assert exc.value.reason_code == "resource_malformed"
+
 
 # ---------------------------------------------------------------------------
 # _audience_to_slug
@@ -106,6 +134,23 @@ class TestAudienceToSlug:
     def test_returns_none_on_malformed(self) -> None:
         assert _audience_to_slug("acme") is None
         assert _audience_to_slug("") is None
+
+
+# ---------------------------------------------------------------------------
+# _resource_to_project_id
+# ---------------------------------------------------------------------------
+
+
+class TestResourceToProjectId:
+    def test_strips_prefix(self) -> None:
+        assert (
+            _resource_to_project_id("urn:rhesis:project:11111111-2222-3333-4444-555555555555")
+            == "11111111-2222-3333-4444-555555555555"
+        )
+
+    def test_returns_none_on_malformed(self) -> None:
+        assert _resource_to_project_id("not-a-urn") is None
+        assert _resource_to_project_id("") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/ee/sso/token_exchange/test_resource_project_rls.py
+++ b/tests/backend/ee/sso/token_exchange/test_resource_project_rls.py
@@ -1,0 +1,109 @@
+"""``_resolve_resource_project`` must work for an app role subject to RLS.
+
+``project`` and ``project_membership`` are both FORCE ROW LEVEL SECURITY with a
+strict ``organization_id = current_setting('app.current_organization')::uuid``
+policy and no empty-org passthrough (unlike ``organization``). The exchange runs
+on ``get_db_session``, which binds no tenant GUCs, so the resource lookup has to
+bind org scope itself or it raises ``invalid input syntax for type uuid: ""``.
+
+The test DB role is a superuser and bypasses RLS entirely, so an
+orchestrator-level test would pass either way. These use a real row and a real
+non-BYPASSRLS role -- the same technique as ``TestResolveUnderEnforcedRLS`` in
+tests/backend/routes/test_resolve.py, whose docstring records the same trap
+(ORM-level bypass passing tests yet 404-ing in production).
+"""
+
+import uuid as _uuid
+
+import pytest
+from sqlalchemy import text
+
+from rhesis.backend.app.models.project import Project
+from rhesis.backend.app.models.project_membership import ProjectMembership
+from rhesis.backend.ee.sso.token_exchange.exchange import _resolve_resource_project
+
+
+@pytest.mark.integration
+class TestResolveResourceProjectUnderEnforcedRLS:
+    def _make_project(self, test_db, test_organization, db_user, db_owner_user, db_status):
+        project = Project(
+            name=f"Resource RLS {_uuid.uuid4().hex[:6]}",
+            is_active=True,
+            user_id=db_user.id,
+            owner_id=db_owner_user.id,
+            organization_id=test_organization.id,
+            status_id=db_status.id,
+        )
+        test_db.add(project)
+        test_db.flush()
+        return project
+
+    def _enter_rls_role(self, test_db):
+        """Switch to a non-BYPASSRLS role with the org GUC blanked.
+
+        Blanking matters: the ``test_db`` fixture leaves its own org scope bound,
+        so without this the lookup would resolve regardless of the fix and the
+        test would be vacuous.
+        """
+        probe = f"resource_rls_probe_{_uuid.uuid4().hex[:8]}"
+        test_db.execute(text(f'CREATE ROLE "{probe}" NOLOGIN'))
+        test_db.execute(
+            text(f'GRANT SELECT ON public.project, public.project_membership TO "{probe}"')
+        )
+        test_db.execute(text(f'SET LOCAL ROLE "{probe}"'))
+        test_db.execute(text("SET LOCAL app.current_organization = ''"))
+
+    def test_resolves_member_project(
+        self, test_db, test_organization, db_user, db_owner_user, db_status
+    ):
+        project = self._make_project(test_db, test_organization, db_user, db_owner_user, db_status)
+        test_db.add(
+            ProjectMembership(
+                project_id=project.id,
+                user_id=db_user.id,
+                organization_id=test_organization.id,
+            )
+        )
+        test_db.flush()
+        project_id = str(project.id)
+
+        self._enter_rls_role(test_db)
+        found, is_member = _resolve_resource_project(
+            test_db, test_organization, db_user, project_id
+        )
+
+        assert found is not None, (
+            "project invisible to an RLS-enforced role -- the org scope binding "
+            "in _resolve_resource_project regressed"
+        )
+        assert str(found.id) == project_id
+        assert is_member is True
+        test_db.execute(text("RESET ROLE"))
+
+    def test_non_member_project_resolves_but_is_not_member(
+        self, test_db, test_organization, db_user, db_owner_user, db_status
+    ):
+        """No ProjectMembership row -> found, but is_member False (a deny)."""
+        project = self._make_project(test_db, test_organization, db_user, db_owner_user, db_status)
+        test_db.flush()
+
+        self._enter_rls_role(test_db)
+        found, is_member = _resolve_resource_project(
+            test_db, test_organization, db_user, str(project.id)
+        )
+
+        assert found is not None
+        assert is_member is False
+        test_db.execute(text("RESET ROLE"))
+
+    def test_unknown_project_returns_none(
+        self, test_db, test_organization, db_user, db_owner_user, db_status
+    ):
+        self._enter_rls_role(test_db)
+        found, is_member = _resolve_resource_project(
+            test_db, test_organization, db_user, str(_uuid.uuid4())
+        )
+
+        assert found is None
+        assert is_member is False
+        test_db.execute(text("RESET ROLE"))

--- a/tests/backend/utils/test_auth_utils.py
+++ b/tests/backend/utils/test_auth_utils.py
@@ -11,6 +11,7 @@ This module tests authentication utility functions including:
 
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -404,6 +405,91 @@ class TestGetAuthenticatedUserWithContext:
 
                 assert result == mock_user
                 mock_get_jwt_user.assert_called_once_with("jwt-token", "secret")
+
+    def _token_exchange_jwt(self, *, scope: str) -> str:
+        """A real token-exchange-issued JWT (azp + scope claims), signed with 'secret'."""
+        from types import SimpleNamespace
+
+        from rhesis.backend.app.auth.token_utils import create_session_token
+
+        subject_user = SimpleNamespace(
+            id="user123",
+            organization_id="org456",
+            email="user@example.com",
+            name="Test User",
+            picture=None,
+            is_email_verified=True,
+        )
+        with patch("rhesis.backend.app.auth.token_utils.get_secret_key", return_value="secret"):
+            return create_session_token(subject_user, azp="warehouse-sync", epoch=0, scope=scope)
+
+    def test_jwt_read_scope_sets_read_only_capabilities_on_request_state(self):
+        """The gap peqy flagged: an exchanged token's scope claim must narrow
+        Principal.scopes, not be silently ignored (which left every exchanged
+        token with full access regardless of what scope it requested)."""
+        mock_user = Mock(spec=User)
+        mock_user.id = "user123"
+        mock_user.organization_id = "org456"
+        token = self._token_exchange_jwt(scope="read")
+
+        request = Mock()
+        request.session = {}
+        request.state = SimpleNamespace()
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        with patch(
+            "rhesis.backend.app.auth.user_utils.get_user_from_jwt",
+            return_value=mock_user,
+        ):
+            with patch(
+                "rhesis.backend.app.auth.user_utils.get_current_user",
+                return_value=None,
+            ):
+                with patch(
+                    "rhesis.backend.app.auth.capabilities.get_all_capabilities",
+                    return_value=["endpoint:read", "endpoint:create", "test_set:read"],
+                ):
+                    result = pytest.run(
+                        get_authenticated_user_with_context(
+                            request, credentials=credentials, secret_key="secret"
+                        )
+                    )
+
+                assert result == mock_user
+                assert request.state.api_token_scopes == frozenset(
+                    {"endpoint:read", "test_set:read"}
+                )
+                assert request.state.auth_kind == "token"
+
+    def test_jwt_full_scope_leaves_scopes_unset(self):
+        """full maps to the same "inherit full access" sentinel as an unscoped
+        rh-* token: request.state.api_token_scopes stays unset, not set-to-everything."""
+        mock_user = Mock(spec=User)
+        mock_user.id = "user123"
+        mock_user.organization_id = "org456"
+        token = self._token_exchange_jwt(scope="full")
+
+        request = Mock()
+        request.session = {}
+        request.state = SimpleNamespace()
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+        with patch(
+            "rhesis.backend.app.auth.user_utils.get_user_from_jwt",
+            return_value=mock_user,
+        ):
+            with patch(
+                "rhesis.backend.app.auth.user_utils.get_current_user",
+                return_value=None,
+            ):
+                result = pytest.run(
+                    get_authenticated_user_with_context(
+                        request, credentials=credentials, secret_key="secret"
+                    )
+                )
+
+        assert result == mock_user
+        assert not hasattr(request.state, "api_token_scopes")
 
     def test_get_authenticated_user_without_context(self):
         """Test authentication with without_context flag"""


### PR DESCRIPTION
## Purpose

Tests could no longer be run through the Java SDK: every attempt failed with "Endpoint not found" for a valid endpoint id. The cause is that token exchange is the only credential type in Rhesis that carries no project binding, and there was no way to supply one. Since `endpoint.project_id` is `NOT NULL` (`7b998a6fe52d`) and project isolation is fail-closed (`b8c9d0e1f2a3`), an exchanged token can never see any endpoint at all. Both migrations already shipped in v0.10.0, so upgrading does not help.

Fixing that surfaced a second, pre-existing bug of the same shape: `authenticate_client` queries `auth_client` on a session with no tenant GUCs bound, which raises for any DB role subject to RLS. That means API Clients has never worked on a managed deployment; it works self-hosted only because docker-compose makes the DB user a superuser, which bypasses RLS entirely.

## What Changed

- `POST /auth/token-exchange` accepts the optional RFC 8693 `resource` parameter naming the target project: `resource=urn:rhesis:project:<uuid>`. The project is validated against the resolved user's `ProjectMembership` at mint time and carried as a `project` claim on the JWT. Omitting it keeps the previous behaviour (org-level rows only), so no existing exchange breaks.
- The JWT branch of `get_authenticated_user_with_context` stores that claim on `request.state.api_token_project_id`, the same request state a project-scoped `rh-*` token uses. `get_project_context` and all 39 RLS policies then work unchanged, membership is re-checked on every request, and a mismatched `X-Project-Id` still 403s.
- `refresh_token` gains a `project_id` column (migration `a4b5c6d7e8f9`, following `d8a5e0f3c4b2`). Without it the claim would survive the exchange and then vanish on the first refresh, roughly 15 minutes in — a credential that works, stops, then works again after a re-exchange.
- `authenticate_client` binds org scope for its lookup, fixing the pre-existing RLS bug above. Scoped inside the function rather than at its two call sites so a third caller cannot reintroduce it.
- The success audit event and the three `resource_*` denials record the project, so a scoping decision is reconstructable after the fact.
- "Endpoint not found" now explains when the request simply has no project scope, instead of implying a bad id. That ambiguity is what cost a day of debugging here.
- Docs cover `resource`, the new error reasons, and a discovery flow: project UUIDs appear nowhere in the IdP or client config, so an integrator exchanges once without `resource`, lists projects with that org-scoped token, then exchanges again naming one.

No SDK change is needed. The project rides inside the token, so clients keep sending an opaque bearer string, and one project per token means a service spanning two projects exchanges twice.

## Additional Context

- Filed #2525 from this work: the backend suite runs as a Postgres superuser, so RLS is never enforced and this class of bug passes CI green. Three instances have now been found this way, including the two fixed here. `TestResolveUnderEnforcedRLS` in `tests/backend/routes/test_resolve.py` already documents the trap.
- Table audit behind the RLS fix — only `auth_client`, `project` and `project_membership` are unsafe with an empty org GUC; `organization` has a CASE passthrough and `user` / `token` / `refresh_token` have no policies at all.
- Considered and rejected for now: membership-union RLS, where a request with no declared project sees every project the caller belongs to. It is arguably the better long-term model and would remove the reason `routers/resolve.py` exists, but it rewrites the policy on 39 tables, needs a tiebreak rule for writes since `auto_stamp` needs one value not a set, and changes UI-visible list behaviour. That is a product decision to make on its own merits.
- `_RESOURCE_RE` is case-sensitive and lowercase-only, matching `_AUDIENCE_RE`. Every project UUID we emit is lowercase, so a caller echoing back an id we gave them always matches.

## Testing

1067 tests pass across `tests/backend/auth/`, `tests/backend/ee/`, `test_test_set.py`, `test_endpoint.py` and `test_resolve.py`.

Three new tests run against a real non-BYPASSRLS role rather than the suite's superuser, and each was verified to fail with the exact production error (`invalid input syntax for type uuid: ""`) when its fix is reverted:

- `tests/backend/ee/api_clients/test_clients_rls.py` — `authenticate_client` under enforced RLS
- `tests/backend/ee/sso/token_exchange/test_resource_project_rls.py` — the project lookup, covering member / non-member / unknown
- plus `project_id` propagation across refresh rotation in `test_refresh_token_utils.py` and `test_refresh_minter.py`

Manually verified end to end against a running backend with a local fake OIDC IdP (throwaway scripts under `playground/token-exchange/`, gitignored). 15/15 checks pass, and they pass again with the DB role switched to `NOSUPERUSER NOBYPASSRLS` — the managed-production shape:

1. exchange with no `resource` → org-scoped token, no `project` claim
2. that token lists projects → the discovery step
3. that token cannot see the endpoint → reproduces the report
4. exchange with `resource` → `project` claim present
5. that token can see the endpoint → the fix
6. refresh → claim survives rotation
7-10. non-member, unknown, malformed and uppercase `resource`, replayed subject `jti` → correct rejections

With RLS enforced, removing the `temporary_project_scope` call from `authenticate_client` turns every exchange into an HTTP 500 — confirming the harness has teeth and that this is what managed production would have done before this branch.

To review manually: `./rh dev up`, then follow `playground/token-exchange/README.md`. Note that `API_CLIENTS` is licence-gated and needs `SSO_ENCRYPTION_KEY`; `preflight.py` reports both and `mint_license.py` handles the local dev licence.
