### PR TITLE
fix(frontend): hide embedding models from model selection dropdowns

### DIFF
--- a/apps/frontend/src/components/common/ModelSelector.tsx
+++ b/apps/frontend/src/components/common/ModelSelector.tsx
@@ -111,7 +111,11 @@ export default function ModelSelector({
   );
 
   // If preloaded data is supplied, use it; otherwise fetch internally.
-  const models = preloadedModels ?? fetchedModels ?? EMPTY_MODELS;
+  const allModels = preloadedModels ?? fetchedModels ?? EMPTY_MODELS;
+  const models =
+    purpose === 'embedding'
+      ? allModels
+      : allModels.filter(m => m.model_type !== 'embedding');
   const isLoading =
     preloadedModels !== undefined ? (isLoadingModelsProp ?? false) : isFetching;
 


### PR DESCRIPTION
## Summary

- Cherry-pick of #2539 from `release/v0.12.0` to `release/v0.13.0`.
- Embedding models (e.g. `text-embedding-3-small`) were showing up in generation/evaluation/execution model dropdowns. They are now filtered out unless the selector's purpose is `embedding`.

## Test plan

- [ ] Open any model selection dropdown (e.g. endpoint config, metric config)
- [ ] Verify embedding models do not appear
- [ ] Open an embedding-purpose selector and verify embedding models still appear