### PR TITLE
feat(frontend): display organization ID on settings page

### DIFF
--- a/apps/frontend/src/app/(protected)/organizations/settings/components/OrganizationDetailsForm.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/settings/components/OrganizationDetailsForm.tsx
@@ -143,12 +143,19 @@ function DetailsFields({
   );
   const [copied, setCopied] = useState(false);
 
-  const handleCopyId = useCallback(() => {
-    navigator.clipboard.writeText(organizationId).then(() => {
+  const notifications = useNotifications();
+
+  const handleCopyId = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(organizationId);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    });
-  }, [organizationId]);
+    } catch (_err) {
+      notifications.show('Failed to copy organization ID', {
+        severity: 'error',
+      });
+    }
+  }, [organizationId, notifications]);
 
   const handleChange =
     (field: keyof DetailsDraft) => (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -195,7 +202,12 @@ function DetailsFields({
           >
             {organizationId}
             <Tooltip title={copied ? 'Copied' : 'Copy'}>
-              <IconButton size="small" onClick={handleCopyId} sx={{ ml: 0.5 }}>
+              <IconButton
+                size="small"
+                onClick={handleCopyId}
+                aria-label="Copy organization ID"
+                sx={{ ml: 0.5 }}
+              >
                 {copied ? (
                   <CheckIcon fontSize="inherit" />
                 ) : (

--- a/apps/frontend/src/app/(protected)/organizations/settings/components/OrganizationDetailsForm.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/settings/components/OrganizationDetailsForm.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import React, { useMemo } from 'react';
-import { Grid, TextField } from '@mui/material';
+import React, { useMemo, useState, useCallback } from 'react';
+import { Box, Grid, TextField, IconButton, Tooltip } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckIcon from '@mui/icons-material/Check';
 import { useRouter } from 'next/navigation';
 import { Organization } from '@/utils/api-client/interfaces/organization';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -115,6 +117,7 @@ export default function OrganizationDetailsForm({
     >
       {({ draft, setDraft, isEditing }) => (
         <DetailsFields
+          organizationId={organization.id}
           draft={draft}
           setDraft={setDraft}
           isEditing={isEditing}
@@ -125,10 +128,12 @@ export default function OrganizationDetailsForm({
 }
 
 function DetailsFields({
+  organizationId,
   draft,
   setDraft,
   isEditing,
 }: {
+  organizationId: string;
   draft: DetailsDraft;
   setDraft: (next: DetailsDraft | ((p: DetailsDraft) => DetailsDraft)) => void;
   isEditing: boolean;
@@ -136,6 +141,14 @@ function DetailsFields({
   const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>(
     {}
   );
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyId = useCallback(() => {
+    navigator.clipboard.writeText(organizationId).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [organizationId]);
 
   const handleChange =
     (field: keyof DetailsDraft) => (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -163,6 +176,37 @@ function DetailsFields({
 
   return (
     <Grid container columnSpacing={columnSpacing} rowSpacing={gridSpacing}>
+      <Grid size={12}>
+        <ViewField
+          label="Organization ID"
+          helperText="Used for API integrations and support requests"
+          bgcolor="transparent"
+        >
+          <Box
+            sx={{
+              fontFamily: 'monospace',
+              fontSize: theme => theme.typography.body2.fontSize,
+              letterSpacing: '0.01em',
+              color: theme => theme.palette.greyscale.body,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+            }}
+          >
+            {organizationId}
+            <Tooltip title={copied ? 'Copied' : 'Copy'}>
+              <IconButton size="small" onClick={handleCopyId} sx={{ ml: 0.5 }}>
+                {copied ? (
+                  <CheckIcon fontSize="inherit" />
+                ) : (
+                  <ContentCopyIcon fontSize="inherit" />
+                )}
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </ViewField>
+      </Grid>
+
       <Grid size={{ xs: 12, md: 6 }}>
         {isEditing ? (
           <TextField


### PR DESCRIPTION
## Summary
- Adds a read-only Organization ID field at the top of the Basic Information section on the Organization Settings page.
- Displays the UUID in monospace font with a copy-to-clipboard button (checkmark feedback on copy).
- Uses theme tokens for all styling (no hardcoded values).

## Test plan
- [ ] Open Organization Settings, verify the Organization ID appears as the first field in Basic Information
- [ ] Click the copy button, verify the UUID is copied and the icon changes to a checkmark briefly
- [ ] Toggle edit mode, verify the Organization ID field stays read-only
- [ ] Check both light and dark themes render correctly