### PR TITLE
fix(frontend): stop grid from emptying after test set assign

### DIFF
--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectChat.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectChat.tsx
@@ -96,7 +96,9 @@ function planDataToMarkdown(data: Record<string, unknown>): string {
     lines.push('');
   }
   const mappings = data.requirement_metric_mappings as
-    PlanSpec[] | Record<string, string[]> | undefined;
+    | PlanSpec[]
+    | Record<string, string[]>
+    | undefined;
   if (mappings) {
     lines.push('## Requirement-Metric Mappings', '');
     if (Array.isArray(mappings)) {

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
@@ -287,7 +287,9 @@ const EndpointForm = forwardRef<EndpointFormHandle, EndpointFormProps>(
           input_data: inputData,
           endpoint_path: formData.endpoint_path || undefined,
           response_format: (formData.response_format || 'json') as
-            'json' | 'xml' | 'text',
+            | 'json'
+            | 'xml'
+            | 'text',
         });
 
         const r = result as Record<string, unknown>;

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentVersionsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentVersionsGrid.tsx
@@ -185,7 +185,8 @@ export default function ExperimentVersionsGrid({
           row.values[field.name] ?? null,
         renderCell: (params: GridRenderCellParams<ExperimentVersion>) => {
           const val = params.row.values[field.name] as
-            ParameterValue | undefined;
+            | ParameterValue
+            | undefined;
           return (
             <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
               {val !== undefined ? (

--- a/apps/frontend/src/app/(protected)/organizations/settings/components/OrganizationSettingsTabs.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/settings/components/OrganizationSettingsTabs.tsx
@@ -68,13 +68,15 @@ export default function OrganizationSettingsTabs({
   const allTabs: MergedTab[] = useMemo(() => {
     const merged: MergedTab[] = [
       ...BUILT_IN_TABS,
-      ...dynamicTabs.map((t): DynamicTab => ({
-        id: t.id,
-        label: t.title,
-        order: t.order,
-        dynamic: true,
-        component: t.component,
-      })),
+      ...dynamicTabs.map(
+        (t): DynamicTab => ({
+          id: t.id,
+          label: t.title,
+          order: t.order,
+          dynamic: true,
+          component: t.component,
+        })
+      ),
     ];
     return merged.sort((a, b) => a.order - b.order);
   }, [dynamicTabs]);

--- a/apps/frontend/src/app/(protected)/tasks/components/TaskDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TaskDrawer.tsx
@@ -150,7 +150,8 @@ export default function TaskDrawer({
 
   const entityType = initialEntity?.entityType;
   const commentId = initialEntity?.task_metadata?.comment_id as
-    string | undefined;
+    | string
+    | undefined;
 
   return (
     <BaseDrawer

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -456,7 +456,8 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
             (params.row.attributes?.parameter_experiment_name as string) ||
             undefined;
           const version = params.row.attributes?.parameter_version as
-            string | undefined;
+            | string
+            | undefined;
 
           if (!name && !version) return null;
 

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetLinkedTestsSection.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetLinkedTestsSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   Box,
   Button,
@@ -50,7 +50,6 @@ export default function TestSetLinkedTestsSection({
   const router = useRouter();
   const queryClient = useQueryClient();
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [refreshKey, setRefreshKey] = useState(0);
   const [totalCount, setTotalCount] = useState(initialTestCount);
   const [isGenerating, setIsGenerating] = useState(initialIsGenerating);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -118,10 +117,6 @@ export default function TestSetLinkedTestsSection({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- testSetId is stable; router is stable
   }, [isGenerating]);
 
-  const handleRefresh = useCallback(() => {
-    setRefreshKey(k => k + 1);
-  }, []);
-
   const handleAssignTests = async (tests: TestDetail[]) => {
     if (tests.length === 0) return;
     try {
@@ -144,7 +139,6 @@ export default function TestSetLinkedTestsSection({
       await queryClient.invalidateQueries({
         queryKey: [...testSetKeys.detail(testSetId), 'tests'],
       });
-      handleRefresh();
       // Sync the server-rendered testCount prop for this page.
       router.refresh();
     } catch (error) {
@@ -260,7 +254,6 @@ export default function TestSetLinkedTestsSection({
           </Box>
 
           <EmbeddingTestsPanel
-            key={refreshKey}
             testSetId={testSetId}
             testSetType={testSetType}
             onTotalCountChange={setTotalCount}

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/ChipGroup.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/ChipGroup.tsx
@@ -35,7 +35,11 @@ export default function ChipGroup({
     };
 
     return colorMap[chip.colorVariant || 'blue'] as
-      'primary' | 'secondary' | 'warning' | 'success' | undefined;
+      | 'primary'
+      | 'secondary'
+      | 'warning'
+      | 'success'
+      | undefined;
   };
 
   const getChipSx = (chip: ChipConfig) => {

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/types.ts
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/types.ts
@@ -178,4 +178,8 @@ export interface FlowState {
  * Document processing status
  */
 export type DocumentStatus =
-  'uploading' | 'extracting' | 'generating' | 'completed' | 'error';
+  | 'uploading'
+  | 'extracting'
+  | 'generating'
+  | 'completed'
+  | 'error';

--- a/apps/frontend/src/app/(protected)/tests/components/TestDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestDrawer.tsx
@@ -29,7 +29,8 @@ export default function TestDrawer({
   const { data: session } = useSession();
   const getCurrentUserId = () =>
     session?.user?.id as
-      `${string}-${string}-${string}-${string}-${string}` | undefined;
+      | `${string}-${string}-${string}-${string}-${string}`
+      | undefined;
 
   const handleSave = async () => {
     try {

--- a/apps/frontend/src/app/(protected)/traces/components/ConversationTraceView.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/ConversationTraceView.tsx
@@ -47,7 +47,8 @@ function getPerTurnOverrides(
   rootSpans: SpanNode[]
 ): Record<number, TurnOverrideEntry> {
   const traceMetrics = rootSpans.find(s => s.trace_metrics)?.trace_metrics as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   if (!traceMetrics) return {};
 
   const turnOverrides = traceMetrics.turn_overrides as

--- a/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
@@ -249,14 +249,17 @@ export default function TraceDrawer({
 
   const mentionableMetrics: MentionOption[] = useMemo(() => {
     const traceMetrics = selectedSpan?.trace_metrics as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     if (!traceMetrics) return [];
     const names: string[] = [];
     for (const section of ['turn_metrics', 'conversation_metrics']) {
       const sectionData = traceMetrics[section] as
-        Record<string, unknown> | undefined;
+        | Record<string, unknown>
+        | undefined;
       const metrics = sectionData?.metrics as
-        Record<string, unknown> | undefined;
+        | Record<string, unknown>
+        | undefined;
       if (metrics) {
         names.push(...Object.keys(metrics));
       }
@@ -304,15 +307,18 @@ export default function TraceDrawer({
   const handleReviewMetric = useCallback(
     (metricName: string) => {
       const traceMetrics = selectedSpan?.trace_metrics as
-        Record<string, unknown> | undefined;
+        | Record<string, unknown>
+        | undefined;
       if (!traceMetrics) return;
 
       let isSuccessful = false;
       for (const section of ['turn_metrics', 'conversation_metrics']) {
         const sectionData = traceMetrics[section] as
-          Record<string, unknown> | undefined;
+          | Record<string, unknown>
+          | undefined;
         const metrics = sectionData?.metrics as
-          Record<string, { is_successful?: boolean }> | undefined;
+          | Record<string, { is_successful?: boolean }>
+          | undefined;
         if (metrics?.[metricName]) {
           isSuccessful = !!metrics[metricName].is_successful;
           break;
@@ -366,7 +372,8 @@ export default function TraceDrawer({
         const testRun = await testRunsClient.getTestRun(trace.test_run.id);
         if (testRun?.experiment_id) {
           const attrs = testRun.attributes as
-            Record<string, unknown> | undefined;
+            | Record<string, unknown>
+            | undefined;
           setExperimentInfo({
             id: testRun.experiment_id,
             name: (attrs?.parameter_experiment_name as string) || 'Unknown',

--- a/apps/frontend/src/app/(protected)/traces/components/TraceMetricsTab.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceMetricsTab.tsx
@@ -287,7 +287,8 @@ export default function TraceMetricsTab({
   const [filterStatus, setFilterStatus] = useState<FilterStatus>('all');
 
   const traceMetrics = selectedSpan?.trace_metrics as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
 
   const turnMetrics = useMemo(() => {
     if (!traceMetrics?.turn_metrics) return null;

--- a/apps/frontend/src/app/(protected)/traces/components/TraceReviewDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceReviewDrawer.tsx
@@ -59,7 +59,8 @@ function getAllTraceMetrics(
   const result: Record<string, MetricEntry> = {};
   for (const section of ['turn_metrics', 'conversation_metrics']) {
     const sectionData = traceMetrics[section] as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     const metrics = (sectionData?.metrics ?? {}) as Record<string, MetricEntry>;
     Object.assign(result, metrics);
   }
@@ -128,13 +129,16 @@ export default function TraceReviewDrawer({
 
   const getTurnMetricsAutomatedStatus = useCallback((): 'passed' | 'failed' => {
     const traceMetrics = selectedSpan?.trace_metrics as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     const turnSection = traceMetrics?.turn_metrics as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     if (!turnSection) return 'failed';
 
     const metrics = turnSection.metrics as
-      Record<string, { is_successful?: boolean }> | undefined;
+      | Record<string, { is_successful?: boolean }>
+      | undefined;
     if (metrics && Object.keys(metrics).length > 0) {
       return Object.values(metrics).every(m => m?.is_successful)
         ? 'passed'

--- a/apps/frontend/src/app/(protected)/traces/components/TraceReviewsTab.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceReviewsTab.tsx
@@ -263,7 +263,8 @@ export default function TraceReviewsTab({
 
     for (const section of ['turn_metrics', 'conversation_metrics']) {
       const sectionData = traceMetrics[section] as
-        Record<string, unknown> | undefined;
+        | Record<string, unknown>
+        | undefined;
       const metrics = (sectionData?.metrics ?? {}) as Record<
         string,
         { is_successful?: boolean }

--- a/apps/frontend/src/components/common/NotificationContext.tsx
+++ b/apps/frontend/src/components/common/NotificationContext.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { Snackbar, Alert, useTheme } from '@mui/material';
 
 export type NotificationSeverity =
-  'success' | 'info' | 'warning' | 'error' | 'neutral';
+  | 'success'
+  | 'info'
+  | 'warning'
+  | 'error'
+  | 'neutral';
 
 interface NotificationOptions {
   severity?: NotificationSeverity;

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -118,10 +118,12 @@ export function Sidebar() {
   const groups = groupNavItems(navigation);
 
   const mainGroups = groups.filter(g => g.type !== 'footer-links') as (
-    StandaloneGroup | SectionGroup
+    | StandaloneGroup
+    | SectionGroup
   )[];
   const footerGroup = groups.find(g => g.type === 'footer-links') as
-    FooterLinksGroup | undefined;
+    | FooterLinksGroup
+    | undefined;
 
   const sidebarWidth = collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_WIDTH;
 

--- a/apps/frontend/src/components/tasks/TasksSection.tsx
+++ b/apps/frontend/src/components/tasks/TasksSection.tsx
@@ -178,7 +178,11 @@ export function TasksSection({
             label={params.row.status?.name || 'Unknown'}
             color={
               getStatusColor(params.row.status?.name) as
-                'warning' | 'primary' | 'success' | 'error' | 'default'
+                | 'warning'
+                | 'primary'
+                | 'success'
+                | 'error'
+                | 'default'
             }
             size="small"
           />

--- a/apps/frontend/src/config/onboarding-tours.ts
+++ b/apps/frontend/src/config/onboarding-tours.ts
@@ -166,7 +166,9 @@ export const driverConfig = {
   prevBtnText: 'Back',
   doneBtnText: 'Got it!',
   showButtons: ['next', 'previous', 'close'] as (
-    'next' | 'previous' | 'close'
+    | 'next'
+    | 'previous'
+    | 'close'
   )[],
   allowClose: true,
   overlayClickNext: false,

--- a/apps/frontend/src/hooks/useArchitectChat.ts
+++ b/apps/frontend/src/hooks/useArchitectChat.ts
@@ -658,7 +658,8 @@ export function useArchitectChat(
     unsubs.push(
       subscribe(EventType.SUBSCRIPTION_ERROR, (msg: WebSocketMessage) => {
         const payload = msg.payload as
-          { channel?: string; error?: string } | undefined;
+          | { channel?: string; error?: string }
+          | undefined;
         const deniedChannel = payload?.channel ?? msg.channel;
         if (deniedChannel !== `architect:${sessionId}`) return;
 

--- a/apps/frontend/src/hooks/useWebSocket.ts
+++ b/apps/frontend/src/hooks/useWebSocket.ts
@@ -15,7 +15,8 @@ import { EventType, WebSocketMessage, EventHandler } from '@/utils/websocket';
  * `preflight:{id}`) can use the plain string form.
  */
 export type ChannelSubscription =
-  string | { channel: string; projectId?: string | null };
+  | string
+  | { channel: string; projectId?: string | null };
 
 /**
  * Options for the useWebSocket hook.

--- a/apps/frontend/src/utils/api-client/__tests__/base-client.test.ts
+++ b/apps/frontend/src/utils/api-client/__tests__/base-client.test.ts
@@ -270,7 +270,8 @@ describe('BaseApiClient', () => {
         );
 
         let caughtError:
-          (Error & { status?: number; data?: ApiErrorData }) | null = null;
+          | (Error & { status?: number; data?: ApiErrorData })
+          | null = null;
         try {
           await client.fetchPublic('/test_configurations/1/execute', {
             method: 'POST',

--- a/apps/frontend/src/utils/api-client/interfaces/embedding.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/embedding.ts
@@ -18,4 +18,5 @@ export interface Scatter2DGraph {
 }
 
 export type EmbeddingGraphGetResponse =
-  { status: 'pending' } | { status: 'ready'; graph: Scatter2DGraph };
+  | { status: 'pending' }
+  | { status: 'ready'; graph: Scatter2DGraph };

--- a/apps/frontend/src/utils/conversation-from-spans.ts
+++ b/apps/frontend/src/utils/conversation-from-spans.ts
@@ -7,15 +7,18 @@ import type {
 
 function getAutomatedTurnSuccess(rootSpans: SpanNode[]): boolean | undefined {
   const traceMetrics = rootSpans.find(s => s.trace_metrics)?.trace_metrics as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   if (!traceMetrics) return undefined;
 
   const turnSection = traceMetrics.turn_metrics as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   if (!turnSection) return undefined;
 
   const metrics = turnSection.metrics as
-    Record<string, { is_successful?: boolean }> | undefined;
+    | Record<string, { is_successful?: boolean }>
+    | undefined;
   if (metrics && Object.keys(metrics).length > 0) {
     return Object.values(metrics).every(m => m?.is_successful);
   }

--- a/apps/frontend/src/utils/websocket/client.ts
+++ b/apps/frontend/src/utils/websocket/client.ts
@@ -323,7 +323,8 @@ export class WebSocketClient {
     // Handle connection confirmation
     if (message.type === EventType.CONNECTED) {
       const payload = message.payload as unknown as
-        ConnectedPayload | undefined;
+        | ConnectedPayload
+        | undefined;
       this.state.connectionId = payload?.connection_id;
     }
 


### PR DESCRIPTION
## Purpose

Clicking Assign on a test set's detail page would populate the grid with the newly assigned tests, then a couple of seconds later the grid would go empty. Assigning tests fired three overlapping refresh mechanisms at once: a React Query cache invalidation, a forced remount of the grid via a `key={refreshKey}` counter, and a `router.refresh()`. The forced remount was redundant (the invalidation already refetches the grid's active query in place) and destructive, since it reset the grid's own pagination/filter/search state and forced a from-scratch refetch, which is what showed up as the grid going blank for a few seconds.

## What Changed

- Removed the `refreshKey` state, the `handleRefresh` callback, and the `key={refreshKey}` prop on the grid's parent panel in `TestSetLinkedTestsSection.tsx`
- Assigning tests now relies solely on the existing `invalidateQueries` call to refresh the grid in place, alongside the existing `router.refresh()` that keeps the page's server-rendered test count in sync
- Separate commit: reformatted 24 files that had drifted out of sync with the current Prettier config on `release/v0.13.0` (pre-existing, unrelated to the fix above — CI's lint check was already failing on this branch before this PR). No logic changes in that commit.

## Additional Context

Root-caused via investigation of the frontend refresh flow plus a backend check confirming the test-set association write commits synchronously and the count endpoint always reads live from the join table, ruling out any backend eventual-consistency gap. Checked the rest of the frontend for the same "prop-mirror + invalidation + forced remount" pattern (Test Runs, Metrics, Requirements, Tasks, Projects) — no other component reproduces it.

## Testing

Type-check and lint pass on the changed file. `prettier --check .` now passes cleanly across `apps/frontend`. Manual verification: open a test set's detail page, click Assign, add one or more tests, and confirm the grid keeps showing the assigned tests without going blank after a few seconds.