### PR TITLE
Expire a tuning run claim that stops advancing

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/metric_tuning.py
+++ b/apps/backend/src/rhesis/backend/app/routers/metric_tuning.py
@@ -264,6 +264,18 @@ def start_tuning_run(
     # not yet written the claim it is about to update.
     db.commit()
 
-    task_launcher(run_metric_tuning, str(metric_id), current_user=current_user, db=db)
+    try:
+        task_launcher(run_metric_tuning, str(metric_id), current_user=current_user, db=db)
+    except Exception as e:
+        # The claim is already committed, so a dispatch that never reaches a
+        # worker -- broker down, publish error -- would leave the metric refusing
+        # every later run with nothing on its way to clear the claim. Released
+        # here rather than left for the staleness window to pick up: this side
+        # knows for certain that no run is coming.
+        logger.exception("Failed to queue tuning run for metric %s", metric_id)
+        service.fail_tuning_run(db, metric, organization_id, "it could not be queued.")
+        raise HTTPException(
+            status_code=503, detail="The run could not be queued. Please try again."
+        ) from e
 
     return MetricTuningRun(**summary.model_dump(mode="json"))

--- a/apps/backend/src/rhesis/backend/app/schemas/metric_tuning_metadata.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/metric_tuning_metadata.py
@@ -165,6 +165,10 @@ class MetricTuningRunSummary(BaseModel):
     status: TuningRunStatus = TuningRunStatus.NEVER_RUN
     started_at: Optional[str] = None
     completed_at: Optional[str] = None
+    # Touched when the run claims its slot and again after every case. A running
+    # claim that stops advancing is taken over rather than refusing every later
+    # run forever -- see services/metric_tuning/staleness.py.
+    progressed_at: Optional[str] = None
     total_cases: int = 0
     completed_cases: int = 0
     # How many cases the metric call failed on. Reported apart from the verdicts
@@ -174,7 +178,7 @@ class MetricTuningRunSummary(BaseModel):
     # fail the run -- that is `errored_cases`.
     error: Optional[str] = None
 
-    @field_validator("error", "started_at", "completed_at", mode="before")
+    @field_validator("error", "started_at", "completed_at", "progressed_at", mode="before")
     @classmethod
     def _validate_optional_str(cls, v: Any) -> Optional[str]:
         return _coerce_optional_str(v)

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/__init__.py
@@ -43,12 +43,19 @@ from rhesis.backend.app.services.metric_tuning.runs import (
     get_tuning_run,
     start_tuning_run,
 )
+from rhesis.backend.app.services.metric_tuning.staleness import (
+    STALE_RUN_AFTER,
+    STALE_RUN_MESSAGE,
+    run_is_stale,
+)
 from rhesis.backend.app.services.metric_tuning.test_sets import (
     get_or_create_tuning_test_set,
     get_tuning_test_set,
 )
 
 __all__ = [
+    "STALE_RUN_AFTER",
+    "STALE_RUN_MESSAGE",
     "MetricModelNotConfigured",
     "NoTuningCases",
     "NothingToReview",
@@ -69,6 +76,7 @@ __all__ = [
     "resolve_metric_model",
     "review_case",
     "review_still_stands",
+    "run_is_stale",
     "standing_review",
     "start_tuning_run",
     "to_api",

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/runs.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/runs.py
@@ -34,6 +34,7 @@ from rhesis.backend.app.services.metric_tuning.invoke import (
     resolve_metric_model,
 )
 from rhesis.backend.app.services.metric_tuning.payload import parse_payload
+from rhesis.backend.app.services.metric_tuning.staleness import abandoned, run_is_stale
 from rhesis.backend.app.services.metric_tuning.test_sets import get_tuning_test_set
 
 logger = logging.getLogger(__name__)
@@ -52,11 +53,17 @@ def _now() -> str:
 
 
 def get_tuning_run(db: Session, metric: models.Metric, organization_id: str):
-    """The metric's latest run. ``never_run`` when there has not been one."""
+    """The metric's latest run. ``never_run`` when there has not been one.
+
+    A claim that has stopped advancing reads as failed rather than as forever in
+    progress -- otherwise the interface shows a spinner nothing is behind and
+    keeps its own Run button disabled. Derived, not written: see ``staleness``.
+    """
     test_set = get_tuning_test_set(db, metric.id, organization_id)
     if not test_set:
         return MetricTuningRunSummary()
-    return crud_metric_tuning.get_run_summary(test_set)
+    summary = crud_metric_tuning.get_run_summary(test_set)
+    return abandoned(summary) if run_is_stale(summary) else summary
 
 
 def start_tuning_run(
@@ -70,8 +77,11 @@ def start_tuning_run(
     The refusal while a run is in flight is advisory: the stored status is the
     only check, so two requests in the same instant can both pass. The failure
     mode is a summary belonging to neither run rather than corruption, which is
-    the trade ADR-0004 accepts for a flagged feature. Making it actually safe is
-    its own ticket.
+    the trade ADR-0004 accepts for a flagged feature.
+
+    A claim that has stopped advancing is taken over instead of refused, so a
+    worker that died -- or a dispatch that never reached one -- cannot wedge the
+    metric permanently.
     """
     test_set = get_tuning_test_set(db, metric.id, organization_id)
     if not test_set:
@@ -83,16 +93,24 @@ def start_tuning_run(
 
     current = crud_metric_tuning.get_run_summary(test_set)
     if current.status == TuningRunStatus.RUNNING:
-        raise TuningRunInFlight("A run is already in progress for this metric.")
+        if not run_is_stale(current):
+            raise TuningRunInFlight("A run is already in progress for this metric.")
+        logger.warning(
+            "Taking over a tuning run for metric %s that stopped advancing at %s",
+            metric.id,
+            current.progressed_at or current.started_at,
+        )
 
     # Checked here, before anything is written or queued, so a metric with no
     # model is refused outright rather than producing a run that judges with
     # something nobody picked. Raises MetricModelNotConfigured.
     resolve_metric_model(db, metric, organization_id, user_id)
 
+    claimed_at = _now()
     summary = MetricTuningRunSummary(
         status=TuningRunStatus.RUNNING,
-        started_at=_now(),
+        started_at=claimed_at,
+        progressed_at=claimed_at,
         total_cases=len(cases),
         completed_cases=0,
         errored_cases=0,
@@ -145,6 +163,7 @@ def execute_tuning_run(
     summary.error = None
     if not summary.started_at:
         summary.started_at = _now()
+    summary.progressed_at = _now()
 
     _clear_previous_results(db, cases)
     crud_metric_tuning.set_run_summary(db, test_set, summary)
@@ -158,6 +177,9 @@ def execute_tuning_run(
         summary.completed_cases += 1
         if result.error:
             summary.errored_cases += 1
+        # Renewed per case, so a long set never looks abandoned while it is
+        # working and a dead worker's claim expires on the same short window.
+        summary.progressed_at = _now()
         crud_metric_tuning.set_run_summary(db, test_set, summary)
         db.commit()
 

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/staleness.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/staleness.py
@@ -1,0 +1,87 @@
+"""When a run that still says ``running`` has stopped being true.
+
+A tuning run claims its slot by writing ``running`` to the summary, and the next
+run is refused while that claim stands. The refusal is advisory rather than a
+lock -- ADR-0004 accepts that for a flagged feature with one author per metric --
+but only the run itself ever clears the claim, which leaves two ways for one to
+stay behind forever:
+
+* the worker dies mid-run, so ``fail_tuning_run`` never happens;
+* the dispatch straight after the claim raises -- broker unreachable, publish
+  error -- so no worker ever picks the run up.
+
+Either way every later run is refused, and the interface disables its own Run
+button on the same ``running`` status, so there is no way out from the interface
+at all. Recovery meant editing the database.
+
+The escape hatch is a heartbeat, and it is one hatch for both entrances. A run
+touches ``progressed_at`` when it claims the slot and again after every case, so
+a claim nothing is advancing goes stale and stops refusing anything. The window
+only has to cover a single case's evaluation and whatever retries the evaluator
+already does -- a forty-case run keeps renewing it -- which is why it can be far
+shorter than any whole run.
+
+Staleness is derived here on read and never written: a GET does not repair the
+database, and the next run overwrites the summary regardless.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from rhesis.backend.app.schemas.metric_tuning_metadata import (
+    MetricTuningRunSummary,
+    TuningRunStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+# How long a claim may go without advancing before anyone may take it over. Per
+# case, not per run -- see the module docstring.
+STALE_RUN_AFTER = timedelta(minutes=15)
+
+# Phrased to follow the interface's "The last run failed: " rather than repeat it.
+STALE_RUN_MESSAGE = "it stopped responding and was abandoned. Press Run to try again."
+
+
+def parse_timestamp(value: Optional[str]) -> Optional[datetime]:
+    """A stored ISO timestamp as an aware datetime, or None if it is not one."""
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except ValueError:
+        logger.warning("Unparseable tuning run timestamp %r", value)
+        return None
+    # Everything written here is UTC and aware; anything else is read as UTC
+    # rather than crashing the comparison it is about to be used in.
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def run_is_stale(summary: MetricTuningRunSummary, now: Optional[datetime] = None) -> bool:
+    """True when this run claims to be running but has stopped advancing."""
+    if summary.status != TuningRunStatus.RUNNING:
+        return False
+
+    # `progressed_at` is the heartbeat; `started_at` covers a claim written
+    # before this rule existed, and stands in until the first case finishes.
+    heartbeat = parse_timestamp(summary.progressed_at) or parse_timestamp(summary.started_at)
+    if heartbeat is None:
+        # A claim with no readable timestamp cannot be shown to be alive, and
+        # holding the metric on the strength of it is the wedge itself.
+        return True
+
+    return (now or datetime.now(timezone.utc)) - heartbeat > STALE_RUN_AFTER
+
+
+def abandoned(summary: MetricTuningRunSummary) -> MetricTuningRunSummary:
+    """The same run, presented as the failure it turned out to be.
+
+    A copy, because the caller is holding the parsed summary of a live row and
+    nothing about reading a run should write one. ``completed_at`` stays unset:
+    it never completed.
+    """
+    stale = summary.model_copy(deep=True)
+    stale.status = TuningRunStatus.FAILED
+    stale.error = STALE_RUN_MESSAGE
+    return stale

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
@@ -367,6 +367,25 @@ describe('MetricTuningTab — runs', () => {
     render(<MetricTuningTab metricId={METRIC_ID} />);
 
     expect(await screen.findByText(/the worker died/i)).toBeInTheDocument();
+    // The counts belong to the run that failed, and reading them as the result
+    // of the edit that was just made is the whole failure mode.
+    expect(screen.queryByText(/over 1 case/i)).not.toBeInTheDocument();
+  });
+
+  it('leaves the run control usable after a run failed', async () => {
+    // A failed run that disabled the button would be a dead end: the button is
+    // disabled on `running`, which is what an abandoned run used to stay.
+    mockGetTuningRun.mockResolvedValue({
+      ...COMPLETED,
+      status: 'failed',
+      error: 'the run stopped responding',
+    });
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    expect(
+      await screen.findByRole('button', { name: /run metric/i })
+    ).toBeEnabled();
   });
 
   it('survives a failed start', async () => {

--- a/tests/backend/routes/test_metric_tuning_runs.py
+++ b/tests/backend/routes/test_metric_tuning_runs.py
@@ -22,6 +22,7 @@ Run with: python -m pytest tests/backend/routes/test_metric_tuning_runs.py -v
 """
 
 import uuid
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -30,7 +31,12 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models
+from rhesis.backend.app.crud import metric_tuning as crud_metric_tuning
 from rhesis.backend.app.schemas.metric import MetricScope
+from rhesis.backend.app.schemas.metric_tuning_metadata import (
+    MetricTuningRunSummary,
+    TuningRunStatus,
+)
 from rhesis.backend.app.services import metric_tuning as service
 from rhesis.backend.app.utils.crud_utils import get_or_create_type_lookup
 from rhesis.backend.metrics.result_builder import MetricResultBuilder
@@ -208,6 +214,20 @@ def no_dispatch():
         yield launcher
 
 
+@pytest.fixture
+def broken_dispatch():
+    """Dispatch that raises, the way an unreachable broker does.
+
+    The claim is committed before this is called, so what the route does with the
+    failure is the whole question.
+    """
+    with patch(
+        "rhesis.backend.app.routers.metric_tuning.task_launcher",
+        side_effect=RuntimeError("broker unreachable"),
+    ) as launcher:
+        yield launcher
+
+
 def _create_case(client: TestClient, metric_id, **overrides) -> dict:
     body = {
         "input": CASE_INPUT,
@@ -296,6 +316,32 @@ def _stored_reviews(db: Session, case_id) -> list:
     db.expire_all()
     db_test = db.query(models.Test).filter(models.Test.id == uuid.UUID(str(case_id))).first()
     return (db_test.test_metadata or {}).get("reviews", [])
+
+
+def _claim(
+    test_db: Session,
+    metric: models.Metric,
+    org_id,
+    *,
+    last_advanced: timedelta = timedelta(seconds=0),
+    heartbeat: bool = True,
+) -> None:
+    """Leave a ``running`` claim behind, the way a worker that died would.
+
+    ``last_advanced`` is how long ago the run last got anywhere. ``heartbeat``
+    off writes the claim without ``progressed_at``, which is what a claim made
+    before that field existed looks like.
+    """
+    test_set = service.get_tuning_test_set(test_db, metric.id, org_id)
+    when = (datetime.now(timezone.utc) - last_advanced).isoformat()
+    summary = MetricTuningRunSummary(
+        status=TuningRunStatus.RUNNING,
+        started_at=when,
+        progressed_at=when if heartbeat else None,
+        total_cases=1,
+    )
+    crud_metric_tuning.set_run_summary(test_db, test_set, summary)
+    test_db.commit()
 
 
 def _run(test_db: Session, metric: models.Metric, org_id, *results, user_id=None, by_input=None):
@@ -960,3 +1006,187 @@ class TestRunsAndStandingReviews:
         assert [review["comment"] for review in _stored_reviews(test_db, rejected["id"])] == [
             REVIEW_COMMENT
         ]
+
+
+@pytest.mark.integration
+@pytest.mark.routes
+class TestARunThatNeverFinishes:
+    """A `running` claim nobody is behind must not wedge the metric forever.
+
+    Only the run itself ever clears its claim, so a worker that dies — or a
+    dispatch that never reaches one — leaves the claim standing, every later run
+    refused, and the Run button disabled on that same status. There is no reset
+    route by design: the claim carries a heartbeat and expires on its own.
+    """
+
+    def test_a_stale_claim_does_not_refuse_the_next_run(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+        no_dispatch,
+    ):
+        """The crashed-worker entrance: recovery used to mean editing the database."""
+        _create_case(authenticated_client, tuning_metric.id)
+        _claim(test_db, tuning_metric, test_org_id, last_advanced=service.STALE_RUN_AFTER * 2)
+
+        response = authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.json()["status"] == "running"
+        assert no_dispatch.call_count == 1
+
+    def test_a_stale_claim_reads_as_failed_rather_than_forever_running(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """Otherwise the interface polls a spinner nothing is behind."""
+        _create_case(authenticated_client, tuning_metric.id)
+        _claim(test_db, tuning_metric, test_org_id, last_advanced=service.STALE_RUN_AFTER * 2)
+
+        body = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+
+        assert body["status"] == "failed"
+        assert body["error"] == service.STALE_RUN_MESSAGE
+        assert body["completed_at"] is None
+
+    def test_a_claim_from_before_the_heartbeat_existed_still_expires(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+        no_dispatch,
+    ):
+        """Nothing migrates the stored summary, so `started_at` has to stand in."""
+        _create_case(authenticated_client, tuning_metric.id)
+        _claim(
+            test_db,
+            tuning_metric,
+            test_org_id,
+            last_advanced=service.STALE_RUN_AFTER * 2,
+            heartbeat=False,
+        )
+
+        response = authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+
+    def test_a_run_that_is_still_advancing_is_left_alone(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+        no_dispatch,
+    ):
+        """The escape hatch must not become a second way to double-run a metric."""
+        _create_case(authenticated_client, tuning_metric.id)
+        _claim(test_db, tuning_metric, test_org_id, last_advanced=timedelta(seconds=30))
+
+        response = authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        no_dispatch.assert_not_called()
+        still = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+        assert still["status"] == "running"
+
+    def test_a_long_run_keeps_renewing_its_claim(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """The window covers one case, not the whole set — a run advances the heartbeat."""
+        _create_case(authenticated_client, tuning_metric.id)
+        _claim(test_db, tuning_metric, test_org_id, last_advanced=service.STALE_RUN_AFTER * 2)
+
+        _run(test_db, tuning_metric, test_org_id, {"score": 1.0, "reason": "toxic"})
+
+        body = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+
+        assert body["status"] == "completed"
+
+    def test_the_refusal_does_not_disturb_the_run_in_progress(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+        no_dispatch,
+    ):
+        """A rejected second press must cost the first run nothing."""
+        case = _create_case(authenticated_client, tuning_metric.id)
+        authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        refused = authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+        assert refused.status_code == status.HTTP_409_CONFLICT
+
+        _run(test_db, tuning_metric, test_org_id, {"score": 1.0, "reason": "toxic"})
+
+        body = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+        assert body["status"] == "completed"
+        assert body["completed_cases"] == 1
+        assert body["errored_cases"] == 0
+        result = _cases_by_id(authenticated_client, tuning_metric.id)[case["id"]]["result"]
+        assert result["reasoning"] == "toxic"
+
+
+@pytest.mark.integration
+@pytest.mark.routes
+class TestADispatchThatNeverReachesAWorker:
+    """The claim is committed before dispatch, so a broker failure needs releasing.
+
+    This is the second entrance to the same wedge, and the one that does not need
+    waiting out: the request itself knows no run is coming.
+    """
+
+    def test_a_dispatch_failure_is_reported_rather_than_read_as_started(
+        self,
+        authenticated_client: TestClient,
+        tuning_metric: models.Metric,
+        broken_dispatch,
+    ):
+        _create_case(authenticated_client, tuning_metric.id)
+
+        response = authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "broker" not in response.text, "the broker's own words are not the caller's business"
+
+    def test_a_dispatch_failure_leaves_no_run_in_flight(
+        self,
+        authenticated_client: TestClient,
+        tuning_metric: models.Metric,
+        broken_dispatch,
+    ):
+        _create_case(authenticated_client, tuning_metric.id)
+        authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        body = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+
+        assert body["status"] == "failed"
+        assert body["error"]
+
+    def test_the_next_run_is_not_refused(
+        self,
+        authenticated_client: TestClient,
+        tuning_metric: models.Metric,
+        no_dispatch,
+    ):
+        """Waiting out the staleness window for a run never queued is not recovery."""
+        _create_case(authenticated_client, tuning_metric.id)
+        with patch(
+            "rhesis.backend.app.routers.metric_tuning.task_launcher",
+            side_effect=RuntimeError("broker unreachable"),
+        ):
+            authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        response = authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_202_ACCEPTED

--- a/tests/backend/services/metric_tuning/test_staleness.py
+++ b/tests/backend/services/metric_tuning/test_staleness.py
@@ -1,0 +1,145 @@
+"""Unit tests for the stale-run rule.
+
+A narrow pure function over a run summary and a clock, tested directly for the
+same reason ``material_change`` is: the branches are the point, and driving each
+one through a whole run would be slow and would hide what is being asserted.
+
+The rule exists to stop a ``running`` claim nobody is behind from refusing every
+later run forever — a crashed worker, or a dispatch that never reached one.
+
+Run with: python -m pytest tests/backend/services/metric_tuning/test_staleness.py -v
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from rhesis.backend.app.schemas.metric_tuning_metadata import (
+    MetricTuningRunSummary,
+    TuningRunStatus,
+)
+from rhesis.backend.app.services.metric_tuning.staleness import (
+    STALE_RUN_AFTER,
+    STALE_RUN_MESSAGE,
+    abandoned,
+    parse_timestamp,
+    run_is_stale,
+)
+
+NOW = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+
+
+def _running(**fields) -> MetricTuningRunSummary:
+    return MetricTuningRunSummary(status=TuningRunStatus.RUNNING, **fields)
+
+
+def _iso(delta: timedelta) -> str:
+    return (NOW - delta).isoformat()
+
+
+@pytest.mark.unit
+class TestRunIsStale:
+    """Only a claim that has stopped advancing is stale."""
+
+    def test_a_run_that_just_started_is_not_stale(self):
+        assert not run_is_stale(_running(started_at=_iso(timedelta(seconds=1))), NOW)
+
+    def test_a_run_advancing_within_the_window_is_not_stale(self):
+        """The heartbeat is per case, so a long set keeps renewing it."""
+        summary = _running(
+            started_at=_iso(timedelta(hours=4)),
+            progressed_at=_iso(STALE_RUN_AFTER - timedelta(minutes=1)),
+        )
+
+        assert not run_is_stale(summary, NOW)
+
+    def test_a_run_that_stopped_advancing_is_stale(self):
+        summary = _running(
+            started_at=_iso(timedelta(hours=4)),
+            progressed_at=_iso(STALE_RUN_AFTER + timedelta(minutes=1)),
+        )
+
+        assert run_is_stale(summary, NOW)
+
+    def test_exactly_on_the_window_is_not_yet_stale(self):
+        """The boundary belongs to the run that is still going."""
+        assert not run_is_stale(_running(progressed_at=_iso(STALE_RUN_AFTER)), NOW)
+
+    def test_the_heartbeat_wins_over_the_start(self):
+        """A run started long ago but still working is alive."""
+        summary = _running(
+            started_at=_iso(timedelta(days=2)),
+            progressed_at=_iso(timedelta(minutes=1)),
+        )
+
+        assert not run_is_stale(summary, NOW)
+
+    def test_a_claim_written_before_the_heartbeat_existed_falls_back_to_started_at(self):
+        """Nothing migrates the summary, so an old claim is read on `started_at`."""
+        assert run_is_stale(_running(started_at=_iso(STALE_RUN_AFTER * 2)), NOW)
+        assert not run_is_stale(_running(started_at=_iso(timedelta(minutes=1))), NOW)
+
+    def test_a_claim_with_no_timestamps_at_all_is_stale(self):
+        """It cannot be shown to be alive, and holding the metric on it is the wedge."""
+        assert run_is_stale(_running(), NOW)
+
+    def test_an_unparseable_timestamp_is_stale(self):
+        assert run_is_stale(_running(progressed_at="whenever"), NOW)
+
+    def test_a_naive_timestamp_is_read_as_utc_rather_than_crashing(self):
+        naive = NOW.replace(tzinfo=None) - timedelta(minutes=1)
+        assert not run_is_stale(_running(progressed_at=naive.isoformat()), NOW)
+
+    @pytest.mark.parametrize(
+        "status",
+        [TuningRunStatus.NEVER_RUN, TuningRunStatus.COMPLETED, TuningRunStatus.FAILED],
+    )
+    def test_only_a_running_claim_can_be_stale(self, status):
+        """A finished run is not blocking anything, however old it is."""
+        summary = MetricTuningRunSummary(status=status, progressed_at=_iso(timedelta(days=30)))
+
+        assert not run_is_stale(summary, NOW)
+
+    def test_the_clock_defaults_to_now(self):
+        assert run_is_stale(_running(progressed_at=_iso(timedelta(days=1))))
+
+
+@pytest.mark.unit
+class TestAbandoned:
+    """How a stale claim is presented to whoever asked about the run."""
+
+    def test_it_reads_as_failed_and_says_why(self):
+        stale = abandoned(_running(started_at=_iso(timedelta(hours=1)), total_cases=5))
+
+        assert stale.status == TuningRunStatus.FAILED
+        assert stale.error == STALE_RUN_MESSAGE
+
+    def test_it_keeps_the_counts_the_run_did_reach(self):
+        stale = abandoned(_running(total_cases=5, completed_cases=2, errored_cases=1))
+
+        assert (stale.total_cases, stale.completed_cases, stale.errored_cases) == (5, 2, 1)
+
+    def test_it_never_completed_so_it_has_no_completion_time(self):
+        assert abandoned(_running(started_at=_iso(timedelta(hours=1)))).completed_at is None
+
+    def test_the_stored_summary_is_left_alone(self):
+        """Reading a run must not rewrite one — the copy is the whole point."""
+        summary = _running(started_at=_iso(timedelta(hours=1)))
+
+        abandoned(summary)
+
+        assert summary.status == TuningRunStatus.RUNNING
+        assert summary.error is None
+
+
+@pytest.mark.unit
+class TestParseTimestamp:
+    def test_none_and_empty_are_not_timestamps(self):
+        assert parse_timestamp(None) is None
+        assert parse_timestamp("") is None
+
+    def test_garbage_is_not_a_timestamp(self):
+        assert parse_timestamp("last tuesday") is None
+
+    def test_an_aware_timestamp_keeps_its_zone(self):
+        assert parse_timestamp(NOW.isoformat()) == NOW


### PR DESCRIPTION
## Purpose

A tuning run claims its slot by writing `running` to the summary, and the next run is refused while that claim stands. Only the run itself ever cleared the claim, which left two ways for one to stay behind forever: a worker that dies mid-run never reaches `fail_tuning_run`, and a dispatch that raises after the claim is committed means no worker ever picks the run up. Either way every later run is refused, the interface disables its own Run button on that same `running` status, and there was no timeout, no reset route and no way out from the interface — recovery meant editing the database.

Both entrances want the same escape hatch, which is why they are fixed together rather than by patching the dispatch ordering on its own.

## What Changed

- **A heartbeat on the run summary.** `progressed_at` is touched when the run claims its slot and again after every case. A `running` claim that has not advanced for `STALE_RUN_AFTER` (15 minutes) is stale: it stops refusing new runs, and reads as `failed` rather than as forever in progress. The window only has to cover a single case's evaluation plus whatever retries the evaluator already does — a forty-case run keeps renewing it — which is why it can be far shorter than any whole run.
- **`services/metric_tuning/staleness.py`** (new) holds the rule: `run_is_stale`, and `abandoned` for presenting a stale claim as the failure it turned out to be. Derived on read and never written — a `GET` does not repair the database, and the next run overwrites the summary anyway. Same reasoning as the outcome and the threshold bucket in ADR-0005.
- **The dispatch failure is released on the spot.** `POST .../tuning/run` now wraps `task_launcher`: if the dispatch raises, the claim is released immediately and the caller gets a `503`, rather than being made to wait out a window for a run that was never queued. That side knows for certain no run is coming.
- **No reset route and no timeout field**, both considered and neither needed: the claim expiring on its own is the hatch, and a reset button would be a second way to start a run that skips the refusal.
- **No API or interface change.** `progressed_at` stays internal — `MetricTuningRun` never exposes it, because the frontend has no use for it. The tab already renders `failed` with its message and enables Run on any status but `running`, so an abandoned run recovers by itself: the poll flips to `failed` within one tick and stops.

## Additional Context

- Ticket: `playground/tracker/tuning-runs/issues/04-make-runs-safe-to-press-twice.md`, including the note from the review of #2470 that identified the second entrance.
- **Targets `feat/metric-tuning-test-sets`, not `main`** — every ticket in this effort is cut from and merges back into that integration branch, per the Branching section of the tuning-runs spec. `main` sees one merge when the feature is finished.
- The refusal remains **advisory rather than a lock**, as ADR-0004 has it: two requests in the same instant can both pass the stored-status check. The failure mode is a summary belonging to neither run rather than corruption, which is the accepted trade for a flagged feature with one author per metric. The staleness window does not change that and is not meant to.
- No migration: the summary is JSONB, and a claim written before `progressed_at` existed falls back to `started_at`.

## Testing

All green: 128 backend tuning tests, 36 frontend Tuning tab tests, ruff clean on the changed files.

```bash
cd apps/backend
uv sync --extra all --extra ee
uv run pytest ../../tests/backend/routes/test_metric_tuning_runs.py ../../tests/backend/services/metric_tuning -v

cd ../frontend
npx jest --testPathPatterns MetricTuningTab
```

New coverage, one class per entrance to the wedge:

- `TestARunThatNeverFinishes` — a stale claim taken over rather than refused, a stale claim reading as failed, a pre-heartbeat claim falling back to `started_at`, a run still advancing left alone (so the hatch does not become a second way to double-run a metric), a long run renewing its own claim, and a refused second press costing the first run nothing.
- `TestADispatchThatNeverReachesAWorker` — the `503`, the claim released, and the next run going through without waiting.
- `test_staleness.py` — the rule per branch: either side of the window and exactly on it, the heartbeat winning over the start, no timestamps at all, an unparseable one, a naive one, and every status that cannot go stale.
- Frontend: the run control stays usable after a failure. The existing "reports a failed run instead of leaving old numbers on screen" test was named for something it did not assert — it only checked the error text appeared, never that the previous run's counts were gone. The behaviour was already right; the assertion was missing.

To see the wedge by hand: start a run, kill the worker, and confirm the tab shows the run as failed and lets you press Run again once the window passes.
