### PR TITLE
fix(backend): resync OWASP metrics to existing orgs

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/e4f5a6b7c8d9_resync_owasp_to_existing_orgs.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/e4f5a6b7c8d9_resync_owasp_to_existing_orgs.py
@@ -1,0 +1,128 @@
+"""resync_owasp_to_existing_orgs
+
+38ed899b9f41 syncs OWASP behaviors and metrics to existing organizations,
+and b857edcac3c0 tags them.  Both migrations run before 491519fd3010
+(rename behavior -> requirement), so on a database that encounters the
+full chain for the first time both are skipped by the "no requirement
+table yet" guard added in PR #2512.
+
+New orgs still get the data via onboarding, but every org that existed
+before v0.13.0 is left without OWASP metrics.
+
+This migration re-runs the same sync + tag logic, now positioned after
+the rename and after the calibrated-rubric push, so the requirement
+table exists and the latest initial_data.json rubrics are picked up.
+
+Revision ID: e4f5a6b7c8d9
+Revises: a4b5c6d7e8f9
+Create Date: 2026-08-20
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy.orm import Session
+
+from rhesis.backend.alembic.utils.metric_sync import (
+    _list_organizations_with_owner,
+    load_metrics_from_initial_data,
+    load_requirements_from_initial_data,
+    sync_metrics_to_organizations,
+    sync_requirements_to_organizations,
+)
+from rhesis.backend.app import models
+
+revision: str = "e4f5a6b7c8d9"
+down_revision: Union[str, None] = "a4b5c6d7e8f9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_OWASP_PREFIX = "OWASP"
+_TAG_NAME = "OWASP"
+
+
+def _owasp_requirement_names() -> list[str]:
+    return [
+        r["name"]
+        for r in load_requirements_from_initial_data()
+        if r["name"].startswith(_OWASP_PREFIX)
+    ]
+
+
+def _owasp_metric_names() -> list[str]:
+    return [m["name"] for m in load_metrics_from_initial_data() if m["name"].startswith(_OWASP_PREFIX)]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    try:
+        requirement_names = _owasp_requirement_names()
+        metric_names = _owasp_metric_names()
+
+        # Sync requirements first so metric -> requirement associations resolve.
+        sync_requirements_to_organizations(
+            session=session,
+            requirement_names=requirement_names,
+            verbose=True,
+            commit=False,
+        )
+
+        sync_metrics_to_organizations(
+            session=session,
+            metric_names=metric_names,
+            verbose=True,
+            commit=False,
+        )
+
+        # Tag OWASP metrics and behaviors (mirrors b857edcac3c0).
+        orgs = _list_organizations_with_owner(session)
+        for org_id, user_id in orgs:
+            tag = session.query(models.Tag).filter_by(name=_TAG_NAME, organization_id=org_id).first()
+            if not tag:
+                tag = models.Tag(name=_TAG_NAME, organization_id=org_id, user_id=user_id)
+                session.add(tag)
+                session.flush()
+            for model_cls in (models.Metric, models.Requirement):
+                rows = (
+                    session.query(model_cls)
+                    .filter(
+                        model_cls.name.like(f"{_OWASP_PREFIX}%"),
+                        model_cls.organization_id == org_id,
+                    )
+                    .all()
+                )
+                for entity in rows:
+                    exists = (
+                        session.query(models.TaggedItem)
+                        .filter_by(
+                            tag_id=tag.id,
+                            entity_id=entity.id,
+                            entity_type=model_cls.__name__,
+                            organization_id=org_id,
+                        )
+                        .first()
+                    )
+                    if not exists:
+                        session.add(
+                            models.TaggedItem(
+                                tag_id=tag.id,
+                                entity_id=entity.id,
+                                entity_type=model_cls.__name__,
+                                organization_id=org_id,
+                                user_id=user_id,
+                            )
+                        )
+
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def downgrade() -> None:
+    # Idempotent sync; no structural changes to reverse.
+    pass

--- a/apps/backend/src/rhesis/backend/alembic/versions/e4f5a6b7c8d9_resync_owasp_to_existing_orgs.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/e4f5a6b7c8d9_resync_owasp_to_existing_orgs.py
@@ -50,7 +50,9 @@ def _owasp_requirement_names() -> list[str]:
 
 
 def _owasp_metric_names() -> list[str]:
-    return [m["name"] for m in load_metrics_from_initial_data() if m["name"].startswith(_OWASP_PREFIX)]
+    return [
+        m["name"] for m in load_metrics_from_initial_data() if m["name"].startswith(_OWASP_PREFIX)
+    ]
 
 
 def upgrade() -> None:
@@ -79,7 +81,9 @@ def upgrade() -> None:
         # Tag OWASP metrics and behaviors (mirrors b857edcac3c0).
         orgs = _list_organizations_with_owner(session)
         for org_id, user_id in orgs:
-            tag = session.query(models.Tag).filter_by(name=_TAG_NAME, organization_id=org_id).first()
+            tag = (
+                session.query(models.Tag).filter_by(name=_TAG_NAME, organization_id=org_id).first()
+            )
             if not tag:
                 tag = models.Tag(name=_TAG_NAME, organization_id=org_id, user_id=user_id)
                 session.add(tag)


### PR DESCRIPTION
## Summary

- The OWASP sync migration (`38ed899b9f41`) runs before the behavior-to-requirement rename (`491519fd3010`) in the alembic chain. PR #2512 added a guard that skips it when the `requirement` table doesn't exist yet, which is always the case on a database encountering both migrations for the first time (v0.13.0 upgrade).
- New orgs get OWASP data from onboarding, but existing orgs are left without OWASP requirements, metrics, and tags.
- Adds migration `e4f5a6b7c8d9` at the chain head that re-runs the same idempotent sync now that the `requirement` table exists. Also re-applies OWASP tags (mirrors `b857edcac3c0`).

## Test plan

- [x] Applied migration on a fresh local DB. Ran without errors, found 2 requirements and 20 metrics from `initial_data.json`, 0 orgs to sync (fresh DB).
- [ ] Verify on staging (which has existing orgs) that OWASP metrics appear after running `alembic upgrade head`.