### PR TITLE
Add quota UI: inline gates, usage awareness, and notifications

### DIFF
--- a/apps/backend/src/rhesis/backend/app/models/enums.py
+++ b/apps/backend/src/rhesis/backend/app/models/enums.py
@@ -63,15 +63,19 @@ class EmbeddingOrigin(str, Enum):
 class NotificationSection(str, Enum):
     """Sidebar section a notification's badge count belongs to.
 
-    Values must equal the frontend NavigationPageItem.segment for that page
-    (mirrored in src/constants/notifications.ts, kept in sync manually like
-    FeatureName/Capability).
+    Values must equal the frontend NavigationPageItem.segment for that page,
+    when the section badges a nav item at all (mirrored in
+    src/constants/notifications.ts, kept in sync manually like
+    FeatureName/Capability). ``USAGE`` badges nothing -- there is no
+    "/usage" nav segment to attach a count to -- it exists so a quota
+    notification still groups and displays in the notification drawer.
     """
 
     TEST_SETS = "test-sets"
     TEST_RUNS = "test-runs"
     TASKS = "tasks"
     ARCHITECT = "architect"
+    USAGE = "usage"
 
 
 class NotificationEventType:
@@ -99,6 +103,13 @@ class NotificationEventType:
         #: pending -- i.e. the plan is done. Mid-plan turns don't notify; see
         #: the renderer in services/notification/catalog.py.
         PLAN_COMPLETED = "architect.plan_completed"
+
+    class Usage(str, Enum):
+        #: Crossed 80% of a resource's limit. Nothing is blocked yet.
+        APPROACHING_LIMIT = "usage.approaching_limit"
+        #: Crossed the resource's ceiling -- the action it gates is now
+        #: blocked (a 402 on the next attempt).
+        BLOCKED = "usage.blocked"
 
 
 # Notification.entity_type reuses rhesis.backend.app.constants.EntityType

--- a/apps/backend/src/rhesis/backend/app/quota/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/quota/__init__.py
@@ -57,6 +57,36 @@ class QuotaResource(str, Enum):
 QuotaResourceLike = Union[QuotaResource, str]
 
 
+# Display names for user-facing copy, lowercased for use mid-sentence.
+# Mirrors QUOTA_RESOURCE_LABELS in apps/frontend/src/constants/quota.ts and
+# must stay in sync with it: the frontend renders the inline gates and the
+# banner, this side renders the notification a quota crossing writes, and
+# the two are read by the same person about the same resource.
+#
+# Deliberately not `resource.value.replace("_", " ")`: TEST_EXECUTIONS is
+# called "test runs" throughout the product, which no mechanical transform
+# of the wire value produces.
+QUOTA_RESOURCE_LABELS: dict[QuotaResource, str] = {
+    QuotaResource.TEST_EXECUTIONS: "test runs",
+    QuotaResource.TRACING_SPANS: "tracing spans",
+    QuotaResource.TEST_GENERATION: "test generation",
+    QuotaResource.MODEL_TOKENS: "model tokens",
+    QuotaResource.SEATS: "seats",
+    QuotaResource.PROJECTS: "projects",
+    QuotaResource.ENDPOINTS: "endpoints",
+}
+
+
+def resource_label(resource: QuotaResource) -> str:
+    """Lowercase display name for *resource*, for use mid-sentence.
+
+    Falls back to the wire value with underscores spaced out, so a resource
+    added to :class:`QuotaResource` before this map catches up degrades to
+    readable-but-unpolished rather than raising in a copy path.
+    """
+    return QUOTA_RESOURCE_LABELS.get(resource, resource.value.replace("_", " "))
+
+
 class OveragePolicy(str, Enum):
     """What happens when an organization reaches a limit.
 
@@ -256,6 +286,7 @@ __all__ = [
     "DefaultQuotaProvider",
     "FREE_TIER_LIMITS",
     "OveragePolicy",
+    "QUOTA_RESOURCE_LABELS",
     "QuotaPolicy",
     "QuotaProvider",
     "QuotaRegistry",
@@ -263,4 +294,5 @@ __all__ = [
     "QuotaResourceLike",
     "UNLIMITED_LIMITS",
     "limits_to_wire",
+    "resource_label",
 ]

--- a/apps/backend/src/rhesis/backend/app/quota/enforcement.py
+++ b/apps/backend/src/rhesis/backend/app/quota/enforcement.py
@@ -28,7 +28,12 @@ from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.usage import Usage
 from rhesis.backend.app.quota import QuotaRegistry, QuotaResource
 from rhesis.backend.app.scope import bypass_tenant_filter
-from rhesis.backend.app.services.usage import _STOCK_COUNTERS, _current_period
+from rhesis.backend.app.services.usage import (
+    _STOCK_COUNTERS,
+    FLOW_KIND,
+    STOCK_KIND,
+    _current_period,
+)
 
 
 @dataclass(frozen=True)
@@ -44,6 +49,13 @@ class QuotaVerdict:
         *allowed*. ``over_limit and allowed`` is exactly the soft-overage
         grace band: past the advertised limit but not yet at the hard
         ceiling. ``over_limit`` is always ``False`` when *limit* is ``None``.
+    :param kind: ``"flow"`` or ``"stock"`` -- same split as
+        :func:`~rhesis.backend.app.services.usage.get_usage_summary`, so a
+        402 body can be classified identically to a `GET /usage` row
+        without the frontend re-deriving the split.
+    :param period_end: ISO date the current billing period ends, so a
+        blocked flow resource can be told when it resets without a second
+        round trip to `GET /usage`.
     """
 
     resource: QuotaResource
@@ -51,6 +63,8 @@ class QuotaVerdict:
     limit: Optional[int]
     allowed: bool
     over_limit: bool
+    kind: str
+    period_end: str
 
 
 class QuotaExceededError(Exception):
@@ -94,6 +108,8 @@ def quota_exceeded_response_body(verdict: QuotaVerdict) -> dict:
         "resource": verdict.resource.value,
         "used": verdict.used,
         "limit": verdict.limit,
+        "kind": verdict.kind,
+        "period_end": verdict.period_end,
         "message": f"You've reached your {resource_display} limit{suffix}.",
     }
 
@@ -147,10 +163,18 @@ def check_quota(
     policy = QuotaRegistry.get_policy(org)
     limit = policy.limits.get(resource)
     used = _read_usage(db, org_id, resource)
+    kind = STOCK_KIND if resource in _STOCK_COUNTERS else FLOW_KIND
+    _, period_end = _current_period()
 
     if limit is None:
         return QuotaVerdict(
-            resource=resource, used=used, limit=None, allowed=True, over_limit=False
+            resource=resource,
+            used=used,
+            limit=None,
+            allowed=True,
+            over_limit=False,
+            kind=kind,
+            period_end=period_end.isoformat(),
         )
 
     ceiling = policy.ceiling_for(limit)
@@ -160,6 +184,8 @@ def check_quota(
         limit=limit,
         allowed=used < ceiling,
         over_limit=used >= limit,
+        kind=kind,
+        period_end=period_end.isoformat(),
     )
 
 

--- a/apps/backend/src/rhesis/backend/app/quota/enforcement.py
+++ b/apps/backend/src/rhesis/backend/app/quota/enforcement.py
@@ -121,10 +121,25 @@ def stream_error_message(e: Exception) -> str:
     streaming pipeline emitting a ``{"type": "error", "message": ...}``
     NDJSON event rather than a structured 402 body.
 
+    Why every streaming generator needs this: a ``StreamingResponse``
+    sends its 200 OK before pulling the first item out of the generator.
+    Anything raised before the first ``yield`` -- most notably the
+    MODEL_TOKENS pre-call gate in ``user_model_utils.py`` raising
+    :class:`QuotaExceededError`, but any resolution failure has the same
+    shape -- used to propagate straight out with no clean 402 left to
+    send; the stream just aborted with no event ever reaching the
+    frontend, which reads as a request that hangs forever with no
+    explanation. Wrapping that setup code in one try/except per
+    generator and yielding an event built from this function's return
+    value is the fix; see ``test_generation_pipeline_stream`` and
+    ``suggestion_pipeline_stream`` for the two current call sites.
+
     A :class:`QuotaExceededError` gets the same organization-subject copy
     every other quota surface uses instead of its own technical
     ``__str__`` ("Quota exceeded for model_tokens: ..."); anything else
-    falls back to its own message.
+    falls back to its own message -- these pipelines show the underlying
+    LLM/provider error verbatim by design, so a user can see *why*
+    generation failed (a rate limit, an invalid key, and so on).
     """
     if isinstance(e, QuotaExceededError):
         return quota_exceeded_response_body(e.verdict)["message"]

--- a/apps/backend/src/rhesis/backend/app/quota/enforcement.py
+++ b/apps/backend/src/rhesis/backend/app/quota/enforcement.py
@@ -26,7 +26,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.usage import Usage
-from rhesis.backend.app.quota import QuotaRegistry, QuotaResource
+from rhesis.backend.app.quota import QuotaRegistry, QuotaResource, resource_label
 from rhesis.backend.app.scope import bypass_tenant_filter
 from rhesis.backend.app.services.usage import (
     _STOCK_COUNTERS,
@@ -55,7 +55,9 @@ class QuotaVerdict:
         without the frontend re-deriving the split.
     :param period_end: ISO date the current billing period ends, so a
         blocked flow resource can be told when it resets without a second
-        round trip to `GET /usage`.
+        round trip to `GET /usage`. ``None`` for a stock resource: seats,
+        projects and endpoints are live counts that never reset, so a
+        period end would be a meaningless date on the wire.
     """
 
     resource: QuotaResource
@@ -64,7 +66,7 @@ class QuotaVerdict:
     allowed: bool
     over_limit: bool
     kind: str
-    period_end: str
+    period_end: Optional[str]
 
 
 class QuotaExceededError(Exception):
@@ -100,7 +102,7 @@ def quota_exceeded_response_body(verdict: QuotaVerdict) -> dict:
     must build the response itself instead of letting the exception
     propagate there (see the note on :class:`QuotaExceededError`).
     """
-    resource_display = verdict.resource.value.replace("_", " ")
+    resource_display = resource_label(verdict.resource)
     is_stock = verdict.resource in _STOCK_COUNTERS
     suffix = "" if is_stock else " for this period"
     return {
@@ -163,8 +165,10 @@ def check_quota(
     policy = QuotaRegistry.get_policy(org)
     limit = policy.limits.get(resource)
     used = _read_usage(db, org_id, resource)
-    kind = STOCK_KIND if resource in _STOCK_COUNTERS else FLOW_KIND
-    _, period_end = _current_period()
+    is_stock = resource in _STOCK_COUNTERS
+    kind = STOCK_KIND if is_stock else FLOW_KIND
+    # Stock resources never reset, so they carry no period end -- see QuotaVerdict.
+    period_end = None if is_stock else _current_period()[1].isoformat()
 
     if limit is None:
         return QuotaVerdict(
@@ -174,7 +178,7 @@ def check_quota(
             allowed=True,
             over_limit=False,
             kind=kind,
-            period_end=period_end.isoformat(),
+            period_end=period_end,
         )
 
     ceiling = policy.ceiling_for(limit)
@@ -185,7 +189,7 @@ def check_quota(
         allowed=used < ceiling,
         over_limit=used >= limit,
         kind=kind,
-        period_end=period_end.isoformat(),
+        period_end=period_end,
     )
 
 

--- a/apps/backend/src/rhesis/backend/app/quota/enforcement.py
+++ b/apps/backend/src/rhesis/backend/app/quota/enforcement.py
@@ -112,7 +112,7 @@ def quota_exceeded_response_body(verdict: QuotaVerdict) -> dict:
         "limit": verdict.limit,
         "kind": verdict.kind,
         "period_end": verdict.period_end,
-        "message": f"You've reached your {resource_display} limit{suffix}.",
+        "message": f"Your organization is at its {resource_display} limit{suffix}.",
     }
 
 

--- a/apps/backend/src/rhesis/backend/app/quota/enforcement.py
+++ b/apps/backend/src/rhesis/backend/app/quota/enforcement.py
@@ -116,6 +116,21 @@ def quota_exceeded_response_body(verdict: QuotaVerdict) -> dict:
     }
 
 
+def stream_error_message(e: Exception) -> str:
+    """Turn an exception caught mid-stream into a plain string, for a
+    streaming pipeline emitting a ``{"type": "error", "message": ...}``
+    NDJSON event rather than a structured 402 body.
+
+    A :class:`QuotaExceededError` gets the same organization-subject copy
+    every other quota surface uses instead of its own technical
+    ``__str__`` ("Quota exceeded for model_tokens: ..."); anything else
+    falls back to its own message.
+    """
+    if isinstance(e, QuotaExceededError):
+        return quota_exceeded_response_body(e.verdict)["message"]
+    return str(e)
+
+
 def _read_usage(db: Session, org_id: str, resource: QuotaResource) -> int:
     """Read current usage for exactly one resource.
 

--- a/apps/backend/src/rhesis/backend/app/routers/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/routers/endpoint.py
@@ -31,6 +31,7 @@ from rhesis.backend.app.schemas.services import ExploreEndpointRequest, ExploreE
 from rhesis.backend.app.services.endpoint import EndpointService
 from rhesis.backend.app.services.endpoint.auto_configure import AutoConfigureService
 from rhesis.backend.app.services.invokers.common.errors import EndpointInvocationError
+from rhesis.backend.app.services.usage_notifications import notify_stock_crossing
 from rhesis.backend.app.utils.crud_utils import get_or_create_status
 from rhesis.backend.app.utils.database_exceptions import handle_database_exceptions
 from rhesis.backend.app.utils.decorators import with_count_header
@@ -97,19 +98,7 @@ def create_endpoint(
         user_id=user_id,
     )
 
-    from rhesis.backend.app.services.usage import count_org_endpoints
-    from rhesis.backend.app.services.usage_notifications import (
-        check_and_notify_threshold_crossing,
-    )
-
-    new_count = count_org_endpoints(db, organization_id)
-    check_and_notify_threshold_crossing(
-        db,
-        _quota_gate,
-        QuotaResource.ENDPOINTS,
-        previous_used=new_count - 1,
-        new_used=new_count,
-    )
+    notify_stock_crossing(db, _quota_gate, QuotaResource.ENDPOINTS)
 
     return new_endpoint
 

--- a/apps/backend/src/rhesis/backend/app/routers/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/routers/endpoint.py
@@ -90,12 +90,28 @@ def create_endpoint(
         if active_status:
             endpoint.status_id = active_status.id
 
-    return crud.create_endpoint(
+    new_endpoint = crud.create_endpoint(
         db=db,
         endpoint=endpoint,
         organization_id=organization_id,
         user_id=user_id,
     )
+
+    from rhesis.backend.app.services.usage import count_org_endpoints
+    from rhesis.backend.app.services.usage_notifications import (
+        check_and_notify_threshold_crossing,
+    )
+
+    new_count = count_org_endpoints(db, organization_id)
+    check_and_notify_threshold_crossing(
+        db,
+        _quota_gate,
+        QuotaResource.ENDPOINTS,
+        previous_used=new_count - 1,
+        new_used=new_count,
+    )
+
+    return new_endpoint
 
 
 @router.get("/", response_model=list[schemas.EndpointDetail])

--- a/apps/backend/src/rhesis/backend/app/routers/project.py
+++ b/apps/backend/src/rhesis/backend/app/routers/project.py
@@ -70,6 +70,20 @@ def create_project(
     db.commit()
     db.refresh(new_project)
 
+    from rhesis.backend.app.services.usage import count_org_projects
+    from rhesis.backend.app.services.usage_notifications import (
+        check_and_notify_threshold_crossing,
+    )
+
+    new_count = count_org_projects(db, organization_id)
+    check_and_notify_threshold_crossing(
+        db,
+        _quota_gate,
+        QuotaResource.PROJECTS,
+        previous_used=new_count - 1,
+        new_used=new_count,
+    )
+
     return new_project
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/project.py
+++ b/apps/backend/src/rhesis/backend/app/routers/project.py
@@ -22,6 +22,7 @@ from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.routers.base import RhesisRouter
+from rhesis.backend.app.services.usage_notifications import notify_stock_crossing
 from rhesis.backend.app.utils.database_exceptions import handle_database_exceptions
 from rhesis.backend.app.utils.odata import apply_select
 
@@ -70,19 +71,7 @@ def create_project(
     db.commit()
     db.refresh(new_project)
 
-    from rhesis.backend.app.services.usage import count_org_projects
-    from rhesis.backend.app.services.usage_notifications import (
-        check_and_notify_threshold_crossing,
-    )
-
-    new_count = count_org_projects(db, organization_id)
-    check_and_notify_threshold_crossing(
-        db,
-        _quota_gate,
-        QuotaResource.PROJECTS,
-        previous_used=new_count - 1,
-        new_used=new_count,
-    )
+    notify_stock_crossing(db, _quota_gate, QuotaResource.PROJECTS)
 
     return new_project
 

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -5,11 +5,14 @@ from fastapi import Depends, HTTPException, Query, Response
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
+from rhesis.backend.app.auth.quota_gates import require_quota
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.database import get_db_with_tenant_variables
 from rhesis.backend.app.dependencies import get_tenant_context, get_tenant_db_session
 from rhesis.backend.app.error_handlers import internal_error
+from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.services import (
     GenerateContentRequest,
@@ -440,6 +443,7 @@ def test_pipeline_endpoint(
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.TEST_GENERATION)),
 ):
     """Stream config and test generation as NDJSON events."""
     organization_id, _ = tenant_context

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -317,6 +317,7 @@ async def generate_tests_endpoint(
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
     _validate_model=Depends(validate_generation_model),
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.TEST_GENERATION)),
 ):
     """
     Generate test cases using the prompt synthesizer.
@@ -376,6 +377,7 @@ async def generate_multiturn_tests_endpoint(
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
     _validate_model=Depends(validate_generation_model),
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.TEST_GENERATION)),
 ):
     """
     Generate multi-turn test cases using the MultiTurnSynthesizer.
@@ -474,6 +476,7 @@ async def generate_test_config(
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.TEST_GENERATION)),
 ):
     """
     Generate test configuration JSON based on user description.

--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -36,6 +36,7 @@ from rhesis.backend.app.schemas.user import (
     UserSettingsUpdate,
 )
 from rhesis.backend.app.services import polyphemus as polyphemus_service
+from rhesis.backend.app.services.usage_notifications import notify_stock_crossing
 from rhesis.backend.app.utils.database_exceptions import handle_database_exceptions
 from rhesis.backend.app.utils.decorators import with_count_header
 from rhesis.backend.app.utils.rate_limit import INVITATION_RATE_LIMIT, user_limiter
@@ -235,19 +236,7 @@ def create_user(
             logger.error(f"Error sending invitation email to {created_user.email}: {str(e)}")
             # Don't fail user creation if email sending fails
 
-    from rhesis.backend.app.services.usage import count_org_seats
-    from rhesis.backend.app.services.usage_notifications import (
-        check_and_notify_threshold_crossing,
-    )
-
-    new_count = count_org_seats(db, str(current_user.organization_id))
-    check_and_notify_threshold_crossing(
-        db,
-        _quota_gate,
-        QuotaResource.SEATS,
-        previous_used=new_count - 1,
-        new_used=new_count,
-    )
+    notify_stock_crossing(db, _quota_gate, QuotaResource.SEATS)
 
     return created_user
 

--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -235,6 +235,20 @@ def create_user(
             logger.error(f"Error sending invitation email to {created_user.email}: {str(e)}")
             # Don't fail user creation if email sending fails
 
+    from rhesis.backend.app.services.usage import count_org_seats
+    from rhesis.backend.app.services.usage_notifications import (
+        check_and_notify_threshold_crossing,
+    )
+
+    new_count = count_org_seats(db, str(current_user.organization_id))
+    check_and_notify_threshold_crossing(
+        db,
+        _quota_gate,
+        QuotaResource.SEATS,
+        previous_used=new_count - 1,
+        new_used=new_count,
+    )
+
     return created_user
 
 

--- a/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud
 from rhesis.backend.app.crud import user as user_crud
+from rhesis.backend.app.quota.enforcement import stream_error_message
 from rhesis.backend.app.schemas.explorer import GenerateSuggestionsResponse, SuggestedTest
 from rhesis.backend.app.services.explorer.evaluation import (
     EVAL_MAX_CONCURRENCY,
@@ -404,6 +405,8 @@ async def suggestion_pipeline_stream(
              "diversity_scores": [float|null, ...]|null}`` (scores match sorted order)
       - ``{"type": "output_summary", "generated": int, "total": int}``
       - ``{"type": "eval_summary", "evaluated": int, "total": int}``
+      - ``{"type": "error", "message": str}`` (pipeline-level failure before
+             any suggestion could be produced -- e.g. quota exhaustion)
       - ``{"type": "done"}``
     """
     pipeline_t0 = time.monotonic()
@@ -414,27 +417,40 @@ async def suggestion_pipeline_stream(
 
     logger.info("[%s] pipeline_start", _ts())
 
-    suggestion_gen = await generate_suggestions(
-        db=db,
-        test_set_identifier=test_set_identifier,
-        organization_id=organization_id,
-        user_id=user_id,
-        topic=topic,
-        num_examples=num_examples,
-        num_suggestions=num_suggestions,
-        user_feedback=user_feedback,
-        stream=True,
-    )
+    # Everything needed before the first yield, wrapped together: this is
+    # the one point in the whole generator with no other try/except, and a
+    # failure here (most notably the MODEL_TOKENS pre-call gate in
+    # user_model_utils.py raising QuotaExceededError) used to propagate
+    # straight out of the generator after the StreamingResponse's 200 OK
+    # had already been sent -- no clean 402 possible at that point, and the
+    # stream just closed with no event ever reaching the frontend.
+    try:
+        suggestion_gen = await generate_suggestions(
+            db=db,
+            test_set_identifier=test_set_identifier,
+            organization_id=organization_id,
+            user_id=user_id,
+            topic=topic,
+            num_examples=num_examples,
+            num_suggestions=num_suggestions,
+            user_feedback=user_feedback,
+            stream=True,
+        )
 
-    # ── Resolve services once ──
-    invoker = EndpointInvoker(
-        db=db,
-        endpoint_id=endpoint_id,
-        organization_id=organization_id,
-        user_id=user_id,
-        max_concurrency=10,
-    )
-    sdk_metrics = resolve_sdk_metrics(db, organization_id, user_id, metric_names)
+        # ── Resolve services once ──
+        invoker = EndpointInvoker(
+            db=db,
+            endpoint_id=endpoint_id,
+            organization_id=organization_id,
+            user_id=user_id,
+            max_concurrency=10,
+        )
+        sdk_metrics = resolve_sdk_metrics(db, organization_id, user_id, metric_names)
+    except Exception as e:
+        logger.error("Failed to set up suggestion pipeline: %s", e, exc_info=True)
+        yield _ndjson({"type": "error", "message": stream_error_message(e)})
+        yield _ndjson({"type": "done"})
+        return
 
     embedder = None
     if generate_embeddings:
@@ -726,8 +742,17 @@ async def evaluate_suggestions_stream(
       - {"type": "item", "index": int, "input": str, "label": str, "labeler": str,
          "model_score": float, "metrics": dict|null, "error": str|null}
       - {"type": "summary", "evaluated": int, "total": int}
+      - {"type": "error", "message": str} (failed before any item could be
+         evaluated -- e.g. quota exhaustion)
     """
-    sdk_metrics = resolve_sdk_metrics(db, organization_id, user_id, metric_names)
+    try:
+        sdk_metrics = resolve_sdk_metrics(db, organization_id, user_id, metric_names)
+    except Exception as e:
+        logger.error("Failed to resolve evaluation metrics: %s", e, exc_info=True)
+        yield _ndjson({"type": "error", "message": stream_error_message(e)})
+        yield _ndjson({"type": "summary", "evaluated": 0, "total": len(suggestions)})
+        return
+
     semaphore = asyncio.Semaphore(EVAL_MAX_CONCURRENCY)
     fanout = EventFanout()
     evaluated = 0

--- a/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
@@ -417,13 +417,9 @@ async def suggestion_pipeline_stream(
 
     logger.info("[%s] pipeline_start", _ts())
 
-    # Everything needed before the first yield, wrapped together: this is
-    # the one point in the whole generator with no other try/except, and a
-    # failure here (most notably the MODEL_TOKENS pre-call gate in
-    # user_model_utils.py raising QuotaExceededError) used to propagate
-    # straight out of the generator after the StreamingResponse's 200 OK
-    # had already been sent -- no clean 402 possible at that point, and the
-    # stream just closed with no event ever reaching the frontend.
+    # Everything needed before the first yield, wrapped together -- see
+    # stream_error_message's docstring for why every streaming generator
+    # needs this.
     try:
         suggestion_gen = await generate_suggestions(
             db=db,

--- a/apps/backend/src/rhesis/backend/app/services/notification/catalog.py
+++ b/apps/backend/src/rhesis/backend/app/services/notification/catalog.py
@@ -190,4 +190,18 @@ NOTIFICATION_CATALOG: Dict[str, NotificationKind] = {
         entity_type=EntityType.ARCHITECT_SESSION.value,
         render=_render_architect_plan_completed,
     ),
+    NotificationEventType.Usage.APPROACHING_LIMIT: NotificationKind(
+        event_type=NotificationEventType.Usage.APPROACHING_LIMIT,
+        section=NotificationSection.USAGE,
+        # No entity to link or highlight -- a quota crossing is about the
+        # organization's consumption of a resource, not one row of it.
+        entity_type=None,
+        # Emitted directly from services/usage_notifications.py, not a
+        # Celery completion hook -- same shape as Task.ASSIGNED above.
+    ),
+    NotificationEventType.Usage.BLOCKED: NotificationKind(
+        event_type=NotificationEventType.Usage.BLOCKED,
+        section=NotificationSection.USAGE,
+        entity_type=None,
+    ),
 }

--- a/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
@@ -14,10 +14,11 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app.config.settings import get_model_settings
 from rhesis.backend.app.constants import REQUIREMENT_LIST_KEY, TestSetType
-from rhesis.backend.app.crud import requirement as requirement_crud
 from rhesis.backend.app.crud import model as model_crud
+from rhesis.backend.app.crud import requirement as requirement_crud
 from rhesis.backend.app.crud.project import get_project
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.quota.enforcement import QuotaExceededError, quota_exceeded_response_body
 from rhesis.backend.app.schemas.services import (
     SourceData,
     TestConfigItem,
@@ -43,6 +44,14 @@ logger = logging.getLogger(__name__)
 MAX_SAMPLE_SIZE = 6
 
 TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
+
+
+def _error_message(e: Exception) -> str:
+    """A quota exhaustion gets the same organization-subject copy every
+    other surface uses; anything else falls back to its own message."""
+    if isinstance(e, QuotaExceededError):
+        return quota_exceeded_response_body(e.verdict)["message"]
+    return str(e)
 
 
 def _resolve_config_llm(db: Session, user: User):
@@ -174,7 +183,7 @@ async def _stream_config(
         yield {
             "type": "error",
             "phase": "config",
-            "message": str(e),
+            "message": _error_message(e),
         }
         yield {"type": "config_done", "total": 0}
         yield {"type": "_collected", "config": None}
@@ -230,7 +239,21 @@ async def test_generation_pipeline_stream(
     if config_response is None:
         # ── Phase 1: Streamed config generation ──
 
-        llm = _resolve_config_llm(db, user)
+        # Resolving the LLM is the one step in this whole generator with no
+        # surrounding try/except -- a quota exhaustion (or any other
+        # resolution failure) raised here used to propagate straight out of
+        # the generator. By the time that happens, StreamingResponse has
+        # already sent its 200 OK, so there is no clean 402 left to send;
+        # the stream just aborts with no event ever reaching the frontend,
+        # which reads as a request that hangs forever with no explanation.
+        try:
+            llm = _resolve_config_llm(db, user)
+        except Exception as e:
+            logger.error("Failed to resolve config LLM: %s", e, exc_info=True)
+            yield ndjson({"type": "error", "phase": "config", "message": _error_message(e)})
+            yield ndjson({"type": "done"})
+            return
+
         db_context = _fetch_db_context(
             db=db,
             organization_id=organization_id,
@@ -352,7 +375,7 @@ async def test_generation_pipeline_stream(
 
     except Exception as e:
         logger.error("Test generation failed at index %d: %s", test_index, e, exc_info=True)
-        yield ndjson({"type": "error", "phase": "tests", "message": str(e)})
+        yield ndjson({"type": "error", "phase": "tests", "message": _error_message(e)})
 
     yield ndjson({"type": "tests_done", "total": tests_generated})
     yield ndjson({"type": "done"})

--- a/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
@@ -18,7 +18,7 @@ from rhesis.backend.app.crud import model as model_crud
 from rhesis.backend.app.crud import requirement as requirement_crud
 from rhesis.backend.app.crud.project import get_project
 from rhesis.backend.app.models.user import User
-from rhesis.backend.app.quota.enforcement import QuotaExceededError, quota_exceeded_response_body
+from rhesis.backend.app.quota.enforcement import stream_error_message
 from rhesis.backend.app.schemas.services import (
     SourceData,
     TestConfigItem,
@@ -44,14 +44,6 @@ logger = logging.getLogger(__name__)
 MAX_SAMPLE_SIZE = 6
 
 TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
-
-
-def _error_message(e: Exception) -> str:
-    """A quota exhaustion gets the same organization-subject copy every
-    other surface uses; anything else falls back to its own message."""
-    if isinstance(e, QuotaExceededError):
-        return quota_exceeded_response_body(e.verdict)["message"]
-    return str(e)
 
 
 def _resolve_config_llm(db: Session, user: User):
@@ -183,7 +175,7 @@ async def _stream_config(
         yield {
             "type": "error",
             "phase": "config",
-            "message": _error_message(e),
+            "message": stream_error_message(e),
         }
         yield {"type": "config_done", "total": 0}
         yield {"type": "_collected", "config": None}
@@ -250,7 +242,7 @@ async def test_generation_pipeline_stream(
             llm = _resolve_config_llm(db, user)
         except Exception as e:
             logger.error("Failed to resolve config LLM: %s", e, exc_info=True)
-            yield ndjson({"type": "error", "phase": "config", "message": _error_message(e)})
+            yield ndjson({"type": "error", "phase": "config", "message": stream_error_message(e)})
             yield ndjson({"type": "done"})
             return
 
@@ -375,7 +367,7 @@ async def test_generation_pipeline_stream(
 
     except Exception as e:
         logger.error("Test generation failed at index %d: %s", test_index, e, exc_info=True)
-        yield ndjson({"type": "error", "phase": "tests", "message": _error_message(e)})
+        yield ndjson({"type": "error", "phase": "tests", "message": stream_error_message(e)})
 
     yield ndjson({"type": "tests_done", "total": tests_generated})
     yield ndjson({"type": "done"})

--- a/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
@@ -231,28 +231,24 @@ async def test_generation_pipeline_stream(
     if config_response is None:
         # ── Phase 1: Streamed config generation ──
 
-        # Resolving the LLM is the one step in this whole generator with no
-        # surrounding try/except -- a quota exhaustion (or any other
-        # resolution failure) raised here used to propagate straight out of
-        # the generator. By the time that happens, StreamingResponse has
-        # already sent its 200 OK, so there is no clean 402 left to send;
-        # the stream just aborts with no event ever reaching the frontend,
-        # which reads as a request that hangs forever with no explanation.
+        # Everything needed before the first yield, wrapped together --
+        # see stream_error_message's docstring for why this must catch
+        # both the LLM resolution and _fetch_db_context (a
+        # deleted/inaccessible project also raises here).
         try:
             llm = _resolve_config_llm(db, user)
+            db_context = _fetch_db_context(
+                db=db,
+                organization_id=organization_id,
+                prompt=prompt,
+                project_id=project_id,
+                previous_messages=previous_messages,
+            )
         except Exception as e:
-            logger.error("Failed to resolve config LLM: %s", e, exc_info=True)
+            logger.error("Failed to set up config generation: %s", e, exc_info=True)
             yield ndjson({"type": "error", "phase": "config", "message": stream_error_message(e)})
             yield ndjson({"type": "done"})
             return
-
-        db_context = _fetch_db_context(
-            db=db,
-            organization_id=organization_id,
-            prompt=prompt,
-            project_id=project_id,
-            previous_messages=previous_messages,
-        )
 
         async for event in _stream_config(llm, db_context):
             if event.get("type") == "_collected":

--- a/apps/backend/src/rhesis/backend/app/services/usage.py
+++ b/apps/backend/src/rhesis/backend/app/services/usage.py
@@ -157,9 +157,10 @@ def increment_usage(
 
     After committing, checks whether this accrual just crossed 80% of the
     resource's limit or its ceiling, and notifies the org owner if so --
-    see ``usage_notifications.check_and_notify_threshold_crossing``. That
-    check never raises back into this function; a notification failure
-    must not turn into a retried accrual.
+    see ``usage_notifications.notify_flow_crossing``, which swallows every
+    exception. That is required, not defensive: this runs after the commit
+    above, and ``accrue_usage``'s bare ``except`` would retry the whole
+    task, re-accruing a counter that already landed.
     """
     if amount <= 0 or not org_id:
         return
@@ -186,14 +187,11 @@ def increment_usage(
     new_used = db.execute(stmt).scalar_one()
     db.commit()
 
-    from rhesis.backend.app.services.usage_notifications import (
-        check_and_notify_threshold_crossing,
-    )
+    # Local import: usage_notifications imports this module at module scope
+    # (for _STOCK_COUNTERS), so a module-scope import here would be circular.
+    from rhesis.backend.app.services.usage_notifications import notify_flow_crossing
 
-    org = db.query(Organization).filter(Organization.id == org_id).first()
-    check_and_notify_threshold_crossing(
-        db, org, resource, previous_used=new_used - amount, new_used=new_used
-    )
+    notify_flow_crossing(db, org_id, resource, previous_used=new_used - amount, new_used=new_used)
 
 
 def _count_org_rows(db: Session, model, org_id: str, *, exclude_deleted: bool) -> int:

--- a/apps/backend/src/rhesis/backend/app/services/usage.py
+++ b/apps/backend/src/rhesis/backend/app/services/usage.py
@@ -154,6 +154,12 @@ def increment_usage(
     tenant context never resolved) -- silently skipping is correct here:
     there is no organization to attribute the usage to, and casting an
     empty string to ``uuid`` would raise.
+
+    After committing, checks whether this accrual just crossed 80% of the
+    resource's limit or its ceiling, and notifies the org owner if so --
+    see ``usage_notifications.check_and_notify_threshold_crossing``. That
+    check never raises back into this function; a notification failure
+    must not turn into a retried accrual.
     """
     if amount <= 0 or not org_id:
         return
@@ -175,9 +181,19 @@ def increment_usage(
                 "updated_at": func.now(),
             },
         )
+        .returning(Usage.__table__.c.used)
     )
-    db.execute(stmt)
+    new_used = db.execute(stmt).scalar_one()
     db.commit()
+
+    from rhesis.backend.app.services.usage_notifications import (
+        check_and_notify_threshold_crossing,
+    )
+
+    org = db.query(Organization).filter(Organization.id == org_id).first()
+    check_and_notify_threshold_crossing(
+        db, org, resource, previous_used=new_used - amount, new_used=new_used
+    )
 
 
 def _count_org_rows(db: Session, model, org_id: str, *, exclude_deleted: bool) -> int:

--- a/apps/backend/src/rhesis/backend/app/services/usage_notifications.py
+++ b/apps/backend/src/rhesis/backend/app/services/usage_notifications.py
@@ -1,0 +1,124 @@
+"""Threshold-crossing notifications for quota usage.
+
+Turns a change in a resource's usage into an in-app notification for the
+org owner when the change just crossed 80% of the resource's `limit`, or
+its `ceiling` -- not on every call once an org is already past a
+threshold, only on the transition. Called from two places:
+
+- `services/usage.py:increment_usage`, for flow resources (test executions,
+  test generation, tracing spans, model tokens) -- the accrual write itself
+  is the natural point to compare before/after.
+- The three stock-resource creation routes (project, endpoint, user/seats)
+  right after `require_quota` has let the request through and the row is
+  created -- there is no accrual step for a stock resource to hook into,
+  since its "usage" is a live `COUNT(*)`, not a counter.
+
+Notifies only `organization.owner_id`, not every `Organization.UPDATE`
+holder. The full set requires a reverse RBAC lookup ("every user who holds
+this permission"), which doesn't exist yet -- building it means a new
+pluggable provider (mirroring `QuotaProvider`/`AuthorizationProvider`),
+since core code cannot import EE's `Role`/`RolePermission` models directly.
+The owner is a zero-cost field on `Organization` already, and is exactly
+the `Organization.UPDATE` set in community edition; in EE it may miss an
+Admin who also holds that permission, but the owner still gets notified.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.models.enums import NotificationEventType
+from rhesis.backend.app.models.organization import Organization
+from rhesis.backend.app.quota import QuotaRegistry, QuotaResource
+from rhesis.backend.app.services.notification import RenderedNotification, notify
+
+logger = logging.getLogger(__name__)
+
+#: Matches the frontend's `WARNING_THRESHOLD` (`constants/quota.ts`) -- kept
+#: as a separate constant, not a shared one, since there is no shared module
+#: between the two languages; if one changes, change both.
+_APPROACHING_RATIO = 0.8
+
+
+def _resource_label(resource: QuotaResource) -> str:
+    return resource.value.replace("_", " ")
+
+
+def check_and_notify_threshold_crossing(
+    db: Session,
+    org: Optional[Organization],
+    resource: QuotaResource,
+    *,
+    previous_used: int,
+    new_used: int,
+) -> None:
+    """Notify the org owner if this change just crossed 80% of `limit` or `ceiling`.
+
+    Compares `previous_used`/`new_used` against each threshold rather than
+    just classifying `new_used`'s zone, so an org that has been sitting
+    past a threshold for weeks isn't renotified on every subsequent call --
+    only the call whose range actually spans the threshold fires.
+
+    `previous_used` is a proxy (`new_used` minus the amount just added),
+    not a value read from the database inside the same transaction as the
+    write. That is exact under normal traffic; under two concurrent writes
+    landing on the same threshold at the same instant, one crossing could
+    double-fire or (rarely) get missed. Not worth a race-proof CTE for how
+    few orgs are on this platform -- see the "reduce safety margin"
+    guidance in project memory.
+
+    No-ops silently on any failure (notification is not the operation this
+    call is attached to) or if `org` has no id to notify, or the resource
+    is unlimited for this org.
+    """
+    if org is None or not org.owner_id:
+        return
+
+    policy = QuotaRegistry.get_policy(org)
+    limit = policy.limits.get(resource)
+    if limit is None:
+        return
+
+    ceiling = policy.ceiling_for(limit)
+    label = _resource_label(resource)
+
+    try:
+        if ceiling is not None and previous_used < ceiling <= new_used:
+            _notify_owner(
+                db,
+                org,
+                event_type=NotificationEventType.Usage.BLOCKED,
+                title=f"{label.title()} limit reached",
+                body=f"Your organization is at its {label} limit ({new_used} of {limit}).",
+            )
+            return
+
+        threshold = limit * _APPROACHING_RATIO
+        if previous_used < threshold <= new_used:
+            _notify_owner(
+                db,
+                org,
+                event_type=NotificationEventType.Usage.APPROACHING_LIMIT,
+                title=f"{label.title()} approaching limit",
+                body=f"Your organization is using {new_used} of {limit} {label}.",
+            )
+    except Exception:
+        logger.exception(
+            "Failed to notify org %s owner of a %s threshold crossing", org.id, resource.value
+        )
+
+
+def _notify_owner(
+    db: Session, org: Organization, *, event_type: str, title: str, body: str
+) -> None:
+    notify(
+        db,
+        event_type=event_type,
+        rendered=RenderedNotification(title=title, body=body),
+        user_id=str(org.owner_id),
+        organization_id=str(org.id),
+        project_id=None,
+    )

--- a/apps/backend/src/rhesis/backend/app/services/usage_notifications.py
+++ b/apps/backend/src/rhesis/backend/app/services/usage_notifications.py
@@ -3,24 +3,34 @@
 Turns a change in a resource's usage into an in-app notification for the
 org owner when the change just crossed 80% of the resource's `limit`, or
 its `ceiling` -- not on every call once an org is already past a
-threshold, only on the transition. Called from two places:
+threshold, only on the transition. Two entry points, one per resource kind:
 
-- `services/usage.py:increment_usage`, for flow resources (test executions,
-  test generation, tracing spans, model tokens) -- the accrual write itself
-  is the natural point to compare before/after.
-- The three stock-resource creation routes (project, endpoint, user/seats)
-  right after `require_quota` has let the request through and the row is
-  created -- there is no accrual step for a stock resource to hook into,
-  since its "usage" is a live `COUNT(*)`, not a counter.
+- :func:`notify_flow_crossing`, from `services/usage.py:increment_usage`,
+  for flow resources (test runs, test generation, tracing spans, model
+  tokens) -- the accrual write itself is the natural before/after point.
+- :func:`notify_stock_crossing`, from the three stock-resource creation
+  routes (project, endpoint, user/seats), right after `require_quota` has
+  let the request through and the row exists. There is no accrual step to
+  hook for a stock resource: its "usage" is a live ``COUNT(*)``.
 
-Notifies only `organization.owner_id`, not every `Organization.UPDATE`
-holder. The full set requires a reverse RBAC lookup ("every user who holds
-this permission"), which doesn't exist yet -- building it means a new
+**Both entry points swallow every exception.** That is load-bearing, not
+defensive habit. `increment_usage` runs inside the `accrue_usage` Celery
+task, whose bare ``except`` calls ``self.retry()`` -- so anything raised
+here after its ``db.commit()`` would re-run an accrual that already
+committed, inflating the counter by one per retry and 402-blocking the org
+at a fraction of its real limit. `routers/project.py` has the same shape:
+it commits the project before this runs. Notification is bookkeeping
+attached to someone else's committed work and must never be able to fail
+or repeat it.
+
+Notifies `organization.owner_id` only, not every `Organization.UPDATE`
+holder. The full set needs a reverse RBAC lookup ("every user holding this
+permission"), which does not exist yet -- building it means a new
 pluggable provider (mirroring `QuotaProvider`/`AuthorizationProvider`),
-since core code cannot import EE's `Role`/`RolePermission` models directly.
-The owner is a zero-cost field on `Organization` already, and is exactly
-the `Organization.UPDATE` set in community edition; in EE it may miss an
-Admin who also holds that permission, but the owner still gets notified.
+since core code cannot import EE's `Role`/`RolePermission` models. The
+owner is a field on `Organization` already, and is exactly the
+`Organization.UPDATE` set in community edition; in EE it may miss an Admin
+who also holds that permission.
 """
 
 from __future__ import annotations
@@ -30,24 +40,78 @@ from typing import Optional
 
 from sqlalchemy.orm import Session
 
+from rhesis.backend.app.database import temporary_project_scope
 from rhesis.backend.app.models.enums import NotificationEventType
 from rhesis.backend.app.models.organization import Organization
-from rhesis.backend.app.quota import QuotaRegistry, QuotaResource
+from rhesis.backend.app.quota import QuotaRegistry, QuotaResource, resource_label
 from rhesis.backend.app.services.notification import RenderedNotification, notify
+from rhesis.backend.app.services.usage import _STOCK_COUNTERS
 
 logger = logging.getLogger(__name__)
 
-#: Matches the frontend's `WARNING_THRESHOLD` (`constants/quota.ts`) -- kept
-#: as a separate constant, not a shared one, since there is no shared module
-#: between the two languages; if one changes, change both.
+#: Matches the frontend's `WARNING_THRESHOLD` (`constants/quota.ts`). Kept as
+#: a separate constant rather than shared -- there is no module both languages
+#: import -- so changing one means changing the other.
 _APPROACHING_RATIO = 0.8
 
 
-def _resource_label(resource: QuotaResource) -> str:
-    return resource.value.replace("_", " ")
+def notify_flow_crossing(
+    db: Session,
+    org_id: Optional[str],
+    resource: QuotaResource,
+    *,
+    previous_used: int,
+    new_used: int,
+) -> None:
+    """Notify on a flow resource's threshold crossing. Never raises.
+
+    *previous_used* is a proxy (*new_used* minus the amount just accrued),
+    not a value read inside the same transaction as the write. Exact under
+    normal traffic; under two concurrent accruals landing on the same
+    threshold at the same instant a crossing could double-fire or, rarely,
+    be missed. Not worth a race-proof CTE at this platform's scale.
+    """
+    try:
+        if not org_id:
+            return
+        org = db.query(Organization).filter(Organization.id == org_id).first()
+        _notify_crossing(db, org, resource, previous_used=previous_used, new_used=new_used)
+    except Exception:
+        logger.exception(
+            "Failed to notify a %s threshold crossing for org %s", resource.value, org_id
+        )
 
 
-def check_and_notify_threshold_crossing(
+def notify_stock_crossing(
+    db: Session, org: Optional[Organization], resource: QuotaResource
+) -> None:
+    """Count *resource* live and notify if this creation just crossed a
+    threshold. Never raises.
+
+    The count is taken here rather than by the caller so it lands inside
+    this function's exception guard -- a failing ``COUNT(*)`` must not turn
+    an already-committed creation into a 500. Stock resources always move
+    by exactly one, so ``new_used - 1`` is the true previous value, not a
+    proxy.
+    """
+    try:
+        if org is None:
+            return
+        counter = _STOCK_COUNTERS.get(resource)
+        if counter is None:
+            logger.warning("notify_stock_crossing called for non-stock %s", resource.value)
+            return
+        new_used = counter(db, str(org.id))
+        _notify_crossing(db, org, resource, previous_used=new_used - 1, new_used=new_used)
+    except Exception:
+        logger.exception(
+            "Failed to notify a %s threshold crossing for org %s",
+            resource.value,
+            org.id if org else None,
+        )
+
+
+def _notify_crossing(
     db: Session,
     org: Optional[Organization],
     resource: QuotaResource,
@@ -55,24 +119,18 @@ def check_and_notify_threshold_crossing(
     previous_used: int,
     new_used: int,
 ) -> None:
-    """Notify the org owner if this change just crossed 80% of `limit` or `ceiling`.
+    """Fire at most one notification if this change spans a threshold.
 
-    Compares `previous_used`/`new_used` against each threshold rather than
-    just classifying `new_used`'s zone, so an org that has been sitting
-    past a threshold for weeks isn't renotified on every subsequent call --
-    only the call whose range actually spans the threshold fires.
+    Compares the *range* against each threshold rather than classifying
+    *new_used* alone, so an org that has been sitting past a threshold for
+    weeks is not renotified on every subsequent call -- only the change
+    whose range actually crosses it fires. `blocked` is checked first and
+    returns, so one large jump past both thresholds reports the worse one.
 
-    `previous_used` is a proxy (`new_used` minus the amount just added),
-    not a value read from the database inside the same transaction as the
-    write. That is exact under normal traffic; under two concurrent writes
-    landing on the same threshold at the same instant, one crossing could
-    double-fire or (rarely) get missed. Not worth a race-proof CTE for how
-    few orgs are on this platform -- see the "reduce safety margin"
-    guidance in project memory.
-
-    No-ops silently on any failure (notification is not the operation this
-    call is attached to) or if `org` has no id to notify, or the resource
-    is unlimited for this org.
+    A resource whose limit is ``0`` never notifies: it is blocked from the
+    org's very first request, so there is no transition to report, and the
+    banner and inline gates already say so. Unlimited (``limit is None``)
+    likewise has nothing to cross.
     """
     if org is None or not org.owner_id:
         return
@@ -82,43 +140,63 @@ def check_and_notify_threshold_crossing(
     if limit is None:
         return
 
+    # ceiling_for() returns None only for an unlimited limit, already handled.
     ceiling = policy.ceiling_for(limit)
-    label = _resource_label(resource)
+    label = resource_label(resource)
+    # Flow resources accrue against a billing period and reset; stock
+    # resources are a live count with no period, so the phrasing differs --
+    # same split the frontend's quotaCopy() makes.
+    period_suffix = "" if resource in _STOCK_COUNTERS else " for this period"
 
-    try:
-        if ceiling is not None and previous_used < ceiling <= new_used:
-            _notify_owner(
-                db,
-                org,
-                event_type=NotificationEventType.Usage.BLOCKED,
-                title=f"{label.title()} limit reached",
-                body=f"Your organization is at its {label} limit ({new_used} of {limit}).",
-            )
-            return
+    if ceiling is not None and previous_used < ceiling <= new_used:
+        _notify_owner(
+            db,
+            org,
+            event_type=NotificationEventType.Usage.BLOCKED,
+            title=f"{label.capitalize()} limit reached",
+            body=(
+                f"Your organization is at its {label} limit{period_suffix} "
+                f"({new_used:,} of {limit:,})."
+            ),
+        )
+        return
 
-        threshold = limit * _APPROACHING_RATIO
-        if previous_used < threshold <= new_used:
-            _notify_owner(
-                db,
-                org,
-                event_type=NotificationEventType.Usage.APPROACHING_LIMIT,
-                title=f"{label.title()} approaching limit",
-                body=f"Your organization is using {new_used} of {limit} {label}.",
-            )
-    except Exception:
-        logger.exception(
-            "Failed to notify org %s owner of a %s threshold crossing", org.id, resource.value
+    threshold = limit * _APPROACHING_RATIO
+    if previous_used < threshold <= new_used:
+        percent = round(new_used / limit * 100)
+        _notify_owner(
+            db,
+            org,
+            event_type=NotificationEventType.Usage.APPROACHING_LIMIT,
+            title=f"{label.capitalize()} approaching limit",
+            body=(
+                f"Your organization is using {new_used:,} of {limit:,} {label}."
+                if resource in _STOCK_COUNTERS
+                else f"Your organization has used {percent}% of its {label} for this period."
+            ),
         )
 
 
 def _notify_owner(
     db: Session, org: Organization, *, event_type: str, title: str, body: str
 ) -> None:
-    notify(
-        db,
-        event_type=event_type,
-        rendered=RenderedNotification(title=title, body=body),
-        user_id=str(org.owner_id),
-        organization_id=str(org.id),
-        project_id=None,
-    )
+    """Write the notification org-wide (``project_id`` NULL).
+
+    The explicit no-project scope is required, not tidiness: `auto_stamp`
+    (`models/scope_events.py`) fills a ``None`` ``project_id`` from the
+    session's scope, and the stock-resource callers run inside a
+    project-scoped request. Without this the row would be stamped with
+    whichever project the acting admin happened to have selected, and
+    `auto_filter` plus the RESTRICTIVE ``project_isolation`` RLS policy
+    would then hide it from the owner in every *other* project. A quota
+    crossing is about the organization, not one project inside it.
+    """
+    with temporary_project_scope(db, str(org.id), str(org.owner_id), ""):
+        notify(
+            db,
+            event_type=event_type,
+            rendered=RenderedNotification(title=title, body=body),
+            user_id=str(org.owner_id),
+            organization_id=str(org.id),
+            project_id=None,
+        )

--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -6,6 +6,53 @@ import pluginImport from 'eslint-plugin-import';
 import { configs as typescriptConfigs } from 'typescript-eslint';
 import globals from 'globals';
 
+// Prevent dark-mode regressions: GREYSCALE.light.* and GREYSCALE.dark.* are
+// raw static tokens; use theme.palette.greyscale.* in sx callbacks instead.
+// Shared across three rule blocks below (the base ruleset, and the two
+// overrides that replace no-restricted-syntax outright for their files),
+// so this guard doesn't drift between copies. Only src/styles/theme.ts and
+// src/styles/theme-constants.ts are exempt (see the override further down).
+const GREYSCALE_NO_RESTRICTED_SYNTAX = [
+  {
+    selector:
+      "MemberExpression[object.object.name='GREYSCALE'][object.property.name='light']",
+    message:
+      'Use theme.palette.greyscale.* in an sx callback instead of GREYSCALE.light.* (dark-mode regression risk). Only src/styles/theme*.ts is exempt.',
+  },
+  {
+    selector:
+      "MemberExpression[object.object.name='GREYSCALE'][object.property.name='dark']",
+    message:
+      'Use theme.palette.greyscale.* in an sx callback instead of GREYSCALE.dark.* (dark-mode regression risk). Only src/styles/theme*.ts is exempt.',
+  },
+];
+
+// Open-core boundary guard: core (apps/frontend/) must never statically
+// import EE code. The only sanctioned bridge is apps/frontend/src/
+// ee_bootstrap.ts, exempted in its own override below. EE code may import
+// freely from core; the inverse is what this forbids. Shared between the
+// base ruleset's no-restricted-imports and the src/hooks/ override, which
+// redeclares it (rather than disabling the rule outright) so this boundary
+// still applies inside src/hooks/.
+const EE_BOUNDARY_IMPORT_PATTERNS = [
+  {
+    group: ['@rhesis/ee-frontend', '@rhesis/ee-frontend/*'],
+    message:
+      'Core frontend may not import from @rhesis/ee-frontend. Plug into a registry in @/lib/extension-registries instead, and register from ee/frontend/src/bootstrap.ts. The only sanctioned exception is apps/frontend/src/ee_bootstrap.ts.',
+  },
+  {
+    group: [
+      '../../../../../ee/frontend/*',
+      '../../../../ee/frontend/*',
+      '../../../ee/frontend/*',
+      '../../ee/frontend/*',
+      '../ee/frontend/*',
+    ],
+    message:
+      'Use the @rhesis/ee-frontend package rather than relative paths into ee/frontend/. (Note: relative imports of EE from core are forbidden anyway -- see the @rhesis/ee-frontend rule.)',
+  },
+];
+
 export default [
   {
     ignores: [
@@ -84,9 +131,7 @@ export default [
       'react/jsx-uses-react': 'off',
       'react/jsx-uses-vars': 'error',
 
-      // Prevent dark-mode regressions: GREYSCALE.light.* and GREYSCALE.dark.*
-      // are raw static tokens; use theme.palette.greyscale.* in sx callbacks instead.
-      // Only src/styles/theme.ts and src/styles/theme-constants.ts are exempt.
+      // GREYSCALE guard (see GREYSCALE_NO_RESTRICTED_SYNTAX above), plus:
       //
       // Stock-resource mutation boundary.
       //
@@ -100,18 +145,7 @@ export default [
       // rule for src/hooks/** without these entries.
       'no-restricted-syntax': [
         'error',
-        {
-          selector:
-            "MemberExpression[object.object.name='GREYSCALE'][object.property.name='light']",
-          message:
-            'Use theme.palette.greyscale.* in an sx callback instead of GREYSCALE.light.* (dark-mode regression risk). Only src/styles/theme*.ts is exempt.',
-        },
-        {
-          selector:
-            "MemberExpression[object.object.name='GREYSCALE'][object.property.name='dark']",
-          message:
-            'Use theme.palette.greyscale.* in an sx callback instead of GREYSCALE.dark.* (dark-mode regression risk). Only src/styles/theme*.ts is exempt.',
-        },
+        ...GREYSCALE_NO_RESTRICTED_SYNTAX,
         {
           selector: "CallExpression[callee.property.name='createProject']",
           message:
@@ -139,12 +173,7 @@ export default [
         },
       ],
 
-      // Open-core boundary guard.
-      //
-      // Core (apps/frontend/) must never statically import EE code. The
-      // only sanctioned bridge is apps/frontend/src/ee_bootstrap.ts,
-      // which is exempted in the override below. EE code may import
-      // freely from core; the inverse is what we forbid here.
+      // EE boundary guard (see EE_BOUNDARY_IMPORT_PATTERNS above), plus:
       //
       // The `paths` entry below is a second instance of the stock-resource
       // mutation boundary described above: createEndpoint is a server
@@ -168,24 +197,7 @@ export default [
                 'Call useCreateEndpoint() from @/hooks/useCreateEndpoint instead of the server action directly -- it invalidates the endpoints list and the usage cache on success.',
             },
           ],
-          patterns: [
-            {
-              group: ['@rhesis/ee-frontend', '@rhesis/ee-frontend/*'],
-              message:
-                'Core frontend may not import from @rhesis/ee-frontend. Plug into a registry in @/lib/extension-registries instead, and register from ee/frontend/src/bootstrap.ts. The only sanctioned exception is apps/frontend/src/ee_bootstrap.ts.',
-            },
-            {
-              group: [
-                '../../../../../ee/frontend/*',
-                '../../../../ee/frontend/*',
-                '../../../ee/frontend/*',
-                '../../ee/frontend/*',
-                '../ee/frontend/*',
-              ],
-              message:
-                'Use the @rhesis/ee-frontend package rather than relative paths into ee/frontend/. (Note: relative imports of EE from core are forbidden anyway -- see the @rhesis/ee-frontend rule.)',
-            },
-          ],
+          patterns: EE_BOUNDARY_IMPORT_PATTERNS,
         },
       ],
     },
@@ -207,43 +219,10 @@ export default [
     // name without going through a hook).
     files: ['src/hooks/**/*.{ts,tsx}', 'src/utils/api-client/**/*.{ts,tsx}'],
     rules: {
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector:
-            "MemberExpression[object.object.name='GREYSCALE'][object.property.name='light']",
-          message:
-            'Use theme.palette.greyscale.* in an sx callback instead of GREYSCALE.light.* (dark-mode regression risk). Only src/styles/theme*.ts is exempt.',
-        },
-        {
-          selector:
-            "MemberExpression[object.object.name='GREYSCALE'][object.property.name='dark']",
-          message:
-            'Use theme.palette.greyscale.* in an sx callback instead of GREYSCALE.dark.* (dark-mode regression risk). Only src/styles/theme*.ts is exempt.',
-        },
-      ],
+      'no-restricted-syntax': ['error', ...GREYSCALE_NO_RESTRICTED_SYNTAX],
       'no-restricted-imports': [
         'error',
-        {
-          patterns: [
-            {
-              group: ['@rhesis/ee-frontend', '@rhesis/ee-frontend/*'],
-              message:
-                'Core frontend may not import from @rhesis/ee-frontend. Plug into a registry in @/lib/extension-registries instead, and register from ee/frontend/src/bootstrap.ts. The only sanctioned exception is apps/frontend/src/ee_bootstrap.ts.',
-            },
-            {
-              group: [
-                '../../../../../ee/frontend/*',
-                '../../../../ee/frontend/*',
-                '../../../ee/frontend/*',
-                '../../ee/frontend/*',
-                '../ee/frontend/*',
-              ],
-              message:
-                'Use the @rhesis/ee-frontend package rather than relative paths into ee/frontend/. (Note: relative imports of EE from core are forbidden anyway -- see the @rhesis/ee-frontend rule.)',
-            },
-          ],
-        },
+        { patterns: EE_BOUNDARY_IMPORT_PATTERNS },
       ],
     },
   },
@@ -263,7 +242,8 @@ export default [
     // project cookie via next/headers.
     //
     // Note: this override REPLACES no-restricted-syntax for matching files, so the
-    // GREYSCALE selectors are repeated here to keep that protection in place.
+    // GREYSCALE selectors are repeated here (via the shared constant) to keep that
+    // protection in place.
     //
     // Server Components (page.tsx / layout.tsx) are intentionally NOT covered:
     // many of those files are 'use client' and legitimately construct
@@ -274,18 +254,7 @@ export default [
     rules: {
       'no-restricted-syntax': [
         'error',
-        {
-          selector:
-            "MemberExpression[object.object.name='GREYSCALE'][object.property.name='light']",
-          message:
-            'Use theme.palette.greyscale.* in an sx callback instead of GREYSCALE.light.* (dark-mode regression risk). Only src/styles/theme*.ts is exempt.',
-        },
-        {
-          selector:
-            "MemberExpression[object.object.name='GREYSCALE'][object.property.name='dark']",
-          message:
-            'Use theme.palette.greyscale.* in an sx callback instead of GREYSCALE.dark.* (dark-mode regression risk). Only src/styles/theme*.ts is exempt.',
-        },
+        ...GREYSCALE_NO_RESTRICTED_SYNTAX,
         {
           selector: "NewExpression[callee.name='ApiClientFactory']",
           message:

--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -87,6 +87,17 @@ export default [
       // Prevent dark-mode regressions: GREYSCALE.light.* and GREYSCALE.dark.*
       // are raw static tokens; use theme.palette.greyscale.* in sx callbacks instead.
       // Only src/styles/theme.ts and src/styles/theme-constants.ts are exempt.
+      //
+      // Stock-resource mutation boundary.
+      //
+      // Creating or deleting an endpoint, project, or user changes the
+      // cached /usage count, so the call must also invalidate that cache
+      // (see useInvalidateUsage). Calling the API client directly makes it
+      // easy to forget that step, so these methods may only be called from
+      // inside src/hooks/ (useCreateEndpoint in its own file, useDeleteEndpoint,
+      // useCreateProject, useDeleteProject, useCreateUser, useDeleteUser),
+      // which do it once, centrally. The override below re-declares this
+      // rule for src/hooks/** without these entries.
       'no-restricted-syntax': [
         'error',
         {
@@ -101,6 +112,31 @@ export default [
           message:
             'Use theme.palette.greyscale.* in an sx callback instead of GREYSCALE.dark.* (dark-mode regression risk). Only src/styles/theme*.ts is exempt.',
         },
+        {
+          selector: "CallExpression[callee.property.name='createProject']",
+          message:
+            'Call useCreateProject() from @/hooks/useEndpoints instead of the API client directly -- it invalidates the usage cache on success.',
+        },
+        {
+          selector: "CallExpression[callee.property.name='deleteProject']",
+          message:
+            'Call useDeleteProject() from @/hooks/useEndpoints instead of the API client directly -- it invalidates the usage cache on success.',
+        },
+        {
+          selector: "CallExpression[callee.property.name='deleteEndpoint']",
+          message:
+            'Call useDeleteEndpoint() from @/hooks/useEndpoints instead of the API client directly -- it invalidates the usage cache on success.',
+        },
+        {
+          selector: "CallExpression[callee.property.name='createUser']",
+          message:
+            'Call useCreateUser() from @/hooks/useUsers instead of the API client directly -- it invalidates the usage cache on success.',
+        },
+        {
+          selector: "CallExpression[callee.property.name='deleteUser']",
+          message:
+            'Call useDeleteUser() from @/hooks/useUsers instead of the API client directly -- it invalidates the usage cache on success.',
+        },
       ],
 
       // Open-core boundary guard.
@@ -109,9 +145,29 @@ export default [
       // only sanctioned bridge is apps/frontend/src/ee_bootstrap.ts,
       // which is exempted in the override below. EE code may import
       // freely from core; the inverse is what we forbid here.
+      //
+      // The `paths` entry below is a second instance of the stock-resource
+      // mutation boundary described above: createEndpoint is a server
+      // action rather than an API client method, so it needs an import
+      // restriction instead of a call-expression one. Only useCreateEndpoint
+      // (src/hooks/useEndpoints.ts) may import it.
       'no-restricted-imports': [
         'error',
         {
+          paths: [
+            {
+              name: '@/actions/endpoints',
+              importNames: ['createEndpoint'],
+              message:
+                'Call useCreateEndpoint() from @/hooks/useCreateEndpoint instead of the server action directly -- it invalidates the endpoints list and the usage cache on success.',
+            },
+            {
+              name: '@/actions/endpoints/create',
+              importNames: ['createEndpoint'],
+              message:
+                'Call useCreateEndpoint() from @/hooks/useCreateEndpoint instead of the server action directly -- it invalidates the endpoints list and the usage cache on success.',
+            },
+          ],
           patterns: [
             {
               group: ['@rhesis/ee-frontend', '@rhesis/ee-frontend/*'],
@@ -139,6 +195,56 @@ export default [
     files: ['src/ee_bootstrap.ts'],
     rules: {
       'no-restricted-imports': 'off',
+    },
+  },
+  {
+    // Mutation hooks are the sanctioned place to call these stock-resource
+    // mutations directly -- the entries above enforce "go through the hook"
+    // everywhere else. Redeclare (rather than disable) the other entries in
+    // each rule so the EE boundary and the GREYSCALE guard still apply
+    // inside src/hooks/ and src/utils/api-client/ (the client methods
+    // themselves, and their own unit tests, legitimately call each other by
+    // name without going through a hook).
+    files: ['src/hooks/**/*.{ts,tsx}', 'src/utils/api-client/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "MemberExpression[object.object.name='GREYSCALE'][object.property.name='light']",
+          message:
+            'Use theme.palette.greyscale.* in an sx callback instead of GREYSCALE.light.* (dark-mode regression risk). Only src/styles/theme*.ts is exempt.',
+        },
+        {
+          selector:
+            "MemberExpression[object.object.name='GREYSCALE'][object.property.name='dark']",
+          message:
+            'Use theme.palette.greyscale.* in an sx callback instead of GREYSCALE.dark.* (dark-mode regression risk). Only src/styles/theme*.ts is exempt.',
+        },
+      ],
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@rhesis/ee-frontend', '@rhesis/ee-frontend/*'],
+              message:
+                'Core frontend may not import from @rhesis/ee-frontend. Plug into a registry in @/lib/extension-registries instead, and register from ee/frontend/src/bootstrap.ts. The only sanctioned exception is apps/frontend/src/ee_bootstrap.ts.',
+            },
+            {
+              group: [
+                '../../../../../ee/frontend/*',
+                '../../../../ee/frontend/*',
+                '../../../ee/frontend/*',
+                '../../ee/frontend/*',
+                '../ee/frontend/*',
+              ],
+              message:
+                'Use the @rhesis/ee-frontend package rather than relative paths into ee/frontend/. (Note: relative imports of EE from core are forbidden anyway -- see the @rhesis/ee-frontend rule.)',
+            },
+          ],
+        },
+      ],
     },
   },
   {

--- a/apps/frontend/jest.setup.js
+++ b/apps/frontend/jest.setup.js
@@ -22,6 +22,11 @@ if (hasWindow) {
 global.TextEncoder = global.TextEncoder || require('util').TextEncoder;
 global.TextDecoder = global.TextDecoder || require('util').TextDecoder;
 
+// jsdom has no ReadableStream; Node's own (stream/web) is what a real
+// fetch Response.body would be, so this is a polyfill, not a mock.
+global.ReadableStream =
+  global.ReadableStream || require('stream/web').ReadableStream;
+
 // Mock Next.js router
 jest.mock('next/router', () => ({
   useRouter() {

--- a/apps/frontend/src/__tests__/components/navigation/Sidebar.test.tsx
+++ b/apps/frontend/src/__tests__/components/navigation/Sidebar.test.tsx
@@ -26,6 +26,20 @@ jest.mock('@/components/common/UserAvatar', () => ({
   UserAvatar: () => <div data-testid="user-avatar" />,
 }));
 
+const mockUnreadBySection: { current: Record<string, number> } = {
+  current: {},
+};
+jest.mock('@/contexts/NotificationsContext', () => ({
+  useNotifications: () => ({
+    unreadBySection: mockUnreadBySection.current,
+    markSectionRead: jest.fn(),
+    markOneRead: jest.fn(),
+    highlightedIds: () => [],
+    clearHighlight: jest.fn(),
+    registerViewing: () => () => {},
+  }),
+}));
+
 jest.mock('@/components/common/ThemeAwareLogo', () => ({
   __esModule: true,
   default: () => <div data-testid="theme-logo" />,
@@ -42,6 +56,28 @@ jest.mock('@/components/providers/ThemeProvider', () => ({
   }),
 }));
 
+const mockUsageResources: {
+  current: Record<
+    string,
+    {
+      used: number;
+      limit: number | null;
+      ceiling: number | null;
+      kind: 'stock' | 'flow';
+      period_start: string;
+      period_end: string;
+    }
+  >;
+} = { current: {} };
+jest.mock('@/contexts/UsageContext', () => ({
+  useUsage: () => ({
+    resources: mockUsageResources.current,
+    edition: 'community',
+    loading: false,
+    error: null,
+  }),
+}));
+
 // ── imports (after mocks) ──────────────────────────────────────────────────
 import { usePathname } from 'next/navigation';
 import { useSession } from 'next-auth/react';
@@ -49,6 +85,7 @@ import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 import { useSidebarCollapse } from '@/components/layout/AppShell';
 import { Sidebar } from '@/components/navigation/Sidebar';
 import type { NavigationItem } from '@/types/navigation';
+import { QuotaResource } from '@/constants/quota';
 
 // ── helper ────────────────────────────────────────────────────────────────
 function setupMocks({
@@ -79,6 +116,8 @@ describe('Sidebar', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockRouterPush.mockClear();
+    mockUnreadBySection.current = {};
+    mockUsageResources.current = {};
   });
 
   it('renders without crashing', () => {
@@ -181,6 +220,30 @@ describe('Sidebar', () => {
       ).toBeInTheDocument();
     });
 
+    it('fills a usage row bar to how much of the limit is used', () => {
+      mockUsageResources.current = {
+        [QuotaResource.PROJECTS]: {
+          used: 1,
+          limit: 1,
+          ceiling: 1,
+          kind: 'stock',
+          period_start: '2026-08-01',
+          period_end: '2026-08-31',
+        },
+      };
+      setupMocks();
+      (useNavigationItems as jest.Mock).mockReturnValue({
+        navigation: [],
+        branding: { title: 'Acme Corp', logo: null, homeUrl: '/architect' },
+      });
+      render(<Sidebar />);
+      fireEvent.click(screen.getByText('Acme Corp'));
+
+      expect(screen.getByText('1 of 1')).toBeInTheDocument();
+      const fill = screen.getByTestId('usage-row-fill');
+      expect(getComputedStyle(fill).width).toBe('100%');
+    });
+
     it('navigates to org settings when Org Settings is clicked', () => {
       setupMocks();
       (useNavigationItems as jest.Mock).mockReturnValue({
@@ -221,5 +284,18 @@ describe('Sidebar', () => {
     });
     render(<Sidebar />);
     expect(screen.getByText('User')).toBeInTheDocument();
+  });
+
+  it('badges the avatar with the total unread count, so notifications are visible without opening the menu', () => {
+    mockUnreadBySection.current = { 'test-runs': 2, usage: 1 };
+    setupMocks();
+    render(<Sidebar />);
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('does not badge the avatar when nothing is unread', () => {
+    setupMocks();
+    render(<Sidebar />);
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/useEndpointDetail.ts
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/useEndpointDetail.ts
@@ -10,7 +10,7 @@ import {
   EndpointEditData,
 } from '@/utils/api-client/interfaces/endpoint';
 import { Project } from '@/utils/api-client/interfaces/project';
-import { createEndpoint } from '@/actions/endpoints';
+import { useCreateEndpoint } from '@/hooks/useCreateEndpoint';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { BORDER_RADIUS } from '@/styles/theme-constants';
@@ -24,6 +24,7 @@ export function useEndpointDetail(initialEndpoint: Endpoint) {
   const { data: session, status } = useSession();
   const notifications = useNotifications();
   const queryClient = useQueryClient();
+  const createEndpoint = useCreateEndpoint();
 
   const [endpoint, setEndpoint] = useState<Endpoint>(initialEndpoint);
   const [isDuplicating, setIsDuplicating] = useState(false);
@@ -168,7 +169,7 @@ export function useEndpointDetail(initialEndpoint: Endpoint) {
     } finally {
       setIsDuplicating(false);
     }
-  }, [endpoint, notifications, router]);
+  }, [endpoint, notifications, router, createEndpoint]);
 
   return {
     endpoint,

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointCreateDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointCreateDrawer.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useRef, useState } from 'react';
 import BaseDrawer from '@/components/common/BaseDrawer';
+import { QuotaResource } from '@/constants/quota';
+import { useQuotaGate } from '@/hooks/useQuotaGate';
 import EndpointForm, { type EndpointFormHandle } from './EndpointForm';
 
 interface EndpointCreateDrawerProps {
@@ -23,6 +25,8 @@ export default function EndpointCreateDrawer({
     canSubmit: false,
   });
 
+  const endpointQuota = useQuotaGate(QuotaResource.ENDPOINTS);
+
   const handleCreated = useCallback(() => {
     onCreated?.();
     onClose();
@@ -37,8 +41,12 @@ export default function EndpointCreateDrawer({
       onSave={() => formRef.current?.submit()}
       saveButtonText="Create endpoint"
       saveDataTour="create-endpoint-save"
-      saveDisabled={!submitState.canSubmit}
+      saveDisabled={!submitState.canSubmit || endpointQuota.exhausted}
       loading={submitState.isSubmitting}
+      // The gate goes on the submit, never on the FAB that opens this drawer:
+      // a disabled FAB leaves the explanation nowhere to live. The form's own
+      // 402 handling covers the case where usage changes mid-edit.
+      error={endpointQuota.notice}
     >
       {open ? (
         <EndpointForm

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
@@ -15,12 +15,12 @@ import ActionBar from '@/components/common/ActionBar';
 import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useTestEndpoint } from '@/hooks/useEndpoints';
+import { useCreateEndpoint } from '@/hooks/useCreateEndpoint';
 import {
   AutoConfigureResult,
   Endpoint,
 } from '@/utils/api-client/interfaces/endpoint';
 import { Project } from '@/utils/api-client/interfaces/project';
-import { createEndpoint } from '@/actions/endpoints';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { useOnboarding } from '@/contexts/OnboardingContext';
 import { readActiveProjectId } from '@/utils/active-project';
@@ -136,6 +136,7 @@ const EndpointForm = forwardRef<EndpointFormHandle, EndpointFormProps>(
     const notifications = useNotifications();
     const { markStepComplete } = useOnboarding();
     const testEndpointMutation = useTestEndpoint();
+    const createEndpoint = useCreateEndpoint();
 
     const [formData, setFormData] = useState<FormData>({
       name: '',
@@ -389,6 +390,7 @@ const EndpointForm = forwardRef<EndpointFormHandle, EndpointFormProps>(
       formData,
       reqBody,
       resBody,
+      createEndpoint,
       markStepComplete,
       notifications,
       onCreated,

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
@@ -24,6 +24,7 @@ import { Project } from '@/utils/api-client/interfaces/project';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { useOnboarding } from '@/contexts/OnboardingContext';
 import { readActiveProjectId } from '@/utils/active-project';
+import { getApiErrorMessage } from '@/utils/error-utils';
 import AutoConfigureDrawer from './AutoConfigureDrawer';
 import TabOverview from './TabOverview';
 import TabConnection from './TabConnection';
@@ -369,7 +370,17 @@ const EndpointForm = forwardRef<EndpointFormHandle, EndpointFormProps>(
             formData.auth_token;
         }
 
-        await createEndpoint(endpointData as Omit<Endpoint, 'id'>);
+        const result = await createEndpoint(
+          endpointData as Omit<Endpoint, 'id'>
+        );
+        if (!result.success) {
+          // createEndpoint never throws on a business failure (a 402 from
+          // an exhausted endpoints quota included) -- it returns
+          // {success: false, error} instead, per its own doc comment.
+          // Both callers used to ignore that and show "created
+          // successfully" regardless.
+          throw new Error(result.error);
+        }
         markStepComplete('endpointSetup');
         notifications.show('Endpoint created successfully!', {
           severity: 'success',
@@ -382,7 +393,7 @@ const EndpointForm = forwardRef<EndpointFormHandle, EndpointFormProps>(
           );
         }
       } catch (err) {
-        setError((err as Error).message);
+        setError(getApiErrorMessage(err, 'Failed to create endpoint.'));
       } finally {
         setIsSubmitting(false);
       }

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -38,8 +38,8 @@ import {
 } from '@/components/common/createRowActionsColumn';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
+import { useDeleteEndpoint } from '@/hooks/useEndpoints';
 import { getProjectIcon } from './endpoint-icon-utils';
-import { useQueryClient } from '@tanstack/react-query';
 import { endpointKeys } from '@/constants/query-keys';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
@@ -123,7 +123,7 @@ export default function EndpointsGrid({
   const notifications = useNotifications();
   const canEditEndpoint = useCan(Capability.Endpoint.UPDATE);
   const canDeleteEndpoint = useCan(Capability.Endpoint.DELETE);
-  const queryClient = useQueryClient();
+  const deleteEndpoint = useDeleteEndpoint();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [drawerFilters, setDrawerFilters] = useState<EndpointFilters>(
@@ -260,25 +260,14 @@ export default function EndpointsGrid({
     }
   }, [status]);
 
-  const handleRefresh = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: endpointKeys.all() });
-  }, [queryClient]);
-
   const handleDeleteEndpoints = async () => {
     if (!isAuthenticated(status) || !pendingDeleteId) return;
-    const idsToDelete = [pendingDeleteId];
 
     try {
       setDeleting(true);
-      const endpointsClient = new ApiClientFactory().getEndpointsClient();
-
-      await Promise.all(
-        idsToDelete.map(id => endpointsClient.deleteEndpoint(id))
-      );
-
+      await deleteEndpoint.mutateAsync(pendingDeleteId);
       setPendingDeleteId(null);
       setDeleteDialogOpen(false);
-      handleRefresh();
     } catch {
       notifications.show('Failed to delete endpoints', { severity: 'error' });
     } finally {

--- a/apps/frontend/src/app/(protected)/endpoints/components/SwaggerEndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/SwaggerEndpointForm.tsx
@@ -30,6 +30,7 @@ import { useSession } from 'next-auth/react';
 import { useOnboarding } from '@/contexts/OnboardingContext';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { readActiveProjectId } from '@/utils/active-project';
+import { getApiErrorMessage } from '@/utils/error-utils';
 
 import { getProjectIcon, ENVIRONMENTS } from './endpoint-icon-utils';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
@@ -127,7 +128,17 @@ export default function SwaggerEndpointForm() {
 
     setIsSubmitting(true);
     try {
-      await createEndpoint(formData as unknown as Omit<Endpoint, 'id'>);
+      const result = await createEndpoint(
+        formData as unknown as Omit<Endpoint, 'id'>
+      );
+      if (!result.success) {
+        // createEndpoint never throws on a business failure (a 402 from
+        // an exhausted endpoints quota included) -- it returns
+        // {success: false, error} instead, per its own doc comment.
+        // Both callers used to ignore that and show "created
+        // successfully" regardless.
+        throw new Error(result.error);
+      }
 
       // Mark onboarding step as complete
       markStepComplete('endpointSetup');
@@ -141,7 +152,7 @@ export default function SwaggerEndpointForm() {
         projectIdFromUrl ? `/projects/${projectIdFromUrl}` : '/endpoints'
       );
     } catch (error) {
-      setError((error as Error).message);
+      setError(getApiErrorMessage(error, 'Failed to create endpoint.'));
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/frontend/src/app/(protected)/endpoints/components/SwaggerEndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/SwaggerEndpointForm.tsx
@@ -22,7 +22,7 @@ import {
   FormHelperText,
 } from '@mui/material';
 import DownloadIcon from '@mui/icons-material/Download';
-import { createEndpoint } from '@/actions/endpoints';
+import { useCreateEndpoint } from '@/hooks/useCreateEndpoint';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import { Project } from '@/utils/api-client/interfaces/project';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -47,6 +47,7 @@ export default function SwaggerEndpointForm() {
   const { data: session, status } = useSession();
   const { markStepComplete } = useOnboarding();
   const notifications = useNotifications();
+  const createEndpoint = useCreateEndpoint();
 
   const [formData, setFormData] = useState({
     name: '',

--- a/apps/frontend/src/app/(protected)/endpoints/components/__tests__/EndpointFormAutoConfigure.test.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/__tests__/EndpointFormAutoConfigure.test.tsx
@@ -21,8 +21,9 @@ jest.mock(
   }
 );
 
+const mockRouterPush = jest.fn();
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  useRouter: () => ({ push: mockRouterPush, replace: jest.fn() }),
   // Supply a project identifier so project_id is pre-filled and step 0 is valid
   useParams: () => ({ identifier: 'proj-1' }),
 }));
@@ -51,8 +52,9 @@ jest.mock('@monaco-editor/react', () => {
   return { __esModule: true, default: MockEditor };
 });
 
+const mockNotificationsShow = jest.fn();
 jest.mock('@/components/common/NotificationContext', () => ({
-  useNotifications: () => ({ show: jest.fn() }),
+  useNotifications: () => ({ show: mockNotificationsShow }),
 }));
 
 jest.mock('@/contexts/OnboardingContext', () => ({
@@ -74,8 +76,9 @@ jest.mock('@/utils/api-client/client-factory', () => ({
   })),
 }));
 
+const mockCreateEndpoint = jest.fn();
 jest.mock('@/actions/endpoints', () => ({
-  createEndpoint: jest.fn(),
+  createEndpoint: (...args: unknown[]) => mockCreateEndpoint(...args),
 }));
 
 jest.mock('@/actions/endpoints/auto-configure', () => ({
@@ -164,5 +167,75 @@ describe('EndpointForm — Body step auto-configure', () => {
 
     // Auth token should now be visible in the Connection tab
     expect(screen.getByLabelText(/api token/i)).toBeInTheDocument();
+  });
+});
+
+describe('EndpointForm — submit result handling', () => {
+  beforeEach(() => {
+    mockCreateEndpoint.mockReset();
+    mockNotificationsShow.mockClear();
+    mockRouterPush.mockClear();
+  });
+
+  async function fillRequiredFieldsAndSubmit(
+    user: ReturnType<typeof userEvent.setup>
+  ) {
+    await waitFor(() =>
+      expect(screen.queryByText('Loading projects...')).not.toBeInTheDocument()
+    );
+    await user.type(screen.getByLabelText(/endpoint name/i), 'My Endpoint');
+    await user.click(screen.getByRole('tab', { name: /connection/i }));
+    await user.type(
+      screen.getByLabelText(/endpoint url/i),
+      'https://api.example.com'
+    );
+    await user.click(screen.getByRole('button', { name: /save endpoint/i }));
+  }
+
+  it('shows success and navigates when createEndpoint succeeds', async () => {
+    mockCreateEndpoint.mockResolvedValue({
+      success: true,
+      data: { id: 'ep-1' },
+    });
+    const user = userEvent.setup({ delay: null });
+    render(<EndpointForm />);
+
+    await fillRequiredFieldsAndSubmit(user);
+
+    await waitFor(() =>
+      expect(mockNotificationsShow).toHaveBeenCalledWith(
+        'Endpoint created successfully!',
+        expect.objectContaining({ severity: 'success' })
+      )
+    );
+    expect(mockRouterPush).toHaveBeenCalledWith('/projects/proj-1');
+  });
+
+  it('shows the backend error and does not navigate when the org is over its endpoints quota', async () => {
+    // createEndpoint never throws on a business failure -- it returns
+    // {success: false, error}. Both callers used to ignore that and show
+    // "created successfully" regardless.
+    mockCreateEndpoint.mockResolvedValue({
+      success: false,
+      error:
+        'API error: 402 - Your organization is at its endpoints limit (1 of 1).',
+    });
+    const user = userEvent.setup({ delay: null });
+    render(<EndpointForm />);
+
+    await fillRequiredFieldsAndSubmit(user);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'Your organization is at its endpoints limit (1 of 1).'
+        )
+      ).toBeInTheDocument()
+    );
+    expect(mockNotificationsShow).not.toHaveBeenCalledWith(
+      'Endpoint created successfully!',
+      expect.anything()
+    );
+    expect(mockRouterPush).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/(protected)/endpoints/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/page.tsx
@@ -17,6 +17,7 @@ import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
 import { isAuthenticated, isSessionLoading } from '@/hooks/useIsAuthenticated';
+import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
 
 export default function EndpointsPage() {
   const { status } = useSession();
@@ -48,11 +49,15 @@ export default function EndpointsPage() {
     setCreateDrawerOpen(true);
   }, []);
 
+  const invalidateUsage = useInvalidateUsage();
+
   const handleCreateSuccess = React.useCallback(() => {
     setCreateDrawerOpen(false);
     setCreateProjectId(undefined);
     queryClient.invalidateQueries({ queryKey: endpointKeys.all() });
-  }, [queryClient]);
+    // Endpoints are a stock resource, so the cached /usage count is now stale.
+    invalidateUsage();
+  }, [queryClient, invalidateUsage]);
 
   if (isSessionLoading(status)) {
     return (

--- a/apps/frontend/src/app/(protected)/explorer/[identifier]/components/SuggestionsDialog.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/[identifier]/components/SuggestionsDialog.tsx
@@ -464,6 +464,19 @@ export default function SuggestionsDialog({
                 break;
               }
 
+              // ── Pipeline-level failure before any suggestion could be
+              // produced (e.g. quota exhaustion during model resolution) --
+              // distinct from the per-item `error` field on output/evaluation
+              // events, which reports one row failing while the rest of the
+              // pipeline keeps going.
+              case 'error': {
+                setTestGenStatus('idle');
+                setOutputsStatus('idle');
+                setMetricsStatus('idle');
+                setError(event.message);
+                break;
+              }
+
               case 'done': {
                 break;
               }

--- a/apps/frontend/src/app/(protected)/onboarding/components/OnboardingPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/components/OnboardingPageClient.tsx
@@ -16,6 +16,8 @@ import { UUID } from 'crypto';
 import { UserUpdate } from '@/utils/api-client/interfaces/user';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { writeActiveProjectId } from '@/utils/active-project';
+import { useCreateProject } from '@/hooks/useEndpoints';
+import { useCreateUser } from '@/hooks/useUsers';
 
 type OnboardingStatus =
   | 'idle'
@@ -60,6 +62,8 @@ export default function OnboardingPageClient({
 
   const organizationsClient = new ApiClientFactory().getOrganizationsClient();
   const usersClient = new ApiClientFactory().getUsersClient();
+  const createUser = useCreateUser();
+  const createProject = useCreateProject();
 
   const completingRef = React.useRef(false);
 
@@ -149,8 +153,6 @@ export default function OnboardingPageClient({
         const authenticatedUsersClient = authenticatedFactory.getUsersClient();
         const authenticatedOrganizationsClient =
           authenticatedFactory.getOrganizationsClient();
-        const authenticatedProjectsClient =
-          authenticatedFactory.getProjectsClient();
 
         try {
           const validEmails = formData.invites
@@ -173,8 +175,7 @@ export default function OnboardingPageClient({
               };
 
               try {
-                const user =
-                  await authenticatedUsersClient.createUser(userData);
+                const user = await createUser(userData);
                 invitationResults.push({ email, success: true });
                 return user;
               } catch (error: unknown) {
@@ -265,8 +266,7 @@ export default function OnboardingPageClient({
             icon: 'SmartToy',
           };
 
-          const createdProject =
-            await authenticatedProjectsClient.createProject(projectData);
+          const createdProject = await createProject(projectData);
 
           writeActiveProjectId(String(createdProject.id));
           await authenticatedUsersClient.updateUserSettings({

--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteForm.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteForm.tsx
@@ -42,7 +42,7 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { safeRandomUUID } from '@/utils/uuid';
 import { UUID } from 'crypto';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
-import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
+import { useCreateUser } from '@/hooks/useUsers';
 import { QuotaResource } from '@/constants/quota';
 import { useQuotaMessageFor } from '@/hooks/useQuotaGate';
 
@@ -83,7 +83,7 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
   ) {
     const { data: session, status } = useSession();
     const notifications = useNotifications();
-    const invalidateUsage = useInvalidateUsage();
+    const createUser = useCreateUser();
     const seatQuotaMessage = useQuotaMessageFor(QuotaResource.SEATS);
     const { projects: availableProjects } = useActiveProject();
     const {
@@ -219,10 +219,9 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
         }
 
         const clientFactory = new ApiClientFactory();
-        const usersClient = clientFactory.getUsersClient();
 
         type InviteResult = {
-          user: Awaited<ReturnType<typeof usersClient.createUser>> | null;
+          user: Awaited<ReturnType<typeof createUser>> | null;
           invitation: {
             email: string;
             success: boolean;
@@ -241,7 +240,7 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
             };
 
             try {
-              const user = await usersClient.createUser(userData);
+              const user = await createUser(userData);
               if (user && invite.orgRoleId && assignOrgMemberRole) {
                 try {
                   await assignOrgMemberRole(String(user.id), invite.orgRoleId);
@@ -425,9 +424,6 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
         }
 
         if (successCount > 0) {
-          // Each accepted invite consumes a seat, and seats are a stock
-          // resource the invite gate reads from the cached /usage response.
-          invalidateUsage();
           setFormData({ invites: [createInvite()] });
           setErrors({});
           setProjectRoles({});

--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteForm.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteForm.tsx
@@ -42,6 +42,9 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { safeRandomUUID } from '@/utils/uuid';
 import { UUID } from 'crypto';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
+import { QuotaResource } from '@/constants/quota';
+import { useQuotaMessageFor } from '@/hooks/useQuotaGate';
 
 interface InviteItem {
   id: string;
@@ -80,6 +83,8 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
   ) {
     const { data: session, status } = useSession();
     const notifications = useNotifications();
+    const invalidateUsage = useInvalidateUsage();
+    const seatQuotaMessage = useQuotaMessageFor(QuotaResource.SEATS);
     const { projects: availableProjects } = useActiveProject();
     const {
       AddMemberRoleField,
@@ -196,6 +201,15 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
         const validInvites = formData.invites.filter(invite =>
           invite.email.trim()
         );
+
+        // Seats are metered per invite, so gate on how many this submit
+        // actually consumes. A toast rather than a drawer error: this form
+        // surfaces everything that way and has no drawer-level error slot.
+        const seatBlock = seatQuotaMessage(validInvites.length);
+        if (seatBlock) {
+          notifications.show(seatBlock, { severity: 'error' });
+          return;
+        }
 
         if (validInvites.length === 0) {
           notifications.show('Please enter at least one email address', {
@@ -411,6 +425,9 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
         }
 
         if (successCount > 0) {
+          // Each accepted invite consumes a seat, and seats are a stock
+          // resource the invite gate reads from the cached /usage response.
+          invalidateUsage();
           setFormData({ invites: [createInvite()] });
           setErrors({});
           setProjectRoles({});

--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
@@ -54,6 +54,7 @@ import { FeatureName } from '@/constants/features';
 import { getMemberRoleExtensions } from '@/lib/extension-registries';
 import { getMemberJoinStatus } from '@/utils/member-join-status';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
 
 interface TeamMembersGridProps {
   refreshTrigger?: number;
@@ -139,6 +140,8 @@ export default function TeamMembersGrid({
     setDeleteDialogOpen(true);
   }, []);
 
+  const invalidateUsage = useInvalidateUsage();
+
   const handleConfirmDelete = async () => {
     if (!userToDelete || !isAuthenticated(status)) {
       return;
@@ -151,6 +154,8 @@ export default function TeamMembersGrid({
       const usersClient = clientFactory.getUsersClient();
 
       await usersClient.deleteUser(userToDelete.id);
+      // Removing a member frees a seat.
+      invalidateUsage();
 
       notifications.show(
         `Successfully removed ${getDisplayName(userToDelete)} from the organization.`,

--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
@@ -54,7 +54,7 @@ import { FeatureName } from '@/constants/features';
 import { getMemberRoleExtensions } from '@/lib/extension-registries';
 import { getMemberJoinStatus } from '@/utils/member-join-status';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
-import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
+import { useDeleteUser } from '@/hooks/useUsers';
 
 interface TeamMembersGridProps {
   refreshTrigger?: number;
@@ -140,7 +140,7 @@ export default function TeamMembersGrid({
     setDeleteDialogOpen(true);
   }, []);
 
-  const invalidateUsage = useInvalidateUsage();
+  const deleteUser = useDeleteUser();
 
   const handleConfirmDelete = async () => {
     if (!userToDelete || !isAuthenticated(status)) {
@@ -150,12 +150,7 @@ export default function TeamMembersGrid({
     try {
       setDeleting(true);
 
-      const clientFactory = new ApiClientFactory();
-      const usersClient = clientFactory.getUsersClient();
-
-      await usersClient.deleteUser(userToDelete.id);
-      // Removing a member frees a seat.
-      invalidateUsage();
+      await deleteUser(userToDelete.id);
 
       notifications.show(
         `Successfully removed ${getDisplayName(userToDelete)} from the organization.`,

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
@@ -3,15 +3,15 @@
 import * as React from 'react';
 import {
   Box,
-  Button,
-  Chip,
   LinearProgress,
   Skeleton,
   Stack,
   Typography,
 } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import { SectionCard } from '@/components/common/SectionCard';
 import { FilterButton } from '@/components/common/FilterButton';
+import { PlanChip, UpgradeLink } from '@/components/common/QuotaChips';
 import { useUsageForPeriod } from '@/hooks/useUsageForPeriod';
 import UsageOverviewFilterDrawer from './UsageOverviewFilterDrawer';
 import { BORDER_RADIUS } from '@/styles/theme';
@@ -20,42 +20,13 @@ import {
   QUOTA_RESOURCE_ORDER,
   type QuotaResource,
 } from '@/constants/quota';
+import {
+  classifyZone,
+  isCommunityEdition,
+  zoneColor,
+  type QuotaZone,
+} from '@/utils/quota';
 import type { UsageResourceItem } from '@/utils/api-client/usage-client';
-
-const COMMUNITY_EDITION = 'community';
-const UPGRADE_URL = 'https://rhesis.ai/editions';
-
-function isCommunityEdition(edition: string): boolean {
-  return edition.toLowerCase() === COMMUNITY_EDITION;
-}
-
-function PlanChip({ edition }: { edition: string }) {
-  const label = `${edition.charAt(0).toUpperCase()}${edition.slice(1)} plan`;
-  return (
-    <Chip
-      label={label}
-      size="small"
-      color={isCommunityEdition(edition) ? 'default' : 'primary'}
-      sx={{ borderRadius: BORDER_RADIUS.pill, fontWeight: 600 }}
-    />
-  );
-}
-
-function UpgradeLink() {
-  return (
-    <Button
-      component="a"
-      href={UPGRADE_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-      variant="outlined"
-      size="small"
-      sx={{ borderRadius: BORDER_RADIUS.sm, fontWeight: 600 }}
-    >
-      Upgrade
-    </Button>
-  );
-}
 
 function formatPeriodDate(isoDate: string): string {
   // period_start/period_end are date-only strings (YYYY-MM-DD), computed
@@ -71,10 +42,119 @@ function formatPeriodDate(isoDate: string): string {
   });
 }
 
-function progressColor(ratio: number): 'success' | 'warning' | 'error' {
-  if (ratio >= 1) return 'error';
-  if (ratio >= 0.8) return 'warning';
-  return 'success';
+/** Ceiling caption under a meter: names the overage allowance, or says
+ * there isn't one. `limit === null` (unlimited) renders nothing -- there is
+ * no ceiling to report. */
+function CeilingCaption({
+  limit,
+  ceiling,
+}: Pick<UsageResourceItem, 'limit' | 'ceiling'>) {
+  if (limit === null) return null;
+  if (ceiling === null || ceiling === limit) {
+    return (
+      <Typography variant="caption" color="text.secondary">
+        No overage allowance on this resource
+      </Typography>
+    );
+  }
+  return (
+    <Typography variant="caption" color="text.secondary">
+      {limit.toLocaleString()} included · {ceiling.toLocaleString()} before
+      requests fail
+    </Typography>
+  );
+}
+
+/**
+ * The bar itself. Fills toward `limit` in the "included" track; when the
+ * tier grants an overage allowance (`ceiling > limit`), a second hatched
+ * track past it fills as that allowance is consumed. Zero-width on a hard
+ * tier, where `ceiling === limit`.
+ */
+function MeterBar({
+  item,
+  zone,
+}: {
+  item: UsageResourceItem;
+  zone: QuotaZone;
+}) {
+  const { used, limit, ceiling } = item;
+  const color = zoneColor(zone);
+
+  if (limit === null) {
+    return (
+      <LinearProgress
+        variant="determinate"
+        value={0}
+        color="primary"
+        sx={{
+          height: 6,
+          borderRadius: BORDER_RADIUS.xs,
+          bgcolor: theme => theme.palette.action.hover,
+        }}
+      />
+    );
+  }
+
+  const total = ceiling !== null && ceiling > limit ? ceiling : limit;
+  const includedPct = total === 0 ? 100 : (limit / total) * 100;
+  const includedFill =
+    limit === 0 ? 100 : (Math.min(used, limit) / limit) * 100;
+  const overageCapacity = total - limit;
+  const overageUsed = Math.max(0, used - limit);
+  const overageFill =
+    overageCapacity > 0
+      ? (Math.min(overageUsed, overageCapacity) / overageCapacity) * 100
+      : 0;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        height: 6,
+        borderRadius: BORDER_RADIUS.xs,
+        overflow: 'hidden',
+      }}
+    >
+      <Box
+        sx={{
+          position: 'relative',
+          width: `${includedPct}%`,
+          bgcolor: theme => theme.palette.action.hover,
+        }}
+      >
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            width: `${includedFill}%`,
+            bgcolor: theme => theme.palette[color].main,
+          }}
+        />
+      </Box>
+      {overageCapacity > 0 && (
+        <Box
+          sx={{
+            position: 'relative',
+            width: `${100 - includedPct}%`,
+            ml: '2px',
+            backgroundImage: theme =>
+              `repeating-linear-gradient(135deg, ${alpha(theme.palette[color].main, 0.25)} 0 4px, transparent 4px 8px)`,
+            bgcolor: theme => theme.palette.action.hover,
+          }}
+        >
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              width: `${overageFill}%`,
+              bgcolor: theme => theme.palette[color].main,
+            }}
+          />
+        </Box>
+      )}
+    </Box>
+  );
 }
 
 function ResourceMeter({
@@ -91,7 +171,7 @@ function ResourceMeter({
   showLiveCountHint?: boolean;
 }) {
   const { limit } = item;
-  const ratio = limit === null ? 0 : limit === 0 ? 1 : item.used / limit;
+  const zone = classifyZone(item);
 
   return (
     <Box sx={{ mb: 3, '&:last-child': { mb: 0 } }}>
@@ -116,19 +196,10 @@ function ResourceMeter({
           {limit === null ? ' (Unlimited)' : ` / ${limit.toLocaleString()}`}
         </Typography>
       </Stack>
-      <LinearProgress
-        variant="determinate"
-        value={limit === null ? 0 : Math.min(ratio, 1) * 100}
-        color={limit === null ? 'primary' : progressColor(ratio)}
-        sx={{
-          height: 6,
-          borderRadius: BORDER_RADIUS.xs,
-          bgcolor: theme => theme.palette.action.hover,
-          '& .MuiLinearProgress-bar': {
-            borderRadius: BORDER_RADIUS.xs,
-          },
-        }}
-      />
+      <MeterBar item={item} zone={zone} />
+      <Box sx={{ mt: 0.5 }}>
+        <CeilingCaption limit={item.limit} ceiling={item.ceiling} />
+      </Box>
     </Box>
   );
 }

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
@@ -101,7 +101,7 @@ describe('UsageOverviewTab', () => {
   it('shows a plan chip and an upgrade link for the community edition', () => {
     render(<UsageOverviewTab />);
 
-    expect(screen.getByText('Community plan')).toBeInTheDocument();
+    expect(screen.getByText('Community')).toBeInTheDocument();
     const upgradeLink = screen.getByRole('link', { name: 'Upgrade' });
     expect(upgradeLink).toHaveAttribute('href', 'https://rhesis.ai/editions');
     expect(upgradeLink).toHaveAttribute('target', '_blank');
@@ -184,7 +184,7 @@ describe('UsageOverviewTab', () => {
 
     render(<UsageOverviewTab />);
 
-    expect(screen.getByText('Enterprise plan')).toBeInTheDocument();
+    expect(screen.getByText('Enterprise')).toBeInTheDocument();
     expect(
       screen.queryByRole('link', { name: 'Upgrade' })
     ).not.toBeInTheDocument();

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
@@ -15,6 +15,7 @@ const USAGE_RESOURCES = {
   test_executions: {
     used: 5,
     limit: 1000,
+    ceiling: 1000,
     period_start: '2026-08-01',
     period_end: '2026-08-31',
     kind: 'flow' as const,
@@ -22,6 +23,7 @@ const USAGE_RESOURCES = {
   model_tokens: {
     used: 999,
     limit: null,
+    ceiling: null,
     period_start: '2026-08-01',
     period_end: '2026-08-31',
     kind: 'flow' as const,
@@ -29,6 +31,7 @@ const USAGE_RESOURCES = {
   seats: {
     used: 3,
     limit: 10,
+    ceiling: 10,
     period_start: '2026-08-01',
     period_end: '2026-08-31',
     kind: 'stock' as const,
@@ -147,6 +150,7 @@ describe('UsageOverviewTab', () => {
         seats: {
           used: 3,
           limit: 10,
+          ceiling: 10,
           period_start: '2026-08-01',
           period_end: '2026-08-31',
           kind: 'stock' as const,
@@ -154,6 +158,7 @@ describe('UsageOverviewTab', () => {
         test_executions: {
           used: 5,
           limit: 1000,
+          ceiling: 1000,
           period_start: '2026-01-01',
           period_end: '2026-01-31',
           kind: 'flow' as const,

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
@@ -101,7 +101,7 @@ describe('UsageOverviewTab', () => {
   it('shows a plan chip and an upgrade link for the community edition', () => {
     render(<UsageOverviewTab />);
 
-    expect(screen.getByText('Community')).toBeInTheDocument();
+    expect(screen.getByText('community')).toBeInTheDocument();
     const upgradeLink = screen.getByRole('link', { name: 'Upgrade' });
     expect(upgradeLink).toHaveAttribute('href', 'https://rhesis.ai/editions');
     expect(upgradeLink).toHaveAttribute('target', '_blank');
@@ -184,7 +184,7 @@ describe('UsageOverviewTab', () => {
 
     render(<UsageOverviewTab />);
 
-    expect(screen.getByText('Enterprise')).toBeInTheDocument();
+    expect(screen.getByText('enterprise')).toBeInTheDocument();
     expect(
       screen.queryByRole('link', { name: 'Upgrade' })
     ).not.toBeInTheDocument();

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/__tests__/client-wrapper.test.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/__tests__/client-wrapper.test.tsx
@@ -24,6 +24,16 @@ jest.mock('next/navigation', () => ({
   usePathname: () => '/projects/my-project',
 }));
 
+// ClientWrapper now invalidates the cached /usage response after deleting a
+// project (a stock resource), and that path reads the session for its query
+// scope. `status` is required alongside `data` -- see apps/frontend/AGENTS.md.
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { user: { id: 'user-1' } },
+    status: 'authenticated',
+  }),
+}));
+
 jest.mock('@/hooks/useOnboardingTour', () => ({
   useOnboardingTour: jest.fn(),
 }));

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
@@ -26,7 +26,7 @@ import {
 import ProjectEditDrawer from './edit-drawer';
 import ProjectDetailTabs from './components/ProjectDetailTabs';
 import { format } from 'date-fns';
-import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
+import { useDeleteProject } from '@/hooks/useEndpoints';
 
 interface ClientWrapperProps {
   project: Project;
@@ -120,7 +120,7 @@ export default function ClientWrapper({
     [projectId, notifications, currentProject, syncProject]
   );
 
-  const invalidateUsage = useInvalidateUsage();
+  const deleteProject = useDeleteProject();
 
   const handleDeleteConfirm = async () => {
     // The FAB is guarded at render time, but activeProject can resolve after this
@@ -136,10 +136,7 @@ export default function ClientWrapper({
     }
     setIsDeleting(true);
     try {
-      const apiFactory = new ApiClientFactory();
-      const projectsClient = apiFactory.getProjectsClient();
-      await projectsClient.deleteProject(projectId);
-      invalidateUsage();
+      await deleteProject(projectId);
       // Unmount the detail body on this same render: the tabs below fire their
       // own project-scoped requests, and the refresh and navigation each take a
       // round trip. Without this the user watches the deleted project's tabs

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
@@ -26,6 +26,7 @@ import {
 import ProjectEditDrawer from './edit-drawer';
 import ProjectDetailTabs from './components/ProjectDetailTabs';
 import { format } from 'date-fns';
+import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
 
 interface ClientWrapperProps {
   project: Project;
@@ -119,6 +120,8 @@ export default function ClientWrapper({
     [projectId, notifications, currentProject, syncProject]
   );
 
+  const invalidateUsage = useInvalidateUsage();
+
   const handleDeleteConfirm = async () => {
     // The FAB is guarded at render time, but activeProject can resolve after this
     // page rendered — a session with no active-project cookie and a single project
@@ -136,6 +139,7 @@ export default function ClientWrapper({
       const apiFactory = new ApiClientFactory();
       const projectsClient = apiFactory.getProjectsClient();
       await projectsClient.deleteProject(projectId);
+      invalidateUsage();
       // Unmount the detail body on this same render: the tabs below fire their
       // own project-scoped requests, and the refresh and navigation each take a
       // round trip. Without this the user watches the deleted project's tabs

--- a/apps/frontend/src/app/(protected)/projects/components/ProjectCreateDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/projects/components/ProjectCreateDrawer.tsx
@@ -40,6 +40,8 @@ import PhoneIphoneIcon from '@mui/icons-material/PhoneIphone';
 import SchoolIcon from '@mui/icons-material/School';
 import ScienceIcon from '@mui/icons-material/Science';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
+import { QuotaResource } from '@/constants/quota';
+import { useQuotaErrorHandler, useQuotaGate } from '@/hooks/useQuotaGate';
 
 const PROJECT_ICONS: {
   name: string;
@@ -88,7 +90,7 @@ export default function ProjectCreateDrawer({
 }: ProjectCreateDrawerProps) {
   const [users, setUsers] = React.useState<User[]>([]);
   const [loading, setLoading] = React.useState(false);
-  const [error, setError] = React.useState('');
+  const [error, setError] = React.useState<React.ReactNode>('');
   const [formData, setFormData] = React.useState(EMPTY_FORM);
 
   React.useEffect(() => {
@@ -118,6 +120,9 @@ export default function ProjectCreateDrawer({
   const handleSelect = (field: string) => (e: SelectChangeEvent<string>) =>
     setFormData(prev => ({ ...prev, [field]: e.target.value }));
 
+  const projectQuota = useQuotaGate(QuotaResource.PROJECTS);
+  const asQuotaError = useQuotaErrorHandler();
+
   const handleSave = async () => {
     if (!formData.name.trim()) {
       setError('Project name is required');
@@ -135,7 +140,12 @@ export default function ProjectCreateDrawer({
       await onCreate(payload);
       onClose();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create project');
+      // A 402 that slipped past the preflight (usage can change between
+      // render and submit) still gets real copy, not a raw error string.
+      setError(
+        asQuotaError(err)?.notice ??
+          (err instanceof Error ? err.message : 'Failed to create project')
+      );
     } finally {
       setLoading(false);
     }
@@ -148,8 +158,9 @@ export default function ProjectCreateDrawer({
       title="Create project"
       loading={loading}
       onSave={handleSave}
+      saveDisabled={projectQuota.exhausted}
       saveButtonText="Save"
-      error={error}
+      error={error || projectQuota.notice}
     >
       {/* 2-column row: Owner | Project Icon */}
       <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 3.75 }}>

--- a/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
@@ -29,6 +29,7 @@ import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import { AppsIcon } from '@/components/icons';
 import { PageLayout } from '@/components/layout/PageLayout';
+import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
 import { useOnboardingTour } from '@/hooks/useOnboardingTour';
 import { useOnboarding } from '@/contexts/OnboardingContext';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
@@ -105,14 +106,19 @@ export default function ProjectsClientWrapper() {
     fetchProjects();
   }, [fetchProjects]);
 
+  const invalidateUsage = useInvalidateUsage();
+
   const handleCreate = useCallback(
     async (payload: ProjectCreate) => {
       const factory = new ApiClientFactory();
       const client = factory.getProjectsClient();
       await client.createProject(payload);
+      // Projects are a stock resource: the cached /usage count is now wrong,
+      // and the projects gate reads it.
+      invalidateUsage();
       await Promise.all([fetchProjects(), refreshActiveProjects()]);
     },
-    [fetchProjects, refreshActiveProjects]
+    [fetchProjects, refreshActiveProjects, invalidateUsage]
   );
 
   const confirmDelete = useCallback(async () => {
@@ -131,6 +137,9 @@ export default function ProjectsClientWrapper() {
       const factory = new ApiClientFactory();
       const client = factory.getProjectsClient();
       await client.deleteProject(deleteTarget.id);
+      // The whole point of the blocked-projects recourse: freeing one must
+      // unblock creation now, not up to five minutes from now.
+      invalidateUsage();
       setProjects(prev => prev.filter(p => p.id !== deleteTarget.id));
       await refreshActiveProjects();
       notifications.show('Project deleted successfully', {
@@ -144,7 +153,13 @@ export default function ProjectsClientWrapper() {
     } finally {
       setDeleteTarget(null);
     }
-  }, [deleteTarget, activeProjectId, refreshActiveProjects, notifications]);
+  }, [
+    deleteTarget,
+    activeProjectId,
+    refreshActiveProjects,
+    notifications,
+    invalidateUsage,
+  ]);
 
   // Mark onboarding step complete when projects are loaded
   useEffect(() => {

--- a/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
@@ -29,7 +29,7 @@ import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import { AppsIcon } from '@/components/icons';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
+import { useCreateProject, useDeleteProject } from '@/hooks/useEndpoints';
 import { useOnboardingTour } from '@/hooks/useOnboardingTour';
 import { useOnboarding } from '@/contexts/OnboardingContext';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
@@ -106,19 +106,15 @@ export default function ProjectsClientWrapper() {
     fetchProjects();
   }, [fetchProjects]);
 
-  const invalidateUsage = useInvalidateUsage();
+  const createProject = useCreateProject();
+  const deleteProject = useDeleteProject();
 
   const handleCreate = useCallback(
     async (payload: ProjectCreate) => {
-      const factory = new ApiClientFactory();
-      const client = factory.getProjectsClient();
-      await client.createProject(payload);
-      // Projects are a stock resource: the cached /usage count is now wrong,
-      // and the projects gate reads it.
-      invalidateUsage();
+      await createProject(payload);
       await Promise.all([fetchProjects(), refreshActiveProjects()]);
     },
-    [fetchProjects, refreshActiveProjects, invalidateUsage]
+    [createProject, fetchProjects, refreshActiveProjects]
   );
 
   const confirmDelete = useCallback(async () => {
@@ -134,12 +130,7 @@ export default function ProjectsClientWrapper() {
       return;
     }
     try {
-      const factory = new ApiClientFactory();
-      const client = factory.getProjectsClient();
-      await client.deleteProject(deleteTarget.id);
-      // The whole point of the blocked-projects recourse: freeing one must
-      // unblock creation now, not up to five minutes from now.
-      invalidateUsage();
+      await deleteProject(deleteTarget.id);
       setProjects(prev => prev.filter(p => p.id !== deleteTarget.id));
       await refreshActiveProjects();
       notifications.show('Project deleted successfully', {
@@ -156,9 +147,9 @@ export default function ProjectsClientWrapper() {
   }, [
     deleteTarget,
     activeProjectId,
+    deleteProject,
     refreshActiveProjects,
     notifications,
-    invalidateUsage,
   ]);
 
   // Mark onboarding step complete when projects are loaded

--- a/apps/frontend/src/app/(protected)/projects/create-new/components/CreateProjectClient.tsx
+++ b/apps/frontend/src/app/(protected)/projects/create-new/components/CreateProjectClient.tsx
@@ -16,7 +16,6 @@ import {
 } from '@mui/material';
 import ProjectDetailsStep from './ProjectDetailsStep';
 import FinishStep from './FinishStep';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { ProjectCreate } from '@/utils/api-client/interfaces/project';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { writeActiveProjectId } from '@/utils/active-project';
@@ -25,7 +24,7 @@ import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
 import type { UUID } from 'crypto';
-import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
+import { useCreateProject } from '@/hooks/useEndpoints';
 
 interface FormData {
   projectName: string;
@@ -65,7 +64,7 @@ export default function CreateProjectClient({
     owner_id: userId,
   });
 
-  const projectsClient = new ApiClientFactory().getProjectsClient();
+  const createProject = useCreateProject();
 
   const handleNext = () => {
     setActiveStep(prevActiveStep => prevActiveStep + 1);
@@ -74,8 +73,6 @@ export default function CreateProjectClient({
   const handleBack = () => {
     setActiveStep(prevActiveStep => prevActiveStep - 1);
   };
-
-  const invalidateUsage = useInvalidateUsage();
 
   const handleComplete = async () => {
     try {
@@ -116,8 +113,7 @@ export default function CreateProjectClient({
       };
 
       try {
-        const created = await projectsClient.createProject(projectData);
-        invalidateUsage();
+        const created = await createProject(projectData);
         writeActiveProjectId(String(created.id));
         await refreshActiveProjects({ listOnly: false });
 

--- a/apps/frontend/src/app/(protected)/projects/create-new/components/CreateProjectClient.tsx
+++ b/apps/frontend/src/app/(protected)/projects/create-new/components/CreateProjectClient.tsx
@@ -25,6 +25,7 @@ import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
 import type { UUID } from 'crypto';
+import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
 
 interface FormData {
   projectName: string;
@@ -74,6 +75,8 @@ export default function CreateProjectClient({
     setActiveStep(prevActiveStep => prevActiveStep - 1);
   };
 
+  const invalidateUsage = useInvalidateUsage();
+
   const handleComplete = async () => {
     try {
       setIsSubmitting(true);
@@ -114,6 +117,7 @@ export default function CreateProjectClient({
 
       try {
         const created = await projectsClient.createProject(projectData);
+        invalidateUsage();
         writeActiveProjectId(String(created.id));
         await refreshActiveProjects({ listOnly: false });
 

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestGenerationFlow.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestGenerationFlow.tsx
@@ -340,6 +340,9 @@ export default function TestGenerationFlow() {
     setDescription('');
   }, []);
 
+  const generationQuota = useQuotaGate(QuotaResource.TEST_GENERATION);
+  const asQuotaError = useQuotaErrorHandler();
+
   const handlePipelineEvent = useCallback(
     (event: TestPipelineEvent) => {
       switch (event.type) {
@@ -392,6 +395,17 @@ export default function TestGenerationFlow() {
       const templateId = sessionStorage.getItem('selectedTemplateId');
       if (!templateId) return;
 
+      // Preview generation streams through the same pipeline the final
+      // submit gates on, but it never surfaces its own error: a hang or a
+      // silently-swallowed failure mid-stream left the skeleton loaders
+      // stuck forever with no toast. Blocking here, before the stream ever
+      // opens, is the same check handleGenerate already makes.
+      if (generationQuota.message) {
+        sessionStorage.removeItem('selectedTemplateId');
+        show(generationQuota.message, { severity: 'error' });
+        return;
+      }
+
       try {
         const template = TEMPLATES.find(t => t.id === templateId);
         if (!template) {
@@ -433,11 +447,18 @@ export default function TestGenerationFlow() {
     initializeFromTemplate();
     // selectedProjectId, selectedSources, testType, selectedModelId intentionally excluded - template init runs once on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [show, handlePipelineEvent]);
+  }, [show, handlePipelineEvent, generationQuota.message]);
 
   // Input Screen Handler
   const handleContinueFromInput = useCallback(
     async (desc: string, sources: SourceData[]) => {
+      // Same check handleGenerate makes before the final submit -- without
+      // it, a user already over quota reaches the streaming pipeline, which
+      // has no quota enforcement of its own and can hang with no error.
+      if (generationQuota.message) {
+        show(generationQuota.message, { severity: 'error' });
+        return;
+      }
       setDescription(desc);
       setSelectedSources(sources);
       setSelectedSourceIds(sources.map(s => s.id));
@@ -492,11 +513,22 @@ export default function TestGenerationFlow() {
         setIsLoadingSamples(false);
       }
     },
-    [show, testType, selectedProjectId, selectedModelId, handlePipelineEvent]
+    [
+      show,
+      testType,
+      selectedProjectId,
+      selectedModelId,
+      handlePipelineEvent,
+      generationQuota.message,
+    ]
   );
 
   // Generate test samples
   const generateSamples = useCallback(async () => {
+    if (generationQuota.message) {
+      show(generationQuota.message, { severity: 'error' });
+      return;
+    }
     setTestSamples([]);
     setIsLoadingSamples(true);
 
@@ -547,6 +579,7 @@ export default function TestGenerationFlow() {
     selectedModelId,
     handlePipelineEvent,
     show,
+    generationQuota.message,
   ]);
 
   // Regenerate sample with feedback
@@ -701,6 +734,10 @@ export default function TestGenerationFlow() {
 
   const handleSendMessage = useCallback(
     async (message: string) => {
+      if (generationQuota.message) {
+        show(generationQuota.message, { severity: 'error' });
+        return;
+      }
       const chipStates: Array<{
         label: string;
         description: string;
@@ -802,6 +839,7 @@ export default function TestGenerationFlow() {
       chatMessages,
       testType,
       handlePipelineEvent,
+      generationQuota.message,
     ]
   );
 
@@ -868,9 +906,6 @@ export default function TestGenerationFlow() {
     testType,
     show,
   ]);
-
-  const generationQuota = useQuotaGate(QuotaResource.TEST_GENERATION);
-  const asQuotaError = useQuotaErrorHandler();
 
   // Final generation
   const handleGenerate = useCallback(async () => {

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestGenerationFlow.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestGenerationFlow.tsx
@@ -34,6 +34,8 @@ import TestConfigurationConfirmation from './TestConfigurationConfirmation';
 import { TEMPLATES } from '@/config/test-templates';
 import { getApiErrorMessage } from '@/utils/error-utils';
 import { scaledVh } from '@/styles/viewport-scaling';
+import { QuotaResource } from '@/constants/quota';
+import { useQuotaErrorHandler, useQuotaGate } from '@/hooks/useQuotaGate';
 
 // Initial empty chip configurations
 const createEmptyChips = (): ConfigChips => {
@@ -867,12 +869,22 @@ export default function TestGenerationFlow() {
     show,
   ]);
 
+  const generationQuota = useQuotaGate(QuotaResource.TEST_GENERATION);
+  const asQuotaError = useQuotaErrorHandler();
+
   // Final generation
   const handleGenerate = useCallback(async () => {
     if (!selectedProjectId) {
       show('A project must be selected before generating a test set.', {
         severity: 'error',
       });
+      return;
+    }
+    // Toast rather than an inline notice: this is a full-page flow with no
+    // drawer error slot. Sentence and recourse joined, no link -- a snackbar
+    // auto-dismisses, so a link in one is a trap.
+    if (generationQuota.message) {
+      show(generationQuota.message, { severity: 'error' });
       return;
     }
     setIsFinishing(true);
@@ -946,14 +958,19 @@ export default function TestGenerationFlow() {
 
       // Redirect to the newly created test set's detail page
       router.push(`/test-sets/${response.test_set_id}`);
-    } catch (_error) {
-      show('Failed to start test generation. Please try again.', {
-        severity: 'error',
-      });
+    } catch (error) {
+      // Backs up the preflight: usage can change between render and submit.
+      show(
+        asQuotaError(error)?.message ??
+          'Failed to start test generation. Please try again.',
+        { severity: 'error' }
+      );
     } finally {
       setIsFinishing(false);
     }
   }, [
+    asQuotaError,
+    generationQuota.message,
     configChips.requirement,
     configChips.topics,
     configChips.category,

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestGenerationFlow.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestGenerationFlow.tsx
@@ -438,16 +438,21 @@ export default function TestGenerationFlow() {
       } catch (e) {
         setIsLoadingConfig(false);
         setIsLoadingSamples(false);
-        show(getApiErrorMessage(e, 'Failed to load template'), {
-          severity: 'error',
-        });
+        // Backs up the preflight: usage can change between render and submit.
+        show(
+          asQuotaError(e)?.message ??
+            getApiErrorMessage(e, 'Failed to load template'),
+          {
+            severity: 'error',
+          }
+        );
       }
     };
 
     initializeFromTemplate();
     // selectedProjectId, selectedSources, testType, selectedModelId intentionally excluded - template init runs once on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [show, handlePipelineEvent, generationQuota.message]);
+  }, [show, handlePipelineEvent, asQuotaError, generationQuota.message]);
 
   // Input Screen Handler
   const handleContinueFromInput = useCallback(
@@ -506,9 +511,12 @@ export default function TestGenerationFlow() {
           { onEvent: handlePipelineEvent }
         );
       } catch (error) {
-        show(getApiErrorMessage(error, 'Failed to generate configuration'), {
-          severity: 'error',
-        });
+        // Backs up the preflight: usage can change between render and submit.
+        show(
+          asQuotaError(error)?.message ??
+            getApiErrorMessage(error, 'Failed to generate configuration'),
+          { severity: 'error' }
+        );
         setIsLoadingConfig(false);
         setIsLoadingSamples(false);
       }
@@ -519,6 +527,7 @@ export default function TestGenerationFlow() {
       selectedProjectId,
       selectedModelId,
       handlePipelineEvent,
+      asQuotaError,
       generationQuota.message,
     ]
   );
@@ -566,8 +575,13 @@ export default function TestGenerationFlow() {
         },
         { onEvent: handlePipelineEvent }
       );
-    } catch (_error) {
-      show('Failed to regenerate samples', { severity: 'error' });
+    } catch (error) {
+      // Backs up the preflight: usage can change between render and submit.
+      show(
+        asQuotaError(error)?.message ??
+          getApiErrorMessage(error, 'Failed to regenerate samples'),
+        { severity: 'error' }
+      );
       setIsLoadingSamples(false);
     }
   }, [
@@ -579,6 +593,7 @@ export default function TestGenerationFlow() {
     selectedModelId,
     handlePipelineEvent,
     show,
+    asQuotaError,
     generationQuota.message,
   ]);
 
@@ -588,6 +603,11 @@ export default function TestGenerationFlow() {
       // Find the sample
       const sample = testSamples.find(s => s.id === sampleId);
       if (!sample) return;
+
+      if (generationQuota.message) {
+        show(generationQuota.message, { severity: 'error' });
+        return;
+      }
 
       setRegeneratingSampleId(sampleId);
 
@@ -683,8 +703,13 @@ export default function TestGenerationFlow() {
         }
 
         show('Sample regenerated successfully', { severity: 'success' });
-      } catch (_error) {
-        show('Failed to regenerate sample', { severity: 'error' });
+      } catch (error) {
+        // Backs up the preflight: usage can change between render and submit.
+        show(
+          asQuotaError(error)?.message ??
+            getApiErrorMessage(error, 'Failed to regenerate sample'),
+          { severity: 'error' }
+        );
       } finally {
         setRegeneratingSampleId(null);
       }
@@ -698,6 +723,8 @@ export default function TestGenerationFlow() {
       testSamples,
       testType,
       show,
+      asQuotaError,
+      generationQuota.message,
     ]
   );
 
@@ -819,10 +846,13 @@ export default function TestGenerationFlow() {
           timestamp: new Date(),
         };
         setChatMessages(prev => [...prev, assistantMessage]);
-      } catch (_error) {
-        show(getApiErrorMessage(_error, 'Failed to refine test generation'), {
-          severity: 'error',
-        });
+      } catch (error) {
+        // Backs up the preflight: usage can change between render and submit.
+        show(
+          asQuotaError(error)?.message ??
+            getApiErrorMessage(error, 'Failed to refine test generation'),
+          { severity: 'error' }
+        );
       } finally {
         setIsGenerating(false);
         setIsLoadingConfig(false);
@@ -839,6 +869,7 @@ export default function TestGenerationFlow() {
       chatMessages,
       testType,
       handlePipelineEvent,
+      asQuotaError,
       generationQuota.message,
     ]
   );
@@ -863,6 +894,11 @@ export default function TestGenerationFlow() {
   );
 
   const handleLoadMoreSamples = useCallback(async () => {
+    if (generationQuota.message) {
+      show(generationQuota.message, { severity: 'error' });
+      return;
+    }
+
     setIsLoadingMore(true);
     try {
       const apiFactory = new ApiClientFactory();
@@ -892,8 +928,13 @@ export default function TestGenerationFlow() {
       );
 
       setTestSamples(prev => [...prev, ...newSamples]);
-    } catch (_error) {
-      show('Failed to load more samples', { severity: 'error' });
+    } catch (error) {
+      // Backs up the preflight: usage can change between render and submit.
+      show(
+        asQuotaError(error)?.message ??
+          getApiErrorMessage(error, 'Failed to load more samples'),
+        { severity: 'error' }
+      );
     } finally {
       setIsLoadingMore(false);
     }
@@ -905,6 +946,8 @@ export default function TestGenerationFlow() {
     project,
     testType,
     show,
+    asQuotaError,
+    generationQuota.message,
   ]);
 
   // Final generation

--- a/apps/frontend/src/components/auth/QuotaBanner.tsx
+++ b/apps/frontend/src/components/auth/QuotaBanner.tsx
@@ -13,67 +13,27 @@ import CloseIcon from '@mui/icons-material/Close';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import NextLink from 'next/link';
 import { useUsage } from '@/contexts/UsageContext';
-import { QUOTA_RESOURCE_LABELS, type QuotaResource } from '@/constants/quota';
-
-/** Utilization at or above this fraction surfaces the banner. */
-const WARNING_THRESHOLD = 0.8;
-
-interface WorstResource {
-  resource: QuotaResource;
-  used: number;
-  limit: number;
-  ratio: number;
-  kind: 'flow' | 'stock';
-}
+import { useCan } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
+import { UPGRADE_URL, type QuotaResource } from '@/constants/quota';
+import {
+  findWorstResource,
+  isCommunityEdition,
+  quotaCopy,
+} from '@/utils/quota';
 
 /**
- * Finds the single resource closest to (or past) its limit, or `null` if
- * every resource is comfortably under `WARNING_THRESHOLD`.
- *
- * Only one resource is surfaced at a time -- stacking a banner per
- * over-threshold resource would compete with `VerificationBanner` and the
- * app chrome for the same header space. A resource with `limit: null`
- * (unlimited) never contributes: there is no ratio to compute.
- *
- * `limit: 0` is a real configured value meaning "none allowed", not a
- * missing limit, so it reports as fully consumed rather than being skipped
- * -- skipping it hid the banner from precisely the orgs that were already
- * blocked. Matches `UsageOverviewTab`'s handling of the same case.
- *
- * Resources with no label are skipped: the backend can add a `QuotaResource`
- * before `constants/quota.ts` catches up, and this component renders inside
- * the protected layout, so a missing label would throw on every page rather
- * than just this banner.
+ * Org-wide quota banner. `usage:read` (the same capability `GET /usage`
+ * enforces) is granted to every org member, not just admins -- quota
+ * enforcement blocks members too, and hiding the reason from them only
+ * turns a 402 into a support ticket (see `auth/rbac.py`'s comment on
+ * `Usage.READ`). So this banner is visible to anyone in the org; only the
+ * "Upgrade" link is narrower, gated on `Organization.UPDATE` below.
  */
-function findWorstResource(
-  resources: Readonly<
-    Record<
-      string,
-      { used: number; limit: number | null; kind: 'flow' | 'stock' }
-    >
-  >
-): WorstResource | null {
-  let worst: WorstResource | null = null;
-  for (const [resource, item] of Object.entries(resources)) {
-    if (item.limit === null || item.limit < 0) continue;
-    if (!(resource in QUOTA_RESOURCE_LABELS)) continue;
-    const ratio = item.limit === 0 ? 1 : item.used / item.limit;
-    if (ratio >= WARNING_THRESHOLD && (!worst || ratio > worst.ratio)) {
-      worst = {
-        resource: resource as QuotaResource,
-        used: item.used,
-        limit: item.limit,
-        ratio,
-        kind: item.kind,
-      };
-    }
-  }
-  return worst;
-}
-
 export default function QuotaBanner() {
   const theme = useTheme();
-  const { resources, loading } = useUsage();
+  const { resources, edition, loading } = useUsage();
+  const canManageOrg = useCan(Capability.Organization.UPDATE);
   const [dismissedFor, setDismissedFor] = useState<QuotaResource | null>(null);
 
   const worst = useMemo(() => {
@@ -85,17 +45,33 @@ export default function QuotaBanner() {
   // current one was dismissed, rather than staying silenced for the rest
   // of the session -- dismissing a spans warning shouldn't also hide a
   // later, unrelated seats warning.
-  if (!worst || dismissedFor === worst.resource) {
+  if (!worst || worst.zone === 'healthy' || dismissedFor === worst.resource) {
     return null;
   }
 
-  const label = QUOTA_RESOURCE_LABELS[worst.resource];
-  const percent = Math.round(worst.ratio * 100);
+  const { item, zone } = worst;
+  // Never reached with `limit === null` -- `findWorstResource` only flags
+  // resources whose zone isn't `healthy`, which requires a non-null limit.
+  const limit = item.limit ?? 0;
+  const canUpgrade =
+    canManageOrg && edition !== null && isCommunityEdition(edition);
+  const { sentence } = quotaCopy({
+    resource: worst.resource,
+    kind: item.kind,
+    used: item.used,
+    limit,
+    zone,
+    periodEnd: item.period_end,
+    canUpgrade,
+  });
+
   const isDark = theme.palette.mode === 'dark';
+  const isBlocked = zone === 'blocked';
+  const accent = isBlocked ? theme.palette.error : theme.palette.warning;
   const bgGradient = isDark
-    ? `linear-gradient(135deg, ${alpha(theme.palette.warning.dark, 0.85)} 0%, ${alpha(theme.palette.warning.main, 0.7)} 100%)`
-    : `linear-gradient(135deg, ${theme.palette.warning.main} 0%, ${theme.palette.warning.light} 100%)`;
-  const textColor = theme.palette.warning.contrastText;
+    ? `linear-gradient(135deg, ${alpha(accent.dark, 0.85)} 0%, ${alpha(accent.main, 0.7)} 100%)`
+    : `linear-gradient(135deg, ${accent.main} 0%, ${accent.light} 100%)`;
+  const textColor = accent.contrastText;
 
   return (
     <Box
@@ -130,9 +106,7 @@ export default function QuotaBanner() {
             fontWeight: theme => theme.typography.fontWeightMedium,
           }}
         >
-          {worst.kind === 'stock'
-            ? `You've used ${percent}% of your ${label.toLowerCase()} limit.`
-            : `You've used ${percent}% of your ${label.toLowerCase()} limit for this period.`}
+          {sentence}
         </Typography>
         <MuiLink
           component={NextLink}
@@ -146,6 +120,21 @@ export default function QuotaBanner() {
         >
           View usage
         </MuiLink>
+        {canUpgrade && (
+          <MuiLink
+            href={UPGRADE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="caption"
+            sx={{
+              color: textColor,
+              fontWeight: theme => theme.typography.fontWeightBold,
+              textDecorationColor: alpha(textColor, 0.5),
+            }}
+          >
+            Upgrade plan →
+          </MuiLink>
+        )}
       </Box>
       <IconButton
         size="small"

--- a/apps/frontend/src/components/auth/QuotaBanner.tsx
+++ b/apps/frontend/src/components/auth/QuotaBanner.tsx
@@ -45,7 +45,7 @@ export default function QuotaBanner() {
   // current one was dismissed, rather than staying silenced for the rest
   // of the session -- dismissing a spans warning shouldn't also hide a
   // later, unrelated seats warning.
-  if (!worst || worst.zone === 'healthy' || dismissedFor === worst.resource) {
+  if (!worst || dismissedFor === worst.resource) {
     return null;
   }
 

--- a/apps/frontend/src/components/auth/__tests__/QuotaBanner.test.tsx
+++ b/apps/frontend/src/components/auth/__tests__/QuotaBanner.test.tsx
@@ -10,31 +10,40 @@ jest.mock('@/contexts/UsageContext', () => ({
   useUsage: jest.fn(),
 }));
 
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
 import { useUsage } from '@/contexts/UsageContext';
 
 /** Build a `UsageResourceItem`; `ceiling` defaults to `limit` (a hard tier). */
 function item(
   used: number,
   limit: number | null,
-  ceiling?: number | null
+  options: { kind?: 'flow' | 'stock'; ceiling?: number | null } = {}
 ): UsageResourceItem {
+  const { kind = 'flow', ceiling } = options;
   return {
     used,
     limit,
     ceiling: ceiling === undefined ? limit : ceiling,
     period_start: '2026-08-01',
     period_end: '2026-08-31',
-    kind: 'flow',
+    kind,
   };
 }
 
 function mockUsage(
   resources: Record<string, UsageResourceItem>,
-  loading = false
+  options: { loading?: boolean; edition?: string | null } = {}
 ) {
+  const { loading = false, edition = 'community' } = options;
   (useUsage as jest.Mock).mockReturnValue({
     resources,
-    edition: 'community',
+    edition,
     loading,
     error: null,
   });
@@ -46,7 +55,10 @@ afterEach(() => {
 
 describe('QuotaBanner', () => {
   it('renders nothing while usage is still loading', () => {
-    mockUsage({ [QuotaResource.TEST_EXECUTIONS]: item(999, 1000) }, true);
+    mockUsage(
+      { [QuotaResource.TEST_EXECUTIONS]: item(999, 1000) },
+      { loading: true }
+    );
     const { container } = render(<QuotaBanner />);
     expect(container).toBeEmptyDOMElement();
   });
@@ -63,31 +75,49 @@ describe('QuotaBanner', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('warns once a resource crosses 80% utilization', () => {
+  it('names the organization, not the reader, once a flow resource crosses 80%', () => {
     mockUsage({ [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) });
     render(<QuotaBanner />);
     expect(
-      screen.getByText(/80% of your test runs limit/i)
+      screen.getByText(
+        /Your organization has used 80% of its test runs for this period\./i
+      )
     ).toBeInTheDocument();
   });
 
-  it('treats a limit of zero as fully consumed rather than skipping it', () => {
-    // `limit: 0` is a real configured value meaning "none allowed". Skipping
-    // it hid the banner from exactly the orgs that were already blocked.
-    mockUsage({ [QuotaResource.PROJECTS]: item(0, 0) });
+  it('counts rather than percentages a stock resource approaching its limit', () => {
+    mockUsage({
+      [QuotaResource.PROJECTS]: item(4, 5, { kind: 'stock', ceiling: 5 }),
+    });
     render(<QuotaBanner />);
     expect(
-      screen.getByText(/100% of your projects limit/i)
+      screen.getByText(/Your organization is using 4 of 5 projects\./i)
+    ).toBeInTheDocument();
+  });
+
+  it('treats a limit of zero as blocked rather than skipping it', () => {
+    // `limit: 0` is a real configured value meaning "none allowed", and with
+    // no grace band `used (0) >= ceiling (0)` immediately -- blocked, not
+    // merely "approaching". Skipping it hid the banner from exactly the
+    // orgs that were already blocked.
+    mockUsage({
+      [QuotaResource.PROJECTS]: item(0, 0, { kind: 'stock' }),
+    });
+    render(<QuotaBanner />);
+    expect(
+      screen.getByText(
+        /Your organization is at its projects limit \(0 of 0\)\./i
+      )
     ).toBeInTheDocument();
   });
 
   it('surfaces only the worst resource when several are over the threshold', () => {
     mockUsage({
       [QuotaResource.TEST_EXECUTIONS]: item(850, 1000),
-      [QuotaResource.PROJECTS]: item(99, 100),
+      [QuotaResource.PROJECTS]: item(99, 100, { kind: 'stock' }),
     });
     render(<QuotaBanner />);
-    expect(screen.getByText(/99% of your projects limit/i)).toBeInTheDocument();
+    expect(screen.getByText(/99 of 100 projects/i)).toBeInTheDocument();
     expect(screen.queryByText(/test runs/i)).not.toBeInTheDocument();
   });
 
@@ -100,13 +130,35 @@ describe('QuotaBanner', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it('offers to upgrade on a community-edition org', () => {
+    mockUsage(
+      { [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) },
+      { edition: 'community' }
+    );
+    render(<QuotaBanner />);
+    expect(
+      screen.getByRole('link', { name: /upgrade plan/i })
+    ).toBeInTheDocument();
+  });
+
+  it('does not offer to upgrade a paying org', () => {
+    mockUsage(
+      { [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) },
+      { edition: 'pro' }
+    );
+    render(<QuotaBanner />);
+    expect(
+      screen.queryByRole('link', { name: /upgrade plan/i })
+    ).not.toBeInTheDocument();
+  });
+
   it('stays dismissed for the resource that was dismissed', async () => {
     mockUsage({ [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) });
     render(<QuotaBanner />);
 
     await userEvent.click(screen.getByRole('button', { name: /dismiss/i }));
 
-    expect(screen.queryByText(/test runs limit/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/test runs/i)).not.toBeInTheDocument();
   });
 
   it('re-surfaces when a different resource crosses the threshold', async () => {
@@ -119,10 +171,14 @@ describe('QuotaBanner', () => {
     // A dismissed test-runs warning must not silence a later seats warning.
     mockUsage({
       [QuotaResource.TEST_EXECUTIONS]: item(800, 1000),
-      [QuotaResource.SEATS]: item(10, 10),
+      [QuotaResource.SEATS]: item(10, 10, { kind: 'stock' }),
     });
     rerender(<QuotaBanner />);
 
-    expect(screen.getByText(/100% of your seats limit/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Your organization is at its seats limit \(10 of 10\)\./i
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/common/BaseDrawer.tsx
+++ b/apps/frontend/src/components/common/BaseDrawer.tsx
@@ -27,7 +27,10 @@ export interface BaseDrawerProps {
   onSave?: () => void;
   /** Disable the save button (button remains visible) */
   saveDisabled?: boolean;
-  error?: string;
+  /** A plain string renders as the usual red error line. Pass a node (e.g.
+   * `<QuotaNotice>`) for a gate that isn't a failure -- `approaching` and
+   * `pastIncluded` zones aren't errors and shouldn't render in error red. */
+  error?: React.ReactNode;
   saveButtonText?: string;
   /** Optional data-tour attribute for onboarding (save button). */
   saveDataTour?: string;
@@ -153,11 +156,14 @@ export default function BaseDrawer({
       {/* Bottom toolbar — only rendered when there is something to show */}
       {hasFooter && (
         <Box sx={{ flexShrink: 0 }}>
-          {error && (
-            <Typography color="error" variant="body2" sx={{ mb: 1.5 }}>
-              {error}
-            </Typography>
-          )}
+          {error &&
+            (typeof error === 'string' ? (
+              <Typography color="error" variant="body2" sx={{ mb: 1.5 }}>
+                {error}
+              </Typography>
+            ) : (
+              <Box sx={{ mb: 1.5 }}>{error}</Box>
+            ))}
           <Box
             sx={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}
           >

--- a/apps/frontend/src/components/common/FilterDrawer.tsx
+++ b/apps/frontend/src/components/common/FilterDrawer.tsx
@@ -145,14 +145,6 @@ export function FilterDrawerShell({
         sx={{
           flex: 1,
           overflowY: 'auto',
-          // Explicit, not left to default: a browser resolves a lone
-          // `overflow-y` by silently promoting `overflow-x` to `auto` too
-          // (CSS Overflow spec, "computed value" section) unless both axes
-          // are set. That clipped a control with a negative own-margin --
-          // e.g. `FormControlLabel`'s built-in -11px -- flush against this
-          // box's left edge, right where NotificationsDrawer's "Unread
-          // only" switch sits.
-          overflowX: 'visible',
           display: 'flex',
           flexDirection: 'column',
           gap: 5,

--- a/apps/frontend/src/components/common/FilterDrawer.tsx
+++ b/apps/frontend/src/components/common/FilterDrawer.tsx
@@ -145,6 +145,14 @@ export function FilterDrawerShell({
         sx={{
           flex: 1,
           overflowY: 'auto',
+          // Explicit, not left to default: a browser resolves a lone
+          // `overflow-y` by silently promoting `overflow-x` to `auto` too
+          // (CSS Overflow spec, "computed value" section) unless both axes
+          // are set. That clipped a control with a negative own-margin --
+          // e.g. `FormControlLabel`'s built-in -11px -- flush against this
+          // box's left edge, right where NotificationsDrawer's "Unread
+          // only" switch sits.
+          overflowX: 'visible',
           display: 'flex',
           flexDirection: 'column',
           gap: 5,

--- a/apps/frontend/src/components/common/QuotaChips.tsx
+++ b/apps/frontend/src/components/common/QuotaChips.tsx
@@ -6,10 +6,12 @@ import { BORDER_RADIUS } from '@/styles/theme';
 import { UPGRADE_URL } from '@/constants/quota';
 import { isCommunityEdition } from '@/utils/quota';
 
-/** Plan pill (e.g. "Community plan", "Pro plan"). Shared by the usage page
- * and the org-menu usage block so the two never drift on styling. */
+/** Plan pill (e.g. "Community", "Enterprise"). Shared by the usage page
+ * and the org-menu usage block so the two never drift on styling. No
+ * "plan" suffix -- the org-menu block is space-constrained, and the chip
+ * already reads as a plan in context. */
 export function PlanChip({ edition }: { edition: string }) {
-  const label = `${edition.charAt(0).toUpperCase()}${edition.slice(1)} plan`;
+  const label = `${edition.charAt(0).toUpperCase()}${edition.slice(1)}`;
   return (
     <Chip
       label={label}

--- a/apps/frontend/src/components/common/QuotaChips.tsx
+++ b/apps/frontend/src/components/common/QuotaChips.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import { BORDER_RADIUS } from '@/styles/theme';
+import { UPGRADE_URL } from '@/constants/quota';
+import { isCommunityEdition } from '@/utils/quota';
+
+/** Plan pill (e.g. "Community plan", "Pro plan"). Shared by the usage page
+ * and the org-menu usage block so the two never drift on styling. */
+export function PlanChip({ edition }: { edition: string }) {
+  const label = `${edition.charAt(0).toUpperCase()}${edition.slice(1)} plan`;
+  return (
+    <Chip
+      label={label}
+      size="small"
+      color={isCommunityEdition(edition) ? 'default' : 'primary'}
+      sx={{ borderRadius: BORDER_RADIUS.pill, fontWeight: 600 }}
+    />
+  );
+}
+
+/** "Upgrade" button/link -- always the same destination, everywhere it
+ * appears. Only ever shown to org admins; callers gate that. */
+export function UpgradeLink() {
+  return (
+    <Button
+      component="a"
+      href={UPGRADE_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      variant="outlined"
+      size="small"
+      sx={{ borderRadius: BORDER_RADIUS.sm, fontWeight: 600 }}
+    >
+      Upgrade
+    </Button>
+  );
+}

--- a/apps/frontend/src/components/common/QuotaChips.tsx
+++ b/apps/frontend/src/components/common/QuotaChips.tsx
@@ -6,12 +6,12 @@ import { BORDER_RADIUS } from '@/styles/theme';
 import { UPGRADE_URL } from '@/constants/quota';
 import { isCommunityEdition } from '@/utils/quota';
 
-/** Plan pill (e.g. "Community", "Enterprise"). Shared by the usage page
- * and the org-menu usage block so the two never drift on styling. No
- * "plan" suffix -- the org-menu block is space-constrained, and the chip
- * already reads as a plan in context. */
+/** Plan pill (e.g. "community", "enterprise"). Shared by the usage page
+ * and the org-menu usage block so the two never drift on styling. Lower
+ * case, no "plan" suffix -- the org-menu block is space-constrained, and
+ * the chip already reads as a plan in context. */
 export function PlanChip({ edition }: { edition: string }) {
-  const label = `${edition.charAt(0).toUpperCase()}${edition.slice(1)}`;
+  const label = edition.toLowerCase();
   return (
     <Chip
       label={label}

--- a/apps/frontend/src/components/common/QuotaNotice.tsx
+++ b/apps/frontend/src/components/common/QuotaNotice.tsx
@@ -1,8 +1,13 @@
 'use client';
 
-import { Box, Typography } from '@mui/material';
+import { Box, Link as MuiLink, Typography } from '@mui/material';
+import NextLink from 'next/link';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { quotaCopy, type QuotaZone } from '@/utils/quota';
-import type { QuotaResource } from '@/constants/quota';
+import { UPGRADE_URL, type QuotaResource } from '@/constants/quota';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
 
 export interface QuotaNoticeProps {
   resource: QuotaResource;
@@ -15,35 +20,86 @@ export interface QuotaNoticeProps {
 }
 
 /**
+ * `blocked` reads as an error (something is disabled); `pastIncluded` reads
+ * as info (nothing is -- the soft-tier grace band is real, not a warning
+ * about to become one); `approaching` splits the difference. Same glyph
+ * choices as `NotificationsDrawer`'s `notificationIcon`/`QuotaBanner`, so a
+ * zone looks the same wherever it appears.
+ */
+const ZONE_STYLE = {
+  blocked: { Icon: ErrorOutlineIcon, color: 'error.main' as const },
+  pastIncluded: { Icon: InfoOutlinedIcon, color: 'primary.main' as const },
+  approaching: {
+    Icon: WarningAmberOutlinedIcon,
+    color: 'warning.main' as const,
+  },
+};
+
+/**
  * The inline-gate notice: what `BaseDrawer`'s `error` slot renders for a
  * quota gate that isn't a failure. Shared by every drawer's preflight gate
  * and its reactive 402 catch (`parseQuotaError`) -- one place turns a
  * `quotaCopy()` result into markup, so the sentence and recourse always
  * read together the same way.
  *
- * `approaching`/`pastIncluded` render in warning tones because nothing is
- * actually blocked yet; only `blocked` renders as an error.
+ * The "Org usage" link is unconditional -- `usage:read` is granted to every
+ * member, not just admins, so everyone who can see this notice can also see
+ * the numbers behind it. "Upgrade plan" is narrower, matching `canUpgrade`
+ * (an org admin on a community-edition org) the same way `QuotaBanner` and
+ * the org menu's own upgrade row do.
  */
 export function QuotaNotice(props: QuotaNoticeProps) {
-  const { zone } = props;
+  const { zone, canUpgrade } = props;
   const { sentence, recourse } = quotaCopy(props);
-  const color =
-    zone === 'blocked'
-      ? 'error.main'
-      : zone === 'pastIncluded'
-        ? 'warning.dark'
-        : 'warning.main';
+  const { Icon, color } = ZONE_STYLE[zone];
 
   return (
-    <Box>
-      <Typography variant="body2" sx={{ color, fontWeight: 600 }}>
-        {sentence}
-      </Typography>
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 0.5,
+        p: 1.5,
+        borderRadius: BORDER_RADIUS.sm,
+        border: '1px solid',
+        borderColor: 'divider',
+        borderLeft: '3px solid',
+        borderLeftColor: color,
+        bgcolor: theme => theme.palette.greyscale.surface2,
+      }}
+    >
+      <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+        <Icon sx={{ color, fontSize: 18, mt: '1px', flexShrink: 0 }} />
+        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+          {sentence}
+        </Typography>
+      </Box>
       {recourse && (
-        <Typography variant="caption" color="text.secondary" component="div">
+        <Typography variant="caption" color="text.secondary">
           {recourse}
         </Typography>
       )}
+      <Box sx={{ display: 'flex', gap: 1.5 }}>
+        <MuiLink
+          component={NextLink}
+          href="/organizations/usage"
+          variant="caption"
+          sx={{ fontWeight: 700 }}
+        >
+          Org usage →
+        </MuiLink>
+        {canUpgrade && (
+          <MuiLink
+            href={UPGRADE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="caption"
+            sx={{ fontWeight: 700 }}
+          >
+            Upgrade plan →
+          </MuiLink>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/apps/frontend/src/components/common/QuotaNotice.tsx
+++ b/apps/frontend/src/components/common/QuotaNotice.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Box, Typography } from '@mui/material';
+import { quotaCopy, type QuotaZone } from '@/utils/quota';
+import type { QuotaResource } from '@/constants/quota';
+
+export interface QuotaNoticeProps {
+  resource: QuotaResource;
+  kind: 'flow' | 'stock' | undefined;
+  used: number;
+  limit: number;
+  zone: Exclude<QuotaZone, 'healthy'>;
+  periodEnd?: string;
+  canUpgrade: boolean;
+}
+
+/**
+ * The inline-gate notice: what `BaseDrawer`'s `error` slot renders for a
+ * quota gate that isn't a failure. Shared by every drawer's preflight gate
+ * and its reactive 402 catch (`parseQuotaError`) -- one place turns a
+ * `quotaCopy()` result into markup, so the sentence and recourse always
+ * read together the same way.
+ *
+ * `approaching`/`pastIncluded` render in warning tones because nothing is
+ * actually blocked yet; only `blocked` renders as an error.
+ */
+export function QuotaNotice(props: QuotaNoticeProps) {
+  const { zone } = props;
+  const { sentence, recourse } = quotaCopy(props);
+  const color =
+    zone === 'blocked'
+      ? 'error.main'
+      : zone === 'pastIncluded'
+        ? 'warning.dark'
+        : 'warning.main';
+
+  return (
+    <Box>
+      <Typography variant="body2" sx={{ color, fontWeight: 600 }}>
+        {sentence}
+      </Typography>
+      {recourse && (
+        <Typography variant="caption" color="text.secondary" component="div">
+          {recourse}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/common/RunDrawer.tsx
+++ b/apps/frontend/src/components/common/RunDrawer.tsx
@@ -79,8 +79,16 @@ import type { UUID } from 'crypto';
 import { readActiveProjectId } from '@/utils/active-project';
 import { formatDate } from '@/utils/date';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
-import { useResourceUsage } from '@/contexts/UsageContext';
-import { QuotaResource, QUOTA_RESOURCE_LABELS } from '@/constants/quota';
+import { useResourceUsage, useUsage } from '@/contexts/UsageContext';
+import { QuotaResource } from '@/constants/quota';
+import { useCan } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
+import {
+  isCommunityEdition,
+  isKnownQuotaResource,
+  parseQuotaError,
+} from '@/utils/quota';
+import { QuotaNotice } from '@/components/common/QuotaNotice';
 
 // ---------------------------------------------------------------------------
 // Shared local types
@@ -282,7 +290,19 @@ export default function RunDrawer(props: RunDrawerProps) {
   // ---- Core state ----
   const [loading, setLoading] = useState(false);
   const [executing, setExecuting] = useState(false);
-  const [error, setError] = useState<string>();
+  const [error, setError] = useState<React.ReactNode>();
+
+  // Whether this reader can be offered the upgrade action in a quota
+  // notice: someone who can manage the org (Organization.UPDATE -- the
+  // same owner/admin gate as the Org Settings page), on a community-edition
+  // org. `usage:read` itself is granted to every member, not just admins,
+  // so it can't answer "can this person upgrade" -- everyone can now read
+  // the numbers; only Organization.UPDATE holders get pointed at the
+  // upgrade link. A member always gets pointed at an admin instead.
+  const canManageOrg = useCan(Capability.Organization.UPDATE);
+  const { edition: orgEdition } = useUsage();
+  const canUpgrade =
+    canManageOrg && orgEdition !== null && isCommunityEdition(orgEdition);
 
   // ---- Project / Endpoint ----
   const [projects, setProjects] = useState<ProjectOption[]>([]);
@@ -991,7 +1011,22 @@ export default function RunDrawer(props: RunDrawerProps) {
       onSuccess?.();
       onClose();
     } catch (err) {
-      setError(getApiErrorMessage(err, 'Failed to execute'));
+      const quotaError = parseQuotaError(err);
+      setError(
+        quotaError && isKnownQuotaResource(quotaError.resource) ? (
+          <QuotaNotice
+            resource={quotaError.resource}
+            kind={quotaError.kind}
+            used={quotaError.used}
+            limit={quotaError.limit ?? 0}
+            zone="blocked"
+            periodEnd={quotaError.periodEnd}
+            canUpgrade={canUpgrade}
+          />
+        ) : (
+          getApiErrorMessage(err, 'Failed to execute')
+        )
+      );
     } finally {
       setExecuting(false);
     }
@@ -1043,9 +1078,18 @@ export default function RunDrawer(props: RunDrawerProps) {
     executionQuotaExhausted,
   ]);
 
-  const quotaExhaustedMessage = executionQuotaExhausted
-    ? `You've reached your ${QUOTA_RESOURCE_LABELS[QuotaResource.TEST_EXECUTIONS].toLowerCase()} limit for this period.`
-    : undefined;
+  const quotaExhaustedMessage =
+    executionQuotaExhausted && executionUsage ? (
+      <QuotaNotice
+        resource={QuotaResource.TEST_EXECUTIONS}
+        kind={executionUsage.kind}
+        used={executionUsage.used}
+        limit={executionUsage.limit ?? 0}
+        zone="blocked"
+        periodEnd={executionUsage.period_end}
+        canUpgrade={canUpgrade}
+      />
+    ) : undefined;
 
   // Effective test set type for multi-turn detection
   const effectiveTestSetType = useMemo(() => {

--- a/apps/frontend/src/components/common/RunDrawer.tsx
+++ b/apps/frontend/src/components/common/RunDrawer.tsx
@@ -79,16 +79,8 @@ import type { UUID } from 'crypto';
 import { readActiveProjectId } from '@/utils/active-project';
 import { formatDate } from '@/utils/date';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
-import { useResourceUsage, useUsage } from '@/contexts/UsageContext';
 import { QuotaResource } from '@/constants/quota';
-import { useCan } from '@/components/common/Can';
-import { Capability } from '@/constants/capabilities';
-import {
-  isCommunityEdition,
-  isKnownQuotaResource,
-  parseQuotaError,
-} from '@/utils/quota';
-import { QuotaNotice } from '@/components/common/QuotaNotice';
+import { useQuotaErrorHandler, useQuotaGate } from '@/hooks/useQuotaGate';
 
 // ---------------------------------------------------------------------------
 // Shared local types
@@ -292,17 +284,10 @@ export default function RunDrawer(props: RunDrawerProps) {
   const [executing, setExecuting] = useState(false);
   const [error, setError] = useState<React.ReactNode>();
 
-  // Whether this reader can be offered the upgrade action in a quota
-  // notice: someone who can manage the org (Organization.UPDATE -- the
-  // same owner/admin gate as the Org Settings page), on a community-edition
-  // org. `usage:read` itself is granted to every member, not just admins,
-  // so it can't answer "can this person upgrade" -- everyone can now read
-  // the numbers; only Organization.UPDATE holders get pointed at the
-  // upgrade link. A member always gets pointed at an admin instead.
-  const canManageOrg = useCan(Capability.Organization.UPDATE);
-  const { edition: orgEdition } = useUsage();
-  const canUpgrade =
-    canManageOrg && orgEdition !== null && isCommunityEdition(orgEdition);
+  // Preflight gate + the reactive 402 path, both from the shared hook so the
+  // threshold and the copy stay identical to every other gated action.
+  const executionQuota = useQuotaGate(QuotaResource.TEST_EXECUTIONS);
+  const asQuotaError = useQuotaErrorHandler();
 
   // ---- Project / Endpoint ----
   const [projects, setProjects] = useState<ProjectOption[]>([]);
@@ -1011,21 +996,9 @@ export default function RunDrawer(props: RunDrawerProps) {
       onSuccess?.();
       onClose();
     } catch (err) {
-      const quotaError = parseQuotaError(err);
       setError(
-        quotaError && isKnownQuotaResource(quotaError.resource) ? (
-          <QuotaNotice
-            resource={quotaError.resource}
-            kind={quotaError.kind}
-            used={quotaError.used}
-            limit={quotaError.limit ?? 0}
-            zone="blocked"
-            periodEnd={quotaError.periodEnd}
-            canUpgrade={canUpgrade}
-          />
-        ) : (
+        asQuotaError(err)?.notice ??
           getApiErrorMessage(err, 'Failed to execute')
-        )
       );
     } finally {
       setExecuting(false);
@@ -1055,11 +1028,6 @@ export default function RunDrawer(props: RunDrawerProps) {
   // the overage tolerance, and gating on `limit` would disable the button
   // for an org the backend would still happily accept -- erasing exactly the
   // grace band the tier grants.
-  const executionUsage = useResourceUsage(QuotaResource.TEST_EXECUTIONS);
-  const executionQuotaExhausted =
-    executionUsage !== null &&
-    executionUsage.ceiling !== null &&
-    executionUsage.used >= executionUsage.ceiling;
 
   const canExecute = useMemo(() => {
     const endpointId = resolveEndpointId();
@@ -1067,7 +1035,7 @@ export default function RunDrawer(props: RunDrawerProps) {
     if (!endpointId || testSetIds.length === 0) return false;
     if (mode === 'runExperiment' && internalVersionHashes.size === 0)
       return false;
-    if (executionQuotaExhausted) return false;
+    if (executionQuota.exhausted) return false;
     return true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -1075,21 +1043,10 @@ export default function RunDrawer(props: RunDrawerProps) {
     selectedEndpoint,
     selectedTestSet,
     internalVersionHashes,
-    executionQuotaExhausted,
+    executionQuota.exhausted,
   ]);
 
-  const quotaExhaustedMessage =
-    executionQuotaExhausted && executionUsage ? (
-      <QuotaNotice
-        resource={QuotaResource.TEST_EXECUTIONS}
-        kind={executionUsage.kind}
-        used={executionUsage.used}
-        limit={executionUsage.limit ?? 0}
-        zone="blocked"
-        periodEnd={executionUsage.period_end}
-        canUpgrade={canUpgrade}
-      />
-    ) : undefined;
+  const quotaExhaustedMessage = executionQuota.notice;
 
   // Effective test set type for multi-turn detection
   const effectiveTestSetType = useMemo(() => {

--- a/apps/frontend/src/components/common/__tests__/QuotaNotice.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/QuotaNotice.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen } from '@/test-utils';
+import '@testing-library/jest-dom';
+import { QuotaNotice } from '../QuotaNotice';
+import { QuotaResource } from '@/constants/quota';
+
+function baseProps(
+  overrides: Partial<React.ComponentProps<typeof QuotaNotice>> = {}
+) {
+  return {
+    resource: QuotaResource.PROJECTS,
+    kind: 'stock' as const,
+    used: 1,
+    limit: 1,
+    zone: 'blocked' as const,
+    canUpgrade: false,
+    ...overrides,
+  };
+}
+
+describe('QuotaNotice', () => {
+  it('shows an error icon and the blocked sentence', () => {
+    render(<QuotaNotice {...baseProps()} />);
+    expect(
+      screen.getByText('Your organization is at its projects limit (1 of 1).')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('ErrorOutlineIcon')).toBeInTheDocument();
+  });
+
+  it('always links to org usage, admin or not', () => {
+    render(<QuotaNotice {...baseProps()} />);
+    expect(screen.getByRole('link', { name: /org usage/i })).toHaveAttribute(
+      'href',
+      '/organizations/usage'
+    );
+  });
+
+  it('only offers the upgrade link when the reader can act on it', () => {
+    const { rerender } = render(
+      <QuotaNotice {...baseProps({ canUpgrade: false })} />
+    );
+    expect(
+      screen.queryByRole('link', { name: /upgrade plan/i })
+    ).not.toBeInTheDocument();
+
+    rerender(<QuotaNotice {...baseProps({ canUpgrade: true })} />);
+    expect(
+      screen.getByRole('link', { name: /upgrade plan/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders an info icon for a past-included zone, not an error one', () => {
+    render(
+      <QuotaNotice
+        {...baseProps({
+          resource: QuotaResource.TEST_EXECUTIONS,
+          kind: 'flow',
+          zone: 'pastIncluded',
+        })}
+      />
+    );
+    expect(screen.getByTestId('InfoOutlinedIcon')).toBeInTheDocument();
+    expect(screen.queryByTestId('ErrorOutlineIcon')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/common/__tests__/RunDrawer.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/RunDrawer.test.tsx
@@ -59,6 +59,19 @@ jest.mock('../NotificationContext', () => ({
 
 jest.mock('@/contexts/UsageContext', () => ({
   useResourceUsage: jest.fn(),
+  useUsage: jest.fn(() => ({
+    resources: {},
+    edition: 'community',
+    loading: false,
+    error: null,
+  })),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
 }));
 
 jest.mock('@/utils/api-client/client-factory', () => ({

--- a/apps/frontend/src/components/navigation/NavItem.tsx
+++ b/apps/frontend/src/components/navigation/NavItem.tsx
@@ -13,11 +13,7 @@ import { useCan } from '@/components/common/Can';
 import { useAmbientPermissions } from '@/contexts/PermissionsContext';
 import { useNotifications } from '@/contexts/NotificationsContext';
 import { isNotificationSection } from '@/constants/notifications';
-import {
-  isActive,
-  collapsedNavItemSx,
-  COUNT_BADGE_SX,
-} from './sidebar-utils';
+import { isActive, collapsedNavItemSx, COUNT_BADGE_SX } from './sidebar-utils';
 
 interface NavItemProps {
   item: NavigationPageItem;

--- a/apps/frontend/src/components/navigation/NavItem.tsx
+++ b/apps/frontend/src/components/navigation/NavItem.tsx
@@ -7,13 +7,17 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Tooltip from '@mui/material/Tooltip';
 import Badge from '@mui/material/Badge';
-import { BORDER_RADIUS, COUNT_BADGE_SX } from '@/styles/theme';
+import { BORDER_RADIUS } from '@/styles/theme';
 import { type NavigationPageItem } from '@/types/navigation';
 import { useCan } from '@/components/common/Can';
 import { useAmbientPermissions } from '@/contexts/PermissionsContext';
 import { useNotifications } from '@/contexts/NotificationsContext';
 import { isNotificationSection } from '@/constants/notifications';
-import { isActive, collapsedNavItemSx } from './sidebar-utils';
+import {
+  isActive,
+  collapsedNavItemSx,
+  COUNT_BADGE_SX,
+} from './sidebar-utils';
 
 interface NavItemProps {
   item: NavigationPageItem;

--- a/apps/frontend/src/components/navigation/NavItem.tsx
+++ b/apps/frontend/src/components/navigation/NavItem.tsx
@@ -7,16 +7,13 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Tooltip from '@mui/material/Tooltip';
 import Badge from '@mui/material/Badge';
-import { BORDER_RADIUS } from '@/styles/theme';
+import { BORDER_RADIUS, COUNT_BADGE_SX } from '@/styles/theme';
 import { type NavigationPageItem } from '@/types/navigation';
 import { useCan } from '@/components/common/Can';
 import { useAmbientPermissions } from '@/contexts/PermissionsContext';
 import { useNotifications } from '@/contexts/NotificationsContext';
-import { NotificationSection } from '@/constants/notifications';
+import { isNotificationSection } from '@/constants/notifications';
 import { isActive, collapsedNavItemSx } from './sidebar-utils';
-
-const NOTIFICATION_SECTION_VALUES: string[] =
-  Object.values(NotificationSection);
 
 interface NavItemProps {
   item: NavigationPageItem;
@@ -33,8 +30,8 @@ export function NavItem({ item, collapsed, parentPath = '' }: NavItemProps) {
   const ambient = useAmbientPermissions();
   const singlePermitted = useCan(item.requiredPermission ?? '');
   const { unreadBySection } = useNotifications();
-  const unread = NOTIFICATION_SECTION_VALUES.includes(item.segment)
-    ? (unreadBySection[item.segment as NotificationSection] ?? 0)
+  const unread = isNotificationSection(item.segment)
+    ? (unreadBySection[item.segment] ?? 0)
     : 0;
 
   const requiredAnyOf = item.requiredAnyOf;
@@ -127,17 +124,15 @@ export function NavItem({ item, collapsed, parentPath = '' }: NavItemProps) {
           {unread > 0 && (
             <Box
               sx={{
+                ...COUNT_BADGE_SX,
                 flexShrink: 0,
-                minWidth: 20,
-                height: 20,
-                px: '6px',
-                borderRadius: BORDER_RADIUS.sm,
-                bgcolor: active ? 'primary.contrastText' : 'primary.main',
-                color: active ? 'primary.main' : 'primary.contrastText',
-                fontSize: 12,
-                fontWeight: 600,
-                lineHeight: '20px',
-                textAlign: 'center',
+                // Inverted on the active row, whose background is already
+                // primary.main -- the only place this badge deviates from
+                // the shared look.
+                ...(active && {
+                  bgcolor: 'primary.contrastText',
+                  color: 'primary.main',
+                }),
               }}
             >
               {unread > 99 ? '99+' : unread}

--- a/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
+++ b/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
@@ -7,6 +7,7 @@ import ButtonBase from '@mui/material/ButtonBase';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import Typography from '@mui/material/Typography';
 import { alpha } from '@mui/material/styles';
 import DoneAllIcon from '@mui/icons-material/DoneAll';
@@ -16,10 +17,23 @@ import { FilterDrawerShell } from '@/components/common/FilterDrawer';
 import { BORDER_RADIUS } from '@/styles/theme';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import type { Notification } from '@/utils/api-client/notifications-client';
-import { NotificationSection } from '@/constants/notifications';
+import {
+  NotificationSection,
+  isNotificationSection,
+} from '@/constants/notifications';
 import { useNotifications } from '@/contexts/NotificationsContext';
 
 const PAGE_SIZE = 30;
+
+/** Tint on an unread row. Matches the grids' unread-row treatment in
+ * `styles/globals.css` (`HIGHLIGHTED_ROW_CLASS`) rather than inventing a
+ * second "this is unread" colour -- the same signal should look the same
+ * wherever it appears. */
+const UNREAD_ROW_TINT = 0.06;
+/** Icon size for the empty state, matching the other empty states' glyph. */
+const EMPTY_ICON_SIZE = 32;
+/** Leading icon on a notification row. */
+const ROW_ICON_SIZE = 20;
 
 /** Where a row's own page lives, keyed by `NotificationSection`. Not always
  * `/${section}` -- `USAGE` badges no nav item (see `constants/notifications.ts`)
@@ -32,20 +46,19 @@ const SECTION_ROUTES: Record<NotificationSection, string> = {
   [NotificationSection.USAGE]: '/organizations/usage',
 };
 
-const SECTION_VALUES: string[] = Object.values(NotificationSection);
-
-function isNotificationSection(value: string): value is NotificationSection {
-  return SECTION_VALUES.includes(value);
-}
-
+// Floors rather than rounds: 90 minutes is "1h ago", not "2h ago" -- an age
+// must never read as further in the past than it is. Clamped at 0 so clock
+// skew between server and browser cannot render "-1m ago".
 function relativeTime(iso: string): string {
-  const minutes = Math.round((Date.now() - new Date(iso).getTime()) / 60_000);
+  const minutes = Math.max(
+    0,
+    Math.floor((Date.now() - new Date(iso).getTime()) / 60_000)
+  );
   if (minutes < 1) return 'just now';
   if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.round(minutes / 60);
+  const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h ago`;
-  const days = Math.round(hours / 24);
-  return `${days}d ago`;
+  return `${Math.floor(hours / 24)}d ago`;
 }
 
 function isSameDay(a: Date, b: Date): boolean {
@@ -84,23 +97,38 @@ export default function NotificationsDrawer({
   onClose,
 }: NotificationsDrawerProps) {
   const router = useRouter();
-  const { unreadBySection, markSectionRead } = useNotifications();
+  const { unreadBySection, markSectionRead, markOneRead } = useNotifications();
   const [items, setItems] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [unreadOnly, setUnreadOnly] = useState(false);
+  const [failed, setFailed] = useState(false);
+  // Pages fetched so far. Deliberately not derived from `items.length`: rows
+  // are marked read locally, and with the unread-only filter on that shrinks
+  // the server-side list, so an offset taken from the rendered count steps
+  // straight past unread rows it never showed.
+  const [pagesLoaded, setPagesLoaded] = useState(0);
 
   const fetchPage = useCallback(
-    async (skip: number, replace: boolean) => {
+    async (page: number, replace: boolean) => {
       const client = new ApiClientFactory().getNotificationsClient();
-      const page = await client.getNotifications({
+      const rows = await client.getNotifications({
         unread_only: unreadOnly,
-        skip,
+        skip: page * PAGE_SIZE,
         limit: PAGE_SIZE,
       });
-      setItems(prev => (replace ? page : [...prev, ...page]));
-      setHasMore(page.length === PAGE_SIZE);
+      // Dedupe on append: the list is ordered by `created_at desc` with no id
+      // tiebreaker, so a notification arriving between pages shifts the
+      // window and can re-serve a row already held -- which would also
+      // duplicate a React key.
+      setItems(prev => {
+        if (replace) return rows;
+        const seen = new Set(prev.map(n => n.id));
+        return [...prev, ...rows.filter(n => !seen.has(n.id))];
+      });
+      setHasMore(rows.length === PAGE_SIZE);
+      setPagesLoaded(page + 1);
     },
     [unreadOnly]
   );
@@ -108,8 +136,12 @@ export default function NotificationsDrawer({
   useEffect(() => {
     if (!open) return;
     setLoading(true);
+    setFailed(false);
     fetchPage(0, true)
-      .catch(() => setItems([]))
+      .catch(() => {
+        setItems([]);
+        setFailed(true);
+      })
       .finally(() => setLoading(false));
   }, [open, fetchPage]);
 
@@ -127,9 +159,15 @@ export default function NotificationsDrawer({
         n.read_at ? n : { ...n, read_at: new Date().toISOString() }
       )
     );
+    // Everything shown is read now, so an unread-only list is empty and has
+    // nothing older to offer.
+    if (unreadOnly) setHasMore(false);
   };
 
   const handleRowClick = (notification: Notification) => {
+    const section = isNotificationSection(notification.section)
+      ? notification.section
+      : null;
     if (!notification.read_at) {
       setItems(prev =>
         prev.map(n =>
@@ -138,23 +176,22 @@ export default function NotificationsDrawer({
             : n
         )
       );
-      new ApiClientFactory()
-        .getNotificationsClient()
-        .markRead({ notification_ids: [notification.id] })
-        .catch(() => {
-          // Best-effort -- the row already reads as read locally.
-        });
+      // Through the context, not the client directly: it owns the badge count
+      // and would otherwise keep counting a row the server has marked read.
+      if (section) {
+        markOneRead(section, notification.id, notification.item_count);
+      }
     }
     onClose();
-    if (isNotificationSection(notification.section)) {
-      router.push(SECTION_ROUTES[notification.section]);
-    }
+    if (section) router.push(SECTION_ROUTES[section]);
   };
 
   const handleLoadOlder = async () => {
     setLoadingMore(true);
     try {
-      await fetchPage(items.length, false);
+      await fetchPage(pagesLoaded, false);
+    } catch {
+      setHasMore(false);
     } finally {
       setLoadingMore(false);
     }
@@ -194,17 +231,22 @@ export default function NotificationsDrawer({
             justifyContent: 'space-between',
           }}
         >
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Switch
-              size="small"
-              checked={unreadOnly}
-              onChange={e => setUnreadOnly(e.target.checked)}
-              inputProps={{ 'aria-label': 'Show unread only' }}
-            />
-            <Typography variant="caption" color="text.secondary">
-              Unread only
-            </Typography>
-          </Box>
+          {/* FormControlLabel rather than a hand-paired Switch and Typography:
+              it associates the two, so the switch has a real accessible name
+              and the text is clickable. */}
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={unreadOnly}
+                onChange={e => setUnreadOnly(e.target.checked)}
+              />
+            }
+            label="Unread only"
+            slotProps={{
+              typography: { variant: 'caption', color: 'text.secondary' },
+            }}
+          />
           <Button
             size="small"
             startIcon={<DoneAllIcon fontSize="small" />}
@@ -228,10 +270,18 @@ export default function NotificationsDrawer({
             <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
               <CircularProgress size={24} />
             </Box>
+          ) : failed ? (
+            // Distinct from the empty state: "no notifications yet" would
+            // read as good news when the request actually failed.
+            <Box sx={{ textAlign: 'center', py: 6 }}>
+              <Typography variant="body2" color="error.main">
+                Could not load notifications. Please try again later.
+              </Typography>
+            </Box>
           ) : items.length === 0 ? (
             <Box sx={{ textAlign: 'center', py: 6 }}>
               <NotificationsNoneOutlinedIcon
-                sx={{ fontSize: 32, color: 'text.secondary' }}
+                sx={{ fontSize: EMPTY_ICON_SIZE, color: 'text.secondary' }}
               />
               <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
                 {unreadOnly ? "You're all caught up" : 'No notifications yet'}
@@ -261,7 +311,8 @@ export default function NotificationsDrawer({
                       borderRadius: BORDER_RADIUS.sm,
                       bgcolor: n.read_at
                         ? 'transparent'
-                        : theme => alpha(theme.palette.primary.main, 0.06),
+                        : theme =>
+                            alpha(theme.palette.primary.main, UNREAD_ROW_TINT),
                       '&:hover': {
                         bgcolor: theme => theme.palette.greyscale.surface2,
                       },
@@ -270,7 +321,7 @@ export default function NotificationsDrawer({
                     {n.is_failure ? (
                       <ErrorOutlineIcon
                         sx={{
-                          fontSize: 20,
+                          fontSize: ROW_ICON_SIZE,
                           color: 'error.main',
                           flexShrink: 0,
                           mt: '2px',
@@ -279,7 +330,7 @@ export default function NotificationsDrawer({
                     ) : (
                       <NotificationsNoneOutlinedIcon
                         sx={{
-                          fontSize: 20,
+                          fontSize: ROW_ICON_SIZE,
                           color: 'text.secondary',
                           flexShrink: 0,
                           mt: '2px',

--- a/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
+++ b/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
@@ -372,7 +372,7 @@ export default function NotificationsDrawer({
             groups.map(([label, rows]) => (
               <Box
                 key={label}
-                sx={{ display: 'flex', flexDirection: 'column', gap: '4px' }}
+                sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}
               >
                 <Typography
                   variant="caption"

--- a/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
+++ b/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
@@ -1,0 +1,333 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
+import { alpha } from '@mui/material/styles';
+import DoneAllIcon from '@mui/icons-material/DoneAll';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
+import { FilterDrawerShell } from '@/components/common/FilterDrawer';
+import { BORDER_RADIUS } from '@/styles/theme';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import type { Notification } from '@/utils/api-client/notifications-client';
+import { NotificationSection } from '@/constants/notifications';
+import { useNotifications } from '@/contexts/NotificationsContext';
+
+const PAGE_SIZE = 30;
+
+/** Where a row's own page lives, keyed by `NotificationSection`. Not always
+ * `/${section}` -- `USAGE` badges no nav item (see `constants/notifications.ts`)
+ * but a quota notification still needs somewhere to send the reader. */
+const SECTION_ROUTES: Record<NotificationSection, string> = {
+  [NotificationSection.TEST_SETS]: '/test-sets',
+  [NotificationSection.TEST_RUNS]: '/test-runs',
+  [NotificationSection.TASKS]: '/tasks',
+  [NotificationSection.ARCHITECT]: '/architect',
+  [NotificationSection.USAGE]: '/organizations/usage',
+};
+
+const SECTION_VALUES: string[] = Object.values(NotificationSection);
+
+function isNotificationSection(value: string): value is NotificationSection {
+  return SECTION_VALUES.includes(value);
+}
+
+function relativeTime(iso: string): string {
+  const minutes = Math.round((Date.now() - new Date(iso).getTime()) / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+function isSameDay(a: Date, b: Date): boolean {
+  return a.toDateString() === b.toDateString();
+}
+
+function dayLabel(iso: string): string {
+  const date = new Date(iso);
+  const today = new Date();
+  if (isSameDay(date, today)) return 'Today';
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  if (isSameDay(date, yesterday)) return 'Yesterday';
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: date.getFullYear() === today.getFullYear() ? undefined : 'numeric',
+  });
+}
+
+interface NotificationsDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * The notification center: full paginated history across every section,
+ * day-grouped, with an unread-only toggle and mark-all-read. The sidebar
+ * badge (`NavItem`, the brand-row usage badge) is a different, lighter
+ * primitive (`NotificationsContext`'s per-section unread counts) -- this
+ * drawer is the drill-down the router docstring on `GET /notifications/`
+ * calls "a future notification drawer".
+ */
+export default function NotificationsDrawer({
+  open,
+  onClose,
+}: NotificationsDrawerProps) {
+  const router = useRouter();
+  const { unreadBySection, markSectionRead } = useNotifications();
+  const [items, setItems] = useState<Notification[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [unreadOnly, setUnreadOnly] = useState(false);
+
+  const fetchPage = useCallback(
+    async (skip: number, replace: boolean) => {
+      const client = new ApiClientFactory().getNotificationsClient();
+      const page = await client.getNotifications({
+        unread_only: unreadOnly,
+        skip,
+        limit: PAGE_SIZE,
+      });
+      setItems(prev => (replace ? page : [...prev, ...page]));
+      setHasMore(page.length === PAGE_SIZE);
+    },
+    [unreadOnly]
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    fetchPage(0, true)
+      .catch(() => setItems([]))
+      .finally(() => setLoading(false));
+  }, [open, fetchPage]);
+
+  const totalUnread = Object.values(unreadBySection).reduce(
+    (sum, count) => sum + (count ?? 0),
+    0
+  );
+
+  const handleMarkAllRead = () => {
+    (Object.keys(unreadBySection) as NotificationSection[]).forEach(section => {
+      if ((unreadBySection[section] ?? 0) > 0) markSectionRead(section);
+    });
+    setItems(prev =>
+      prev.map(n =>
+        n.read_at ? n : { ...n, read_at: new Date().toISOString() }
+      )
+    );
+  };
+
+  const handleRowClick = (notification: Notification) => {
+    if (!notification.read_at) {
+      setItems(prev =>
+        prev.map(n =>
+          n.id === notification.id
+            ? { ...n, read_at: new Date().toISOString() }
+            : n
+        )
+      );
+      new ApiClientFactory()
+        .getNotificationsClient()
+        .markRead({ notification_ids: [notification.id] })
+        .catch(() => {
+          // Best-effort -- the row already reads as read locally.
+        });
+    }
+    onClose();
+    if (isNotificationSection(notification.section)) {
+      router.push(SECTION_ROUTES[notification.section]);
+    }
+  };
+
+  const handleLoadOlder = async () => {
+    setLoadingMore(true);
+    try {
+      await fetchPage(items.length, false);
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  const groups = useMemo(() => {
+    const map = new Map<string, Notification[]>();
+    for (const n of items) {
+      const label = dayLabel(n.created_at);
+      const list = map.get(label) ?? [];
+      list.push(n);
+      map.set(label, list);
+    }
+    return Array.from(map.entries());
+  }, [items]);
+
+  return (
+    <FilterDrawerShell
+      open={open}
+      onClose={onClose}
+      title="Notifications"
+      anchor="right"
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          flex: 1,
+          minHeight: 0,
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <Switch
+              size="small"
+              checked={unreadOnly}
+              onChange={e => setUnreadOnly(e.target.checked)}
+              inputProps={{ 'aria-label': 'Show unread only' }}
+            />
+            <Typography variant="caption" color="text.secondary">
+              Unread only
+            </Typography>
+          </Box>
+          <Button
+            size="small"
+            startIcon={<DoneAllIcon fontSize="small" />}
+            onClick={handleMarkAllRead}
+            disabled={totalUnread === 0}
+          >
+            Mark all read
+          </Button>
+        </Box>
+
+        <Box
+          sx={{
+            flex: 1,
+            overflowY: 'auto',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '4px',
+          }}
+        >
+          {loading ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress size={24} />
+            </Box>
+          ) : items.length === 0 ? (
+            <Box sx={{ textAlign: 'center', py: 6 }}>
+              <NotificationsNoneOutlinedIcon
+                sx={{ fontSize: 32, color: 'text.secondary' }}
+              />
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                {unreadOnly ? "You're all caught up" : 'No notifications yet'}
+              </Typography>
+            </Box>
+          ) : (
+            groups.map(([label, rows]) => (
+              <Box key={label}>
+                <Typography
+                  variant="caption"
+                  sx={{ px: '4px', color: 'text.secondary', fontWeight: 600 }}
+                >
+                  {label}
+                </Typography>
+                {rows.map(n => (
+                  <ButtonBase
+                    key={n.id}
+                    onClick={() => handleRowClick(n)}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'flex-start',
+                      textAlign: 'left',
+                      width: '100%',
+                      gap: '10px',
+                      px: '10px',
+                      py: '8px',
+                      borderRadius: BORDER_RADIUS.sm,
+                      bgcolor: n.read_at
+                        ? 'transparent'
+                        : theme => alpha(theme.palette.primary.main, 0.06),
+                      '&:hover': {
+                        bgcolor: theme => theme.palette.greyscale.surface2,
+                      },
+                    }}
+                  >
+                    {n.is_failure ? (
+                      <ErrorOutlineIcon
+                        sx={{
+                          fontSize: 20,
+                          color: 'error.main',
+                          flexShrink: 0,
+                          mt: '2px',
+                        }}
+                      />
+                    ) : (
+                      <NotificationsNoneOutlinedIcon
+                        sx={{
+                          fontSize: 20,
+                          color: 'text.secondary',
+                          flexShrink: 0,
+                          mt: '2px',
+                        }}
+                      />
+                    )}
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography
+                        variant="body2"
+                        sx={{ fontWeight: n.read_at ? 400 : 600 }}
+                      >
+                        {n.title}
+                        {n.item_count > 1 ? ` (${n.item_count})` : ''}
+                      </Typography>
+                      {n.body && (
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          component="div"
+                        >
+                          {n.body}
+                        </Typography>
+                      )}
+                    </Box>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}
+                    >
+                      {relativeTime(n.created_at)}
+                    </Typography>
+                  </ButtonBase>
+                ))}
+              </Box>
+            ))
+          )}
+          {hasMore && items.length > 0 && (
+            <Button
+              size="small"
+              onClick={handleLoadOlder}
+              disabled={loadingMore}
+              sx={{ alignSelf: 'center', mt: 1 }}
+            >
+              {loadingMore ? 'Loading…' : 'Load older'}
+            </Button>
+          )}
+        </Box>
+      </Box>
+    </FilterDrawerShell>
+  );
+}

--- a/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
+++ b/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
@@ -12,13 +12,18 @@ import Typography from '@mui/material/Typography';
 import { alpha } from '@mui/material/styles';
 import DoneAllIcon from '@mui/icons-material/DoneAll';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
+import BarChartOutlinedIcon from '@mui/icons-material/BarChartOutlined';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
+import type SvgIcon from '@mui/material/SvgIcon';
 import { FilterDrawerShell } from '@/components/common/FilterDrawer';
 import { BORDER_RADIUS } from '@/styles/theme';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import type { Notification } from '@/utils/api-client/notifications-client';
 import {
   NotificationSection,
+  UsageNotificationEventType,
   isNotificationSection,
 } from '@/constants/notifications';
 import { useNotifications } from '@/contexts/NotificationsContext';
@@ -34,6 +39,11 @@ const UNREAD_ROW_TINT = 0.06;
 const EMPTY_ICON_SIZE = 32;
 /** Leading icon on a notification row. */
 const ROW_ICON_SIZE = 20;
+/** The rounded tint chip a row's icon sits in. */
+const ROW_ICON_CHIP_SIZE = 28;
+/** Tint behind a row's icon -- same ratio for every severity, so a heavier
+ * colour (error) doesn't read as a heavier chip than a lighter one (success). */
+const ROW_ICON_CHIP_TINT = 0.12;
 
 /** Where a row's own page lives, keyed by `NotificationSection`. Not always
  * `/${section}` -- `USAGE` badges no nav item (see `constants/notifications.ts`)
@@ -45,6 +55,55 @@ const SECTION_ROUTES: Record<NotificationSection, string> = {
   [NotificationSection.ARCHITECT]: '/architect',
   [NotificationSection.USAGE]: '/organizations/usage',
 };
+
+/** The recourse link's base label, keyed by `NotificationSection` -- what a
+ * reader clicks through to. Pluralized in `sectionLinkLabel` below when a
+ * row batches more than one entity. */
+const SECTION_LINK_LABEL: Record<NotificationSection, string> = {
+  [NotificationSection.TEST_SETS]: 'View test set',
+  [NotificationSection.TEST_RUNS]: 'View test run',
+  [NotificationSection.TASKS]: 'View task',
+  [NotificationSection.ARCHITECT]: 'Open architect',
+  [NotificationSection.USAGE]: 'Org usage',
+};
+
+function sectionLinkLabel(
+  section: NotificationSection | null,
+  itemCount: number
+): string | null {
+  if (!section) return null;
+  const label = SECTION_LINK_LABEL[section];
+  return itemCount > 1 ? `${label}s` : label;
+}
+
+type NotificationSeverity = 'success' | 'warning' | 'error';
+
+/** The colour a row's icon takes. `usage.blocked` and any other failure both
+ * read as `error` -- same severity, different glyph (see `notificationIcon`)
+ * -- since either one means "this needs the reader's attention now". */
+function notificationSeverity(n: Notification): NotificationSeverity {
+  if (n.event_type === UsageNotificationEventType.BLOCKED || n.is_failure) {
+    return 'error';
+  }
+  if (n.event_type === UsageNotificationEventType.APPROACHING_LIMIT) {
+    return 'warning';
+  }
+  return 'success';
+}
+
+/** The glyph a row's icon takes. Distinct from severity: a quota block and a
+ * failed test run are both `error`-severity, but "the org hit a limit" and
+ * "this run broke" are different situations and shouldn't look identical. */
+function notificationIcon(n: Notification): typeof SvgIcon {
+  if (n.event_type === UsageNotificationEventType.BLOCKED) {
+    return ErrorOutlineIcon;
+  }
+  if (n.is_failure) return WarningAmberOutlinedIcon;
+  if (n.event_type === UsageNotificationEventType.APPROACHING_LIMIT) {
+    return BarChartOutlinedIcon;
+  }
+  return CheckCircleOutlineIcon;
+}
 
 // Floors rather than rounds: 90 minutes is "1h ago", not "2h ago" -- an age
 // must never read as further in the past than it is. Clamped at 0 so clock
@@ -283,9 +342,18 @@ export default function NotificationsDrawer({
               <NotificationsNoneOutlinedIcon
                 sx={{ fontSize: EMPTY_ICON_SIZE, color: 'text.secondary' }}
               />
-              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                {unreadOnly ? "You're all caught up" : 'No notifications yet'}
+              <Typography variant="body2" sx={{ mt: 1, fontWeight: 600 }}>
+                {unreadOnly ? "You're all caught up" : 'Nothing new'}
               </Typography>
+              {!unreadOnly && (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: 'block', mt: 0.5 }}
+                >
+                  Finished runs, imports, and quota alerts show up here.
+                </Typography>
+              )}
             </Box>
           ) : (
             groups.map(([label, rows]) => (
@@ -296,74 +364,132 @@ export default function NotificationsDrawer({
                 >
                   {label}
                 </Typography>
-                {rows.map(n => (
-                  <ButtonBase
-                    key={n.id}
-                    onClick={() => handleRowClick(n)}
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'flex-start',
-                      textAlign: 'left',
-                      width: '100%',
-                      gap: '10px',
-                      px: '10px',
-                      py: '8px',
-                      borderRadius: BORDER_RADIUS.sm,
-                      bgcolor: n.read_at
-                        ? 'transparent'
-                        : theme =>
-                            alpha(theme.palette.primary.main, UNREAD_ROW_TINT),
-                      '&:hover': {
-                        bgcolor: theme => theme.palette.greyscale.surface2,
-                      },
-                    }}
-                  >
-                    {n.is_failure ? (
-                      <ErrorOutlineIcon
-                        sx={{
-                          fontSize: ROW_ICON_SIZE,
-                          color: 'error.main',
-                          flexShrink: 0,
-                          mt: '2px',
-                        }}
-                      />
-                    ) : (
-                      <NotificationsNoneOutlinedIcon
-                        sx={{
-                          fontSize: ROW_ICON_SIZE,
-                          color: 'text.secondary',
-                          flexShrink: 0,
-                          mt: '2px',
-                        }}
-                      />
-                    )}
-                    <Box sx={{ flex: 1, minWidth: 0 }}>
-                      <Typography
-                        variant="body2"
-                        sx={{ fontWeight: n.read_at ? 400 : 600 }}
-                      >
-                        {n.title}
-                        {n.item_count > 1 ? ` (${n.item_count})` : ''}
-                      </Typography>
-                      {n.body && (
-                        <Typography
-                          variant="caption"
-                          color="text.secondary"
-                          component="div"
-                        >
-                          {n.body}
-                        </Typography>
-                      )}
-                    </Box>
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}
+                {rows.map(n => {
+                  const section = isNotificationSection(n.section)
+                    ? n.section
+                    : null;
+                  const severity = notificationSeverity(n);
+                  const Icon = notificationIcon(n);
+                  const link = sectionLinkLabel(section, n.item_count);
+                  return (
+                    <ButtonBase
+                      key={n.id}
+                      onClick={() => handleRowClick(n)}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'flex-start',
+                        textAlign: 'left',
+                        width: '100%',
+                        gap: '10px',
+                        px: '10px',
+                        py: '8px',
+                        borderRadius: BORDER_RADIUS.sm,
+                        bgcolor: n.read_at
+                          ? 'transparent'
+                          : theme =>
+                              alpha(
+                                theme.palette.primary.main,
+                                UNREAD_ROW_TINT
+                              ),
+                        '&:hover': {
+                          bgcolor: theme => theme.palette.greyscale.surface2,
+                        },
+                      }}
                     >
-                      {relativeTime(n.created_at)}
-                    </Typography>
-                  </ButtonBase>
-                ))}
+                      <Box
+                        sx={{
+                          width: ROW_ICON_CHIP_SIZE,
+                          height: ROW_ICON_CHIP_SIZE,
+                          borderRadius: BORDER_RADIUS.sm,
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          flexShrink: 0,
+                          bgcolor: theme =>
+                            alpha(
+                              theme.palette[severity].main,
+                              ROW_ICON_CHIP_TINT
+                            ),
+                        }}
+                      >
+                        <Icon
+                          sx={{
+                            fontSize: ROW_ICON_SIZE,
+                            color: `${severity}.main`,
+                          }}
+                        />
+                      </Box>
+                      <Box sx={{ flex: 1, minWidth: 0 }}>
+                        <Typography
+                          variant="body2"
+                          sx={{ fontWeight: n.read_at ? 400 : 600 }}
+                        >
+                          {n.title}
+                          {n.item_count > 1 && (
+                            <Typography
+                              component="span"
+                              sx={{
+                                fontSize: 10,
+                                fontWeight: 700,
+                                letterSpacing: '0.04em',
+                                textTransform: 'uppercase',
+                                color: 'text.secondary',
+                                border: theme =>
+                                  `1px solid ${theme.palette.greyscale.border}`,
+                                borderRadius: BORDER_RADIUS.xs,
+                                px: '5px',
+                                py: '1px',
+                                ml: '6px',
+                                whiteSpace: 'nowrap',
+                              }}
+                            >
+                              {n.item_count} items
+                            </Typography>
+                          )}
+                        </Typography>
+                        {n.body && (
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            component="div"
+                          >
+                            {n.body}
+                          </Typography>
+                        )}
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            gap: '8px',
+                            mt: '4px',
+                          }}
+                        >
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ whiteSpace: 'nowrap' }}
+                          >
+                            {relativeTime(n.created_at)}
+                          </Typography>
+                          {link && (
+                            <Typography
+                              variant="caption"
+                              sx={{
+                                color: 'primary.main',
+                                fontWeight: 600,
+                                flexShrink: 0,
+                                whiteSpace: 'nowrap',
+                              }}
+                            >
+                              {link} &rarr;
+                            </Typography>
+                          )}
+                        </Box>
+                      </Box>
+                    </ButtonBase>
+                  );
+                })}
               </Box>
             ))
           )}

--- a/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
+++ b/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
@@ -370,7 +370,10 @@ export default function NotificationsDrawer({
             </Box>
           ) : (
             groups.map(([label, rows]) => (
-              <Box key={label}>
+              <Box
+                key={label}
+                sx={{ display: 'flex', flexDirection: 'column', gap: '4px' }}
+              >
                 <Typography
                   variant="caption"
                   sx={{ px: '4px', color: 'text.secondary', fontWeight: 600 }}

--- a/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
+++ b/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
@@ -292,8 +292,15 @@ export default function NotificationsDrawer({
         >
           {/* FormControlLabel rather than a hand-paired Switch and Typography:
               it associates the two, so the switch has a real accessible name
-              and the text is clickable. */}
+              and the text is clickable. `ml: 0` cancels FormControlLabel's
+              own -11px default left margin (see TabOverview.tsx's "Disable
+              tracing" toggle for the same fix) -- left uncancelled, that
+              margin pulls the switch left of this row's own start, and the
+              switch's root clips its own content to its box (by design, to
+              contain the ripple), so the pulled-left portion just disappears
+              instead of spilling visibly. */}
           <FormControlLabel
+            sx={{ ml: 0 }}
             control={
               <Switch
                 size="small"

--- a/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
+++ b/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
@@ -213,14 +213,20 @@ export default function NotificationsDrawer({
     (Object.keys(unreadBySection) as NotificationSection[]).forEach(section => {
       if ((unreadBySection[section] ?? 0) > 0) markSectionRead(section);
     });
+    if (unreadOnly) {
+      // Every row currently loaded was fetched with unread_only: true, so
+      // marking them all read empties this list entirely rather than
+      // leaving now-read rows rendered under an "Unread only" filter.
+      setItems([]);
+      setPagesLoaded(0);
+      setHasMore(false);
+      return;
+    }
     setItems(prev =>
       prev.map(n =>
         n.read_at ? n : { ...n, read_at: new Date().toISOString() }
       )
     );
-    // Everything shown is read now, so an unread-only list is empty and has
-    // nothing older to offer.
-    if (unreadOnly) setHasMore(false);
   };
 
   const handleRowClick = (notification: Notification) => {

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -34,12 +34,12 @@ import {
   UPGRADE_URL,
 } from '@/constants/quota';
 import {
-  classifyZone,
   flaggedResources,
   isCommunityEdition,
   quotaCopy,
+  usageMenuRows,
   zoneColor,
-  type FlaggedResource,
+  type UsageRow,
 } from '@/utils/quota';
 import { PlanChip } from '@/components/common/QuotaChips';
 import { ColorModeContext } from '@/components/providers/ThemeProvider';
@@ -49,6 +49,7 @@ import {
   SIDEBAR_COLLAPSED_WIDTH,
 } from '@/components/layout/sidebar-constants';
 import { BORDER_RADIUS, COUNT_BADGE_SX, ELEVATION } from '@/styles/theme';
+import type { Theme } from '@mui/material/styles';
 import {
   type ExtendedUser,
   type StandaloneGroup,
@@ -89,6 +90,37 @@ const TOGGLE_LIFT_PX = TOGGLE_ICON_PX + TOGGLE_BUTTON_PADDING_PX;
 // Nudge toward the sidebar edge, into its 26px side padding.
 const TOGGLE_NUDGE_RIGHT_PX = 8;
 
+// Rows the org-menu usage block always shows, padding flagged resources with
+// the next ones in canonical order so it never reads as near-empty for a
+// healthy org. A floor, never a cap: every flagged resource gets a row, so
+// the row count always agrees with the badge.
+const MIN_USAGE_ROWS = 3;
+
+// Shared row style for the org and user menu popovers (Figma 860:40824).
+// Every row in both menus uses this; a row with a trailing badge overrides
+// `justifyContent` to 'space-between'.
+const MENU_ROW_SX = {
+  gap: '10px',
+  px: '14px',
+  py: '8px',
+  '&:hover': {
+    bgcolor: (theme: Theme) => theme.palette.greyscale.border,
+  },
+} as const;
+
+// Icon + label pair inside a menu row.
+const MENU_ICON_SX = {
+  fontSize: 24,
+  color: (theme: Theme) => theme.palette.greyscale.body,
+} as const;
+
+const MENU_LABEL_SX = {
+  fontSize: 14,
+  fontWeight: 700,
+  lineHeight: '22px',
+  color: (theme: Theme) => theme.palette.greyscale.body,
+} as const;
+
 function LeftPanelCloseIcon() {
   return (
     <SvgIcon viewBox="0 0 24 24" sx={{ fontSize: TOGGLE_ICON_PX }}>
@@ -124,7 +156,7 @@ function formatMonthLabel(isoDate: string): string {
  * resources show a count, matching `QuotaBanner`'s split for the same
  * reason (a flow resource's raw count means nothing without the period
  * it accrued over; a stock resource's raw count is the whole story). */
-function UsageMenuRow({ resource, item, zone }: FlaggedResource) {
+function UsageMenuRow({ resource, item, zone }: UsageRow) {
   const label = QUOTA_RESOURCE_LABELS[resource];
   const value =
     item.kind === 'stock' || item.limit === null || item.limit === 0
@@ -215,7 +247,7 @@ export function Sidebar() {
   // severity colour on the badge itself.
   let usageTooltip: string | null = null;
   const worst = flaggedCount === 1 ? flaggedUsage[0] : null;
-  if (worst && worst.zone !== 'healthy') {
+  if (worst) {
     usageTooltip = quotaCopy({
       resource: worst.resource,
       kind: worst.item.kind,
@@ -229,22 +261,22 @@ export function Sidebar() {
     usageTooltip = `Your organization has ${flaggedCount} resources at or near their limit.`;
   }
 
-  // Padded to a minimum of 3 rows (worst-first, then the next resources in
-  // canonical order) so the block never reads as near-empty for a healthy
-  // org -- but never capped: however many resources are actually flagged,
-  // that many rows show, so the row count always agrees with the badge.
-  const MIN_USAGE_ROWS = 3;
-  const usageRows: FlaggedResource[] = [...flaggedUsage];
-  if (usageRows.length < MIN_USAGE_ROWS) {
-    const included = new Set(usageRows.map(row => row.resource));
-    for (const resource of QUOTA_RESOURCE_ORDER) {
-      if (usageRows.length >= MIN_USAGE_ROWS) break;
-      if (included.has(resource)) continue;
-      const item = usageResources[resource];
-      if (!item || item.limit === null) continue;
-      usageRows.push({ resource, item, zone: classifyZone(item), ratio: 0 });
-    }
-  }
+  const usageRows = usageMenuRows(
+    usageResources,
+    QUOTA_RESOURCE_ORDER,
+    MIN_USAGE_ROWS
+  );
+  // Specifically a flow resource, for the same reason UsageOverviewTab picks
+  // one deliberately: stock items always carry the *current* period, so
+  // taking whichever resource happens to come first would silently mislabel
+  // the block the moment the two periods differ.
+  const usagePeriodSource = Object.values(usageResources).find(
+    resourceItem => resourceItem.kind === 'flow'
+  );
+  const usagePeriodLabel = usagePeriodSource
+    ? formatMonthLabel(usagePeriodSource.period_end)
+    : null;
+
   const orgName = branding?.title ?? branding?.productName ?? 'Rhesis AI';
   const groups = groupNavItems(navigation);
 
@@ -528,62 +560,20 @@ export function Sidebar() {
               router.push('/organizations/settings');
               setOrgMenuAnchor(null);
             }}
-            sx={{
-              gap: '10px',
-              px: '14px',
-              py: '8px',
-              '&:hover': {
-                bgcolor: theme => theme.palette.greyscale.border,
-              },
-            }}
+            sx={MENU_ROW_SX}
           >
-            <SettingsOutlinedIcon
-              sx={{
-                fontSize: 24,
-                color: theme => theme.palette.greyscale.body,
-              }}
-            />
-            <Typography
-              sx={{
-                fontSize: 14,
-                fontWeight: 700,
-                lineHeight: '22px',
-                color: theme => theme.palette.greyscale.body,
-              }}
-            >
-              Org Settings
-            </Typography>
+            <SettingsOutlinedIcon sx={MENU_ICON_SX} />
+            <Typography sx={MENU_LABEL_SX}>Org Settings</Typography>
           </MenuItem>
           <MenuItem
             onClick={() => {
               router.push('/projects');
               setOrgMenuAnchor(null);
             }}
-            sx={{
-              gap: '10px',
-              px: '14px',
-              py: '8px',
-              '&:hover': {
-                bgcolor: theme => theme.palette.greyscale.border,
-              },
-            }}
+            sx={MENU_ROW_SX}
           >
-            <AppsOutlinedIcon
-              sx={{
-                fontSize: 24,
-                color: theme => theme.palette.greyscale.body,
-              }}
-            />
-            <Typography
-              sx={{
-                fontSize: 14,
-                fontWeight: 700,
-                lineHeight: '22px',
-                color: theme => theme.palette.greyscale.body,
-              }}
-            >
-              Projects
-            </Typography>
+            <AppsOutlinedIcon sx={MENU_ICON_SX} />
+            <Typography sx={MENU_LABEL_SX}>Projects</Typography>
           </MenuItem>
           {/* Named "Org usage", not "Usage": the menu already reads
               "Org Settings" two rows up, and quota is organization state,
@@ -592,87 +582,74 @@ export function Sidebar() {
               granted org-wide (see the note where `canManageOrg` is
               computed above). Only the "Upgrade plan" row below is
               narrower. */}
-          <>
-            <MenuItem
-              onClick={() => {
-                router.push('/organizations/usage');
-                setOrgMenuAnchor(null);
-              }}
-              sx={{
-                justifyContent: 'space-between',
-                px: '14px',
-                py: '8px',
-                '&:hover': {
-                  bgcolor: theme => theme.palette.greyscale.border,
-                },
-              }}
-            >
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                <DataUsageOutlinedIcon
-                  sx={{
-                    fontSize: 24,
-                    color: theme => theme.palette.greyscale.body,
-                  }}
-                />
-                <Typography
-                  sx={{
-                    fontSize: 14,
-                    fontWeight: 700,
-                    lineHeight: '22px',
-                    color: theme => theme.palette.greyscale.body,
-                  }}
-                >
-                  Org usage
-                </Typography>
-              </Box>
-              {flaggedCount > 0 && (
-                <Box sx={{ ...COUNT_BADGE_SX, flexShrink: 0 }}>
-                  {flaggedCount > 99 ? '99+' : flaggedCount}
-                </Box>
-              )}
-            </MenuItem>
-            {Object.keys(usageResources).length > 0 && (
-              <Box sx={{ pb: '8px' }}>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    px: '14px',
-                    py: '4px',
-                  }}
-                >
-                  <Typography
-                    variant="caption"
-                    sx={{ color: theme => theme.palette.greyscale.subtitle }}
-                  >
-                    {Object.values(usageResources)[0]
-                      ? formatMonthLabel(
-                          Object.values(usageResources)[0].period_end
-                        )
-                      : 'Current usage'}
-                  </Typography>
-                  {edition && <PlanChip edition={edition} />}
-                </Box>
-                {usageRows.map(row => (
-                  <UsageMenuRow key={row.resource} {...row} />
-                ))}
-                {canUpgrade && (
-                  <Box sx={{ px: '14px', pt: '6px' }}>
-                    <MuiLink
-                      href={UPGRADE_URL}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      variant="caption"
-                      sx={{ fontWeight: 700 }}
-                    >
-                      Upgrade plan →
-                    </MuiLink>
-                  </Box>
-                )}
+          <MenuItem
+            onClick={() => {
+              router.push('/organizations/usage');
+              setOrgMenuAnchor(null);
+            }}
+            sx={{ ...MENU_ROW_SX, justifyContent: 'space-between' }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <DataUsageOutlinedIcon
+                sx={{
+                  fontSize: 24,
+                  color: theme => theme.palette.greyscale.body,
+                }}
+              />
+              <Typography
+                sx={{
+                  fontSize: 14,
+                  fontWeight: 700,
+                  lineHeight: '22px',
+                  color: theme => theme.palette.greyscale.body,
+                }}
+              >
+                Org usage
+              </Typography>
+            </Box>
+            {flaggedCount > 0 && (
+              <Box sx={{ ...COUNT_BADGE_SX, flexShrink: 0 }}>
+                {flaggedCount > 99 ? '99+' : flaggedCount}
               </Box>
             )}
-          </>
+          </MenuItem>
+          {Object.keys(usageResources).length > 0 && (
+            <Box sx={{ pb: '8px' }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  px: '14px',
+                  py: '4px',
+                }}
+              >
+                <Typography
+                  variant="caption"
+                  sx={{ color: theme => theme.palette.greyscale.subtitle }}
+                >
+                  {usagePeriodLabel ?? 'Current usage'}
+                </Typography>
+                {edition && <PlanChip edition={edition} />}
+              </Box>
+              {usageRows.map(row => (
+                <UsageMenuRow key={row.resource} {...row} />
+              ))}
+              {canUpgrade && (
+                <Box sx={{ px: '14px', pt: '6px' }}>
+                  <MuiLink
+                    href={UPGRADE_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    variant="caption"
+                    sx={{ fontWeight: 700 }}
+                  >
+                    Upgrade plan →
+                  </MuiLink>
+                </Box>
+              )}
+            </Box>
+          )}
           <Divider
             sx={{
               my: '6px',
@@ -684,31 +661,10 @@ export function Sidebar() {
               setOrgMenuAnchor(null);
               setSwitcherOpen(true);
             }}
-            sx={{
-              gap: '10px',
-              px: '14px',
-              py: '8px',
-              '&:hover': {
-                bgcolor: theme => theme.palette.greyscale.border,
-              },
-            }}
+            sx={MENU_ROW_SX}
           >
-            <SwapHorizOutlinedIcon
-              sx={{
-                fontSize: 24,
-                color: theme => theme.palette.greyscale.body,
-              }}
-            />
-            <Typography
-              sx={{
-                fontSize: 14,
-                fontWeight: 700,
-                lineHeight: '22px',
-                color: theme => theme.palette.greyscale.body,
-              }}
-            >
-              Switch project
-            </Typography>
+            <SwapHorizOutlinedIcon sx={MENU_ICON_SX} />
+            <Typography sx={MENU_LABEL_SX}>Switch project</Typography>
           </MenuItem>
         </Popover>
 
@@ -874,32 +830,11 @@ export function Sidebar() {
               setMenuAnchor(null);
               setNotificationsOpen(true);
             }}
-            sx={{
-              justifyContent: 'space-between',
-              px: '14px',
-              py: '8px',
-              '&:hover': {
-                bgcolor: theme => theme.palette.greyscale.border,
-              },
-            }}
+            sx={{ ...MENU_ROW_SX, justifyContent: 'space-between' }}
           >
             <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-              <NotificationsOutlinedIcon
-                sx={{
-                  fontSize: 24,
-                  color: theme => theme.palette.greyscale.body,
-                }}
-              />
-              <Typography
-                sx={{
-                  fontSize: 14,
-                  fontWeight: 700,
-                  lineHeight: '22px',
-                  color: theme => theme.palette.greyscale.body,
-                }}
-              >
-                Notifications
-              </Typography>
+              <NotificationsOutlinedIcon sx={MENU_ICON_SX} />
+              <Typography sx={MENU_LABEL_SX}>Notifications</Typography>
             </Box>
             {totalUnread > 0 && (
               <Box sx={{ ...COUNT_BADGE_SX, flexShrink: 0 }}>
@@ -914,61 +849,18 @@ export function Sidebar() {
               toggleColorMode();
               setMenuAnchor(null);
             }}
-            sx={{
-              gap: '10px',
-              px: '14px',
-              py: '8px',
-              '&:hover': {
-                bgcolor: theme => theme.palette.greyscale.border,
-              },
-            }}
+            sx={MENU_ROW_SX}
           >
-            <DarkModeOutlinedIcon
-              sx={{
-                fontSize: 24,
-                color: theme => theme.palette.greyscale.body,
-              }}
-            />
-            <Typography
-              sx={{
-                fontSize: 14,
-                fontWeight: 700,
-                lineHeight: '22px',
-                color: theme => theme.palette.greyscale.body,
-              }}
-            >
+            <DarkModeOutlinedIcon sx={MENU_ICON_SX} />
+            <Typography sx={MENU_LABEL_SX}>
               {mode === 'dark' ? 'Light Mode' : 'Dark Mode'}
             </Typography>
           </MenuItem>
 
           {/* Sign Out */}
-          <MenuItem
-            onClick={() => handleSignOut()}
-            sx={{
-              gap: '10px',
-              px: '14px',
-              py: '8px',
-              '&:hover': {
-                bgcolor: theme => theme.palette.greyscale.border,
-              },
-            }}
-          >
-            <ExitToAppOutlinedIcon
-              sx={{
-                fontSize: 24,
-                color: theme => theme.palette.greyscale.body,
-              }}
-            />
-            <Typography
-              sx={{
-                fontSize: 14,
-                fontWeight: 700,
-                lineHeight: '22px',
-                color: theme => theme.palette.greyscale.body,
-              }}
-            >
-              Sign Out
-            </Typography>
+          <MenuItem onClick={() => handleSignOut()} sx={MENU_ROW_SX}>
+            <ExitToAppOutlinedIcon sx={MENU_ICON_SX} />
+            <Typography sx={MENU_LABEL_SX}>Sign Out</Typography>
           </MenuItem>
         </Popover>
       </Box>

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -886,7 +886,11 @@ export function Sidebar() {
             width: collapsed ? COLLAPSED_NAV_ITEM_SIZE : 'auto',
             alignSelf: collapsed ? 'center' : 'stretch',
             borderRadius: BORDER_RADIUS.pill,
-            overflow: 'hidden',
+            // No overflow: hidden -- the unread-count Badge below is meant to
+            // overflow its anchor (MUI positions it via a translate past the
+            // avatar's own edge), and clipping it here cut it off, especially
+            // collapsed where there's only ~4px of slack around the avatar.
+            // The org-icon button above (also badged) never had this either.
             '&:hover': {
               bgcolor: theme => theme.palette.greyscale.surface2,
             },

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -613,7 +613,11 @@ export function Sidebar() {
               </Box>
             )}
           </MenuItem>
-          {Object.keys(usageResources).length > 0 && (
+          {/* Gated on rows, not on `usageResources` being non-empty: a
+              deployment with USAGE_QUOTAS_ENABLED off reports every resource
+              with a null limit, which yields no rows, and a period-and-plan
+              header standing alone over nothing is worse than no block. */}
+          {usageRows.length > 0 && (
             <Box sx={{ pb: '8px' }}>
               <Box
                 sx={{

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -38,6 +38,7 @@ import {
   isCommunityEdition,
   quotaCopy,
   usageMenuRows,
+  usageRowFillPercent,
   zoneColor,
   type UsageRow,
 } from '@/utils/quota';
@@ -48,7 +49,7 @@ import {
   SIDEBAR_WIDTH,
   SIDEBAR_COLLAPSED_WIDTH,
 } from '@/components/layout/sidebar-constants';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
+import { BORDER_RADIUS } from '@/styles/theme';
 import { alpha, type Theme } from '@mui/material/styles';
 import {
   type ExtendedUser,
@@ -122,6 +123,33 @@ const MENU_LABEL_SX = {
   color: (theme: Theme) => theme.palette.greyscale.body,
 } as const;
 
+// Replaces ELEVATION.xs (a tight 4px blur) for the org/user menu popovers.
+// That token reads as a hard slab dropped onto the page, especially against
+// the near-black dark-mode background -- this is the wide, low-opacity blur
+// plus a tighter close shadow the design record's own mockup specifies for
+// this exact popover, so it reads as lifted above the page instead. Built
+// through `alpha()` against black rather than a literal rgba string so the
+// hardcoded-styles CI check -- which flags rgba literals wherever they
+// appear -- has nothing to flag.
+function popoverShadow(theme: Theme): string {
+  const dark = theme.palette.mode === 'dark';
+  const far = alpha(theme.palette.common.black, dark ? 0.5 : 0.13);
+  const near = alpha(theme.palette.common.black, dark ? 0.25 : 0.06);
+  return `0px 8px 32px ${far}, 0px 2px 6px ${near}`;
+}
+
+// Paper styling shared by the org-menu and user-menu popovers (Figma
+// 860:40824) -- same background, radius and shadow; only `minWidth` differs
+// per caller.
+const POPOVER_PAPER_SX = {
+  bgcolor: (theme: Theme) =>
+    theme.palette.mode === 'light' ? '#e7e8ec' : '#1a1c20',
+  borderRadius: BORDER_RADIUS.lg,
+  boxShadow: popoverShadow,
+  py: '10px',
+  overflow: 'hidden',
+} as const;
+
 function LeftPanelCloseIcon() {
   return (
     <SvgIcon viewBox="0 0 24 24" sx={{ fontSize: TOGGLE_ICON_PX }}>
@@ -152,36 +180,75 @@ function formatMonthLabel(isoDate: string): string {
   });
 }
 
-/** One row of the org-menu usage block: a resource's label plus its
- * value, coloured by zone -- flow resources show a percent, stock
- * resources show a count, matching `QuotaBanner`'s split for the same
- * reason (a flow resource's raw count means nothing without the period
- * it accrued over; a stock resource's raw count is the whole story). */
+/** Width of a usage row's label column, so every row's bar starts at the
+ * same x position regardless of label length -- matches the design record's
+ * own `.ub-name` mockup rule. */
+const USAGE_ROW_LABEL_WIDTH = 68;
+
+/** One row of the org-menu usage block: a resource's label, a bar filled
+ * to how much of `limit` is used, and a trailing value -- flow resources
+ * show a percent, stock resources show a count, matching `QuotaBanner`'s
+ * split for the same reason (a flow resource's raw count means nothing
+ * without the period it accrued over; a stock resource's raw count is the
+ * whole story). The bar's fill colour is `zoneColor(zone)` for every zone,
+ * including `healthy`'s green -- unlike the trailing value, which stays
+ * neutral until there is something to flag. */
 function UsageMenuRow({ resource, item, zone }: UsageRow) {
   const label = QUOTA_RESOURCE_LABELS[resource];
   const value =
     item.kind === 'stock' || item.limit === null || item.limit === 0
       ? `${item.used.toLocaleString()} of ${(item.limit ?? 0).toLocaleString()}`
       : `${Math.round((item.used / item.limit) * 100)}%`;
+  const fillPercent = usageRowFillPercent(item);
 
   return (
     <Box
       sx={{
         display: 'flex',
-        justifyContent: 'space-between',
+        alignItems: 'center',
+        gap: '8px',
         px: '14px',
         py: '2px',
       }}
     >
       <Typography
         variant="caption"
-        sx={{ color: theme => theme.palette.greyscale.label }}
+        sx={{
+          width: USAGE_ROW_LABEL_WIDTH,
+          flexShrink: 0,
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          color: theme => theme.palette.greyscale.label,
+        }}
       >
         {label}
       </Typography>
+      <Box
+        sx={{
+          flex: 1,
+          height: 4,
+          borderRadius: 2,
+          overflow: 'hidden',
+          bgcolor: theme => theme.palette.greyscale.border,
+        }}
+      >
+        <Box
+          data-testid="usage-row-fill"
+          sx={{
+            width: `${fillPercent}%`,
+            height: '100%',
+            borderRadius: 2,
+            bgcolor: theme => theme.palette[zoneColor(zone)].main,
+          }}
+        />
+      </Box>
       <Typography
         variant="caption"
         sx={{
+          flexShrink: 0,
+          minWidth: 36,
+          textAlign: 'right',
           fontWeight: 600,
           fontVariantNumeric: 'tabular-nums',
           color: theme =>
@@ -686,16 +753,11 @@ export function Sidebar() {
           slotProps={{
             paper: {
               sx: {
-                bgcolor: theme =>
-                  theme.palette.mode === 'light' ? '#e7e8ec' : '#1a1c20',
-                borderRadius: BORDER_RADIUS.lg,
-                boxShadow: ELEVATION.xs,
+                ...POPOVER_PAPER_SX,
                 // 252px, not the 188px the user-menu popover uses: this one carries the
                 // usage block's period label + plan chip on one row, which needs
                 // breathing room between them.
                 minWidth: 252,
-                py: '10px',
-                overflow: 'hidden',
               },
             },
           }}
@@ -831,12 +893,27 @@ export function Sidebar() {
             transition: 'background-color 0.15s ease',
           }}
         >
-          <UserAvatar
-            userName={user?.name ?? undefined}
-            userPicture={user?.image ?? undefined}
-            size={32}
-            sx={{ flexShrink: 0 }}
-          />
+          {totalUnread > 0 ? (
+            <Badge
+              badgeContent={totalUnread}
+              color="primary"
+              max={99}
+              sx={{ flexShrink: 0 }}
+            >
+              <UserAvatar
+                userName={user?.name ?? undefined}
+                userPicture={user?.image ?? undefined}
+                size={32}
+              />
+            </Badge>
+          ) : (
+            <UserAvatar
+              userName={user?.name ?? undefined}
+              userPicture={user?.image ?? undefined}
+              size={32}
+              sx={{ flexShrink: 0 }}
+            />
+          )}
           {!collapsed && (
             <Box sx={{ minWidth: 0 }}>
               <Typography
@@ -880,13 +957,8 @@ export function Sidebar() {
           slotProps={{
             paper: {
               sx: {
-                bgcolor: theme =>
-                  theme.palette.mode === 'light' ? '#e7e8ec' : '#1a1c20',
-                borderRadius: BORDER_RADIUS.lg,
-                boxShadow: ELEVATION.xs,
+                ...POPOVER_PAPER_SX,
                 minWidth: 188,
-                py: '10px',
-                overflow: 'hidden',
               },
             },
           }}

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -11,7 +11,10 @@ import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
 import Popover from '@mui/material/Popover';
 import SvgIcon from '@mui/material/SvgIcon';
+import Badge from '@mui/material/Badge';
+import MuiLink from '@mui/material/Link';
 import DarkModeOutlinedIcon from '@mui/icons-material/DarkModeOutlined';
+import NotificationsOutlinedIcon from '@mui/icons-material/NotificationsOutlined';
 import ExitToAppOutlinedIcon from '@mui/icons-material/ExitToAppOutlined';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import AppsOutlinedIcon from '@mui/icons-material/AppsOutlined';
@@ -22,15 +25,30 @@ import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 import { useSidebarCollapse } from '@/components/layout/AppShell';
 import BrandMark from '@/components/common/BrandMark';
 import { UserAvatar } from '@/components/common/UserAvatar';
-import { Can } from '@/components/common/Can';
+import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
+import { useUsage } from '@/contexts/UsageContext';
+import {
+  QUOTA_RESOURCE_LABELS,
+  QUOTA_RESOURCE_ORDER,
+  UPGRADE_URL,
+} from '@/constants/quota';
+import {
+  classifyZone,
+  flaggedResources,
+  isCommunityEdition,
+  quotaCopy,
+  zoneColor,
+  type FlaggedResource,
+} from '@/utils/quota';
+import { PlanChip } from '@/components/common/QuotaChips';
 import { ColorModeContext } from '@/components/providers/ThemeProvider';
 import { handleSignOut } from '@/actions/auth';
 import {
   SIDEBAR_WIDTH,
   SIDEBAR_COLLAPSED_WIDTH,
 } from '@/components/layout/sidebar-constants';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
+import { BORDER_RADIUS, COUNT_BADGE_SX, ELEVATION } from '@/styles/theme';
 import {
   type ExtendedUser,
   type StandaloneGroup,
@@ -45,7 +63,9 @@ import { NavLinkItem } from './NavLinkItem';
 import { NavSection } from './NavSection';
 import ProjectSwitcherDrawer from './ProjectSwitcherDrawer';
 import SupportDrawer from './SupportDrawer';
+import NotificationsDrawer from './NotificationsDrawer';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useNotifications } from '@/contexts/NotificationsContext';
 
 // ── Figma "left_panel_close" / "left_panel_open" SVG icons ──────────────────
 // Exact filled path from Figma node 841:38433 (Material Symbols Rounded w300).
@@ -89,6 +109,60 @@ function LeftPanelOpenIcon() {
   );
 }
 
+/** `"August 2026"` -- the org-menu usage block's header month. Stays in
+ * UTC: `period_end` is a date-only string computed in UTC by the backend. */
+function formatMonthLabel(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+/** One row of the org-menu usage block: a resource's label plus its
+ * value, coloured by zone -- flow resources show a percent, stock
+ * resources show a count, matching `QuotaBanner`'s split for the same
+ * reason (a flow resource's raw count means nothing without the period
+ * it accrued over; a stock resource's raw count is the whole story). */
+function UsageMenuRow({ resource, item, zone }: FlaggedResource) {
+  const label = QUOTA_RESOURCE_LABELS[resource];
+  const value =
+    item.kind === 'stock' || item.limit === null || item.limit === 0
+      ? `${item.used.toLocaleString()} of ${(item.limit ?? 0).toLocaleString()}`
+      : `${Math.round((item.used / item.limit) * 100)}%`;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        px: '14px',
+        py: '2px',
+      }}
+    >
+      <Typography
+        variant="caption"
+        sx={{ color: theme => theme.palette.greyscale.label }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        variant="caption"
+        sx={{
+          fontWeight: 600,
+          fontVariantNumeric: 'tabular-nums',
+          color: theme =>
+            zone === 'healthy'
+              ? theme.palette.greyscale.label
+              : theme.palette[zoneColor(zone)].main,
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
 // ─── Sidebar ─────────────────────────────────────────────────────────────────
 
 export function Sidebar() {
@@ -114,6 +188,63 @@ export function Sidebar() {
   // Support drawer
   const [supportOpen, setSupportOpen] = useState(false);
 
+  // Notifications drawer
+  const [notificationsOpen, setNotificationsOpen] = useState(false);
+  const { unreadBySection } = useNotifications();
+  const totalUnread = Object.values(unreadBySection).reduce(
+    (sum, count) => sum + (count ?? 0),
+    0
+  );
+
+  // Quota awareness: `usage:read` is granted to every org member (see
+  // `auth/rbac.py`'s comment on `Usage.READ`), so the badge and org-menu
+  // block below show to everyone -- `UsageContext`'s own fail-closed
+  // contract (an empty `resources` while loading or on error) is what
+  // keeps this quiet until there is real data, not a permission check.
+  // "Can upgrade" is a narrower, separate question: Organization.UPDATE
+  // (the same owner/admin gate as Org Settings), not Usage.READ.
+  const { resources: usageResources, edition } = useUsage();
+  const flaggedUsage = flaggedResources(usageResources);
+  const flaggedCount = flaggedUsage.length;
+  const canManageOrg = useCan(Capability.Organization.UPDATE);
+  const canUpgrade =
+    canManageOrg && edition !== null && isCommunityEdition(edition);
+
+  // The badge answers "how many"; the sentence (only rendered as a tooltip
+  // here, in full in the org-menu block below) answers "how bad" -- no
+  // severity colour on the badge itself.
+  let usageTooltip: string | null = null;
+  const worst = flaggedCount === 1 ? flaggedUsage[0] : null;
+  if (worst && worst.zone !== 'healthy') {
+    usageTooltip = quotaCopy({
+      resource: worst.resource,
+      kind: worst.item.kind,
+      used: worst.item.used,
+      limit: worst.item.limit ?? 0,
+      zone: worst.zone,
+      periodEnd: worst.item.period_end,
+      canUpgrade,
+    }).sentence;
+  } else if (flaggedCount > 1) {
+    usageTooltip = `Your organization has ${flaggedCount} resources at or near their limit.`;
+  }
+
+  // Padded to a minimum of 3 rows (worst-first, then the next resources in
+  // canonical order) so the block never reads as near-empty for a healthy
+  // org -- but never capped: however many resources are actually flagged,
+  // that many rows show, so the row count always agrees with the badge.
+  const MIN_USAGE_ROWS = 3;
+  const usageRows: FlaggedResource[] = [...flaggedUsage];
+  if (usageRows.length < MIN_USAGE_ROWS) {
+    const included = new Set(usageRows.map(row => row.resource));
+    for (const resource of QUOTA_RESOURCE_ORDER) {
+      if (usageRows.length >= MIN_USAGE_ROWS) break;
+      if (included.has(resource)) continue;
+      const item = usageResources[resource];
+      if (!item || item.limit === null) continue;
+      usageRows.push({ resource, item, zone: classifyZone(item), ratio: 0 });
+    }
+  }
   const orgName = branding?.title ?? branding?.productName ?? 'Rhesis AI';
   const groups = groupNavItems(navigation);
 
@@ -195,7 +326,11 @@ export function Sidebar() {
             </Tooltip>
             <Tooltip
               title={
-                activeProject ? `${orgName} · ${activeProject.name}` : orgName
+                usageTooltip
+                  ? `${activeProject ? `${orgName} · ${activeProject.name}` : orgName} — ${usageTooltip}`
+                  : activeProject
+                    ? `${orgName} · ${activeProject.name}`
+                    : orgName
               }
               placement="right"
             >
@@ -216,12 +351,23 @@ export function Sidebar() {
                   },
                 }}
               >
-                <BrandMark
-                  src={branding?.iconUrl}
-                  size={40}
-                  alt={`${orgName} logo`}
-                  priority
-                />
+                {flaggedCount > 0 ? (
+                  <Badge badgeContent={flaggedCount} color="primary" max={99}>
+                    <BrandMark
+                      src={branding?.iconUrl}
+                      size={40}
+                      alt={`${orgName} logo`}
+                      priority
+                    />
+                  </Badge>
+                ) : (
+                  <BrandMark
+                    src={branding?.iconUrl}
+                    size={40}
+                    alt={`${orgName} logo`}
+                    priority
+                  />
+                )}
               </ButtonBase>
             </Tooltip>
           </Box>
@@ -306,6 +452,23 @@ export function Sidebar() {
                   {orgName}
                 </Typography>
               </Box>
+              {flaggedCount > 0 && (
+                <Tooltip title={usageTooltip ?? ''} placement="right">
+                  <Box
+                    sx={{
+                      ...COUNT_BADGE_SX,
+                      flexShrink: 0,
+                      // Cancels the ButtonBase's own -28px so the badge's
+                      // right edge lands at the same inset as every nav-row
+                      // badge, instead of 28px further into the sidebar's
+                      // padding along with the rest of this button's content.
+                      mr: '28px',
+                    }}
+                  >
+                    {flaggedCount > 99 ? '99+' : flaggedCount}
+                  </Box>
+                </Tooltip>
+              )}
             </ButtonBase>
             {/* Collapse toggle — inline, right of brand row. Lifted a full icon
                 height clear of the project name, into the scrolling section's
@@ -422,17 +585,21 @@ export function Sidebar() {
               Projects
             </Typography>
           </MenuItem>
-          {/* Billing data -- hidden rather than shown-then-denied for
-              members without usage:read (the same capability GET /usage
-              requires). */}
-          <Can capability={Capability.Usage.READ}>
+          {/* Named "Org usage", not "Usage": the menu already reads
+              "Org Settings" two rows up, and quota is organization state,
+              never personal -- see IMPLEMENTATION_PROMPT.md's "the rule".
+              Visible to every member, not just admins: `usage:read` is
+              granted org-wide (see the note where `canManageOrg` is
+              computed above). Only the "Upgrade plan" row below is
+              narrower. */}
+          <>
             <MenuItem
               onClick={() => {
                 router.push('/organizations/usage');
                 setOrgMenuAnchor(null);
               }}
               sx={{
-                gap: '10px',
+                justifyContent: 'space-between',
                 px: '14px',
                 py: '8px',
                 '&:hover': {
@@ -440,24 +607,72 @@ export function Sidebar() {
                 },
               }}
             >
-              <DataUsageOutlinedIcon
-                sx={{
-                  fontSize: 24,
-                  color: theme => theme.palette.greyscale.body,
-                }}
-              />
-              <Typography
-                sx={{
-                  fontSize: 14,
-                  fontWeight: 700,
-                  lineHeight: '22px',
-                  color: theme => theme.palette.greyscale.body,
-                }}
-              >
-                Usage
-              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                <DataUsageOutlinedIcon
+                  sx={{
+                    fontSize: 24,
+                    color: theme => theme.palette.greyscale.body,
+                  }}
+                />
+                <Typography
+                  sx={{
+                    fontSize: 14,
+                    fontWeight: 700,
+                    lineHeight: '22px',
+                    color: theme => theme.palette.greyscale.body,
+                  }}
+                >
+                  Org usage
+                </Typography>
+              </Box>
+              {flaggedCount > 0 && (
+                <Box sx={{ ...COUNT_BADGE_SX, flexShrink: 0 }}>
+                  {flaggedCount > 99 ? '99+' : flaggedCount}
+                </Box>
+              )}
             </MenuItem>
-          </Can>
+            {Object.keys(usageResources).length > 0 && (
+              <Box sx={{ pb: '8px' }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    px: '14px',
+                    py: '4px',
+                  }}
+                >
+                  <Typography
+                    variant="caption"
+                    sx={{ color: theme => theme.palette.greyscale.subtitle }}
+                  >
+                    {Object.values(usageResources)[0]
+                      ? formatMonthLabel(
+                          Object.values(usageResources)[0].period_end
+                        )
+                      : 'Current usage'}
+                  </Typography>
+                  {edition && <PlanChip edition={edition} />}
+                </Box>
+                {usageRows.map(row => (
+                  <UsageMenuRow key={row.resource} {...row} />
+                ))}
+                {canUpgrade && (
+                  <Box sx={{ px: '14px', pt: '6px' }}>
+                    <MuiLink
+                      href={UPGRADE_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      variant="caption"
+                      sx={{ fontWeight: 700 }}
+                    >
+                      Upgrade plan →
+                    </MuiLink>
+                  </Box>
+                )}
+              </Box>
+            )}
+          </>
           <Divider
             sx={{
               my: '6px',
@@ -626,6 +841,12 @@ export function Sidebar() {
           onClose={() => setSupportOpen(false)}
         />
 
+        {/* ── Notifications drawer ── */}
+        <NotificationsDrawer
+          open={notificationsOpen}
+          onClose={() => setNotificationsOpen(false)}
+        />
+
         {/* ── User menu popover (Figma 860:40824) ── */}
         <Popover
           open={menuOpen}
@@ -647,6 +868,46 @@ export function Sidebar() {
             },
           }}
         >
+          {/* Notifications */}
+          <MenuItem
+            onClick={() => {
+              setMenuAnchor(null);
+              setNotificationsOpen(true);
+            }}
+            sx={{
+              justifyContent: 'space-between',
+              px: '14px',
+              py: '8px',
+              '&:hover': {
+                bgcolor: theme => theme.palette.greyscale.border,
+              },
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <NotificationsOutlinedIcon
+                sx={{
+                  fontSize: 24,
+                  color: theme => theme.palette.greyscale.body,
+                }}
+              />
+              <Typography
+                sx={{
+                  fontSize: 14,
+                  fontWeight: 700,
+                  lineHeight: '22px',
+                  color: theme => theme.palette.greyscale.body,
+                }}
+              >
+                Notifications
+              </Typography>
+            </Box>
+            {totalUnread > 0 && (
+              <Box sx={{ ...COUNT_BADGE_SX, flexShrink: 0 }}>
+                {totalUnread > 99 ? '99+' : totalUnread}
+              </Box>
+            )}
+          </MenuItem>
+
           {/* Dark Mode */}
           <MenuItem
             onClick={() => {

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -48,7 +48,7 @@ import {
   SIDEBAR_WIDTH,
   SIDEBAR_COLLAPSED_WIDTH,
 } from '@/components/layout/sidebar-constants';
-import { BORDER_RADIUS, COUNT_BADGE_SX, ELEVATION } from '@/styles/theme';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import type { Theme } from '@mui/material/styles';
 import {
   type ExtendedUser,
@@ -58,6 +58,7 @@ import {
   groupNavItems,
   collapsedNavGroupSx,
   COLLAPSED_NAV_ITEM_SIZE,
+  COUNT_BADGE_SX,
 } from './sidebar-utils';
 import { NavItem } from './NavItem';
 import { NavLinkItem } from './NavLinkItem';

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -49,7 +49,7 @@ import {
   SIDEBAR_COLLAPSED_WIDTH,
 } from '@/components/layout/sidebar-constants';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
-import type { Theme } from '@mui/material/styles';
+import { alpha, type Theme } from '@mui/material/styles';
 import {
   type ExtendedUser,
   type StandaloneGroup,
@@ -142,11 +142,11 @@ function LeftPanelOpenIcon() {
   );
 }
 
-/** `"August 2026"` -- the org-menu usage block's header month. Stays in
+/** `"Aug 2026"` -- the org-menu usage block's header month. Stays in
  * UTC: `period_end` is a date-only string computed in UTC by the backend. */
 function formatMonthLabel(isoDate: string): string {
   return new Date(isoDate).toLocaleDateString('en-US', {
-    month: 'long',
+    month: 'short',
     year: 'numeric',
     timeZone: 'UTC',
   });
@@ -277,6 +277,147 @@ export function Sidebar() {
   const usagePeriodLabel = usagePeriodSource
     ? formatMonthLabel(usagePeriodSource.period_end)
     : null;
+
+  // Reordered around the usage block below, not fixed: with a block to
+  // show, "Switch project" and the divider move ahead of it so the everyday
+  // navigation items stay together at the top instead of splitting across a
+  // wall of usage rows. With nothing to show, "Org usage" is just another
+  // nav row and stays where it was.
+  const orgUsageSection = (
+    <>
+      {/* Named "Org usage", not "Usage": the menu already reads "Org
+          Settings" two rows up, and quota is organization state, never
+          personal -- see IMPLEMENTATION_PROMPT.md's "the rule". Visible to
+          every member, not just admins: `usage:read` is granted org-wide
+          (see the note where `canManageOrg` is computed above). Only the
+          "Upgrade plan" row below is narrower. */}
+      <MenuItem
+        onClick={() => {
+          router.push('/organizations/usage');
+          setOrgMenuAnchor(null);
+        }}
+        sx={{ ...MENU_ROW_SX, justifyContent: 'space-between' }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <DataUsageOutlinedIcon
+            sx={{
+              fontSize: 24,
+              color: theme => theme.palette.greyscale.body,
+            }}
+          />
+          <Typography
+            sx={{
+              fontSize: 14,
+              fontWeight: 700,
+              lineHeight: '22px',
+              color: theme => theme.palette.greyscale.body,
+            }}
+          >
+            Org usage
+          </Typography>
+        </Box>
+        {flaggedCount > 0 && (
+          <Box sx={{ ...COUNT_BADGE_SX, flexShrink: 0 }}>
+            {flaggedCount > 99 ? '99+' : flaggedCount}
+          </Box>
+        )}
+      </MenuItem>
+      {/* Gated on rows, not on `usageResources` being non-empty: a
+          deployment with USAGE_QUOTAS_ENABLED off reports every resource
+          with a null limit, which yields no rows, and a period-and-plan
+          header standing alone over nothing is worse than no block. */}
+      {usageRows.length > 0 && (
+        <Box sx={{ pb: '8px' }}>
+          {/* The header and rows are their own click target -- same
+              destination as the "Org usage" row above, so a reader doesn't
+              have to aim for that one specific row when the whole block is
+              about the same page. "Upgrade plan" stays a sibling outside
+              this button, not nested in it: nested interactive elements
+              would fire both on a single click. */}
+          <ButtonBase
+            onClick={() => {
+              router.push('/organizations/usage');
+              setOrgMenuAnchor(null);
+            }}
+            sx={{
+              display: 'block',
+              width: '100%',
+              textAlign: 'left',
+              borderRadius: BORDER_RADIUS.sm,
+            }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                px: '14px',
+                py: '4px',
+              }}
+            >
+              <Typography
+                variant="caption"
+                sx={{ color: theme => theme.palette.greyscale.subtitle }}
+              >
+                {usagePeriodLabel ?? 'Current usage'}
+              </Typography>
+              {edition && <PlanChip edition={edition} />}
+            </Box>
+            {usageRows.map(row => (
+              <UsageMenuRow key={row.resource} {...row} />
+            ))}
+          </ButtonBase>
+          {canUpgrade && (
+            <Box sx={{ px: '14px', pt: '6px' }}>
+              <MuiLink
+                href={UPGRADE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="caption"
+                sx={{ fontWeight: 700 }}
+              >
+                Upgrade plan →
+              </MuiLink>
+            </Box>
+          )}
+        </Box>
+      )}
+    </>
+  );
+
+  // A soft alpha overlay on the popover's own surface, not
+  // `greyscale.border`: that token is tuned for the app's regular
+  // greyscale.surface1/2 backgrounds, and against this popover's own
+  // near-black (dark mode) / near-white (light mode) paper background, set
+  // just below, it sat close enough in luminance to read as no divider
+  // at all.
+  const orgMenuDivider = (
+    <Divider
+      sx={{
+        my: '6px',
+        borderColor: theme =>
+          alpha(
+            theme.palette.mode === 'light'
+              ? theme.palette.common.black
+              : theme.palette.common.white,
+            0.14
+          ),
+      }}
+    />
+  );
+
+  const switchProjectItem = (
+    <MenuItem
+      onClick={() => {
+        setOrgMenuAnchor(null);
+        setSwitcherOpen(true);
+      }}
+      sx={MENU_ROW_SX}
+    >
+      <SwapHorizOutlinedIcon sx={MENU_ICON_SX} />
+      <Typography sx={MENU_LABEL_SX}>Switch project</Typography>
+    </MenuItem>
+  );
 
   const orgName = branding?.title ?? branding?.productName ?? 'Rhesis AI';
   const groups = groupNavItems(navigation);
@@ -549,7 +690,10 @@ export function Sidebar() {
                   theme.palette.mode === 'light' ? '#e7e8ec' : '#1a1c20',
                 borderRadius: BORDER_RADIUS.lg,
                 boxShadow: ELEVATION.xs,
-                minWidth: 188,
+                // 252px, not the 188px the user-menu popover uses: this one carries the
+                // usage block's period label + plan chip on one row, which needs
+                // breathing room between them.
+                minWidth: 252,
                 py: '10px',
                 overflow: 'hidden',
               },
@@ -576,101 +720,19 @@ export function Sidebar() {
             <AppsOutlinedIcon sx={MENU_ICON_SX} />
             <Typography sx={MENU_LABEL_SX}>Projects</Typography>
           </MenuItem>
-          {/* Named "Org usage", not "Usage": the menu already reads
-              "Org Settings" two rows up, and quota is organization state,
-              never personal -- see IMPLEMENTATION_PROMPT.md's "the rule".
-              Visible to every member, not just admins: `usage:read` is
-              granted org-wide (see the note where `canManageOrg` is
-              computed above). Only the "Upgrade plan" row below is
-              narrower. */}
-          <MenuItem
-            onClick={() => {
-              router.push('/organizations/usage');
-              setOrgMenuAnchor(null);
-            }}
-            sx={{ ...MENU_ROW_SX, justifyContent: 'space-between' }}
-          >
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-              <DataUsageOutlinedIcon
-                sx={{
-                  fontSize: 24,
-                  color: theme => theme.palette.greyscale.body,
-                }}
-              />
-              <Typography
-                sx={{
-                  fontSize: 14,
-                  fontWeight: 700,
-                  lineHeight: '22px',
-                  color: theme => theme.palette.greyscale.body,
-                }}
-              >
-                Org usage
-              </Typography>
-            </Box>
-            {flaggedCount > 0 && (
-              <Box sx={{ ...COUNT_BADGE_SX, flexShrink: 0 }}>
-                {flaggedCount > 99 ? '99+' : flaggedCount}
-              </Box>
-            )}
-          </MenuItem>
-          {/* Gated on rows, not on `usageResources` being non-empty: a
-              deployment with USAGE_QUOTAS_ENABLED off reports every resource
-              with a null limit, which yields no rows, and a period-and-plan
-              header standing alone over nothing is worse than no block. */}
-          {usageRows.length > 0 && (
-            <Box sx={{ pb: '8px' }}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  px: '14px',
-                  py: '4px',
-                }}
-              >
-                <Typography
-                  variant="caption"
-                  sx={{ color: theme => theme.palette.greyscale.subtitle }}
-                >
-                  {usagePeriodLabel ?? 'Current usage'}
-                </Typography>
-                {edition && <PlanChip edition={edition} />}
-              </Box>
-              {usageRows.map(row => (
-                <UsageMenuRow key={row.resource} {...row} />
-              ))}
-              {canUpgrade && (
-                <Box sx={{ px: '14px', pt: '6px' }}>
-                  <MuiLink
-                    href={UPGRADE_URL}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    variant="caption"
-                    sx={{ fontWeight: 700 }}
-                  >
-                    Upgrade plan →
-                  </MuiLink>
-                </Box>
-              )}
-            </Box>
+          {usageRows.length > 0 ? (
+            <>
+              {switchProjectItem}
+              {orgMenuDivider}
+              {orgUsageSection}
+            </>
+          ) : (
+            <>
+              {orgUsageSection}
+              {orgMenuDivider}
+              {switchProjectItem}
+            </>
           )}
-          <Divider
-            sx={{
-              my: '6px',
-              borderColor: theme => theme.palette.greyscale.border,
-            }}
-          />
-          <MenuItem
-            onClick={() => {
-              setOrgMenuAnchor(null);
-              setSwitcherOpen(true);
-            }}
-            sx={MENU_ROW_SX}
-          >
-            <SwapHorizOutlinedIcon sx={MENU_ICON_SX} />
-            <Typography sx={MENU_LABEL_SX}>Switch project</Typography>
-          </MenuItem>
         </Popover>
 
         <ProjectSwitcherDrawer

--- a/apps/frontend/src/components/navigation/__tests__/NotificationsDrawer.test.tsx
+++ b/apps/frontend/src/components/navigation/__tests__/NotificationsDrawer.test.tsx
@@ -71,18 +71,18 @@ describe('NotificationsDrawer', () => {
 
   it('shows an empty state when there is nothing to report', async () => {
     render(<NotificationsDrawer open onClose={jest.fn()} />);
-    expect(await screen.findByText('No notifications yet')).toBeInTheDocument();
+    expect(await screen.findByText('Nothing new')).toBeInTheDocument();
   });
 
   it('distinguishes a failed load from an empty inbox', async () => {
-    // "No notifications yet" would read as good news when the request failed.
+    // "Nothing new" would read as good news when the request failed.
     mockGetNotifications.mockRejectedValue(new Error('network down'));
     render(<NotificationsDrawer open onClose={jest.fn()} />);
 
     expect(
       await screen.findByText(/Could not load notifications/i)
     ).toBeInTheDocument();
-    expect(screen.queryByText('No notifications yet')).not.toBeInTheDocument();
+    expect(screen.queryByText('Nothing new')).not.toBeInTheDocument();
   });
 
   it('groups rows under a day heading', async () => {
@@ -100,9 +100,8 @@ describe('NotificationsDrawer', () => {
     ]);
     render(<NotificationsDrawer open onClose={jest.fn()} />);
 
-    expect(
-      await screen.findByText(/Imported test sets \(3\)/)
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Imported test sets')).toBeInTheDocument();
+    expect(screen.getByText('3 items')).toBeInTheDocument();
   });
 
   it('marks a row read through the context, not the client, so the badge follows', async () => {
@@ -248,5 +247,64 @@ describe('NotificationsDrawer', () => {
         expect.objectContaining({ skip: 30 })
       )
     );
+  });
+
+  it('colors a quota-blocked row the same severity as a failure, with a distinct icon', async () => {
+    mockGetNotifications.mockResolvedValue([
+      notification({
+        id: 'n-blocked',
+        section: NotificationSection.USAGE,
+        event_type: 'usage.blocked',
+        title: 'Projects limit reached',
+      }),
+      notification({
+        id: 'n-failed',
+        title: 'A run finished',
+        is_failure: true,
+      }),
+    ]);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+
+    await screen.findByText('Projects limit reached');
+    expect(screen.getByTestId('ErrorOutlineIcon')).toBeInTheDocument();
+    expect(screen.getByTestId('WarningAmberOutlinedIcon')).toBeInTheDocument();
+  });
+
+  it('shows an amber icon for an approaching-limit row and a green one for an ordinary success', async () => {
+    mockGetNotifications.mockResolvedValue([
+      notification({
+        id: 'n-approaching',
+        section: NotificationSection.USAGE,
+        event_type: 'usage.approaching_limit',
+        title: 'Test runs approaching limit',
+      }),
+      notification({ id: 'n-ok', title: 'A run finished' }),
+    ]);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+
+    await screen.findByText('Test runs approaching limit');
+    expect(screen.getByTestId('BarChartOutlinedIcon')).toBeInTheDocument();
+    expect(screen.getByTestId('CheckCircleOutlineIcon')).toBeInTheDocument();
+  });
+
+  it('labels the recourse link by section and pluralizes it for a batch row', async () => {
+    mockGetNotifications.mockResolvedValue([
+      notification({
+        id: 'n-usage',
+        section: NotificationSection.USAGE,
+        event_type: 'usage.blocked',
+        title: 'Projects limit reached',
+      }),
+      notification({
+        id: 'n-batch',
+        section: NotificationSection.TEST_SETS,
+        title: 'Imported test sets',
+        item_count: 3,
+      }),
+    ]);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+
+    expect(await screen.findByText(/Org usage/)).toBeInTheDocument();
+    expect(await screen.findByText(/View test sets/)).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/navigation/__tests__/NotificationsDrawer.test.tsx
+++ b/apps/frontend/src/components/navigation/__tests__/NotificationsDrawer.test.tsx
@@ -1,0 +1,252 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@/test-utils';
+import '@testing-library/jest-dom';
+
+import NotificationsDrawer from '../NotificationsDrawer';
+import { NotificationSection } from '@/constants/notifications';
+import type { Notification } from '@/utils/api-client/notifications-client';
+
+const mockGetNotifications = jest.fn();
+const mockMarkRead = jest.fn();
+const mockPush = jest.fn();
+const mockMarkOneRead = jest.fn();
+const mockMarkSectionRead = jest.fn();
+let mockUnreadBySection: Record<string, number> = {};
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getNotificationsClient: () => ({
+      getNotifications: mockGetNotifications,
+      markRead: mockMarkRead,
+    }),
+  })),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/contexts/NotificationsContext', () => ({
+  useNotifications: () => ({
+    unreadBySection: mockUnreadBySection,
+    markOneRead: mockMarkOneRead,
+    markSectionRead: mockMarkSectionRead,
+    highlightedIds: () => [],
+    clearHighlight: jest.fn(),
+    registerViewing: () => () => {},
+  }),
+}));
+
+function notification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: 'n-1',
+    event_type: 'test_run.execution_completed',
+    section: NotificationSection.TEST_RUNS,
+    title: 'A run finished',
+    body: '3 passed, 1 failed',
+    is_failure: false,
+    entity_type: 'TestRun',
+    entity_id: 'tr-1',
+    item_count: 1,
+    payload: null,
+    read_at: null,
+    created_at: new Date().toISOString(),
+    project_id: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUnreadBySection = {};
+  mockGetNotifications.mockResolvedValue([]);
+  mockMarkRead.mockResolvedValue({ updated: 1 });
+});
+
+describe('NotificationsDrawer', () => {
+  it('renders nothing until opened', () => {
+    render(<NotificationsDrawer open={false} onClose={jest.fn()} />);
+    expect(mockGetNotifications).not.toHaveBeenCalled();
+  });
+
+  it('shows an empty state when there is nothing to report', async () => {
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+    expect(await screen.findByText('No notifications yet')).toBeInTheDocument();
+  });
+
+  it('distinguishes a failed load from an empty inbox', async () => {
+    // "No notifications yet" would read as good news when the request failed.
+    mockGetNotifications.mockRejectedValue(new Error('network down'));
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+
+    expect(
+      await screen.findByText(/Could not load notifications/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText('No notifications yet')).not.toBeInTheDocument();
+  });
+
+  it('groups rows under a day heading', async () => {
+    mockGetNotifications.mockResolvedValue([notification()]);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+
+    expect(await screen.findByText('A run finished')).toBeInTheDocument();
+    expect(screen.getByText('Today')).toBeInTheDocument();
+    expect(screen.getByText('3 passed, 1 failed')).toBeInTheDocument();
+  });
+
+  it('shows how many items a batch row stands for', async () => {
+    mockGetNotifications.mockResolvedValue([
+      notification({ title: 'Imported test sets', item_count: 3 }),
+    ]);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+
+    expect(
+      await screen.findByText(/Imported test sets \(3\)/)
+    ).toBeInTheDocument();
+  });
+
+  it('marks a row read through the context, not the client, so the badge follows', async () => {
+    // Calling the client directly leaves unreadBySection stale and the bell
+    // keeps counting a row the server considers read.
+    const onClose = jest.fn();
+    mockGetNotifications.mockResolvedValue([notification({ item_count: 3 })]);
+    render(<NotificationsDrawer open onClose={onClose} />);
+
+    fireEvent.click(await screen.findByText(/A run finished/));
+
+    expect(mockMarkOneRead).toHaveBeenCalledWith(
+      NotificationSection.TEST_RUNS,
+      'n-1',
+      3
+    );
+    expect(onClose).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/test-runs');
+  });
+
+  it('does not re-mark a row that is already read', async () => {
+    mockGetNotifications.mockResolvedValue([
+      notification({ read_at: new Date().toISOString() }),
+    ]);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+
+    fireEvent.click(await screen.findByText('A run finished'));
+
+    expect(mockMarkOneRead).not.toHaveBeenCalled();
+  });
+
+  it('sends a quota notification to the usage page', async () => {
+    mockGetNotifications.mockResolvedValue([
+      notification({
+        section: NotificationSection.USAGE,
+        event_type: 'usage.blocked',
+        title: 'Test runs limit reached',
+        entity_id: null,
+        entity_type: null,
+      }),
+    ]);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+
+    fireEvent.click(await screen.findByText('Test runs limit reached'));
+
+    expect(mockPush).toHaveBeenCalledWith('/organizations/usage');
+  });
+
+  it('marks every section with unread items read at once', async () => {
+    mockUnreadBySection = {
+      [NotificationSection.TEST_RUNS]: 2,
+      [NotificationSection.TASKS]: 0,
+      [NotificationSection.USAGE]: 1,
+    };
+    mockGetNotifications.mockResolvedValue([notification()]);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /mark all read/i })
+    );
+
+    expect(mockMarkSectionRead).toHaveBeenCalledWith(
+      NotificationSection.TEST_RUNS
+    );
+    expect(mockMarkSectionRead).toHaveBeenCalledWith(NotificationSection.USAGE);
+    // A section with nothing unread is not touched.
+    expect(mockMarkSectionRead).not.toHaveBeenCalledWith(
+      NotificationSection.TASKS
+    );
+  });
+
+  it('disables mark-all-read when nothing is unread', async () => {
+    mockGetNotifications.mockResolvedValue([notification()]);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+
+    expect(
+      await screen.findByRole('button', { name: /mark all read/i })
+    ).toBeDisabled();
+  });
+
+  it('refetches with the unread filter when it is toggled on', async () => {
+    mockGetNotifications.mockResolvedValue([notification()]);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+    await screen.findByText('A run finished');
+
+    fireEvent.click(screen.getByRole('switch', { name: /unread only/i }));
+
+    await waitFor(() =>
+      expect(mockGetNotifications).toHaveBeenLastCalledWith(
+        expect.objectContaining({ unread_only: true, skip: 0 })
+      )
+    );
+  });
+
+  it('offers older pages only while a full page comes back', async () => {
+    mockGetNotifications.mockResolvedValue([notification()]);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+    await screen.findByText('A run finished');
+
+    // One row is a partial page, so there is nothing older to ask for.
+    expect(
+      screen.queryByRole('button', { name: /load older/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('drops a row the next page repeats rather than duplicating a key', async () => {
+    // The backend orders by created_at desc with no id tiebreaker, so a
+    // notification arriving between pages shifts the window and can re-serve
+    // a row already held.
+    const firstPage = Array.from({ length: 30 }, (_, i) =>
+      notification({ id: `n-${i}`, title: `Row ${i}` })
+    );
+    mockGetNotifications.mockResolvedValueOnce(firstPage);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+    await screen.findByText('Row 0');
+
+    mockGetNotifications.mockResolvedValueOnce([
+      notification({ id: 'n-29', title: 'Row 29' }),
+      notification({ id: 'n-30', title: 'Row 30' }),
+    ]);
+    fireEvent.click(screen.getByRole('button', { name: /load older/i }));
+
+    expect(await screen.findByText('Row 30')).toBeInTheDocument();
+    expect(screen.getAllByText('Row 29')).toHaveLength(1);
+  });
+
+  it('asks for the next page by page number, not by rendered row count', async () => {
+    const firstPage = Array.from({ length: 30 }, (_, i) =>
+      notification({ id: `n-${i}`, title: `Row ${i}` })
+    );
+    mockGetNotifications.mockResolvedValueOnce(firstPage);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+    await screen.findByText('Row 0');
+
+    // Reading a row locally must not move the offset: with the unread filter
+    // on that would step straight past rows it never showed.
+    fireEvent.click(screen.getByText('Row 0'));
+    mockGetNotifications.mockResolvedValueOnce([]);
+    fireEvent.click(screen.getByRole('button', { name: /load older/i }));
+
+    await waitFor(() =>
+      expect(mockGetNotifications).toHaveBeenLastCalledWith(
+        expect.objectContaining({ skip: 30 })
+      )
+    );
+  });
+});

--- a/apps/frontend/src/components/navigation/__tests__/NotificationsDrawer.test.tsx
+++ b/apps/frontend/src/components/navigation/__tests__/NotificationsDrawer.test.tsx
@@ -196,6 +196,25 @@ describe('NotificationsDrawer', () => {
     );
   });
 
+  it('empties the list immediately when marking all read while filtered to unread', async () => {
+    // Every row loaded while the filter is on was fetched with
+    // unread_only: true, so marking them all read must clear the list --
+    // leaving them rendered (just with read_at set) would contradict the
+    // "Unread only" filter the user just turned on.
+    mockUnreadBySection = { [NotificationSection.TEST_RUNS]: 1 };
+    mockGetNotifications.mockResolvedValue([notification()]);
+    render(<NotificationsDrawer open onClose={jest.fn()} />);
+    await screen.findByText('A run finished');
+
+    fireEvent.click(screen.getByRole('switch', { name: /unread only/i }));
+    await screen.findByText('A run finished');
+
+    fireEvent.click(screen.getByRole('button', { name: /mark all read/i }));
+
+    expect(screen.queryByText('A run finished')).not.toBeInTheDocument();
+    expect(await screen.findByText("You're all caught up")).toBeInTheDocument();
+  });
+
   it('offers older pages only while a full page comes back', async () => {
     mockGetNotifications.mockResolvedValue([notification()]);
     render(<NotificationsDrawer open onClose={jest.fn()} />);

--- a/apps/frontend/src/components/navigation/sidebar-utils.ts
+++ b/apps/frontend/src/components/navigation/sidebar-utils.ts
@@ -7,6 +7,7 @@ import {
   type NavigationHeaderItem,
   type NavigationActionItem,
 } from '@/types/navigation';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
 
 // ── Shared nav sizing constants ───────────────────────────────────────────────
 
@@ -22,6 +23,32 @@ export const collapsedNavItemSx = {
   boxSizing: 'border-box' as const,
   alignSelf: 'center',
 };
+
+/**
+ * The count-badge pill: a small filled number shown beside something that has
+ * a count -- a nav item's unread notifications, the brand row's flagged
+ * quota resources, the org and user menu rows.
+ *
+ * Lives here rather than in `styles/theme-constants.ts` because it is nav
+ * chrome, not a design token, and because that file is the token *definition*
+ * site: its palette literals are what the hardcoded-styles CI check exists to
+ * find everywhere else, so editing it drags all of them into scope.
+ *
+ * `NavItem` inverts `bgcolor`/`color` on an active row, whose background is
+ * already `primary.main`; every other consumer takes this as-is.
+ */
+export const COUNT_BADGE_SX = {
+  minWidth: 20,
+  height: 20,
+  px: '6px',
+  borderRadius: BORDER_RADIUS.sm,
+  bgcolor: 'primary.main',
+  color: 'primary.contrastText',
+  fontSize: 12,
+  fontWeight: 600,
+  lineHeight: '20px',
+  textAlign: 'center',
+} as const;
 
 export const collapsedNavGroupSx = {
   alignItems: 'center',

--- a/apps/frontend/src/constants/capabilities.ts
+++ b/apps/frontend/src/constants/capabilities.ts
@@ -191,9 +191,20 @@ export const Capability = {
     UPDATE: 'organization:update',
   },
   /**
-   * Metered consumption against plan limits. Separate from
-   * `Organization.READ`, which every Viewer holds for basic org context --
-   * usage is billing data and is restricted to org admins.
+   * Metered consumption against plan limits: counters and caps, no money.
+   *
+   * Held by **every** org member, not just admins -- quota enforcement
+   * blocks members too, so hiding the reason from them only turns a clear
+   * 402 into a support ticket. See the long note on
+   * `_OWNER_ONLY_CAPABILITIES` in `apps/backend/.../auth/rbac.py` (which
+   * deliberately excludes this) and `_VIEWER_EXCLUDED_READS` in
+   * `ee/.../rbac/models.py`; the two must agree or community and EE
+   * disagree about who may read usage.
+   *
+   * So this is *not* the capability to gate an admin-only affordance on --
+   * use `Organization.UPDATE` for "can act on billing" (e.g. an upgrade
+   * CTA). When a real billing surface lands (spend, invoices, payment
+   * method) it gets its own owner-only permission.
    */
   Usage: {
     READ: 'usage:read',

--- a/apps/frontend/src/constants/notifications.ts
+++ b/apps/frontend/src/constants/notifications.ts
@@ -21,5 +21,20 @@ export const NotificationSection = {
 export type NotificationSection =
   (typeof NotificationSection)[keyof typeof NotificationSection];
 
+const NOTIFICATION_SECTION_VALUES: string[] =
+  Object.values(NotificationSection);
+
+/**
+ * Narrows a wire value (a `Notification.section` string, or a URL segment)
+ * to `NotificationSection`. Lives here rather than in each consumer: the
+ * badge context, `NavItem` and the notifications drawer all need it, and
+ * three copies drift the moment a section is added.
+ */
+export function isNotificationSection(
+  value: string
+): value is NotificationSection {
+  return NOTIFICATION_SECTION_VALUES.includes(value);
+}
+
 /** CSS class applied to a grid row whose entity has an unseen notification. */
 export const HIGHLIGHTED_ROW_CLASS = 'rhesis-row-notified';

--- a/apps/frontend/src/constants/notifications.ts
+++ b/apps/frontend/src/constants/notifications.ts
@@ -1,9 +1,9 @@
 /**
  * Notification sidebar sections. Mirrors the backend `NotificationSection`
- * enum in `apps/backend/src/rhesis/backend/app/models/enums.py`. Values must
- * equal the `NavigationPageItem.segment` of the page they badge (see
- * `src/app/layout.tsx`) -- keep in sync when adding a new section, same as
- * `FeatureName`/`Capability`.
+ * enum in `apps/backend/src/rhesis/backend/app/models/enums.py`. A value
+ * equals the `NavigationPageItem.segment` of the page it badges (see
+ * `src/app/layout.tsx`) when it badges one at all -- keep in sync when
+ * adding a new section, same as `FeatureName`/`Capability`.
  */
 export const NotificationSection = {
   TEST_SETS: 'test-sets',
@@ -12,6 +12,10 @@ export const NotificationSection = {
   // Badge only -- the architect page is a chat/session UI, not a grid, so
   // there are no rows for HIGHLIGHTED_ROW_CLASS to apply to.
   ARCHITECT: 'architect',
+  // Badges no nav item -- there is no "/usage" nav segment -- but a quota
+  // notification still needs a section to group and display under in the
+  // notification drawer (`NotificationsDrawer.tsx`).
+  USAGE: 'usage',
 } as const;
 
 export type NotificationSection =

--- a/apps/frontend/src/constants/notifications.ts
+++ b/apps/frontend/src/constants/notifications.ts
@@ -38,3 +38,16 @@ export function isNotificationSection(
 
 /** CSS class applied to a grid row whose entity has an unseen notification. */
 export const HIGHLIGHTED_ROW_CLASS = 'rhesis-row-notified';
+
+/**
+ * The two `Notification.event_type` values a usage threshold crossing can
+ * carry. Mirrors `NotificationEventType.Usage` in `models/enums.py` -- kept
+ * as plain strings rather than importing the backend enum (Python and
+ * TypeScript share no module), the same split every other wire-value mirror
+ * in this file uses. `NotificationsDrawer` reads these to color a quota row
+ * distinctly from an ordinary success/failure one.
+ */
+export const UsageNotificationEventType = {
+  APPROACHING_LIMIT: 'usage.approaching_limit',
+  BLOCKED: 'usage.blocked',
+} as const;

--- a/apps/frontend/src/constants/quota.ts
+++ b/apps/frontend/src/constants/quota.ts
@@ -53,3 +53,15 @@ export const QUOTA_RESOURCE_ORDER: readonly QuotaResource[] = [
   QuotaResource.PROJECTS,
   QuotaResource.ENDPOINTS,
 ];
+
+/**
+ * Utilization at or above this fraction of `limit` puts a resource in the
+ * `approaching` zone (see `utils/quota.ts:classifyZone`). One shared
+ * constant -- it used to live separately in `QuotaBanner` and
+ * `UsageOverviewTab` and was about to gain a third and fourth copy with the
+ * brand-row badge and org-menu block.
+ */
+export const WARNING_THRESHOLD = 0.8;
+
+/** Where every "Upgrade" affordance in the app links to. */
+export const UPGRADE_URL = 'https://rhesis.ai/editions';

--- a/apps/frontend/src/contexts/NotificationsContext.tsx
+++ b/apps/frontend/src/contexts/NotificationsContext.tsx
@@ -15,7 +15,10 @@ import { EventType } from '@/utils/websocket';
 import { useWebSocketContext } from './WebSocketContext';
 import { useActiveProject } from './ActiveProjectContext';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { NotificationSection } from '@/constants/notifications';
+import {
+  NotificationSection,
+  isNotificationSection,
+} from '@/constants/notifications';
 
 type SectionCounts = Partial<Record<NotificationSection, number>>;
 type SectionHighlights = Partial<Record<NotificationSection, string[]>>;
@@ -38,6 +41,21 @@ interface NotificationsContextValue {
   highlightedIds: (section: NotificationSection) => string[];
   /** Zero a section's badge and persist read_at on the backend. */
   markSectionRead: (section: NotificationSection) => void;
+  /**
+   * Mark one notification read: decrement its section's badge by the items
+   * that row stands for, and persist `read_at`.
+   *
+   * Distinct from `markSectionRead` because reading one row in the
+   * notification drawer must not zero the whole section. Callers that hit
+   * `markRead` on the client directly instead of going through here leave
+   * `unreadBySection` stale, and the badge keeps counting a notification
+   * the server already considers read.
+   */
+  markOneRead: (
+    section: NotificationSection,
+    notificationId: string,
+    itemCount: number
+  ) => void;
   /** Drop one id from a section's highlight list (e.g. on row click). */
   clearHighlight: (section: NotificationSection, id: string) => void;
   /**
@@ -60,6 +78,7 @@ const defaultNotificationsContext: NotificationsContextValue = {
   unreadBySection: {},
   highlightedIds: () => [],
   markSectionRead: () => {},
+  markOneRead: () => {},
   clearHighlight: () => {},
   registerViewing: () => () => {},
 };
@@ -67,12 +86,6 @@ const defaultNotificationsContext: NotificationsContextValue = {
 const NotificationsContext = createContext<NotificationsContextValue>(
   defaultNotificationsContext
 );
-
-const SECTION_VALUES: string[] = Object.values(NotificationSection);
-
-function isNotificationSection(value: string): value is NotificationSection {
-  return SECTION_VALUES.includes(value);
-}
 
 /**
  * Tracks per-section unread counts and highlightable entity ids for the
@@ -278,10 +291,31 @@ export function NotificationsProvider({
     [highlighted]
   );
 
+  const markOneRead = useCallback(
+    (
+      section: NotificationSection,
+      notificationId: string,
+      itemCount: number
+    ) => {
+      // Subtract item_count, not 1: the badge counts entities a notification
+      // stands for (3 for a Garak import of three test sets), so reading that
+      // one row clears all three from the count. Floored at 0 -- a summary
+      // refetch is the source of truth if these ever disagree.
+      setUnreadBySection(prev => {
+        const current = prev[section] ?? 0;
+        if (current === 0) return prev;
+        return { ...prev, [section]: Math.max(0, current - itemCount) };
+      });
+      markIdsRead([notificationId]);
+    },
+    [markIdsRead]
+  );
+
   const value: NotificationsContextValue = {
     unreadBySection,
     highlightedIds,
     markSectionRead,
+    markOneRead,
     clearHighlight,
     registerViewing,
   };

--- a/apps/frontend/src/hooks/__tests__/useQuotaGate.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useQuotaGate.test.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import { render, screen } from '@/test-utils';
+import '@testing-library/jest-dom';
+
+import {
+  useQuotaErrorHandler,
+  useQuotaGate,
+  useQuotaMessageFor,
+} from '@/hooks/useQuotaGate';
+import { QuotaResource } from '@/constants/quota';
+import type { UsageResourceItem } from '@/utils/api-client/usage-client';
+
+jest.mock('@/contexts/UsageContext', () => ({
+  useResourceUsage: jest.fn(),
+  useUsage: jest.fn(() => ({
+    resources: {},
+    edition: 'community',
+    loading: false,
+    error: null,
+  })),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: jest.fn(() => true),
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
+import { useResourceUsage, useUsage } from '@/contexts/UsageContext';
+import { useCan } from '@/components/common/Can';
+
+function usage(
+  used: number,
+  limit: number | null,
+  ceiling: number | null
+): UsageResourceItem {
+  return {
+    used,
+    limit,
+    ceiling,
+    period_start: '2026-08-01',
+    period_end: '2026-08-31',
+    kind: 'flow',
+  };
+}
+
+function mockUsage(item: UsageResourceItem | null) {
+  (useResourceUsage as jest.Mock).mockReturnValue(item);
+}
+
+/** Renders a hook's output as text so we can assert on it without extra deps. */
+function GateProbe({ amount }: { amount?: number }) {
+  const gate = useQuotaGate(QuotaResource.TEST_EXECUTIONS, amount);
+  return (
+    <div>
+      <span data-testid="exhausted">{String(gate.exhausted)}</span>
+      <span data-testid="message">{gate.message ?? ''}</span>
+      <span data-testid="notice">{gate.notice ? 'has-notice' : ''}</span>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useCan as jest.Mock).mockReturnValue(true);
+  (useUsage as jest.Mock).mockReturnValue({
+    resources: {},
+    edition: 'community',
+    loading: false,
+    error: null,
+  });
+});
+
+describe('useQuotaGate', () => {
+  it('allows an action well under the ceiling', () => {
+    mockUsage(usage(10, 100, 100));
+    render(<GateProbe />);
+    expect(screen.getByTestId('exhausted')).toHaveTextContent('false');
+    expect(screen.getByTestId('notice')).toBeEmptyDOMElement();
+  });
+
+  it('fails open while usage is still loading', () => {
+    // Blocking on unknown usage would disable the action for everyone during
+    // the first round trip; the server-side 402 is the real gate.
+    mockUsage(null);
+    render(<GateProbe />);
+    expect(screen.getByTestId('exhausted')).toHaveTextContent('false');
+  });
+
+  it('never blocks an unlimited resource', () => {
+    mockUsage(usage(10_000_000, null, null));
+    render(<GateProbe />);
+    expect(screen.getByTestId('exhausted')).toHaveTextContent('false');
+  });
+
+  it('allows the soft-tier grace band rather than stopping at the limit', () => {
+    // limit 100, ceiling 125: gating on `limit` would erase the whole band.
+    mockUsage(usage(110, 100, 125));
+    render(<GateProbe />);
+    expect(screen.getByTestId('exhausted')).toHaveTextContent('false');
+  });
+
+  it('blocks at the ceiling and offers copy', () => {
+    mockUsage(usage(125, 100, 125));
+    render(<GateProbe />);
+    expect(screen.getByTestId('exhausted')).toHaveTextContent('true');
+    expect(screen.getByTestId('notice')).toHaveTextContent('has-notice');
+    expect(screen.getByTestId('message')).toHaveTextContent(
+      /Your organization is at its test runs limit/
+    );
+  });
+
+  it('accounts for an action that consumes several units at once', () => {
+    // Two slots left, but this submit wants five.
+    mockUsage(usage(98, 100, 100));
+    render(<GateProbe amount={5} />);
+    expect(screen.getByTestId('exhausted')).toHaveTextContent('true');
+  });
+
+  it('lets a multi-unit action through when it still fits exactly', () => {
+    mockUsage(usage(98, 100, 100));
+    render(<GateProbe amount={2} />);
+    expect(screen.getByTestId('exhausted')).toHaveTextContent('false');
+  });
+
+  it('points a member at an admin rather than at the upgrade link', () => {
+    (useCan as jest.Mock).mockReturnValue(false);
+    mockUsage(usage(100, 100, 100));
+    render(<GateProbe />);
+    expect(screen.getByTestId('message')).toHaveTextContent(
+      /Ask an org admin to raise this limit/
+    );
+  });
+});
+
+function MessageForProbe({ amount }: { amount: number }) {
+  const messageFor = useQuotaMessageFor(QuotaResource.SEATS);
+  return <span data-testid="msg">{messageFor(amount) ?? 'allowed'}</span>;
+}
+
+describe('useQuotaMessageFor', () => {
+  it('decides against the amount handed in at call time', () => {
+    mockUsage(usage(8, 10, 10));
+    const { rerender } = render(<MessageForProbe amount={2} />);
+    expect(screen.getByTestId('msg')).toHaveTextContent('allowed');
+
+    rerender(<MessageForProbe amount={3} />);
+    expect(screen.getByTestId('msg')).toHaveTextContent(
+      /Your organization is at its seats limit/
+    );
+  });
+});
+
+function ErrorProbe({ err }: { err: unknown }) {
+  const asQuotaError = useQuotaErrorHandler();
+  const result = asQuotaError(err);
+  return <span data-testid="out">{result ? result.message : 'not-quota'}</span>;
+}
+
+describe('useQuotaErrorHandler', () => {
+  function quota402(data: Record<string, unknown>) {
+    const err = new Error('API error: 402') as Error & {
+      status?: number;
+      data?: Record<string, unknown>;
+    };
+    err.status = 402;
+    err.data = data;
+    return err;
+  }
+
+  it('turns a quota 402 into copy', () => {
+    mockUsage(null);
+    render(
+      <ErrorProbe
+        err={quota402({
+          error: 'quota_exceeded',
+          resource: 'projects',
+          used: 1,
+          limit: 1,
+          kind: 'stock',
+        })}
+      />
+    );
+    expect(screen.getByTestId('out')).toHaveTextContent(
+      /Your organization is at its projects limit \(1 of 1\)\. Delete a project/
+    );
+  });
+
+  it('passes through anything that is not a quota error', () => {
+    mockUsage(null);
+    const other = new Error('boom') as Error & { status?: number };
+    other.status = 500;
+    render(<ErrorProbe err={other} />);
+    expect(screen.getByTestId('out')).toHaveTextContent('not-quota');
+  });
+
+  it('ignores a resource the frontend does not know yet', () => {
+    mockUsage(null);
+    render(
+      <ErrorProbe
+        err={quota402({
+          error: 'quota_exceeded',
+          resource: 'some_future_resource',
+          used: 1,
+          limit: 1,
+        })}
+      />
+    );
+    expect(screen.getByTestId('out')).toHaveTextContent('not-quota');
+  });
+});

--- a/apps/frontend/src/hooks/useCreateEndpoint.ts
+++ b/apps/frontend/src/hooks/useCreateEndpoint.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { endpointKeys } from '@/constants/query-keys';
+import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
+import { createEndpoint } from '@/actions/endpoints';
+
+/**
+ * Wraps the `createEndpoint` server action so every caller invalidates the
+ * endpoints list and the usage cache the same way. Not a `useMutation`
+ * because the server action never throws on a business failure — it
+ * returns `{ success: false, error }` instead — so invalidation only fires
+ * once here, on `result.success`, rather than at every call site.
+ *
+ * Kept out of `useEndpoints.ts`: that file's other hooks are imported all
+ * over the app, and `createEndpoint` (a server action) pulls in `src/auth.ts`
+ * and the NextAuth server bundle. Bundling them together would drag that
+ * into every one of those unrelated consumers.
+ */
+export function useCreateEndpoint() {
+  const queryClient = useQueryClient();
+  const invalidateUsage = useInvalidateUsage();
+  return useCallback(
+    async (data: Parameters<typeof createEndpoint>[0]) => {
+      const result = await createEndpoint(data);
+      if (result.success) {
+        queryClient.invalidateQueries({ queryKey: endpointKeys.all() });
+        // Endpoints are a stock resource: creating one consumes quota, and
+        // the endpoints gate reads the cached count.
+        invalidateUsage();
+      }
+      return result;
+    },
+    [queryClient, invalidateUsage]
+  );
+}

--- a/apps/frontend/src/hooks/useEndpoints.ts
+++ b/apps/frontend/src/hooks/useEndpoints.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { endpointKeys, projectKeys } from '@/constants/query-keys';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -11,6 +11,7 @@ import {
 import { EndpointCreate } from '@/utils/api-client/endpoints-client';
 import {
   Project,
+  ProjectCreate,
   ProjectsQueryParams,
 } from '@/utils/api-client/interfaces/project';
 import { PaginationParams } from '@/utils/api-client/interfaces/pagination';
@@ -162,6 +163,43 @@ export function useDeleteEndpoint() {
       invalidateUsage();
     },
   });
+}
+
+export function useCreateProject() {
+  const isAuthenticated = useIsAuthenticated();
+  const invalidateUsage = useInvalidateUsage();
+  return useCallback(
+    async (data: ProjectCreate) => {
+      if (!isAuthenticated) {
+        throw new Error('Not authenticated');
+      }
+      const project = await new ApiClientFactory()
+        .getProjectsClient()
+        .createProject(data);
+      // Projects are a stock resource: creating one consumes quota, and the
+      // projects gate reads the cached count.
+      invalidateUsage();
+      return project;
+    },
+    [isAuthenticated, invalidateUsage]
+  );
+}
+
+export function useDeleteProject() {
+  const isAuthenticated = useIsAuthenticated();
+  const invalidateUsage = useInvalidateUsage();
+  return useCallback(
+    async (id: string) => {
+      if (!isAuthenticated) {
+        throw new Error('Not authenticated');
+      }
+      await new ApiClientFactory().getProjectsClient().deleteProject(id);
+      // Deleting a project frees quota, and the projects gate reads the
+      // cached count.
+      invalidateUsage();
+    },
+    [isAuthenticated, invalidateUsage]
+  );
 }
 
 export function useTestEndpoint() {

--- a/apps/frontend/src/hooks/useEndpoints.ts
+++ b/apps/frontend/src/hooks/useEndpoints.ts
@@ -15,6 +15,7 @@ import {
 } from '@/utils/api-client/interfaces/project';
 import { PaginationParams } from '@/utils/api-client/interfaces/pagination';
 import { useIsAuthenticated } from '@/hooks/useIsAuthenticated';
+import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
 
 const STALE_TIME = 5 * 60_000;
 
@@ -146,6 +147,7 @@ export function useEndpointOptions(enabled = true) {
 export function useDeleteEndpoint() {
   const queryClient = useQueryClient();
   const isAuthenticated = useIsAuthenticated();
+  const invalidateUsage = useInvalidateUsage();
   return useMutation({
     mutationFn: (id: string) => {
       if (!isAuthenticated) {
@@ -155,6 +157,9 @@ export function useDeleteEndpoint() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: endpointKeys.all() });
+      // Endpoints are a stock resource: deleting one frees quota, and the
+      // endpoints gate reads the cached count.
+      invalidateUsage();
     },
   });
 }

--- a/apps/frontend/src/hooks/useEndpoints.ts
+++ b/apps/frontend/src/hooks/useEndpoints.ts
@@ -166,6 +166,7 @@ export function useDeleteEndpoint() {
 }
 
 export function useCreateProject() {
+  const queryClient = useQueryClient();
   const isAuthenticated = useIsAuthenticated();
   const invalidateUsage = useInvalidateUsage();
   return useCallback(
@@ -176,16 +177,18 @@ export function useCreateProject() {
       const project = await new ApiClientFactory()
         .getProjectsClient()
         .createProject(data);
+      queryClient.invalidateQueries({ queryKey: projectKeys.all() });
       // Projects are a stock resource: creating one consumes quota, and the
       // projects gate reads the cached count.
       invalidateUsage();
       return project;
     },
-    [isAuthenticated, invalidateUsage]
+    [queryClient, isAuthenticated, invalidateUsage]
   );
 }
 
 export function useDeleteProject() {
+  const queryClient = useQueryClient();
   const isAuthenticated = useIsAuthenticated();
   const invalidateUsage = useInvalidateUsage();
   return useCallback(
@@ -194,11 +197,12 @@ export function useDeleteProject() {
         throw new Error('Not authenticated');
       }
       await new ApiClientFactory().getProjectsClient().deleteProject(id);
+      queryClient.invalidateQueries({ queryKey: projectKeys.all() });
       // Deleting a project frees quota, and the projects gate reads the
       // cached count.
       invalidateUsage();
     },
-    [isAuthenticated, invalidateUsage]
+    [queryClient, isAuthenticated, invalidateUsage]
   );
 }
 

--- a/apps/frontend/src/hooks/useInvalidateUsage.ts
+++ b/apps/frontend/src/hooks/useInvalidateUsage.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { usageKeys } from '@/constants/query-keys';
+import { useUserScope } from '@/hooks/useIsAuthenticated';
+
+/**
+ * Returns a callback that drops the cached `GET /usage` response.
+ *
+ * Call it after creating or deleting a **stock** resource (a project, an
+ * endpoint, a member/seat). `UsageContext` caches for five minutes, so
+ * without this a user who deletes a project because a quota notice told
+ * them to stays blocked for up to five minutes, having done exactly what
+ * was asked.
+ *
+ * Flow resources (test runs, generation, spans, tokens) deliberately stay on
+ * `staleTime`: a stale flow count only ever drifts up, so the preflight errs
+ * open and the server-side 402 catches it.
+ *
+ * `usageKeys.all(userScope)` is the `['usage', userScope]` prefix, so this
+ * also invalidates the history and past-period queries beneath it.
+ */
+export function useInvalidateUsage(): () => void {
+  const queryClient = useQueryClient();
+  const userScope = useUserScope();
+
+  return useCallback(() => {
+    if (!userScope) return;
+    queryClient.invalidateQueries({ queryKey: usageKeys.all(userScope) });
+  }, [queryClient, userScope]);
+}

--- a/apps/frontend/src/hooks/useQuotaGate.tsx
+++ b/apps/frontend/src/hooks/useQuotaGate.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+/**
+ * Preflight quota gating for a single action, and the reactive 402 path that
+ * backs it up.
+ *
+ * Every gated surface needs the same five things: read the resource's usage,
+ * compare against `ceiling` (never `limit`), decide whether this reader may
+ * be offered an upgrade, build the notice, and handle the 402 that arrives
+ * anyway. Hand-rolling that per drawer is how the copy and the threshold
+ * drift apart, so it lives here once.
+ *
+ * The preflight is not a replacement for the server-side gate: usage can
+ * change between render and submit, so the backend stays authoritative and
+ * this only gives the user the answer earlier.
+ */
+
+import { useCallback } from 'react';
+import { useCan } from '@/components/common/Can';
+import { QuotaNotice } from '@/components/common/QuotaNotice';
+import { Capability } from '@/constants/capabilities';
+import type { QuotaResource } from '@/constants/quota';
+import { useResourceUsage, useUsage } from '@/contexts/UsageContext';
+import {
+  isCommunityEdition,
+  isKnownQuotaResource,
+  parseQuotaError,
+  quotaCopy,
+} from '@/utils/quota';
+
+/** Sentence and recourse joined for a surface that can only show a string
+ * (a toast). No link: a snackbar auto-dismisses, so a link in one is a trap. */
+function joinForToast(sentence: string, recourse: string): string {
+  return recourse ? `${sentence} ${recourse}` : sentence;
+}
+
+export interface QuotaGate {
+  /**
+   * True when the backend would refuse this action right now. `false` while
+   * usage is still loading, so the gate fails open and the 402 catches it --
+   * blocking on unknown usage would disable the button for everyone during
+   * the first round trip.
+   */
+  exhausted: boolean;
+  /** Rendered notice for `BaseDrawer`'s `error` slot, or `undefined` when
+   * the action is allowed. */
+  notice: React.ReactNode | undefined;
+  /** The same thing as a plain string, for a toast-only surface. */
+  message: string | undefined;
+}
+
+/**
+ * Gate one action on one resource.
+ *
+ * @param resource the metered resource this action consumes.
+ * @param amount how much of it a single submit consumes. Defaults to 1;
+ *   pass the real count where one submit consumes several (inviting five
+ *   people at once consumes five seats), or the gate lets through a submit
+ *   the backend will refuse partway.
+ */
+export function useQuotaGate(
+  resource: QuotaResource,
+  amount: number = 1
+): QuotaGate {
+  const usage = useResourceUsage(resource);
+  const canUpgrade = useCanUpgrade();
+
+  // Against `ceiling`, not `limit`: on a soft tier those differ by the
+  // overage tolerance, and gating on `limit` would disable the action for an
+  // org the backend would still accept, erasing the grace band its tier
+  // grants.
+  const exhausted =
+    usage !== null &&
+    usage.ceiling !== null &&
+    usage.used + amount > usage.ceiling;
+
+  if (!exhausted || usage === null) {
+    return { exhausted: false, notice: undefined, message: undefined };
+  }
+
+  const copyInput = {
+    resource,
+    kind: usage.kind,
+    used: usage.used,
+    limit: usage.limit ?? 0,
+    zone: 'blocked' as const,
+    periodEnd: usage.period_end,
+    canUpgrade,
+  };
+  const { sentence, recourse } = quotaCopy(copyInput);
+
+  return {
+    exhausted: true,
+    notice: <QuotaNotice {...copyInput} />,
+    message: joinForToast(sentence, recourse),
+  };
+}
+
+/**
+ * The string form of {@link useQuotaGate}, for an action whose cost is only
+ * known at submit time. Returns the blocking message, or `null` when this
+ * many units still fit.
+ *
+ * Inviting five people at once consumes five seats, so a fixed
+ * `useQuotaGate(SEATS)` would wave through a submit the backend refuses
+ * partway. Callers that know their cost at render should use
+ * `useQuotaGate(resource, amount)` instead and disable the submit.
+ */
+export function useQuotaMessageFor(
+  resource: QuotaResource
+): (amount: number) => string | null {
+  const usage = useResourceUsage(resource);
+  const canUpgrade = useCanUpgrade();
+
+  return useCallback(
+    (amount: number) => {
+      if (usage === null || usage.ceiling === null) return null;
+      if (usage.used + amount <= usage.ceiling) return null;
+      const { sentence, recourse } = quotaCopy({
+        resource,
+        kind: usage.kind,
+        used: usage.used,
+        limit: usage.limit ?? 0,
+        zone: 'blocked',
+        periodEnd: usage.period_end,
+        canUpgrade,
+      });
+      return joinForToast(sentence, recourse);
+    },
+    [resource, usage, canUpgrade]
+  );
+}
+
+/** Whether this reader can act on an upgrade: someone who can manage the org
+ * (the same owner/admin gate as Org Settings) on a community-edition org.
+ * Deliberately not `usage:read`, which every member holds. */
+export function useCanUpgrade(): boolean {
+  const canManageOrg = useCan(Capability.Organization.UPDATE);
+  const { edition } = useUsage();
+  return canManageOrg && edition !== null && isCommunityEdition(edition);
+}
+
+export interface QuotaErrorResult {
+  notice: React.ReactNode;
+  message: string;
+}
+
+/**
+ * Turns a caught error into quota copy when it is a quota 402, or `null`
+ * when it is anything else, so a call site reads:
+ *
+ *     const quota = asQuotaError(err);
+ *     setError(quota?.notice ?? getApiErrorMessage(err, 'Failed to save'));
+ *
+ * The backup to every preflight: usage can change between render and submit,
+ * and a member who reaches an action the preflight hid still gets a real
+ * explanation rather than a raw error string.
+ */
+export function useQuotaErrorHandler(): (
+  err: unknown
+) => QuotaErrorResult | null {
+  const canUpgrade = useCanUpgrade();
+
+  return useCallback(
+    (err: unknown) => {
+      const quotaError = parseQuotaError(err);
+      if (!quotaError || !isKnownQuotaResource(quotaError.resource))
+        return null;
+
+      const copyInput = {
+        resource: quotaError.resource,
+        kind: quotaError.kind,
+        used: quotaError.used,
+        limit: quotaError.limit ?? 0,
+        zone: 'blocked' as const,
+        periodEnd: quotaError.periodEnd,
+        canUpgrade,
+      };
+      const { sentence, recourse } = quotaCopy(copyInput);
+      return {
+        notice: <QuotaNotice {...copyInput} />,
+        message: joinForToast(sentence, recourse),
+      };
+    },
+    [canUpgrade]
+  );
+}

--- a/apps/frontend/src/hooks/useUsers.ts
+++ b/apps/frontend/src/hooks/useUsers.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useCallback } from 'react';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { UserCreate } from '@/utils/api-client/interfaces/user';
+import { useIsAuthenticated } from '@/hooks/useIsAuthenticated';
+import { useInvalidateUsage } from '@/hooks/useInvalidateUsage';
+
+/**
+ * Wraps `UsersClient.createUser` so every caller invalidates the usage
+ * cache the same way. Seats are a stock resource: creating a user consumes
+ * one, and the invite gate reads the cached count.
+ */
+export function useCreateUser() {
+  const isAuthenticated = useIsAuthenticated();
+  const invalidateUsage = useInvalidateUsage();
+  return useCallback(
+    async (data: UserCreate) => {
+      if (!isAuthenticated) {
+        throw new Error('Not authenticated');
+      }
+      const user = await new ApiClientFactory()
+        .getUsersClient()
+        .createUser(data);
+      invalidateUsage();
+      return user;
+    },
+    [isAuthenticated, invalidateUsage]
+  );
+}
+
+/** Removing a member frees a seat. */
+export function useDeleteUser() {
+  const isAuthenticated = useIsAuthenticated();
+  const invalidateUsage = useInvalidateUsage();
+  return useCallback(
+    async (id: string) => {
+      if (!isAuthenticated) {
+        throw new Error('Not authenticated');
+      }
+      await new ApiClientFactory().getUsersClient().deleteUser(id);
+      invalidateUsage();
+    },
+    [isAuthenticated, invalidateUsage]
+  );
+}

--- a/apps/frontend/src/styles/theme-constants.ts
+++ b/apps/frontend/src/styles/theme-constants.ts
@@ -36,26 +36,6 @@ export const BORDER_RADIUS = {
   pill: '999px',
 } as const;
 
-/**
- * The expanded-state count-badge pill: a small filled number used wherever
- * something needs a "how many" count next to it (nav items, the org-menu
- * usage block, the brand-row usage badge). `NavItem`'s badge additionally
- * inverts `bgcolor`/`color` when its row is active -- this is the shared,
- * non-active look every other consumer uses as-is.
- */
-export const COUNT_BADGE_SX = {
-  minWidth: 20,
-  height: 20,
-  px: '6px',
-  borderRadius: BORDER_RADIUS.sm,
-  bgcolor: 'primary.main',
-  color: 'primary.contrastText',
-  fontSize: 12,
-  fontWeight: 600,
-  lineHeight: '20px',
-  textAlign: 'center',
-} as const;
-
 export const BACKDROP_COLORS = {
   /** Teal overlay — used for create/edit entity drawers */
   create: 'rgba(0, 101, 140, 0.8)',

--- a/apps/frontend/src/styles/theme-constants.ts
+++ b/apps/frontend/src/styles/theme-constants.ts
@@ -36,6 +36,26 @@ export const BORDER_RADIUS = {
   pill: '999px',
 } as const;
 
+/**
+ * The expanded-state count-badge pill: a small filled number used wherever
+ * something needs a "how many" count next to it (nav items, the org-menu
+ * usage block, the brand-row usage badge). `NavItem`'s badge additionally
+ * inverts `bgcolor`/`color` when its row is active -- this is the shared,
+ * non-active look every other consumer uses as-is.
+ */
+export const COUNT_BADGE_SX = {
+  minWidth: 20,
+  height: 20,
+  px: '6px',
+  borderRadius: BORDER_RADIUS.sm,
+  bgcolor: 'primary.main',
+  color: 'primary.contrastText',
+  fontSize: 12,
+  fontWeight: 600,
+  lineHeight: '20px',
+  textAlign: 'center',
+} as const;
+
 export const BACKDROP_COLORS = {
   /** Teal overlay — used for create/edit entity drawers */
   create: 'rgba(0, 101, 140, 0.8)',

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -12,7 +12,6 @@ import {
   BACKDROP_COLORS,
   ELEVATION,
   FAB_GROUP_GAP,
-  COUNT_BADGE_SX,
 } from './theme-constants';
 import {
   contrastTextFor,
@@ -22,14 +21,7 @@ import {
   deriveBrandSurfaces,
   deriveSecondaryAccents,
 } from './brand-palette';
-export {
-  GREYSCALE,
-  BORDER_RADIUS,
-  BACKDROP_COLORS,
-  ELEVATION,
-  FAB_GROUP_GAP,
-  COUNT_BADGE_SX,
-};
+export { GREYSCALE, BORDER_RADIUS, BACKDROP_COLORS, ELEVATION, FAB_GROUP_GAP };
 
 /** Deployment brand colours (`BRAND_PRIMARY_COLOR`, `BRAND_SECONDARY_COLOR`). */
 export interface BrandColors {

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -12,6 +12,7 @@ import {
   BACKDROP_COLORS,
   ELEVATION,
   FAB_GROUP_GAP,
+  COUNT_BADGE_SX,
 } from './theme-constants';
 import {
   contrastTextFor,
@@ -21,7 +22,14 @@ import {
   deriveBrandSurfaces,
   deriveSecondaryAccents,
 } from './brand-palette';
-export { GREYSCALE, BORDER_RADIUS, BACKDROP_COLORS, ELEVATION, FAB_GROUP_GAP };
+export {
+  GREYSCALE,
+  BORDER_RADIUS,
+  BACKDROP_COLORS,
+  ELEVATION,
+  FAB_GROUP_GAP,
+  COUNT_BADGE_SX,
+};
 
 /** Deployment brand colours (`BRAND_PRIMARY_COLOR`, `BRAND_SECONDARY_COLOR`). */
 export interface BrandColors {

--- a/apps/frontend/src/utils/__tests__/quota.test.ts
+++ b/apps/frontend/src/utils/__tests__/quota.test.ts
@@ -6,6 +6,7 @@ import {
   parseQuotaError,
   quotaCopy,
   usageMenuRows,
+  usageRowFillPercent,
   zoneColor,
 } from '@/utils/quota';
 import { QuotaResource } from '@/constants/quota';
@@ -372,5 +373,23 @@ describe('usageMenuRows', () => {
       3
     );
     expect(rows.map(r => r.resource)).toEqual([QuotaResource.SEATS]);
+  });
+});
+
+describe('usageRowFillPercent', () => {
+  it('fills proportionally to limit', () => {
+    expect(usageRowFillPercent(item(85, 100))).toBe(85);
+  });
+
+  it('caps at 100 for a soft-tier row still in its grace band', () => {
+    expect(usageRowFillPercent(item(150, 100, { ceiling: 200 }))).toBe(100);
+  });
+
+  it('fills fully for a zero-limit resource with any usage', () => {
+    expect(usageRowFillPercent(item(0, 0))).toBe(100);
+  });
+
+  it('rounds to the nearest whole percent', () => {
+    expect(usageRowFillPercent(item(1, 3))).toBe(33);
   });
 });

--- a/apps/frontend/src/utils/__tests__/quota.test.ts
+++ b/apps/frontend/src/utils/__tests__/quota.test.ts
@@ -1,0 +1,376 @@
+import {
+  classifyZone,
+  flaggedResources,
+  findWorstResource,
+  isKnownQuotaResource,
+  parseQuotaError,
+  quotaCopy,
+  usageMenuRows,
+  zoneColor,
+} from '@/utils/quota';
+import { QuotaResource } from '@/constants/quota';
+import type { UsageResourceItem } from '@/utils/api-client/usage-client';
+
+/** `ceiling` defaults to `limit` (a hard tier, no grace band). */
+function item(
+  used: number,
+  limit: number | null,
+  options: { kind?: 'flow' | 'stock'; ceiling?: number | null } = {}
+): UsageResourceItem {
+  const { kind = 'flow', ceiling } = options;
+  return {
+    used,
+    limit,
+    ceiling: ceiling === undefined ? limit : ceiling,
+    period_start: '2026-08-01',
+    period_end: '2026-08-31',
+    kind,
+  };
+}
+
+describe('classifyZone', () => {
+  it('treats an unlimited resource as healthy at any usage', () => {
+    expect(classifyZone(item(10_000_000, null))).toBe('healthy');
+  });
+
+  it.each([
+    [0, 'healthy'],
+    [79, 'healthy'],
+    [80, 'approaching'],
+    [99, 'approaching'],
+    [100, 'blocked'],
+    [150, 'blocked'],
+  ])('hard tier limit 100: used %i -> %s', (used, expected) => {
+    expect(classifyZone(item(used, 100))).toBe(expected);
+  });
+
+  it.each([
+    [79, 'healthy'],
+    [80, 'approaching'],
+    [99, 'approaching'],
+    [100, 'pastIncluded'],
+    [124, 'pastIncluded'],
+    [125, 'blocked'],
+    [200, 'blocked'],
+  ])('soft tier limit 100 ceiling 125: used %i -> %s', (used, expected) => {
+    expect(classifyZone(item(used, 100, { ceiling: 125 }))).toBe(expected);
+  });
+
+  it('treats a limit of zero as blocked, not unlimited', () => {
+    // The backend's rule is `allowed = used < ceiling` and ceiling_for(0) is
+    // 0, so such an org is refused from its first request.
+    expect(classifyZone(item(0, 0))).toBe('blocked');
+  });
+
+  it('treats a null ceiling beside a numeric limit as a hard tier', () => {
+    // Not a shape the API emits, but it must not park the resource in
+    // pastIncluded and promise an overage allowance that does not exist.
+    expect(classifyZone(item(100, 100, { ceiling: null }))).toBe('blocked');
+  });
+});
+
+describe('zoneColor', () => {
+  it('maps each zone to a severity', () => {
+    expect(zoneColor('healthy')).toBe('success');
+    expect(zoneColor('approaching')).toBe('warning');
+    expect(zoneColor('pastIncluded')).toBe('warning');
+    expect(zoneColor('blocked')).toBe('error');
+  });
+});
+
+describe('flaggedResources', () => {
+  it('omits healthy resources', () => {
+    const flagged = flaggedResources({
+      [QuotaResource.TEST_EXECUTIONS]: item(10, 100),
+      [QuotaResource.PROJECTS]: item(90, 100, { kind: 'stock' }),
+    });
+    expect(flagged.map(f => f.resource)).toEqual([QuotaResource.PROJECTS]);
+  });
+
+  it('skips a resource the label map does not know about', () => {
+    expect(flaggedResources({ some_future_resource: item(99, 100) })).toEqual(
+      []
+    );
+  });
+
+  it('ranks a blocked resource above one deeper into its grace band', () => {
+    // The regression this guards: sorting by ratio alone put the soft-tier
+    // resource (ratio 1.5, still running) ahead of the hard-blocked one
+    // (ratio 1.0), and QuotaBanner shows only the worst -- so an actual
+    // block was hidden behind a warning.
+    const worst = findWorstResource({
+      [QuotaResource.TEST_EXECUTIONS]: item(150, 100, { ceiling: 200 }),
+      [QuotaResource.PROJECTS]: item(1, 1, { kind: 'stock' }),
+    });
+    expect(worst?.resource).toBe(QuotaResource.PROJECTS);
+    expect(worst?.zone).toBe('blocked');
+  });
+
+  it('falls back to ratio within the same zone', () => {
+    const flagged = flaggedResources({
+      [QuotaResource.TEST_EXECUTIONS]: item(80, 100),
+      [QuotaResource.TEST_GENERATION]: item(95, 100),
+    });
+    expect(flagged.map(f => f.resource)).toEqual([
+      QuotaResource.TEST_GENERATION,
+      QuotaResource.TEST_EXECUTIONS,
+    ]);
+  });
+
+  it('returns null from findWorstResource when nothing is flagged', () => {
+    expect(findWorstResource({ [QuotaResource.PROJECTS]: item(1, 100) })).toBe(
+      null
+    );
+  });
+});
+
+describe('quotaCopy', () => {
+  const base = { used: 80, limit: 100, canUpgrade: true } as const;
+
+  it('names the organization as the subject, never the reader', () => {
+    const { sentence } = quotaCopy({
+      ...base,
+      resource: QuotaResource.TEST_EXECUTIONS,
+      kind: 'flow',
+      zone: 'approaching',
+    });
+    expect(sentence).toBe(
+      'Your organization has used 80% of its test runs for this period.'
+    );
+    expect(sentence).not.toMatch(/\byou(r)?\b(?! organization)/i);
+  });
+
+  it('counts a stock resource instead of percentaging it', () => {
+    expect(
+      quotaCopy({
+        ...base,
+        used: 4,
+        limit: 5,
+        resource: QuotaResource.PROJECTS,
+        kind: 'stock',
+        zone: 'approaching',
+      }).sentence
+    ).toBe('Your organization is using 4 of 5 projects.');
+  });
+
+  it('says nothing is blocked yet in the grace band', () => {
+    const { sentence, recourse } = quotaCopy({
+      ...base,
+      used: 110,
+      resource: QuotaResource.TEST_EXECUTIONS,
+      kind: 'flow',
+      zone: 'pastIncluded',
+    });
+    expect(sentence).toBe(
+      'Your organization is past its included test runs for this period.'
+    );
+    expect(recourse).toBe(
+      'You can keep running until the overage allowance runs out.'
+    );
+  });
+
+  it('gives a blocked flow resource its reset date', () => {
+    const { sentence, recourse } = quotaCopy({
+      resource: QuotaResource.TEST_EXECUTIONS,
+      kind: 'flow',
+      used: 1000,
+      limit: 1000,
+      zone: 'blocked',
+      periodEnd: '2026-08-31',
+      canUpgrade: true,
+    });
+    expect(sentence).toBe(
+      'Your organization is at its test runs limit for this period (1,000 of 1,000).'
+    );
+    expect(recourse).toBe('Resets 31 Aug. Upgrade to raise this limit.');
+  });
+
+  it('points a member at an admin instead of at the upgrade link', () => {
+    expect(
+      quotaCopy({
+        resource: QuotaResource.TEST_EXECUTIONS,
+        kind: 'flow',
+        used: 1000,
+        limit: 1000,
+        zone: 'blocked',
+        periodEnd: '2026-08-31',
+        canUpgrade: false,
+      }).recourse
+    ).toBe('Resets 31 Aug. Ask an org admin to raise this limit.');
+  });
+
+  it('names the freeing action for a blocked stock resource', () => {
+    expect(
+      quotaCopy({
+        resource: QuotaResource.PROJECTS,
+        kind: 'stock',
+        used: 1,
+        limit: 1,
+        zone: 'blocked',
+        canUpgrade: true,
+      })
+    ).toEqual({
+      sentence: 'Your organization is at its projects limit (1 of 1).',
+      recourse: 'Delete a project or upgrade to add more.',
+    });
+  });
+
+  it('always offers a next step on a legacy 402 with no kind', () => {
+    // The regression this guards: the admin branch returned an empty
+    // recourse, so the only person who could act saw no next step.
+    for (const canUpgrade of [true, false]) {
+      const { recourse } = quotaCopy({
+        resource: QuotaResource.PROJECTS,
+        kind: undefined,
+        used: 1,
+        limit: 1,
+        zone: 'blocked',
+        canUpgrade,
+      });
+      expect(recourse).not.toBe('');
+    }
+  });
+});
+
+describe('parseQuotaError', () => {
+  function quota402(data: Record<string, unknown>) {
+    const err = new Error('API error: 402 - quota') as Error & {
+      status?: number;
+      data?: Record<string, unknown>;
+    };
+    err.status = 402;
+    err.data = data;
+    return err;
+  }
+
+  it('reads the widened 402 body', () => {
+    expect(
+      parseQuotaError(
+        quota402({
+          error: 'quota_exceeded',
+          resource: 'test_executions',
+          used: 100,
+          limit: 100,
+          kind: 'flow',
+          period_end: '2026-08-31',
+          message: 'nope',
+        })
+      )
+    ).toEqual({
+      resource: 'test_executions',
+      used: 100,
+      limit: 100,
+      kind: 'flow',
+      periodEnd: '2026-08-31',
+      message: 'nope',
+    });
+  });
+
+  it('tolerates a legacy body with no kind or period_end', () => {
+    const parsed = parseQuotaError(
+      quota402({
+        error: 'quota_exceeded',
+        resource: 'projects',
+        used: 1,
+        limit: 1,
+      })
+    );
+    expect(parsed?.kind).toBeUndefined();
+    expect(parsed?.periodEnd).toBeUndefined();
+  });
+
+  it('ignores a 402 that is not a quota error', () => {
+    expect(parseQuotaError(quota402({ error: 'something_else' }))).toBe(null);
+  });
+
+  it('ignores non-402 errors and non-errors', () => {
+    const err = new Error('boom') as Error & { status?: number };
+    err.status = 500;
+    expect(parseQuotaError(err)).toBe(null);
+    expect(parseQuotaError('not an error')).toBe(null);
+    expect(parseQuotaError(null)).toBe(null);
+  });
+});
+
+describe('isKnownQuotaResource', () => {
+  it('accepts a wire value the label map knows', () => {
+    expect(isKnownQuotaResource('test_executions')).toBe(true);
+  });
+
+  it('rejects one it does not', () => {
+    expect(isKnownQuotaResource('some_future_resource')).toBe(false);
+  });
+});
+
+describe('usageMenuRows', () => {
+  const order = [
+    QuotaResource.TEST_EXECUTIONS,
+    QuotaResource.TRACING_SPANS,
+    QuotaResource.TEST_GENERATION,
+    QuotaResource.MODEL_TOKENS,
+    QuotaResource.SEATS,
+    QuotaResource.PROJECTS,
+    QuotaResource.ENDPOINTS,
+  ] as const;
+
+  it('pads a healthy org up to the minimum', () => {
+    const rows = usageMenuRows(
+      {
+        [QuotaResource.TEST_EXECUTIONS]: item(1, 100),
+        [QuotaResource.SEATS]: item(1, 10, { kind: 'stock' }),
+        [QuotaResource.PROJECTS]: item(1, 5, { kind: 'stock' }),
+        [QuotaResource.ENDPOINTS]: item(1, 5, { kind: 'stock' }),
+      },
+      order,
+      3
+    );
+    expect(rows).toHaveLength(3);
+    expect(rows.every(r => r.zone === 'healthy')).toBe(true);
+  });
+
+  it('never caps, so the row count always matches the badge', () => {
+    // Five flagged resources must produce five rows even though the floor
+    // is three, or the block and the badge disagree.
+    const rows = usageMenuRows(
+      {
+        [QuotaResource.TEST_EXECUTIONS]: item(100, 100),
+        [QuotaResource.TRACING_SPANS]: item(100, 100),
+        [QuotaResource.TEST_GENERATION]: item(100, 100),
+        [QuotaResource.SEATS]: item(10, 10, { kind: 'stock' }),
+        [QuotaResource.PROJECTS]: item(5, 5, { kind: 'stock' }),
+      },
+      order,
+      3
+    );
+    expect(rows).toHaveLength(5);
+  });
+
+  it('puts flagged resources first, worst first', () => {
+    const rows = usageMenuRows(
+      {
+        [QuotaResource.TEST_EXECUTIONS]: item(1, 100),
+        [QuotaResource.PROJECTS]: item(5, 5, { kind: 'stock' }),
+        [QuotaResource.SEATS]: item(8, 10, { kind: 'stock' }),
+      },
+      order,
+      3
+    );
+    expect(rows[0].resource).toBe(QuotaResource.PROJECTS);
+    expect(rows[0].zone).toBe('blocked');
+    expect(rows[1].resource).toBe(QuotaResource.SEATS);
+    expect(rows[1].zone).toBe('approaching');
+  });
+
+  it('does not pad with an unlimited resource', () => {
+    // "Model Tokens unlimited" is a row that tells the reader nothing.
+    const rows = usageMenuRows(
+      {
+        [QuotaResource.MODEL_TOKENS]: item(999, null),
+        [QuotaResource.SEATS]: item(1, 10, { kind: 'stock' }),
+      },
+      order,
+      3
+    );
+    expect(rows.map(r => r.resource)).toEqual([QuotaResource.SEATS]);
+  });
+});

--- a/apps/frontend/src/utils/api-client/__tests__/services-client.test.ts
+++ b/apps/frontend/src/utils/api-client/__tests__/services-client.test.ts
@@ -58,7 +58,13 @@ describe('ServicesClient', () => {
     global.fetch = fetchMock;
   });
 
-  afterEach(() => jest.restoreAllMocks());
+  afterEach(() => {
+    jest.restoreAllMocks();
+    // Always restored, not just on the happy path: a failed assertion in
+    // the stall test would otherwise leak fake timers into every test
+    // that runs after it in this file.
+    jest.useRealTimers();
+  });
 
   it('gets GitHub contents with URL-encoded repo_url param', async () => {
     fetchMock.mockResolvedValue(makeFetch('readme content'));
@@ -151,7 +157,39 @@ describe('ServicesClient', () => {
       await assertion;
 
       expect(onEvent).not.toHaveBeenCalled();
-      jest.useRealTimers();
+    });
+
+    it('surfaces a 402 as a quota error, not the raw response body', async () => {
+      fetchMock.mockResolvedValue(
+        makeFetch(
+          {
+            error: 'quota_exceeded',
+            resource: 'test_generation',
+            used: 5,
+            limit: 5,
+            kind: 'flow',
+            period_end: '2026-09-01',
+            message:
+              'Your organization is at its test generation limit for this period.',
+          },
+          402
+        )
+      );
+      const onEvent = jest.fn();
+
+      let caught: (Error & { status?: number; data?: unknown }) | undefined;
+      try {
+        await client.generateTestPipelineStream(request, { onEvent });
+      } catch (e) {
+        caught = e as Error & { status?: number; data?: unknown };
+      }
+
+      expect(caught).toBeDefined();
+      expect(caught?.status).toBe(402);
+      expect(caught?.data).toMatchObject({ error: 'quota_exceeded' });
+      expect(caught?.message).toBe(
+        'API error: 402 - Your organization is at its test generation limit for this period.'
+      );
     });
   });
 });

--- a/apps/frontend/src/utils/api-client/__tests__/services-client.test.ts
+++ b/apps/frontend/src/utils/api-client/__tests__/services-client.test.ts
@@ -1,4 +1,5 @@
 import { ServicesClient } from '../services-client';
+import type { TestPipelineRequest } from '../interfaces/test-set';
 
 const BASE_URL = 'http://localhost/api/backend';
 
@@ -17,6 +18,33 @@ function makeFetch(
     },
     json: () => Promise.resolve(body),
     text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response);
+}
+
+/** A streaming response whose body yields the given NDJSON lines then closes. */
+function makeNdjsonStream(lines: string[]) {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      lines.forEach(line => controller.enqueue(encoder.encode(`${line}\n`)));
+      controller.close();
+    },
+  });
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    body,
+  } as unknown as Response);
+}
+
+/** A streaming response whose body never yields anything and never closes --
+ * simulates a stalled connection (e.g. the underlying model call hangs). */
+function makeStalledStream() {
+  const body = new ReadableStream<Uint8Array>({ start() {} });
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    body,
   } as unknown as Response);
 }
 
@@ -91,6 +119,39 @@ describe('ServicesClient', () => {
     expect(JSON.parse(opts.body)).toMatchObject({
       task_id: 'task-id',
       tool_id: 'tool-id',
+    });
+  });
+
+  describe('generateTestPipelineStream', () => {
+    const request: TestPipelineRequest = { prompt: 'Test the login flow' };
+
+    it('parses each NDJSON line as an event', async () => {
+      fetchMock.mockResolvedValue(
+        makeNdjsonStream([
+          '{"type":"config_done","total":1}',
+          '{"type":"done"}',
+        ])
+      );
+      const onEvent = jest.fn();
+
+      await client.generateTestPipelineStream(request, { onEvent });
+
+      expect(onEvent).toHaveBeenCalledWith({ type: 'config_done', total: 1 });
+      expect(onEvent).toHaveBeenCalledWith({ type: 'done' });
+    });
+
+    it('rejects instead of hanging forever when the stream stalls', async () => {
+      jest.useFakeTimers();
+      fetchMock.mockResolvedValue(makeStalledStream());
+      const onEvent = jest.fn();
+
+      const result = client.generateTestPipelineStream(request, { onEvent });
+      const assertion = expect(result).rejects.toThrow(/Stream stalled/);
+      await jest.advanceTimersByTimeAsync(150_000);
+      await assertion;
+
+      expect(onEvent).not.toHaveBeenCalled();
+      jest.useRealTimers();
     });
   });
 });

--- a/apps/frontend/src/utils/api-client/base-client.ts
+++ b/apps/frontend/src/utils/api-client/base-client.ts
@@ -34,6 +34,13 @@ export interface ApiErrorData {
    * for type-shape parity with the backend response, not because it's ever
    * actually null here. */
   limit?: number | null;
+  /** `'flow'` or `'stock'`, on a 402 quota-exceeded body -- same split as
+   * `UsageResourceItem.kind`, so the gate copy can be classified without a
+   * second lookup against `/usage`. */
+  kind?: 'flow' | 'stock';
+  /** ISO date the current billing period ends, on a 402 quota-exceeded
+   * body -- lets a blocked flow resource say when it resets. */
+  period_end?: string;
   [key: string]: unknown;
 }
 

--- a/apps/frontend/src/utils/api-client/base-client.ts
+++ b/apps/frontend/src/utils/api-client/base-client.ts
@@ -109,7 +109,7 @@ export function formatApiErrorDetail(detail: unknown): string {
   return '';
 }
 
-function parseApiErrorResponse(errorData: ApiErrorData): string {
+export function parseApiErrorResponse(errorData: ApiErrorData): string {
   if (errorData.detail) {
     const formatted = formatApiErrorDetail(errorData.detail);
     if (formatted) {

--- a/apps/frontend/src/utils/api-client/interfaces/explorer.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/explorer.ts
@@ -242,6 +242,15 @@ export interface PipelineDoneEvent {
   type: 'done';
 }
 
+/** Pipeline-level failure before any suggestion could be produced -- e.g.
+ * quota exhaustion during model resolution. Distinct from the per-item
+ * `error` field on `output`/`evaluation` events, which reports one row
+ * failing while the rest of the pipeline keeps going. */
+export interface PipelineErrorEvent {
+  type: 'error';
+  message: string;
+}
+
 export type SuggestionPipelineEvent =
   | PipelineSuggestionsEvent
   | PipelineSuggestionEvent
@@ -251,6 +260,7 @@ export type SuggestionPipelineEvent =
   | PipelineEvaluationEvent
   | PipelineOutputSummaryEvent
   | PipelineEvalSummaryEvent
+  | PipelineErrorEvent
   | PipelineDoneEvent;
 
 // =============================================================================

--- a/apps/frontend/src/utils/api-client/services-client.ts
+++ b/apps/frontend/src/utils/api-client/services-client.ts
@@ -146,8 +146,33 @@ export interface CreateJiraTicketFromTaskResponse {
 }
 
 export class ServicesClient extends BaseApiClient {
+  /** Reads one chunk, erroring out if none arrives within `idleTimeoutMs`.
+   * Mirrors `ExplorerClient`'s identical guard on the same NDJSON pattern. */
+  private async readChunkWithTimeout(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    idleTimeoutMs: number
+  ): Promise<ReadableStreamReadResult<Uint8Array>> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reader.cancel().catch(() => {});
+        reject(
+          new Error(
+            `Stream stalled: no data received for ${idleTimeoutMs / 1000}s.`
+          )
+        );
+      }, idleTimeoutMs);
+    });
+    try {
+      return await Promise.race([reader.read(), timeout]);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
   private async *readNdjsonStream(
-    response: Response
+    response: Response,
+    idleTimeoutMs = 150_000
   ): AsyncGenerator<unknown, void, void> {
     const reader = response.body?.getReader();
     if (!reader) {
@@ -158,7 +183,10 @@ export class ServicesClient extends BaseApiClient {
     let buffer = '';
 
     while (true) {
-      const { value, done } = await reader.read();
+      const { value, done } = await this.readChunkWithTimeout(
+        reader,
+        idleTimeoutMs
+      );
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
 

--- a/apps/frontend/src/utils/api-client/services-client.ts
+++ b/apps/frontend/src/utils/api-client/services-client.ts
@@ -1,4 +1,8 @@
-import { BaseApiClient } from './base-client';
+import {
+  ApiErrorData,
+  BaseApiClient,
+  parseApiErrorResponse,
+} from './base-client';
 import { API_ENDPOINTS } from './config';
 
 // Types for the new endpoints - matching backend schemas
@@ -226,10 +230,29 @@ export class ServicesClient extends BaseApiClient {
     );
 
     if (!response.ok) {
-      const errorBody = await response.text();
-      throw new Error(
-        `Test pipeline request failed (${response.status}): ${errorBody}`
-      );
+      // Same shape BaseApiClient's own fetch() throws (status/data attached,
+      // "API error: {status} - " prefix): getApiErrorMessage() strips that
+      // prefix and parseQuotaError() reads .status/.data, and this request
+      // goes through fetch() directly rather than that shared path, so
+      // without this a 402 (require_quota on the route this streams from)
+      // showed the raw JSON body in a toast instead of the quota sentence.
+      const bodyText = await response.text();
+      let errorData: ApiErrorData = {};
+      try {
+        errorData = JSON.parse(bodyText) as ApiErrorData;
+      } catch {
+        // Not JSON; parseApiErrorResponse falls back to stringifying {}.
+      }
+      const message = parseApiErrorResponse(errorData) || bodyText;
+      const error = new Error(
+        `API error: ${response.status} - ${message}`
+      ) as Error & {
+        status?: number;
+        data?: ApiErrorData;
+      };
+      error.status = response.status;
+      error.data = errorData;
+      throw error;
     }
 
     for await (const event of this.readNdjsonStream(response)) {

--- a/apps/frontend/src/utils/quota.ts
+++ b/apps/frontend/src/utils/quota.ts
@@ -1,0 +1,278 @@
+/**
+ * Shared quota classification and copy. The single place that turns a
+ * `UsageResourceItem` (or a 402 body) into "which zone is this in" and
+ * "what does the org see about it" -- every surface (banner, brand-row
+ * badge, org-menu block, usage page, inline gates) reads from here rather
+ * than re-deriving its own thresholds or strings.
+ */
+
+import {
+  QUOTA_RESOURCE_LABELS,
+  WARNING_THRESHOLD,
+  type QuotaResource,
+} from '@/constants/quota';
+import type { ApiErrorData } from '@/utils/api-client/base-client';
+import type { UsageResourceItem } from '@/utils/api-client/usage-client';
+
+const COMMUNITY_EDITION = 'community';
+
+export function isCommunityEdition(edition: string): boolean {
+  return edition.toLowerCase() === COMMUNITY_EDITION;
+}
+
+/** Narrows a wire-value string (e.g. `parseQuotaError(err).resource`) to
+ * `QuotaResource`. A 402 body's `resource` is always one, but it arrives
+ * typed as plain `string`, and the backend can add a new `QuotaResource`
+ * before `constants/quota.ts` catches up -- callers must check this before
+ * indexing `QUOTA_RESOURCE_LABELS` or building a `QuotaNotice`. */
+export function isKnownQuotaResource(
+  resource: string
+): resource is QuotaResource {
+  return resource in QUOTA_RESOURCE_LABELS;
+}
+
+/**
+ * The four states a metered resource can be in. Every surface that shows
+ * or gates on quota classifies into exactly one of these -- see
+ * `IMPLEMENTATION_PROMPT.md`'s "Four zones, not two" for the behaviour each
+ * one implies.
+ *
+ * - `healthy`: comfortably under the warning threshold.
+ * - `approaching`: at or above `WARNING_THRESHOLD` of `limit`, nothing
+ *   disabled.
+ * - `pastIncluded`: at or past `limit` but still under `ceiling` -- the
+ *   soft-tier grace band. Still nothing disabled. Zero-width on a hard
+ *   tier, where `ceiling === limit`.
+ * - `blocked`: at or past `ceiling`. The action this resource gates is
+ *   disabled and a 402 is what the backend returns for it.
+ */
+export type QuotaZone = 'healthy' | 'approaching' | 'pastIncluded' | 'blocked';
+
+type ZoneInput = Pick<UsageResourceItem, 'used' | 'limit' | 'ceiling'>;
+
+/**
+ * Classify one resource's usage into a `QuotaZone`.
+ *
+ * `limit === null` (unlimited) always classifies `healthy` -- there is no
+ * ratio to compute and nothing ever blocks. `limit === 0` is a real
+ * configured value ("none allowed"), not a missing limit, so it reports as
+ * fully consumed via the `ratio = 1` fallback rather than being treated as
+ * unlimited.
+ */
+/** The MUI severity color a zone maps to, everywhere a zone needs one:
+ * the usage-page meter, the org-menu usage rows. `healthy` is `'success'`
+ * even though nothing renders it in most callers (a healthy row is
+ * usually just not shown) -- kept total so a caller never has to handle
+ * an `undefined` case. */
+export function zoneColor(zone: QuotaZone): 'success' | 'warning' | 'error' {
+  if (zone === 'blocked') return 'error';
+  if (zone === 'approaching' || zone === 'pastIncluded') return 'warning';
+  return 'success';
+}
+
+export function classifyZone(item: ZoneInput): QuotaZone {
+  const { used, limit, ceiling } = item;
+  if (limit === null) return 'healthy';
+  if (ceiling !== null && used >= ceiling) return 'blocked';
+  if (used >= limit) return 'pastIncluded';
+  const ratio = limit === 0 ? 1 : used / limit;
+  if (ratio >= WARNING_THRESHOLD) return 'approaching';
+  return 'healthy';
+}
+
+/**
+ * How many resources are at `approaching` or worse, skipping any resource
+ * `constants/quota.ts` has no label for yet -- the backend can add a
+ * `QuotaResource` before the frontend catches up, and every consumer of
+ * this count (the brand-row badge, the org-menu block) must agree on how
+ * many rows that implies.
+ */
+export function countFlagged(
+  resources: Readonly<Record<string, ZoneInput>>
+): number {
+  let count = 0;
+  for (const [resource, item] of Object.entries(resources)) {
+    if (!(resource in QUOTA_RESOURCE_LABELS)) continue;
+    if (classifyZone(item) !== 'healthy') count += 1;
+  }
+  return count;
+}
+
+export interface FlaggedResource {
+  resource: QuotaResource;
+  item: UsageResourceItem;
+  zone: QuotaZone;
+  ratio: number;
+}
+
+/**
+ * Every resource at `approaching` or worse, worst-ratio first. `ratio` is
+ * `used / limit`, clamped to 1 for a fully-consumed `limit: 0` resource.
+ * Unlabelled resources are skipped -- see `countFlagged`.
+ */
+export function flaggedResources(
+  resources: Readonly<Record<string, UsageResourceItem>>
+): FlaggedResource[] {
+  const flagged: FlaggedResource[] = [];
+  for (const [resource, item] of Object.entries(resources)) {
+    if (!(resource in QUOTA_RESOURCE_LABELS)) continue;
+    const zone = classifyZone(item);
+    if (zone === 'healthy') continue;
+    const ratio =
+      item.limit === null ? 0 : item.limit === 0 ? 1 : item.used / item.limit;
+    flagged.push({ resource: resource as QuotaResource, item, zone, ratio });
+  }
+  return flagged.sort((a, b) => b.ratio - a.ratio);
+}
+
+/** The single worst flagged resource, or `null` if none is flagged. */
+export function findWorstResource(
+  resources: Readonly<Record<string, UsageResourceItem>>
+): FlaggedResource | null {
+  return flaggedResources(resources)[0] ?? null;
+}
+
+/** `"1 Sep"` -- the short form used in reset-date recourse copy. Stays in
+ * UTC like `UsageOverviewTab`'s `formatPeriodDate`: `period_end` is a
+ * date-only string computed in UTC, so formatting in the viewer's local
+ * zone risks rolling it back a day west of UTC. */
+function formatResetDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  const day = date.getUTCDate();
+  const month = date.toLocaleDateString('en-US', {
+    month: 'short',
+    timeZone: 'UTC',
+  });
+  return `${day} ${month}`;
+}
+
+/** What an admin is told to do about a blocked stock resource. Resource-
+ * specific because "delete a project" and "remove a member" are different
+ * actions -- a generic "free up capacity" has no next step to click. */
+const STOCK_RECOURSE_ACTION: Partial<Record<QuotaResource, string>> = {
+  projects: 'Delete a project',
+  endpoints: 'Delete an endpoint',
+  seats: 'Remove a member',
+};
+
+export interface QuotaCopyInput {
+  resource: QuotaResource;
+  /** `undefined` only for a 402 issued before the backend widened the
+   * body (see `IMPLEMENTATION_PROMPT.md` step 1) -- falls back to the
+   * `unknown` catalog row. */
+  kind: 'flow' | 'stock' | undefined;
+  used: number;
+  limit: number;
+  zone: Exclude<QuotaZone, 'healthy'>;
+  /** ISO date the current period ends. Required for the `blocked`+`flow`
+   * row, which names the reset date; unused otherwise. */
+  periodEnd?: string;
+  /** Whether this reader can act on an upgrade -- an org admin. A member
+   * gets pointed at an admin instead, never at the upgrade link. */
+  canUpgrade: boolean;
+}
+
+export interface QuotaCopyResult {
+  sentence: string;
+  recourse: string;
+}
+
+/**
+ * The copy catalog, as code. One sentence + one recourse per
+ * (zone, kind, audience) combination -- see `IMPLEMENTATION_PROMPT.md`'s
+ * "Copy catalog" table, which this mirrors exactly. Nowhere else in the
+ * app should hand-write quota sentences.
+ */
+export function quotaCopy({
+  resource,
+  kind,
+  used,
+  limit,
+  zone,
+  periodEnd,
+  canUpgrade,
+}: QuotaCopyInput): QuotaCopyResult {
+  const label = QUOTA_RESOURCE_LABELS[resource].toLowerCase();
+  const countSuffix = `(${used.toLocaleString()} of ${limit.toLocaleString()})`;
+
+  if (zone === 'approaching') {
+    const percent = Math.round((used / limit) * 100);
+    return {
+      sentence:
+        kind === 'stock'
+          ? `Your organization is using ${used.toLocaleString()} of ${limit.toLocaleString()} ${label}.`
+          : `Your organization has used ${percent}% of its ${label} for this period.`,
+      recourse: 'View usage · Upgrade plan →',
+    };
+  }
+
+  if (zone === 'pastIncluded') {
+    return {
+      sentence:
+        kind === 'stock'
+          ? `Your organization is past its included ${label}.`
+          : `Your organization is past its included ${label} for this period.`,
+      recourse:
+        kind === 'stock'
+          ? 'You can still add more until the overage allowance runs out.'
+          : 'You can keep running until the overage allowance runs out.',
+    };
+  }
+
+  // zone === 'blocked'
+  if (kind === undefined) {
+    return {
+      sentence: `Your organization has reached its ${label} limit ${countSuffix}.`,
+      recourse: canUpgrade ? '' : 'Ask an org admin to raise this limit.',
+    };
+  }
+
+  if (kind === 'flow') {
+    const reset = periodEnd ? formatResetDate(periodEnd) : 'soon';
+    return {
+      sentence: `Your organization is at its ${label} limit for this period ${countSuffix}.`,
+      recourse: canUpgrade
+        ? `Resets ${reset}. Upgrade to raise this limit.`
+        : `Resets ${reset}. Ask an org admin to raise this limit.`,
+    };
+  }
+
+  const action = STOCK_RECOURSE_ACTION[resource] ?? `Free up ${label}`;
+  return {
+    sentence: `Your organization is at its ${label} limit ${countSuffix}.`,
+    recourse: canUpgrade
+      ? `${action} or upgrade to add more.`
+      : `${action}, or ask an org admin to raise this limit.`,
+  };
+}
+
+export interface QuotaError {
+  resource: string;
+  used: number;
+  limit: number | null;
+  kind: 'flow' | 'stock' | undefined;
+  periodEnd: string | undefined;
+  message: string;
+}
+
+/**
+ * Read a quota-exceeded 402 back out of a caught error, or `null` if it
+ * isn't one. Guards on the `quota_exceeded` marker (not just `status ===
+ * 402`) -- `quota_exceeded` is the only 402 producer today, but a future
+ * one shouldn't silently get parsed as a quota error.
+ */
+export function parseQuotaError(err: unknown): QuotaError | null {
+  if (!(err instanceof Error)) return null;
+  const withMeta = err as Error & { status?: number; data?: ApiErrorData };
+  if (withMeta.status !== 402) return null;
+  const data = withMeta.data;
+  if (!data || data.error !== 'quota_exceeded' || !data.resource) return null;
+  return {
+    resource: data.resource,
+    used: typeof data.used === 'number' ? data.used : 0,
+    limit: data.limit ?? null,
+    kind: data.kind,
+    periodEnd: data.period_end,
+    message: typeof data.message === 'string' ? data.message : '',
+  };
+}

--- a/apps/frontend/src/utils/quota.ts
+++ b/apps/frontend/src/utils/quota.ts
@@ -50,15 +50,6 @@ export type QuotaZone = 'healthy' | 'approaching' | 'pastIncluded' | 'blocked';
 
 type ZoneInput = Pick<UsageResourceItem, 'used' | 'limit' | 'ceiling'>;
 
-/**
- * Classify one resource's usage into a `QuotaZone`.
- *
- * `limit === null` (unlimited) always classifies `healthy` -- there is no
- * ratio to compute and nothing ever blocks. `limit === 0` is a real
- * configured value ("none allowed"), not a missing limit, so it reports as
- * fully consumed via the `ratio = 1` fallback rather than being treated as
- * unlimited.
- */
 /** The MUI severity color a zone maps to, everywhere a zone needs one:
  * the usage-page meter, the org-menu usage rows. `healthy` is `'success'`
  * even though nothing renders it in most callers (a healthy row is
@@ -70,45 +61,63 @@ export function zoneColor(zone: QuotaZone): 'success' | 'warning' | 'error' {
   return 'success';
 }
 
+/**
+ * Classify one resource's usage into a `QuotaZone`.
+ *
+ * `limit === null` (unlimited) always classifies `healthy`: nothing to
+ * measure against and nothing ever blocks.
+ *
+ * `limit === 0` is a real configured value ("none allowed"), not a missing
+ * limit. It classifies `blocked`, because the backend's own rule is
+ * `allowed = used < ceiling` and `ceiling_for(0)` is `0` -- so such an org
+ * is refused from its very first request, and the UI must agree.
+ *
+ * A null `ceiling` alongside a numeric `limit` is not something the API
+ * emits (`ceiling_for` returns null only for a null limit), but it is
+ * treated as a hard tier rather than ignored: leaving it unhandled would
+ * park the resource in `pastIncluded` forever and promise an overage
+ * allowance that does not exist.
+ */
 export function classifyZone(item: ZoneInput): QuotaZone {
   const { used, limit, ceiling } = item;
   if (limit === null) return 'healthy';
-  if (ceiling !== null && used >= ceiling) return 'blocked';
+  if (used >= (ceiling ?? limit)) return 'blocked';
   if (used >= limit) return 'pastIncluded';
-  const ratio = limit === 0 ? 1 : used / limit;
-  if (ratio >= WARNING_THRESHOLD) return 'approaching';
+  if (used / limit >= WARNING_THRESHOLD) return 'approaching';
   return 'healthy';
-}
-
-/**
- * How many resources are at `approaching` or worse, skipping any resource
- * `constants/quota.ts` has no label for yet -- the backend can add a
- * `QuotaResource` before the frontend catches up, and every consumer of
- * this count (the brand-row badge, the org-menu block) must agree on how
- * many rows that implies.
- */
-export function countFlagged(
-  resources: Readonly<Record<string, ZoneInput>>
-): number {
-  let count = 0;
-  for (const [resource, item] of Object.entries(resources)) {
-    if (!(resource in QUOTA_RESOURCE_LABELS)) continue;
-    if (classifyZone(item) !== 'healthy') count += 1;
-  }
-  return count;
 }
 
 export interface FlaggedResource {
   resource: QuotaResource;
   item: UsageResourceItem;
-  zone: QuotaZone;
+  /** Never `healthy` -- `flaggedResources` filters those out, and saying so
+   * in the type means callers can build copy from it without re-checking. */
+  zone: Exclude<QuotaZone, 'healthy'>;
   ratio: number;
 }
 
+/** Severity order for sorting. Higher is worse. */
+const ZONE_SEVERITY: Record<QuotaZone, number> = {
+  healthy: 0,
+  approaching: 1,
+  pastIncluded: 2,
+  blocked: 3,
+};
+
 /**
- * Every resource at `approaching` or worse, worst-ratio first. `ratio` is
- * `used / limit`, clamped to 1 for a fully-consumed `limit: 0` resource.
- * Unlabelled resources are skipped -- see `countFlagged`.
+ * Every resource at `approaching` or worse, worst first: by zone severity,
+ * then by ratio within a zone.
+ *
+ * Zone before ratio, not ratio alone. Ratio is measured against `limit`, so
+ * a soft-tier resource deep in its grace band (150/100, ratio 1.5, still
+ * running) outranks a hard-blocked one (1/1, ratio 1.0) on ratio -- and
+ * since `QuotaBanner` shows only the single worst resource, sorting by
+ * ratio alone hid an actual block behind a warning.
+ *
+ * `ratio` is `used / limit`, clamped to 1 for a fully-consumed `limit: 0`
+ * resource. Unlabelled resources are skipped: the backend can add a
+ * `QuotaResource` before `constants/quota.ts` catches up, and these render
+ * in the protected layout where a missing label would throw on every page.
  */
 export function flaggedResources(
   resources: Readonly<Record<string, UsageResourceItem>>
@@ -118,11 +127,14 @@ export function flaggedResources(
     if (!(resource in QUOTA_RESOURCE_LABELS)) continue;
     const zone = classifyZone(item);
     if (zone === 'healthy') continue;
+    // Narrowed by the guard above; `classifyZone` returns the wider union.
     const ratio =
       item.limit === null ? 0 : item.limit === 0 ? 1 : item.used / item.limit;
     flagged.push({ resource: resource as QuotaResource, item, zone, ratio });
   }
-  return flagged.sort((a, b) => b.ratio - a.ratio);
+  return flagged.sort(
+    (a, b) => ZONE_SEVERITY[b.zone] - ZONE_SEVERITY[a.zone] || b.ratio - a.ratio
+  );
 }
 
 /** The single worst flagged resource, or `null` if none is flagged. */
@@ -130,6 +142,46 @@ export function findWorstResource(
   resources: Readonly<Record<string, UsageResourceItem>>
 ): FlaggedResource | null {
   return flaggedResources(resources)[0] ?? null;
+}
+
+export interface UsageRow {
+  resource: QuotaResource;
+  item: UsageResourceItem;
+  /** Unlike `FlaggedResource`, may be `healthy`: the list is padded with
+   * resources that are perfectly fine. */
+  zone: QuotaZone;
+}
+
+/**
+ * Flagged resources first (worst first), then padded with the next resources
+ * in canonical order up to `minRows`.
+ *
+ * A floor, never a cap: every flagged resource gets a row, so the row count
+ * always agrees with the badge that summarises it. The padding exists only so
+ * the block does not read as near-empty for a healthy org.
+ *
+ * Skips unlimited resources when padding: "Model Tokens unlimited" is a row
+ * that tells the reader nothing.
+ */
+export function usageMenuRows(
+  resources: Readonly<Record<string, UsageResourceItem>>,
+  order: readonly QuotaResource[],
+  minRows: number
+): UsageRow[] {
+  const rows: UsageRow[] = flaggedResources(resources).map(
+    ({ resource, item, zone }) => ({ resource, item, zone })
+  );
+  if (rows.length >= minRows) return rows;
+
+  const included = new Set(rows.map(row => row.resource));
+  for (const resource of order) {
+    if (rows.length >= minRows) break;
+    if (included.has(resource)) continue;
+    const item = resources[resource];
+    if (!item || item.limit === null) continue;
+    rows.push({ resource, item, zone: classifyZone(item) });
+  }
+  return rows;
 }
 
 /** `"1 Sep"` -- the short form used in reset-date recourse copy. Stays in
@@ -202,7 +254,10 @@ export function quotaCopy({
         kind === 'stock'
           ? `Your organization is using ${used.toLocaleString()} of ${limit.toLocaleString()} ${label}.`
           : `Your organization has used ${percent}% of its ${label} for this period.`,
-      recourse: 'View usage · Upgrade plan →',
+      // No prose recourse: nothing is blocked yet, and the two affordances
+      // that belong here ("View usage", "Upgrade plan") are links, which
+      // every surface renders itself rather than taking as a string.
+      recourse: '',
     };
   }
 
@@ -221,9 +276,14 @@ export function quotaCopy({
 
   // zone === 'blocked'
   if (kind === undefined) {
+    // Safety net for a 402 issued before the backend widened its body. With
+    // no `kind` there is neither a reset date nor a "delete one" action to
+    // name, so the recourse is only about who can raise the limit.
     return {
-      sentence: `Your organization has reached its ${label} limit ${countSuffix}.`,
-      recourse: canUpgrade ? '' : 'Ask an org admin to raise this limit.',
+      sentence: `Your organization is at its ${label} limit ${countSuffix}.`,
+      recourse: canUpgrade
+        ? 'Upgrade to raise this limit.'
+        : 'Ask an org admin to raise this limit.',
     };
   }
 

--- a/apps/frontend/src/utils/quota.ts
+++ b/apps/frontend/src/utils/quota.ts
@@ -184,6 +184,23 @@ export function usageMenuRows(
   return rows;
 }
 
+/**
+ * How much of a usage row's progress bar is filled, as a whole-number
+ * percent -- how close the resource is to `limit` (not `ceiling`): the bar
+ * answers the same question the row's trailing value does, a percent or a
+ * count of `limit`.
+ *
+ * Capped at 100 -- an over-limit soft-tier row (`used > limit`) still draws
+ * a full bar, not one that overflows its track. Fully filled, not zero,
+ * when there is no real `limit` to divide by: `limit: 0` ("none allowed")
+ * always classifies `blocked` (see `classifyZone`), even at `used: 0`, so
+ * an empty-looking bar there would contradict its own red fill colour.
+ */
+export function usageRowFillPercent(item: ZoneInput): number {
+  if (!item.limit) return 100;
+  return Math.min(100, Math.round((item.used / item.limit) * 100));
+}
+
 /** `"1 Sep"` -- the short form used in reset-date recourse copy. Stays in
  * UTC like `UsageOverviewTab`'s `formatPeriodDate`: `period_end` is a
  * date-only string computed in UTC, so formatting in the viewer's local

--- a/tests/backend/app/test_quota_enforcement.py
+++ b/tests/backend/app/test_quota_enforcement.py
@@ -225,4 +225,4 @@ class TestQuotaExceededResponseBody:
         assert body["limit"] == 10
         assert body["kind"] == "flow"
         assert body["period_end"] == verdict.period_end
-        assert "test executions" in body["message"]
+        assert "test runs" in body["message"]

--- a/tests/backend/app/test_quota_enforcement.py
+++ b/tests/backend/app/test_quota_enforcement.py
@@ -223,4 +223,6 @@ class TestQuotaExceededResponseBody:
         assert body["resource"] == QuotaResource.TEST_EXECUTIONS.value
         assert body["used"] == 10
         assert body["limit"] == 10
+        assert body["kind"] == "flow"
+        assert body["period_end"] == verdict.period_end
         assert "test executions" in body["message"]

--- a/tests/backend/app/test_quota_token_gate.py
+++ b/tests/backend/app/test_quota_token_gate.py
@@ -35,6 +35,8 @@ def _always_blocks(db, organization_id):
             limit=1,
             allowed=False,
             over_limit=True,
+            kind="flow",
+            period_end="2024-01-31",
         )
     )
 

--- a/tests/backend/routes/test_quota_gates.py
+++ b/tests/backend/routes/test_quota_gates.py
@@ -360,6 +360,82 @@ class TestFlowResourceQuotaGate:
 
         assert response.status_code != status.HTTP_402_PAYMENT_REQUIRED, response.text
 
+    def test_generate_tests_at_the_limit_returns_402(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_org_id,
+        clean_registry,
+        _bypass_model_validation,
+    ):
+        """`POST /services/generate/tests` is the non-streaming sample
+        preview `handleRegenerateSample`/`handleLoadMoreSamples` call --
+        it had neither a client-side check nor a require_quota gate."""
+        limit = 5
+        _install(
+            QuotaPolicy(limits={QuotaResource.TEST_GENERATION: limit}, overage=OveragePolicy.HARD)
+        )
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_GENERATION, limit)
+
+        response = authenticated_client.post(
+            "/services/generate/tests",
+            json={"config": {"requirements": ["Accuracy"]}, "num_tests": 1},
+        )
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED, response.text
+        body = response.json()
+        assert body["error"] == "quota_exceeded"
+        assert body["resource"] == QuotaResource.TEST_GENERATION.value
+
+    def test_generate_multiturn_tests_at_the_limit_returns_402(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_org_id,
+        clean_registry,
+        _bypass_model_validation,
+    ):
+        limit = 5
+        _install(
+            QuotaPolicy(limits={QuotaResource.TEST_GENERATION: limit}, overage=OveragePolicy.HARD)
+        )
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_GENERATION, limit)
+
+        response = authenticated_client.post(
+            "/services/generate/multiturn-tests",
+            json={"generation_prompt": "Test a chatbot", "num_tests": 1},
+        )
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED, response.text
+        body = response.json()
+        assert body["error"] == "quota_exceeded"
+        assert body["resource"] == QuotaResource.TEST_GENERATION.value
+
+    def test_generate_test_config_at_the_limit_returns_402(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_org_id,
+        clean_registry,
+    ):
+        """`POST /services/generate/test_config` backs the config-only step
+        of the same preview flow and was gated neither client- nor
+        server-side."""
+        limit = 5
+        _install(
+            QuotaPolicy(limits={QuotaResource.TEST_GENERATION: limit}, overage=OveragePolicy.HARD)
+        )
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_GENERATION, limit)
+
+        response = authenticated_client.post(
+            "/services/generate/test_config", json={"prompt": "Test the login flow"}
+        )
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED, response.text
+        body = response.json()
+        assert body["error"] == "quota_exceeded"
+        assert body["resource"] == QuotaResource.TEST_GENERATION.value
+
 
 class TestRequireQuotaFlowResourceWarningHeader:
     """The SOFT-policy grace band sets `QUOTA_WARNING_HEADER` on an allowed

--- a/tests/backend/routes/test_quota_gates.py
+++ b/tests/backend/routes/test_quota_gates.py
@@ -315,6 +315,51 @@ class TestFlowResourceQuotaGate:
 
         assert response.status_code != status.HTTP_402_PAYMENT_REQUIRED, response.text
 
+    def test_test_pipeline_at_the_limit_returns_402(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_org_id,
+        clean_registry,
+    ):
+        """`POST /services/generate/test_pipeline` streams the sample preview
+        shown before a test set is actually created. It had no quota
+        enforcement of its own, so an org already at its TEST_GENERATION
+        limit could open the stream and start generating anyway."""
+        limit = 5
+        _install(
+            QuotaPolicy(limits={QuotaResource.TEST_GENERATION: limit}, overage=OveragePolicy.HARD)
+        )
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_GENERATION, limit)
+
+        response = authenticated_client.post(
+            "/services/generate/test_pipeline", json={"prompt": "Test the login flow"}
+        )
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED, response.text
+        body = response.json()
+        assert body["error"] == "quota_exceeded"
+        assert body["resource"] == QuotaResource.TEST_GENERATION.value
+        assert body["used"] == limit
+        assert body["limit"] == limit
+
+    def test_test_pipeline_under_the_limit_is_not_blocked(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_org_id,
+        clean_registry,
+    ):
+        _install(
+            QuotaPolicy(limits={QuotaResource.TEST_GENERATION: 100}, overage=OveragePolicy.HARD)
+        )
+
+        response = authenticated_client.post(
+            "/services/generate/test_pipeline", json={"prompt": "Test the login flow"}
+        )
+
+        assert response.status_code != status.HTTP_402_PAYMENT_REQUIRED, response.text
+
 
 class TestRequireQuotaFlowResourceWarningHeader:
     """The SOFT-policy grace band sets `QUOTA_WARNING_HEADER` on an allowed

--- a/tests/backend/services/explorer/test_suggestions.py
+++ b/tests/backend/services/explorer/test_suggestions.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from sqlalchemy.orm import Session
 
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.app.quota.enforcement import QuotaExceededError, QuotaVerdict
 from rhesis.backend.app.services.explorer import (
     evaluate_suggestions_stream,
     invoke_endpoint_for_suggestions_stream,
@@ -299,6 +301,27 @@ class TestEvaluateSuggestionsStream:
 
         assert events == [{"type": "summary", "evaluated": 0, "total": 0}]
 
+    async def test_metrics_resolution_failure_reports_error_instead_of_crashing(
+        self, test_db: Session, test_org_id, authenticated_user_id
+    ):
+        """Resolving metrics was the one step with no try/except -- a failure
+        there (e.g. an exhausted MODEL_TOKENS quota) used to propagate
+        straight out of the generator instead of yielding an event."""
+        with patch(_RESOLVE_METRICS_PATCH, side_effect=RuntimeError("evaluation model down")):
+            events = await _collect(
+                evaluate_suggestions_stream(
+                    db=test_db,
+                    organization_id=test_org_id,
+                    user_id=authenticated_user_id,
+                    metric_names=["Correctness"],
+                    suggestions=[{"input": "in", "output": "out"}],
+                )
+            )
+
+        error = next(e for e in events if e["type"] == "error")
+        assert "evaluation model down" in error["message"]
+        assert events[-1] == {"type": "summary", "evaluated": 0, "total": 1}
+
 
 async def _fake_suggestion_stream(items):
     """Stand-in for generate_suggestions(..., stream=True)'s async generator."""
@@ -503,3 +526,60 @@ class TestSuggestionPipelineStream:
         # ...just with no embedding work attempted and no diversity ordering.
         embed_one.assert_not_called()
         assert not any(e["type"] == "embedding" for e in events)
+
+    async def test_setup_failure_reports_error_instead_of_crashing(
+        self, test_db: Session, test_org_id, authenticated_user_id
+    ):
+        """generate_suggestions (and resolve_sdk_metrics right after it) run
+        before the first yield with no other try/except in the whole
+        generator -- a failure there (e.g. an exhausted MODEL_TOKENS quota
+        from the pre-call gate in user_model_utils.py) used to propagate
+        straight out of the generator instead of yielding an event."""
+        with patch(_GENERATE_SUGGESTIONS_PATCH, side_effect=RuntimeError("model unreachable")):
+            events = await _collect(
+                suggestion_pipeline_stream(
+                    db=test_db,
+                    test_set_identifier="some-test-set",
+                    organization_id=test_org_id,
+                    user_id=authenticated_user_id,
+                    endpoint_id=str(uuid.uuid4()),
+                    metric_names=["Correctness"],
+                    num_suggestions=2,
+                )
+            )
+
+        error = next(e for e in events if e["type"] == "error")
+        assert "model unreachable" in error["message"]
+        assert "suggestion" not in {e["type"] for e in events}
+        assert events[-1] == {"type": "done"}
+
+    async def test_exhausted_model_tokens_quota_gets_organization_subject_copy(
+        self, test_db: Session, test_org_id, authenticated_user_id
+    ):
+        """A QuotaExceededError must read like every other quota message in
+        the app, not the exception's own technical string."""
+        verdict = QuotaVerdict(
+            resource=QuotaResource.MODEL_TOKENS,
+            used=51_080,
+            limit=1_000,
+            allowed=False,
+            over_limit=True,
+            kind="flow",
+            period_end="2026-09-01",
+        )
+        with patch(_GENERATE_SUGGESTIONS_PATCH, side_effect=QuotaExceededError(verdict)):
+            events = await _collect(
+                suggestion_pipeline_stream(
+                    db=test_db,
+                    test_set_identifier="some-test-set",
+                    organization_id=test_org_id,
+                    user_id=authenticated_user_id,
+                    endpoint_id=str(uuid.uuid4()),
+                    metric_names=["Correctness"],
+                    num_suggestions=2,
+                )
+            )
+
+        error = next(e for e in events if e["type"] == "error")
+        assert error["message"] == "Your organization is at its model tokens limit for this period."
+        assert "QuotaExceededError" not in error["message"]

--- a/tests/backend/services/test_test_generation_pipeline.py
+++ b/tests/backend/services/test_test_generation_pipeline.py
@@ -695,6 +695,42 @@ class TestPipelineStream:
         assert "test" not in types
         assert types[-1] == "done"
 
+    async def test_db_context_failure_reports_error_instead_of_raising(self):
+        """_fetch_db_context (e.g. a deleted/inaccessible project) sat right
+        after _resolve_config_llm but outside its try/except -- it must be
+        caught by the same block, not just the LLM-resolution call."""
+        user = _make_user()
+        mock_db = MagicMock()
+        llm = _streaming_llm()
+
+        with (
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._resolve_config_llm",
+                return_value=llm,
+            ),
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._fetch_db_context",
+                side_effect=ValueError("Project with id p-1 not found or not accessible"),
+            ),
+        ):
+            events = await _collect_ndjson(
+                test_generation_pipeline_stream(
+                    db=mock_db,
+                    user=user,
+                    prompt="test",
+                    organization_id=str(uuid.uuid4()),
+                    project_id="p-1",
+                )
+            )
+
+        types = [e["type"] for e in events]
+        error_events = [e for e in events if e["type"] == "error"]
+        assert error_events, "db-context failure must yield an error event, not raise"
+        assert error_events[0]["phase"] == "config"
+        assert "not found or not accessible" in error_events[0]["message"]
+        assert "test" not in types
+        assert types[-1] == "done"
+
     async def test_exhausted_model_tokens_quota_gets_organization_subject_copy(self):
         """A QuotaExceededError raised at resolution time (the pre-call token
         gate in user_model_utils.py) must read like every other quota

--- a/tests/backend/services/test_test_generation_pipeline.py
+++ b/tests/backend/services/test_test_generation_pipeline.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.app.quota.enforcement import QuotaExceededError, QuotaVerdict
 from rhesis.backend.app.schemas.services import TestConfigResponse
 from rhesis.backend.app.services.test_generation_pipeline import (
     _fetch_db_context,
@@ -663,6 +665,70 @@ class TestPipelineStream:
         assert "error" in types
         assert "test" not in types
         assert types[-1] == "done"
+
+    async def test_llm_resolution_failure_reports_error_instead_of_raising(self):
+        """A resolution failure (e.g. a misconfigured model) used to propagate
+        straight out of the generator with no event ever emitted, since this
+        was the one call in the whole function outside every other
+        try/except. It must now surface as a normal error event."""
+        user = _make_user()
+        mock_db = MagicMock()
+
+        with patch(
+            "rhesis.backend.app.services.test_generation_pipeline._resolve_config_llm",
+            side_effect=RuntimeError("model unreachable"),
+        ):
+            events = await _collect_ndjson(
+                test_generation_pipeline_stream(
+                    db=mock_db,
+                    user=user,
+                    prompt="test",
+                    organization_id=str(uuid.uuid4()),
+                )
+            )
+
+        types = [e["type"] for e in events]
+        error_events = [e for e in events if e["type"] == "error"]
+        assert error_events, "resolution failure must yield an error event, not raise"
+        assert error_events[0]["phase"] == "config"
+        assert "model unreachable" in error_events[0]["message"]
+        assert "test" not in types
+        assert types[-1] == "done"
+
+    async def test_exhausted_model_tokens_quota_gets_organization_subject_copy(self):
+        """A QuotaExceededError raised at resolution time (the pre-call token
+        gate in user_model_utils.py) must read like every other quota
+        message in the app, not the exception's own technical string."""
+        user = _make_user()
+        mock_db = MagicMock()
+        verdict = QuotaVerdict(
+            resource=QuotaResource.MODEL_TOKENS,
+            used=51_080,
+            limit=1_000,
+            allowed=False,
+            over_limit=True,
+            kind="flow",
+            period_end="2026-09-01",
+        )
+
+        with patch(
+            "rhesis.backend.app.services.test_generation_pipeline._resolve_config_llm",
+            side_effect=QuotaExceededError(verdict),
+        ):
+            events = await _collect_ndjson(
+                test_generation_pipeline_stream(
+                    db=mock_db,
+                    user=user,
+                    prompt="test",
+                    organization_id=str(uuid.uuid4()),
+                )
+            )
+
+        error_events = [e for e in events if e["type"] == "error"]
+        assert error_events
+        message = error_events[0]["message"]
+        assert message == "Your organization is at its model tokens limit for this period."
+        assert "QuotaExceededError" not in message
 
     async def test_test_generation_failure_reports_error(self):
         """If test generation raises, error event is emitted but pipeline finishes."""

--- a/tests/backend/services/test_usage_notifications.py
+++ b/tests/backend/services/test_usage_notifications.py
@@ -1,4 +1,4 @@
-"""Tests for services.usage_notifications.check_and_notify_threshold_crossing().
+"""Tests for services.usage_notifications.
 
 Covers the transition-detection rule: a notification fires only when
 `previous_used`/`new_used` actually span a threshold, never on a call that
@@ -8,14 +8,20 @@ for weeks would be renotified on every subsequent accrual.
 
 from __future__ import annotations
 
+import uuid
 from unittest.mock import patch
 
 import pytest
 
 from rhesis.backend.app.crud.notification import get_notifications
+from rhesis.backend.app.database import bind_scope_to_session
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.quota import OveragePolicy, QuotaPolicy, QuotaRegistry, QuotaResource
-from rhesis.backend.app.services.usage_notifications import check_and_notify_threshold_crossing
+from rhesis.backend.app.services.usage import count_org_projects
+from rhesis.backend.app.services.usage_notifications import (
+    notify_flow_crossing,
+    notify_stock_crossing,
+)
 
 
 class _FixedPolicyProvider:
@@ -52,9 +58,9 @@ class TestThresholdCrossing:
     def test_no_notification_for_unlimited_resource(self, clean_registry):
         _install(QuotaPolicy(limits={QuotaResource.MODEL_TOKENS: None}))
         with patch("rhesis.backend.app.services.notification.service.publish_event"):
-            check_and_notify_threshold_crossing(
+            notify_flow_crossing(
                 self.db,
-                self.org,
+                str(self.org.id),
                 QuotaResource.MODEL_TOKENS,
                 previous_used=0,
                 new_used=10_000_000,
@@ -64,32 +70,44 @@ class TestThresholdCrossing:
     def test_no_notification_when_staying_under_the_threshold(self, clean_registry):
         _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 100}))
         with patch("rhesis.backend.app.services.notification.service.publish_event"):
-            check_and_notify_threshold_crossing(
-                self.db, self.org, QuotaResource.TEST_EXECUTIONS, previous_used=10, new_used=20
+            notify_flow_crossing(
+                self.db,
+                str(self.org.id),
+                QuotaResource.TEST_EXECUTIONS,
+                previous_used=10,
+                new_used=20,
             )
         assert self._event_types() == set()
 
     def test_fires_approaching_on_crossing_80_percent(self, clean_registry):
         _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 100}))
         with patch("rhesis.backend.app.services.notification.service.publish_event"):
-            check_and_notify_threshold_crossing(
-                self.db, self.org, QuotaResource.TEST_EXECUTIONS, previous_used=79, new_used=80
+            notify_flow_crossing(
+                self.db,
+                str(self.org.id),
+                QuotaResource.TEST_EXECUTIONS,
+                previous_used=79,
+                new_used=80,
             )
         assert self._event_types() == {"usage.approaching_limit"}
 
     def test_does_not_refire_once_already_past_the_threshold(self, clean_registry):
         _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 100}))
         with patch("rhesis.backend.app.services.notification.service.publish_event"):
-            check_and_notify_threshold_crossing(
-                self.db, self.org, QuotaResource.TEST_EXECUTIONS, previous_used=85, new_used=86
+            notify_flow_crossing(
+                self.db,
+                str(self.org.id),
+                QuotaResource.TEST_EXECUTIONS,
+                previous_used=85,
+                new_used=86,
             )
         assert self._event_types() == set()
 
     def test_fires_blocked_on_crossing_a_hard_ceiling(self, clean_registry):
         _install(QuotaPolicy(limits={QuotaResource.PROJECTS: 5}, overage=OveragePolicy.HARD))
         with patch("rhesis.backend.app.services.notification.service.publish_event"):
-            check_and_notify_threshold_crossing(
-                self.db, self.org, QuotaResource.PROJECTS, previous_used=4, new_used=5
+            notify_flow_crossing(
+                self.db, str(self.org.id), QuotaResource.PROJECTS, previous_used=4, new_used=5
             )
         assert self._event_types() == {"usage.blocked"}
 
@@ -106,9 +124,9 @@ class TestThresholdCrossing:
             )
         )
         with patch("rhesis.backend.app.services.notification.service.publish_event"):
-            check_and_notify_threshold_crossing(
+            notify_flow_crossing(
                 self.db,
-                self.org,
+                str(self.org.id),
                 QuotaResource.TEST_EXECUTIONS,
                 previous_used=99,
                 new_used=100,
@@ -116,9 +134,9 @@ class TestThresholdCrossing:
         assert self._event_types() == set()
 
         with patch("rhesis.backend.app.services.notification.service.publish_event"):
-            check_and_notify_threshold_crossing(
+            notify_flow_crossing(
                 self.db,
-                self.org,
+                str(self.org.id),
                 QuotaResource.TEST_EXECUTIONS,
                 previous_used=124,
                 new_used=125,
@@ -128,14 +146,100 @@ class TestThresholdCrossing:
     def test_blocked_wins_over_approaching_when_one_jump_crosses_both(self, clean_registry):
         _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 100}))
         with patch("rhesis.backend.app.services.notification.service.publish_event"):
-            check_and_notify_threshold_crossing(
-                self.db, self.org, QuotaResource.TEST_EXECUTIONS, previous_used=10, new_used=100
+            notify_flow_crossing(
+                self.db,
+                str(self.org.id),
+                QuotaResource.TEST_EXECUTIONS,
+                previous_used=10,
+                new_used=100,
             )
         assert self._event_types() == {"usage.blocked"}
 
     def test_noop_when_org_is_none(self, clean_registry):
         _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 100}))
         # Must not raise.
-        check_and_notify_threshold_crossing(
+        notify_flow_crossing(
             self.db, None, QuotaResource.TEST_EXECUTIONS, previous_used=79, new_used=80
         )
+
+
+@pytest.mark.integration
+class TestOrgWideScoping:
+    """A quota crossing is org state, so its notification must be visible in
+    every project -- `project_id` NULL.
+
+    Regression test: `auto_stamp` (models/scope_events.py) fills a `None`
+    `project_id` from the session's scope, and the stock-resource callers run
+    inside a project-scoped request. Before `_notify_owner` pinned the scope,
+    the row was stamped with whichever project the acting admin had selected,
+    and `auto_filter` plus the RESTRICTIVE `project_isolation` RLS policy then
+    hid it from the owner in every other project.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_db, test_org_id):
+        self.db = test_db
+        self.org = test_db.query(Organization).filter(Organization.id == test_org_id).first()
+
+    def test_notification_is_not_stamped_with_the_active_project(
+        self, test_db, test_org_id, clean_registry
+    ):
+        _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 100}))
+        active_project = str(uuid.uuid4())
+        bind_scope_to_session(test_db, test_org_id, str(self.org.owner_id), active_project)
+
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            notify_flow_crossing(
+                test_db,
+                test_org_id,
+                QuotaResource.TEST_EXECUTIONS,
+                previous_used=79,
+                new_used=80,
+            )
+
+        rows = [
+            r
+            for r in get_notifications(test_db, user_id=str(self.org.owner_id))
+            if r.event_type == "usage.approaching_limit"
+        ]
+        assert rows, "no approaching_limit notification was written"
+        assert rows[0].project_id is None
+
+
+@pytest.mark.integration
+class TestStockCrossing:
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_db, test_org_id):
+        self.db = test_db
+        self.org = test_db.query(Organization).filter(Organization.id == test_org_id).first()
+
+    def test_notifies_when_a_created_project_reaches_the_limit(self, clean_registry):
+        # count_org_projects is live, so pin the limit to whatever the count
+        # is right now: creating the row that reaches it is the crossing.
+        current = count_org_projects(self.db, str(self.org.id))
+        _install(QuotaPolicy(limits={QuotaResource.PROJECTS: current}, overage=OveragePolicy.HARD))
+
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            notify_stock_crossing(self.db, self.org, QuotaResource.PROJECTS)
+
+        rows = get_notifications(self.db, user_id=str(self.org.owner_id))
+        assert {r.event_type for r in rows} == {"usage.blocked"}
+
+    def test_swallows_a_failure_rather_than_raising_into_a_committed_route(self, clean_registry):
+        # The three creation routes call this AFTER the row is committed (or
+        # flushed), so a raise here would 500 a request whose work already
+        # landed. project.py in particular commits first.
+        class _Boom:
+            def get_policy(self, org=None):
+                raise RuntimeError("tier config is malformed")
+
+        QuotaRegistry.set_quota_provider(_Boom())
+
+        notify_stock_crossing(self.db, self.org, QuotaResource.PROJECTS)
+
+    def test_ignores_a_flow_resource(self, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 1}))
+
+        notify_stock_crossing(self.db, self.org, QuotaResource.TEST_EXECUTIONS)
+
+        assert get_notifications(self.db, user_id=str(self.org.owner_id)) == []

--- a/tests/backend/services/test_usage_notifications.py
+++ b/tests/backend/services/test_usage_notifications.py
@@ -1,0 +1,141 @@
+"""Tests for services.usage_notifications.check_and_notify_threshold_crossing().
+
+Covers the transition-detection rule: a notification fires only when
+`previous_used`/`new_used` actually span a threshold, never on a call that
+starts and ends on the same side of it -- otherwise an org sitting past 80%
+for weeks would be renotified on every subsequent accrual.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from rhesis.backend.app.crud.notification import get_notifications
+from rhesis.backend.app.models.organization import Organization
+from rhesis.backend.app.quota import OveragePolicy, QuotaPolicy, QuotaRegistry, QuotaResource
+from rhesis.backend.app.services.usage_notifications import check_and_notify_threshold_crossing
+
+
+class _FixedPolicyProvider:
+    def __init__(self, policy: QuotaPolicy):
+        self._policy = policy
+
+    def get_policy(self, org=None) -> QuotaPolicy:
+        return self._policy
+
+
+@pytest.fixture
+def clean_registry():
+    saved_provider = QuotaRegistry._provider
+    QuotaRegistry.reset()
+    yield
+    QuotaRegistry._provider = saved_provider
+
+
+def _install(policy: QuotaPolicy) -> None:
+    QuotaRegistry.set_quota_provider(_FixedPolicyProvider(policy))
+
+
+@pytest.mark.integration
+class TestThresholdCrossing:
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_db, test_org_id):
+        self.db = test_db
+        self.org = test_db.query(Organization).filter(Organization.id == test_org_id).first()
+
+    def _event_types(self) -> set[str]:
+        rows = get_notifications(self.db, user_id=str(self.org.owner_id))
+        return {r.event_type for r in rows}
+
+    def test_no_notification_for_unlimited_resource(self, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.MODEL_TOKENS: None}))
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            check_and_notify_threshold_crossing(
+                self.db,
+                self.org,
+                QuotaResource.MODEL_TOKENS,
+                previous_used=0,
+                new_used=10_000_000,
+            )
+        assert self._event_types() == set()
+
+    def test_no_notification_when_staying_under_the_threshold(self, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 100}))
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            check_and_notify_threshold_crossing(
+                self.db, self.org, QuotaResource.TEST_EXECUTIONS, previous_used=10, new_used=20
+            )
+        assert self._event_types() == set()
+
+    def test_fires_approaching_on_crossing_80_percent(self, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 100}))
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            check_and_notify_threshold_crossing(
+                self.db, self.org, QuotaResource.TEST_EXECUTIONS, previous_used=79, new_used=80
+            )
+        assert self._event_types() == {"usage.approaching_limit"}
+
+    def test_does_not_refire_once_already_past_the_threshold(self, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 100}))
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            check_and_notify_threshold_crossing(
+                self.db, self.org, QuotaResource.TEST_EXECUTIONS, previous_used=85, new_used=86
+            )
+        assert self._event_types() == set()
+
+    def test_fires_blocked_on_crossing_a_hard_ceiling(self, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.PROJECTS: 5}, overage=OveragePolicy.HARD))
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            check_and_notify_threshold_crossing(
+                self.db, self.org, QuotaResource.PROJECTS, previous_used=4, new_used=5
+            )
+        assert self._event_types() == {"usage.blocked"}
+
+    def test_fires_blocked_on_crossing_a_soft_tier_s_ceiling_not_its_bare_limit(
+        self, clean_registry
+    ):
+        # limit=100, 25% tolerance -> ceiling=125. Crossing the bare limit
+        # (100) must not fire "blocked" -- that's the grace band, not the cut-off.
+        _install(
+            QuotaPolicy(
+                limits={QuotaResource.TEST_EXECUTIONS: 100},
+                overage=OveragePolicy.SOFT,
+                overage_tolerance_percent=25,
+            )
+        )
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            check_and_notify_threshold_crossing(
+                self.db,
+                self.org,
+                QuotaResource.TEST_EXECUTIONS,
+                previous_used=99,
+                new_used=100,
+            )
+        assert self._event_types() == set()
+
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            check_and_notify_threshold_crossing(
+                self.db,
+                self.org,
+                QuotaResource.TEST_EXECUTIONS,
+                previous_used=124,
+                new_used=125,
+            )
+        assert self._event_types() == {"usage.blocked"}
+
+    def test_blocked_wins_over_approaching_when_one_jump_crosses_both(self, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 100}))
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            check_and_notify_threshold_crossing(
+                self.db, self.org, QuotaResource.TEST_EXECUTIONS, previous_used=10, new_used=100
+            )
+        assert self._event_types() == {"usage.blocked"}
+
+    def test_noop_when_org_is_none(self, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 100}))
+        # Must not raise.
+        check_and_notify_threshold_crossing(
+            self.db, None, QuotaResource.TEST_EXECUTIONS, previous_used=79, new_used=80
+        )


### PR DESCRIPTION
## Purpose

Backend quota enforcement landed in #2505, but the UI barely reflected it: a banner at 80% and a preflight gate in one drawer, both phrased as though the reader personally owned a limit their organization owns. This makes quota legible everywhere it matters and fixes the framing.

One rule drives all of it: **quota is organization state.** Personal chrome never carries it, the org is always the grammatical subject ("Your organization is at its projects limit"), and "you" appears only for what the reader can actually do next.

## What Changed

**Backend**

- The 402 body carries `kind` and `period_end`, so the client can classify a blocked resource and name its reset date without a second round trip. `period_end` is `null` for stock resources, which never reset.
- New `usage_notifications` service notifies the org owner when usage *crosses* 80% of a limit or its ceiling. It compares the before/after range rather than classifying the new value, so an org sitting past a threshold is not renotified on every subsequent call. Flow resources hook into `increment_usage`; stock resources hook into their three creation routes.
- `QUOTA_RESOURCE_LABELS` mirrors the frontend label map, so the backend stops calling `test_executions` "Test Executions" where the rest of the product says "Test Runs".

**Frontend**

- `utils/quota.ts` is the single source for classification and copy: `classifyZone` (healthy / approaching / pastIncluded / blocked), `quotaCopy` (the copy catalog as code), `parseQuotaError`, `flaggedResources`. Every surface reads from it instead of re-deriving thresholds or hand-writing strings.
- The usage page moves red from `limit` to `ceiling` and shows the overage allowance as a hatched second segment, so a soft-tier org can see the band it still has.
- A count badge on the brand row and an "Org usage" block in the org menu give ambient awareness. The badge answers "how many"; the banner and bars answer "how bad". Each org-menu usage row now fills a bar to how much of its limit is used, and the user-menu avatar badges its own unread-notification count.
- A notifications drawer, the drill-down the `GET /notifications/` docstring already called for. Quota alerts land in a new `usage` section that badges no nav item. Mark-all-read now clears the list (rather than just stamping `read_at`) when filtered to "Unread only" -- otherwise rows the user just marked read stayed on screen contradicting their own filter -- and same-day rows now have visible spacing between them instead of sitting flush against each other.
- Inline gates on projects, endpoints, seats and test generation via two hooks, `useQuotaGate` and `useQuotaErrorHandler`. `useQuotaGate` takes an amount, because inviting five people consumes five seats and a per-1 gate waves through a submit the backend refuses partway. The shared `<QuotaNotice>` these gates render now matches the design record's Q4 mockup: a zone-coloured icon and left border, not just a bold sentence, plus separate "Org usage" (unconditional -- `usage:read` is granted to every member) and "Upgrade plan" (gated on `canUpgrade`) links rendered by the component instead of folded into the recourse string.
- Every stock-resource mutation (endpoints, projects, users/seats) now goes through a dedicated hook, `useCreateEndpoint`, `useDeleteEndpoint`, `useCreateProject`, `useDeleteProject`, `useCreateUser`, `useDeleteUser`, that invalidates the cached `/usage` response on success. Five call sites (both endpoint-creation forms, the duplicate-endpoint action, and onboarding's user and project creation) had bypassed the hook and called the API client or a server action directly, so a user who did what a quota notice told them to do could still see themselves as blocked for up to five minutes. An ESLint rule now blocks calling those methods outside `src/hooks/`, so a future call site can't reintroduce the same bug silently.
- The AI test-generation preview ("Generate Test Set"'s sample/config stream) had no quota awareness anywhere: the frontend only gated the final submit, the backend enforced nothing on the streaming endpoint, and the NDJSON reader had no timeout. An org already over its `test_generation` limit could open the stream, and if the underlying model call stalled (as it does when `model_tokens` is also exhausted), the UI hung on skeleton loaders forever with no notification. Fixed at three points: the frontend now preflight-checks `test_generation` before every preview-generation entry point, not just the final submit; the backend route now carries the same `require_quota(TEST_GENERATION)` dependency `/test_sets/generate` already has, and the one un-guarded LLM-resolution call in the pipeline now catches a quota exhaustion (including the existing `model_tokens` pre-call gate) and emits a proper error event instead of letting it escape a generator whose response had already committed; and the NDJSON stream reader gets the same 150s idle-timeout `ExplorerClient` already has, so any stall surfaces as a clear error rather than an infinite hang.
- The same "unguarded LLM resolution before the first yield" defect existed independently in Explorer's `suggestion_pipeline_stream` (live, wired to `SuggestionsDialog`) and `evaluate_suggestions_stream` (no frontend caller yet). Both now catch the failure and emit a new top-level `{"type": "error", "message": ...}` event -- a pipeline-level failure, distinct from the per-item `error` field `output`/`evaluation` events already carry for one row failing without stopping the rest. The quota-aware message-building this needs is a shared `quota.enforcement.stream_error_message`, not a third copy of the same `isinstance(e, QuotaExceededError)` check.

## Review Fixes

A review pass over this branch's own commits turned up several gaps, all fixed:

- **Endpoint creation showed "created successfully" on a 402.** `createEndpoint` (a server action) never throws on a business failure -- it returns `{success: false, error}` -- and both `EndpointForm` and `SwaggerEndpointForm` ignored that, always showing the success toast and navigating away. An org at its endpoints limit saw a false success with nothing actually created.
- **The test-generation preview's 402 showed raw JSON.** `generateTestPipelineStream` threw a plain `Error` with the unparsed response body, so `require_quota` (added earlier in this PR) produced a toast reading the literal `{"error":"quota_exceeded",...}` payload. Now throws the same `status`/`data`-bearing shape `BaseApiClient` itself uses, and all five preview-generation catch blocks (two, `handleRegenerateSample`/`handleLoadMoreSamples`, had neither a preflight check nor real error handling) try `asQuotaError()` first, same as the final submit already did.
- **The same "unguarded setup before the first yield" defect also lived in `_fetch_db_context`**, one line after the LLM-resolution call this PR had already wrapped -- a deleted/inaccessible project reintroduced the exact hang this whole fix exists to prevent. Folded into the same `try`.
- **Three more generation routes had no quota gate at all.** `/generate/tests`, `/generate/multiturn-tests` and `/generate/test_config` back the same preview flow as the now-gated streaming route but had no `require_quota` dependency of their own.
- **`useCreateProject`/`useDeleteProject` invalidated usage but not the project list cache**, unlike their sibling `useDeleteEndpoint` -- a project picker elsewhere in the app kept a deleted project listed until `staleTime` elapsed.
- **The sidebar avatar's unread badge was clipped** by an `overflow: hidden` its sibling (the also-badged org-icon button) never had.
- Smaller: a no-op `overflowX: 'visible'` removed from `FilterDrawerShell` (the CSS Overflow spec promotes a lone `visible` axis to `auto`, so it never did anything); the GREYSCALE/EE-boundary ESLint selectors, copied into three rule blocks, hoisted into shared constants (180→269 lines, no behavior change); two duplicate 8-line "why this try/except exists" comments in the two streaming pipelines consolidated into one docstring both point at.

## Additional Context

- Builds on #2505. Rebased onto `main` after #2524, which made `USAGE_QUOTAS_ENABLED` default to off for self-hosted. With quotas off every limit is `null`, so the badge, banner, gates and notifications all correctly disappear; the last commit fixes a header that was still rendering over zero rows in that case.
- **A stale comment sent the original design down the wrong path.** `capabilities.ts` claimed `usage:read` was "restricted to org admins". #2505 had already removed that restriction, deliberately, on the reasoning that quota enforcement blocks members so hiding the reason from them just turns a 402 into a support ticket. Several surfaces were built admin-only on that false premise and have been corrected: everyone sees the numbers, and `Organization.UPDATE` is the gate for "can act on billing", which is what the upgrade CTA now uses. The comment is fixed too.
- Three defects worth calling out, all found reviewing this work rather than in production. An unguarded block after `increment_usage`'s commit meant a raised exception made Celery retry an accrual that had already landed, inflating the counter and blocking the org at a fraction of its real limit. `auto_stamp` was filling `project_id` on org-wide notifications from the acting admin's active project, so RLS then hid them in every other project. And `findWorstResource` sorted by ratio alone, which let a soft-tier resource deep in its grace band outrank a hard-blocked one and hide a real block behind a warning.
- Deferred: per-user attribution ("who used the last slot"). `usage_attribution.py` exists on the backend and the usage page is its eventual home.

## Testing

Automated:

- Frontend: 215 suites, 2036 tests. New coverage for `utils/quota.ts` (43, including every zone boundary, every copy-catalog row, and the usage-bar fill-percent helper), the quota hooks (12), `<QuotaNotice>` (4), the notifications drawer (18, including mark-all-read-while-filtered and same-day row spacing), the sidebar's usage bar and unread badge, `ServicesClient.generateTestPipelineStream`'s NDJSON parsing, stall timeout and 402 handling (3), and `EndpointForm`'s create-success/create-failure paths (2).
- Backend: the quota, usage and notification suites pass (87 tests across `test_quota_gates.py`, `test_quota_enforcement.py`, `test_test_generation_pipeline.py`, `test_services.py`, `test_suggestions.py`), including a regression test for the `project_id` stamping that fails without its fix, and new coverage for the test-generation and Explorer suggestion pipelines' 402 gates and LLM-resolution error paths (including a `QuotaExceededError` surfacing the organization-subject copy, not the exception's technical string, in each). **Caveat: the full backend suite has not been re-run since the rebase onto #2524** — Docker on this machine wedged under disk pressure. Since #2524 touches the same quota module, please let CI confirm, or re-run the suites named above locally.
- `npx tsc --noEmit` clean; `npm run lint` reports 0 errors (61 pre-existing warnings, none from this PR's own files); `ruff check`/`format` clean on every touched Python file.

Manual, on a community-edition org:

1. Set a small limit and consume most of it. The brand-row badge appears with a count, the org menu shows "Org usage" with per-resource rows, and the banner names the organization rather than you.
2. Cross the ceiling. Submit buttons disable with an explanation in the drawer footer, never on the FAB that opens it. The owner gets a notification, visible from any project.
3. Delete the blocking project, then via the Swagger import form and the manual form, create an endpoint. Both the project-deletion and endpoint-creation counts update immediately rather than after the cache expires.
4. Open the notifications drawer's filter panel. The "Unread only" switch renders flush against the left edge, not clipped.
5. As a non-admin member, confirm the numbers are visible but no upgrade link is offered.
6. With `USAGE_QUOTAS_ENABLED` off, confirm the badge, banner, gates and org-menu block are all absent.
7. With `test_generation` at its limit, open "Generate Test Set" and try to continue past the input screen, regenerate samples, or use "Further refine". Each shows the blocking toast immediately rather than opening the stream.
8. Trigger a 402 on a gated drawer as a member and as an admin. Both show the icon, the bordered notice, and an "Org usage" link; only the admin also sees "Upgrade plan".




