### PR TITLE
fix(backend): adjust community plan usage limits

### DIFF
--- a/apps/backend/src/rhesis/backend/app/quota/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/quota/__init__.py
@@ -83,13 +83,13 @@ class OveragePolicy(str, Enum):
 # test asserting the YAML's "community" entry matches -- can reference the
 # same numbers instead of duplicating them.
 FREE_TIER_LIMITS: dict[QuotaResource, int | None] = {
-    QuotaResource.TEST_EXECUTIONS: 1_000,
+    QuotaResource.TEST_EXECUTIONS: 500,
     QuotaResource.TRACING_SPANS: 50_000,
-    QuotaResource.TEST_GENERATION: 500,
+    QuotaResource.TEST_GENERATION: 100,
     QuotaResource.MODEL_TOKENS: 5_000_000,
     QuotaResource.SEATS: 3,
-    QuotaResource.PROJECTS: 1,
-    QuotaResource.ENDPOINTS: 1,
+    QuotaResource.PROJECTS: 3,
+    QuotaResource.ENDPOINTS: 3,
 }
 
 # Every resource explicitly set to None (unlimited). Explicit keys rather than

--- a/ee/backend/src/rhesis/backend/ee/licensing/tier_config.yaml
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tier_config.yaml
@@ -10,13 +10,13 @@ community:
   all_features: false
   features: []
   limits:
-    test_executions: 1000
+    test_executions: 500
     tracing_spans: 50000
-    test_generation: 500
+    test_generation: 100
     model_tokens: 5000000
     seats: 3
-    projects: 1
-    endpoints: 1
+    projects: 3
+    endpoints: 3
   retention_days: 14
   overage: hard
 


### PR DESCRIPTION
## Summary

- Lowered test_executions from 1,000 to 500
- Lowered test_generation from 500 to 100
- Raised projects from 1 to 3
- Raised endpoints from 1 to 3

Updated in both the YAML tier config and the Python `FREE_TIER_LIMITS` fallback constant.

## Test plan

- [x] Verified YAML and Python limits stay in sync (`resolve_limits(COMMUNITY) == FREE_TIER_LIMITS`)