### PR TITLE
Fix false positives on issue refs in hex color check

### DIFF
--- a/scripts/check-hardcoded-styles.js
+++ b/scripts/check-hardcoded-styles.js
@@ -96,6 +96,15 @@ const PATTERNS = {
   emojis: /[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]/gu
 };
 
+// GitHub issue/PR references collide with the hex pattern because digits are valid hex chars.
+// Matched per-match rather than per-line, so `color: '#123456' // fixes #2133` still flags the color.
+const ISSUE_REFERENCE = {
+  // All-digit only, so #abc, #abc123 and #fff2ab stay flagged as colors.
+  digitsOnly: /^#\d+$/,
+  // A reference word directly before the `#`. A real color always has a quote or `:` in between.
+  keyword: /\b(?:issues?|pulls?|prs?|gh|fix(?:e[sd])?|close[sd]?|resolve[sd]?|revert(?:ed|s)?|see|refs?|references?)\s*[:(\-]?\s*$/i,
+};
+
 // Files to exclude from checking
 const EXCLUDE_PATTERNS = [
   /node_modules/,
@@ -185,6 +194,33 @@ class StyleChecker {
   }
 
   /**
+   * Index where a line's comment starts, or -1. Masks `scheme://` first, or a URL's slashes
+   * would read as a comment opener and hide a real color later on the line.
+   */
+  commentStartIndex(line) {
+    const masked = line.replace(/\w+:\/\//g, match => '.'.repeat(match.length));
+    const jsdoc = masked.match(/^\s*\*/);
+    if (jsdoc) {
+      return jsdoc[0].length - 1;
+    }
+    const openers = [masked.indexOf('//'), masked.indexOf('/*')].filter(index => index !== -1);
+    return openers.length > 0 ? Math.min(...openers) : -1;
+  }
+
+  /**
+   * Check if a hex match is really a GitHub issue/PR reference (`closes #2133`, `// TODO(#2133)`)
+   */
+  isIssueReference(line, match, commentStart) {
+    if (!ISSUE_REFERENCE.digitsOnly.test(match[0])) {
+      return false;
+    }
+    if (commentStart !== -1 && match.index > commentStart) {
+      return true;
+    }
+    return ISSUE_REFERENCE.keyword.test(line.slice(0, match.index));
+  }
+
+  /**
    * Get all theme colors as a flat array for checking
    */
   getAllThemeColors() {
@@ -259,7 +295,12 @@ class StyleChecker {
 
         // Check for hex colors
         let match;
+        const commentStart = this.commentStartIndex(line);
+        PATTERNS.hexColors.lastIndex = 0;
         while ((match = PATTERNS.hexColors.exec(line)) !== null) {
+          if (this.isIssueReference(line, match, commentStart)) {
+            continue;
+          }
           this.violations.push({
             file: filePath,
             line: lineNumber,


### PR DESCRIPTION
## Purpose

Fixes #2225. The hardcoded-hex-color check in `scripts/check-hardcoded-styles.js` flags any comment that references a GitHub issue or PR number, because digits 0-9 are always valid hex characters — `// closes #2133` reads as the color `#2133`. This check is blocking CI (`.github/workflows/lint.yml:159-172`, the `styles` job), so the false positive is not cosmetic: on PR #2195 the contributor had to reword comments three separate times, dropping the `#` prefix, just to get CI green.

## What Changed

- Skip a hex match that is really an issue/PR reference. Two signals have to agree: the match is all digits (`/^#\d+$/`), and either a reference keyword precedes it (`fixes`, `closes`, `resolves`, `see`, `refs`, `issue`, `PR`, `gh`, `reverted`, …) or the match sits inside a comment.
- The skip is applied **per-match inside the hex loop**, not through `IGNORE_PATTERNS`. `shouldIgnoreLine()` is whole-line, so an `IGNORE_PATTERNS` entry would have made `const k = { color: '#123456' }; // fixes #2133` stop flagging the real color as well.
- New `commentStartIndex(line)` finds where a line's comment begins, handling `//`, `/*` and JSDoc `*` continuation lines. It masks `\w+://` before searching for `//` — without that mask, a line containing a URL treats the URL's slashes as a comment opener and a real color later on the same line gets silently skipped. Verified: removing the mask drops the fixture from 11 real violations to 10.
- The hex loop also gained the `PATTERNS.hexColors.lastIndex = 0` reset that its sibling loops already had.

Because the all-digit test comes first, anything containing a-f is untouched: `#fff2ab`, `#abc`, `#abc123` and `#0080AF` still flag everywhere, including after a keyword.

## Additional Context

Fixes #2225. Found while reviewing PR #2195 / issue #2133.

Accepted trade-off, stated plainly: an all-digit hex sitting inside a comment with no reference keyword — say a JSDoc line `* color: '#123456'` — is no longer flagged. That is the price of supporting free-form references like `// Workaround for #2133`, which have no keyword either. No such case exists anywhere in the current corpus, and hex values with any a-f character are unaffected.

`scripts/` is repo-level tooling rather than app code, so the commit uses the `dev` scope — the closest fit among the allowed scopes (`backend`, `frontend`, `sdk`, `tests`, `dev`).

## Testing

**Corpus regression — no behavior change on real code.** Ran the pre-change and post-change scripts over all 1005 `.ts`/`.tsx`/`.js`/`.jsx` files in `apps/frontend/src` and `ee/frontend/src`: 37 violations before, 37 after (2 borderRadius, 3 spacing, 2 fontSize, 30 color), and the sorted output is byte-identical.

```bash
find apps/frontend/src ee/frontend/src -type f \
  \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \) \
  | sort | tr '\n' '\0' | xargs -0 node scripts/check-hardcoded-styles.js
```

**Fixture — false positives gone, real colors kept.** The same fixture goes from 23 violations to 11. All 12 that disappeared are issue/PR references; all 11 that remain are genuine hardcoded colors, including the same-line mix on line 25 and the URL case on line 26. `playground/` is gitignored, so the fixture is not part of this PR — reviewers can reproduce with this file:

```tsx
// GitHub refs — must NOT be flagged after the fix
// see issue #2133 and PR #2195
// Closes: #2133
// Fixes #2133, resolves #2195
// TODO(#2133): drop this shim
// Workaround for #2133
// Reverted in #2133
/* resolves #2195 */
/**
 * Background: #2133 explains the ordering constraint.
 */
const a = 1; // closes #2133

// Real colors — must STILL be flagged
const c1 = { color: '#fff2ab' };
const c2 = { color: '#123456' };
const c3 = { color: '#abc' };
const c4 = { color: '#12345678' };
const c5 = { color: '#0080AF' };
const c6 = { color: '#abc123' };
const css = `
  color: #fff2ab;
  background: #123456;
`;
const k = { color: '#123456' }; // fixes #2133
const url = 'https://x'; const c = { color: '#123456' };
// fixes #fff2ab
```

`node --check scripts/check-hardcoded-styles.js` passes.
