### PR TITLE
Use API key instead of session token in k6 load tests

### DIFF
--- a/tests/k6/README.md
+++ b/tests/k6/README.md
@@ -6,12 +6,12 @@ Targets against `api.rhesis.ai` and `app.rhesis.ai`:
   `GET /` on the frontend. `/health` and `/home` aren't decorated with
   `@limiter.limit(...)` in `main.py`, so they sit outside the global slowapi
   rate limiter (100/hour, 1000/day per IP).
-- **Authenticated** (runs only if `AUTH_TOKEN` is set): the highest-traffic
+- **Authenticated** (runs only if `API_KEY` is set): the highest-traffic
   read-only routes — `GET /test_runs/`, `/test_sets/`, `/annotations/`,
   `/projects/`, `/behaviors/`, `/test_sets/stats`, `/categories/`,
   `/test_results/`. All GET-only; nothing that creates, mutates, or deletes
   data. `/annotations/`, `/behaviors/`, and `/categories/` are project-scoped
-  and need `PROJECT_ID` set alongside `AUTH_TOKEN` (see below) — without it
+  and need `PROJECT_ID` set alongside `API_KEY` (see below) — without it
   they 404/422.
 
 Every scenario carries a safety circuit-breaker (`safetyThresholds` in
@@ -19,13 +19,14 @@ Every scenario carries a safety circuit-breaker (`safetyThresholds` in
 for 15s, k6 aborts the run automatically instead of continuing to hammer a
 degraded target.
 
-## Getting a token (do this yourself — don't share your password)
+## Getting an API key (do this yourself — don't share your password)
 
-Login no longer returns the token directly — `/auth/login/email` returns a
-single-use `auth_code` (expires in 60s) that must be immediately exchanged
-for the real token via `/auth/exchange-code`. Run both steps together, from
-your own terminal. Your password stays on your machine; only the resulting
-token gets used by the script:
+API keys authenticate the same way a session JWT does — `Authorization:
+Bearer <token>` — but don't expire by default, so there's no refresh to
+manage. `POST /tokens/` (which mints the key) itself requires a bearer
+token, so the login → exchange-code steps below are a **one-time
+bootstrap**: you need a JWT to mint your first key, but never again after
+that — save the key and reuse it for every future run.
 
 ```bash
 CODE=$(curl -s -X POST https://api.rhesis.ai/auth/login/email \
@@ -33,22 +34,21 @@ CODE=$(curl -s -X POST https://api.rhesis.ai/auth/login/email \
   -d '{"email":"you@example.com","password":"yourpassword"}' \
   | jq -r '.auth_code')
 
-curl -s -X POST https://api.rhesis.ai/auth/exchange-code \
+JWT=$(curl -s -X POST https://api.rhesis.ai/auth/exchange-code \
   -H "Content-Type: application/json" \
-  -d "{\"code\":\"$CODE\"}"
+  -d "{\"code\":\"$CODE\"}" \
+  | jq -r '.session_token')
+
+curl -s -X POST https://api.rhesis.ai/tokens/ \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $JWT" \
+  -d '{"name": "k6-load-test-key"}' \
+  | jq -r '.access_token'
 ```
 
-That last response has both `session_token` and `refresh_token`. (No `jq`?
-Copy them out of the raw JSON by hand — but do it fast, the `auth_code`
-expires in 60 seconds and can only be used once.)
-
-**The session token itself is short-lived — in practice about 15 minutes**,
-not the 7 days older docs claimed (it's the framework's default
-`JWT_ACCESS_TOKEN_EXPIRE_MINUTES=15`, left unset in prod config). It'll
-expire mid-run for every scenario except `spike.js` (~3m), so also grab
-`refresh_token` and pass it as `REFRESH_TOKEN` — the scripts use it to mint
-a fresh session token every 10 minutes via `/auth/refresh`, no password
-needed.
+(No `jq`? Copy the values out of the raw JSON by hand.) The printed key
+starts with `rh-` and is only ever shown this once — save it somewhere.
+Revoke it later with `DELETE /tokens/{id}` if you're done with it.
 
 ## Run
 
@@ -56,9 +56,8 @@ needed.
 brew install k6          # or see https://k6.io/docs/get-started/installation
 cd tests/k6
 
-export AUTH_TOKEN="<paste the session_token here>"       # omit to test public routes only
-export REFRESH_TOKEN="<paste the refresh_token here>"    # keeps AUTH_TOKEN alive past 15m
-export PROJECT_ID="<your project id>"                    # needed for annotations/behaviors/categories
+export API_KEY="<paste the rh-... key here>"   # omit to test public routes only
+export PROJECT_ID="<your project id>"          # needed for annotations/behaviors/categories
 
 k6 run load.js
 k6 run stress.js

--- a/tests/k6/common.js
+++ b/tests/k6/common.js
@@ -8,48 +8,17 @@ import { check, group, sleep } from 'k6';
 export const API_BASE = __ENV.API_BASE || 'https://api.rhesis.ai';
 export const FRONTEND_BASE = __ENV.FRONTEND_BASE || 'https://app.rhesis.ai';
 
-// Obtain by logging in yourself and passing the result as -e AUTH_TOKEN=...
-// (see tests/k6/README.md). Never embed a password in these scripts.
-export const AUTH_TOKEN = __ENV.AUTH_TOKEN || '';
-// Some authenticated routes are project-scoped and need this header alongside the token.
+// Obtain via POST /tokens/ (see tests/k6/README.md) and pass as -e API_KEY=...
+// API keys don't expire by default, so there's no refresh to manage here.
+export const API_KEY = __ENV.API_KEY || '';
+// Some authenticated routes are project-scoped and need this header alongside the key.
 export const PROJECT_ID = __ENV.PROJECT_ID || '';
 
-// The session token lasts ~15 minutes — shorter than every scenario but
-// spike.js. REFRESH_TOKEN (also from /auth/exchange-code) lets each VU mint
-// a fresh session token mid-run without the password ever touching this
-// script. Optional: without it, AUTH_TOKEN is just used as-is for the run.
-const REFRESH_INTERVAL_MS = 10 * 60 * 1000; // 5m margin inside the 15m expiry
-
-let liveToken = AUTH_TOKEN;
-let liveRefreshToken = __ENV.REFRESH_TOKEN || '';
-let tokenMintedAt = -Infinity; // force an immediate refresh on first use
-
-function refreshTokenIfDue() {
-  if (!liveRefreshToken || Date.now() - tokenMintedAt < REFRESH_INTERVAL_MS) return;
-
-  const res = http.post(`${API_BASE}/auth/refresh`, JSON.stringify({ refresh_token: liveRefreshToken }), {
-    headers: { 'Content-Type': 'application/json' },
-    tags: { name: 'auth_refresh' },
-  });
-  const accessToken = res.status === 200 ? res.json('access_token') : null;
-  // Only advance tokenMintedAt on success — on failure, leave it stale so the
-  // very next iteration retries instead of running on an expired token for
-  // the rest of the 10-minute window.
-  if (!accessToken) return;
-
-  liveToken = accessToken;
-  const rotatedRefreshToken = res.json('refresh_token');
-  if (rotatedRefreshToken) liveRefreshToken = rotatedRefreshToken;
-  tokenMintedAt = Date.now();
-}
-
-function authHeaders() {
-  return {
-    headers: liveToken
-      ? { Authorization: `Bearer ${liveToken}`, ...(PROJECT_ID ? { 'X-Project-Id': PROJECT_ID } : {}) }
-      : {},
-  };
-}
+const authHeaders = {
+  headers: API_KEY
+    ? { Authorization: `Bearer ${API_KEY}`, ...(PROJECT_ID ? { 'X-Project-Id': PROJECT_ID } : {}) }
+    : {},
+};
 
 // Safety circuit-breaker shared by every scenario: if error rate or p95
 // latency blows past these for delayAbortEval, k6 stops the run itself
@@ -106,16 +75,14 @@ export const ENDPOINT_TAGS = [
 ];
 
 // Highest-traffic authenticated GET endpoints (see tests/k6/README.md for
-// how this list was derived). Skipped entirely when AUTH_TOKEN is unset, so
+// how this list was derived). Skipped entirely when API_KEY is unset, so
 // the same scripts still work anonymously against just the public routes.
 export function hitAuthenticated() {
-  if (!AUTH_TOKEN) return;
-
-  refreshTokenIfDue();
+  if (!API_KEY) return;
 
   for (const { name, path } of AUTH_ENDPOINTS) {
     group(name, () => {
-      const res = http.get(`${API_BASE}${path}`, { ...authHeaders(), tags: { name } });
+      const res = http.get(`${API_BASE}${path}`, { ...authHeaders, tags: { name } });
       check(res, { [`${name} status 200`]: (r) => r.status === 200 });
     });
   }


### PR DESCRIPTION
## Purpose

The k6 load test scripts previously authenticated with a session JWT, which only lives about 15 minutes in this deployment (the framework's default, left unset in prod config) — shorter than every scenario except spike.js. That required a token-refresh mechanism inside the scripts (calling POST /auth/refresh every 10 minutes) to keep long runs authenticated. Switching to an API key removes that complexity entirely, since API keys don't expire by default.

## What Changed

- Replaced AUTH_TOKEN/REFRESH_TOKEN and the whole refreshTokenIfDue mechanism in tests/k6/common.js with a single API_KEY env var, sent as the same Authorization: Bearer header the backend already accepts for both JWTs and rh-prefixed API keys.
- Updated tests/k6/README.md: replaced the login → exchange-code → refresh-token instructions with a one-time bootstrap flow (login → exchange-code → POST /tokens/ to mint a long-lived key), and updated the Run section's env vars accordingly.

## Additional Context

This branch previously carried the dead-endpoint-removal and refresh-failure-handling fixes; those were merged separately in #2518 and are not part of this diff — this PR only adds the API key switch on top of current main.

## Testing

Ran `k6 run --vus 2 --iterations 2 load.js` (and a broken-API_KEY case) against production with a real API key and PROJECT_ID — 0% error rate on all endpoints, confirming the Authorization header and X-Project-Id behavior work identically to the previous session-token setup.