### PR TITLE
fix(backend): filter insights by test result status, not test status

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/a1b2c3d4e5g7_add_result_status_id_to_test_result_stats_view.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/a1b2c3d4e5g7_add_result_status_id_to_test_result_stats_view.py
@@ -1,0 +1,126 @@
+"""add result_status_id to v_test_result_stats
+
+The view exposes the test's lifecycle status (t.status_id) as test_status_id
+but never exposes the test result's own status (trs.status_id). The insights
+status filter sends test-result status UUIDs (Error/Fail/Pass/Review), which
+were matched against the wrong column and always returned zero rows.
+
+Revision ID: a1b2c3d4e5g7
+Revises: 40a5b6b88a52
+Create Date: 2026-08-20
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5g7"
+down_revision: Union[str, None] = "40a5b6b88a52"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_RESULT_PASSED_IN = (
+    "('complete', 'completed', 'done', 'finished', 'pass', 'passed', 'success', 'successful')"
+)
+_RESULT_FAILED_IN = "('fail', 'failed')"
+
+V_TEST_RESULT_STATS_UP = f"""
+CREATE OR REPLACE VIEW v_test_result_stats AS
+SELECT
+    trs.id           AS test_result_id,
+    trs.organization_id,
+    trs.created_at,
+    trs.test_run_id,
+    trs.test_id,
+    trs.test_metrics,
+    s.name           AS status_name,
+    CASE
+        WHEN LOWER(s.name) IN {_RESULT_PASSED_IN}
+            THEN 'passed'
+        WHEN LOWER(s.name) IN {_RESULT_FAILED_IN}
+            THEN 'failed'
+        ELSE 'pending'
+    END              AS result,
+    trs.status_id    AS result_status_id,
+    t.status_id      AS test_status_id,
+    t.behavior_id,
+    t.category_id,
+    t.topic_id,
+    t.user_id        AS test_user_id,
+    t.assignee_id,
+    t.owner_id,
+    t.prompt_id,
+    t.priority,
+    t.test_type_id,
+    b.name           AS behavior_name,
+    c.name           AS category_name,
+    tp.name          AS topic_name,
+    tr.id            AS run_id,
+    tr.name          AS test_run_name,
+    tr.created_at    AS test_run_created_at,
+    EXTRACT(YEAR  FROM trs.created_at AT TIME ZONE 'UTC')::int AS year,
+    EXTRACT(MONTH FROM trs.created_at AT TIME ZONE 'UTC')::int AS month
+FROM test_result trs
+JOIN test t    ON trs.test_id = t.id AND t.deleted_at IS NULL
+JOIN status s  ON trs.status_id = s.id
+LEFT JOIN behavior b  ON t.behavior_id = b.id
+LEFT JOIN category c  ON t.category_id = c.id
+LEFT JOIN topic tp    ON t.topic_id    = tp.id
+LEFT JOIN test_run tr ON trs.test_run_id = tr.id
+WHERE trs.deleted_at IS NULL
+"""
+
+V_TEST_RESULT_STATS_DOWN = f"""
+CREATE OR REPLACE VIEW v_test_result_stats AS
+SELECT
+    trs.id           AS test_result_id,
+    trs.organization_id,
+    trs.created_at,
+    trs.test_run_id,
+    trs.test_id,
+    trs.test_metrics,
+    s.name           AS status_name,
+    CASE
+        WHEN LOWER(s.name) IN {_RESULT_PASSED_IN}
+            THEN 'passed'
+        WHEN LOWER(s.name) IN {_RESULT_FAILED_IN}
+            THEN 'failed'
+        ELSE 'pending'
+    END              AS result,
+    t.status_id      AS test_status_id,
+    t.behavior_id,
+    t.category_id,
+    t.topic_id,
+    t.user_id        AS test_user_id,
+    t.assignee_id,
+    t.owner_id,
+    t.prompt_id,
+    t.priority,
+    t.test_type_id,
+    b.name           AS behavior_name,
+    c.name           AS category_name,
+    tp.name          AS topic_name,
+    tr.id            AS run_id,
+    tr.name          AS test_run_name,
+    tr.created_at    AS test_run_created_at,
+    EXTRACT(YEAR  FROM trs.created_at AT TIME ZONE 'UTC')::int AS year,
+    EXTRACT(MONTH FROM trs.created_at AT TIME ZONE 'UTC')::int AS month
+FROM test_result trs
+JOIN test t    ON trs.test_id = t.id AND t.deleted_at IS NULL
+JOIN status s  ON trs.status_id = s.id
+LEFT JOIN behavior b  ON t.behavior_id = b.id
+LEFT JOIN category c  ON t.category_id = c.id
+LEFT JOIN topic tp    ON t.topic_id    = tp.id
+LEFT JOIN test_run tr ON trs.test_run_id = tr.id
+WHERE trs.deleted_at IS NULL
+"""
+
+
+def upgrade() -> None:
+    op.execute(V_TEST_RESULT_STATS_UP)
+
+
+def downgrade() -> None:
+    op.execute(V_TEST_RESULT_STATS_DOWN)

--- a/apps/backend/src/rhesis/backend/app/models/stats_views.py
+++ b/apps/backend/src/rhesis/backend/app/models/stats_views.py
@@ -122,6 +122,7 @@ class TestResultStatsView(Base):
     test_metrics = Column(JSONB)
     status_name = Column(String)
     result = Column(String)
+    result_status_id = Column(GUID())
     test_status_id = Column(GUID())
     behavior_id = Column(GUID())
     category_id = Column(GUID())

--- a/apps/backend/src/rhesis/backend/app/services/insights/registry.py
+++ b/apps/backend/src/rhesis/backend/app/services/insights/registry.py
@@ -111,7 +111,7 @@ REGISTRY = {
             "behavior_ids": TR.behavior_id,
             "category_ids": TR.category_id,
             "topic_ids": TR.topic_id,
-            "status_ids": TR.test_status_id,
+            "status_ids": TR.result_status_id,
             "test_ids": TR.test_id,
             "test_type_ids": TR.test_type_id,
             "user_ids": TR.test_user_id,

--- a/apps/backend/src/rhesis/backend/app/services/stats/test_result.py
+++ b/apps/backend/src/rhesis/backend/app/services/stats/test_result.py
@@ -75,7 +75,7 @@ def _apply_filters(query, db, **f):
         ("behavior_ids", V.behavior_id),
         ("category_ids", V.category_id),
         ("topic_ids", V.topic_id),
-        ("status_ids", V.test_status_id),
+        ("status_ids", V.result_status_id),
         ("test_ids", V.test_id),
         ("test_type_ids", V.test_type_id),
         ("user_ids", V.test_user_id),


### PR DESCRIPTION
## Summary

- The `status_ids` filter on the `test_result` insights entity was mapped to `test_status_id` (the test's lifecycle status like Draft/Active) instead of the test result's own `status_id` (Error/Fail/Pass/Review). Selecting individual statuses in the insights filter drawer always returned zero rows because the UUIDs belong to different entity types.
- Adds `result_status_id` (`trs.status_id`) to `v_test_result_stats` and points the `status_ids` filter to it in both the insights registry and the stats service.

## Test plan

- [ ] Deploy migration and verify `v_test_result_stats` now includes `result_status_id`
- [ ] Open the Insights screen, select a single status (e.g. Pass), apply the filter, and confirm results appear
- [ ] Select multiple statuses and verify the results are filtered correctly
- [ ] Select all statuses and verify it behaves the same as no filter (returns everything)
- [ ] Deselect all statuses and verify it shows no data