### PR TITLE
fix(frontend): hide embedding models from model selection dropdowns

### DIFF
--- a/apps/frontend/src/components/common/ModelSelector.tsx
+++ b/apps/frontend/src/components/common/ModelSelector.tsx
@@ -111,7 +111,11 @@ export default function ModelSelector({
   );
 
   // If preloaded data is supplied, use it; otherwise fetch internally.
-  const models = preloadedModels ?? fetchedModels ?? EMPTY_MODELS;
+  const allModels = preloadedModels ?? fetchedModels ?? EMPTY_MODELS;
+  const models =
+    purpose === 'embedding'
+      ? allModels
+      : allModels.filter(m => m.model_type !== 'embedding');
   const isLoading =
     preloadedModels !== undefined ? (isLoadingModelsProp ?? false) : isFetching;
 


### PR DESCRIPTION
## Summary
- Filter out embedding models (`model_type: 'embedding'`) from the `ModelSelector` dropdown when the selector's purpose is not `'embedding'`
- Embedding models were showing up alongside language models in test generation, OWASP, evaluation, and execution model selectors

## Test plan
- [ ] Open a test generation flow and verify no embedding models appear in the model dropdown
- [ ] Open a test run drawer and verify evaluation/execution model selectors only show language models
- [ ] Verify the models management page still shows all models (language + embedding) with its filter tabs