### PR TITLE
Fix unscrollable test set list in Explorer load dialog

### DIFF
--- a/apps/frontend/src/app/(protected)/explorer/components/ImportExplorerTestSetDialog.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/components/ImportExplorerTestSetDialog.tsx
@@ -199,7 +199,12 @@ export default function ImportExplorerTestSetDialog({
           sx={{
             border: theme => `1px solid ${theme.palette.divider}`,
             borderRadius: 1,
-            overflow: 'hidden',
+            // Scroll the list itself, so the search box stays pinned. `overflow: hidden`
+            // here zeroed the flex item's automatic min-height, so a long list was
+            // squashed by the drawer and clipped with no way to reach the rest.
+            minHeight: 0,
+            overflowX: 'hidden',
+            overflowY: 'auto',
           }}
         >
           {testSets.map((ts, idx) => (


### PR DESCRIPTION
## Purpose

In Explorer, the "Load test set" drawer clipped its list of test sets and offered no way to reach the rest — with more than a handful of test sets, the entries past the fold were simply unreachable. Fixes #2394.

## What Changed

- `ImportExplorerTestSetDialog`: the results `<List>` now scrolls itself (`overflowY: 'auto'` + `minHeight: 0`) instead of carrying `overflow: 'hidden'`.

The root cause is a CSS flexbox rule: any `overflow` value other than `visible` zeroes a flex item's automatic minimum size. `BaseDrawer` lays its content out as a flex column, so the list was free to be squashed down to the leftover space and then clipped its own overflow — the drawer's own `overflowY: auto` never kicked in because nothing overflowed it. Scrolling the list itself also keeps the search box pinned while the results move, which reads better than scrolling the whole drawer body.

## Additional Context

- Closes #2394 (found during Testing Day, 6 August 2026).
- Frontend-only, CSS-only change. No API, schema, or behavior changes.

## Testing

Verified against a local stack with 30 test sets seeded through `POST /test_sets/bulk`, driving the real UI in a headless browser:

- The drawer list reports `scrollHeight` 2324 vs `clientHeight` 598 and wheel-scrolls all the way to the last entry, which is fully visible.
- The search box stays in place while the list scrolls.
- After selecting an entry and clicking Load, the import completes and the imported set's page scrolls normally once the auto-opened settings drawer is closed (`body` overflow returns to `visible`).
- Checked at both 900 px and 700 px viewport heights.

`npx tsc --noEmit`, `npm run lint`, and Prettier all pass.

Note on the original report: I could not reproduce a *page*-level scroll lock that outlives the import. Right after import the app navigates to the new set with the settings drawer auto-opened (`?openSettings=1`), which correctly locks body scroll; closing it releases the lock. The unreachable content in the issue is the drawer list, which is what this fixes.
