### PR TITLE
fix(frontend): allow clicking OWASP metrics to view details

### DIFF
--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
@@ -439,8 +439,10 @@ export default function MetricsDirectoryTab({
                 Array.isArray(metric.requirements) &&
                 metric.requirements.length > 0;
 
-              const isCustomMetric =
-                metric.backend_type?.type_value?.toLowerCase() === 'custom';
+              const backendType =
+                metric.backend_type?.type_value?.toLowerCase();
+              const isClickableMetric =
+                backendType === 'custom' || backendType === 'rhesis';
 
               return (
                 <MetricCard
@@ -464,7 +466,7 @@ export default function MetricsDirectoryTab({
                           setSelectedMetric(metric);
                           setAssignDialogOpen(true);
                         }
-                      : isCustomMetric
+                      : isClickableMetric
                         ? () => router.push(`/metrics/${metric.id}`)
                         : undefined
                   }


### PR DESCRIPTION
## Summary

- OWASP metric cards in the metrics directory were not clickable because the `onClick` handler only allowed `custom` backend_type metrics. OWASP metrics have `rhesis` backend_type.
- The detail page (`/metrics/[identifier]`) already accepts both `rhesis` and `custom` types, so this was just a gating mismatch in the directory listing.
- Widened the click gate to include `rhesis` alongside `custom`. Delete stays `custom`-only since OWASP metrics are seeded system data.

## Test plan

- [ ] Navigate to Metrics directory
- [ ] Filter by OWASP pill
- [ ] Click on an OWASP metric card and verify it navigates to the detail view
- [ ] Verify custom metrics remain clickable
- [ ] Verify OWASP metrics do not show a delete option