### PR TITLE
Fix API_BASE_URL fallback and inline the runtime env script

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Metadata } from 'next';
-import Script from 'next/script';
 import { cookies } from 'next/headers';
 import ThemeAwareLogo from '../components/common/ThemeAwareLogo';
 import '../styles/fonts.css';
@@ -365,8 +364,13 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
     productName: deploymentBranding.productName,
     homeUrl: '/architect',
   };
+  // Empty when `API_BASE_URL` is unset or blank — whichever of Helm,
+  // docker-compose or the dev scripts supplies the environment — so
+  // `getClientApiBaseUrl()` throws instead of silently using localhost;
+  // a deployed frontend would otherwise point `/auth/*` at the visitor's
+  // own machine.
   const runtimeEnvScript = `window.__ENV__=${JSON.stringify({
-    apiBaseUrl: process.env.API_BASE_URL ?? 'http://localhost:8080',
+    apiBaseUrl: process.env.API_BASE_URL || '',
     brandPrimaryColor: deploymentBranding.primaryColor,
     brandFaviconUrl: deploymentBranding.faviconUrl,
     brandProductName: deploymentBranding.productName,
@@ -417,6 +421,17 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
     <html lang="en" suppressHydrationWarning data-theme-mode={storedThemeMode}>
       <head>
         {/*
+          Plain inline script rather than `next/script` with
+          `beforeInteractive`: that renders a `self.__next_s` push drained by
+          the client bootstrap, which both logs a React 19 console error and
+          gives up the guarantee that `__ENV__` exists before any client code
+          reads it. Inline in <head> it is in the initial HTML.
+        */}
+        <script
+          id="rhesis-runtime-env"
+          dangerouslySetInnerHTML={{ __html: runtimeEnvScript }}
+        />
+        {/*
           Runs before first paint: when the visitor has made no explicit choice,
           resolve the mode from the browser instead of defaulting to light.
           `ThemeContextProvider` reads the attribute this sets, so the two agree
@@ -432,9 +447,6 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
         />
       </head>
       <body suppressHydrationWarning>
-        <Script id="rhesis-runtime-env" strategy="beforeInteractive">
-          {runtimeEnvScript}
-        </Script>
         <ThemeContextProvider
           disableTransitionOnChange
           initialMode={storedThemeMode ?? 'light'}

--- a/apps/frontend/src/utils/__tests__/url-resolver.test.ts
+++ b/apps/frontend/src/utils/__tests__/url-resolver.test.ts
@@ -50,8 +50,15 @@ describe('getClientApiBaseUrl', () => {
     expect(getClientApiBaseUrl()).toBe('http://127.0.0.1:9090/api');
   });
 
-  it('falls back to default when runtime config is not set', () => {
-    expect(getClientApiBaseUrl()).toBe('http://127.0.0.1:8080');
+  it('throws when runtime config is not set', () => {
+    expect(() => getClientApiBaseUrl()).toThrow('API_BASE_URL');
+  });
+
+  it('throws when runtime config is an empty string', () => {
+    // What an environment that declares API_BASE_URL but leaves it blank
+    // ships — e.g. the chart's default `config.apiBaseUrl: ""`.
+    window.__ENV__ = { apiBaseUrl: '' };
+    expect(() => getClientApiBaseUrl()).toThrow('API_BASE_URL');
   });
 
   it('resolves localhost in the URL', () => {

--- a/apps/frontend/src/utils/url-resolver.ts
+++ b/apps/frontend/src/utils/url-resolver.ts
@@ -19,16 +19,30 @@ export function resolveLocalhostUrl(url: string): string {
 }
 
 /**
- * Gets the API base URL for client-side requests with localhost resolution
- * Uses runtime config injected into window.__ENV__ or falls back to default
+ * Gets the API base URL for the browser's direct calls to the backend's
+ * unauthenticated `/auth/*` endpoints, from the runtime config the root layout
+ * injects into `window.__ENV__` (or `API_BASE_URL` when called on the server).
+ *
+ * Throws when it is not configured. There used to be a `http://localhost:8080`
+ * fallback here, which only ever looked right in local dev: in a deployed
+ * environment it pointed the sign-in, verify-email, magic-link and
+ * reset-password flows at the visitor's own machine instead of failing.
  *
  * @returns Resolved API base URL
  */
 export function getClientApiBaseUrl(): string {
   const baseUrl =
     typeof window === 'undefined'
-      ? process.env.API_BASE_URL || 'http://localhost:8080'
-      : window.__ENV__?.apiBaseUrl || 'http://localhost:8080';
+      ? process.env.API_BASE_URL
+      : window.__ENV__?.apiBaseUrl;
+  if (!baseUrl) {
+    throw new Error(
+      'API_BASE_URL is not configured — cannot resolve the backend URL for ' +
+        'authentication requests. Set API_BASE_URL for the frontend, ' +
+        'wherever its environment comes from (Helm `config.apiBaseUrl`, ' +
+        'docker-compose, or the dev scripts).'
+    );
+  }
   return resolveLocalhostUrl(baseUrl);
 }
 


### PR DESCRIPTION
## Purpose

Fixes #2317.

The valuable part of this ticket is its third acceptance criterion: `getClientApiBaseUrl()` silently fell back to `http://localhost:8080`, and that fallback had a concrete production path. `charts/rhesis/values.yaml:68` defaults `apiBaseUrl: ""`, the ConfigMap at `charts/rhesis/templates/configmap.yaml:36` therefore ships `API_BASE_URL=""`, the `??` in the root layout let that empty string through into `window.__ENV__`, and the `||` in the browser turned it into `http://localhost:8080`. A deployed frontend in that state pointed its unauthenticated `/auth/*` flows — magic link, password reset, email verification, sign-in — and `WebSocketContext` at the visitor's own machine instead of failing. The misconfiguration was invisible precisely because localhost is the right answer in local dev.

One note on the ticket's framing, so reviewers are not looking for something this PR does not contain: the reported React 19 console error from `RootLayout` did not reproduce. It was not observed on current `main` across `/`, `/auth/forgot-password`, `/auth/verify-email` and `/architect`, including reloads, under either bundler, and `window.__ENV__` was already being set well before its first read. So this PR does not claim to fix a console error we cannot demonstrate existed. The mechanical half of the report did check out and is fixed here: the injection really was queued into `self.__next_s` rather than emitted as an inline tag, which gave up the guarantee that `__ENV__` exists in the initial HTML.

## What Changed

- `apps/frontend/src/utils/url-resolver.ts` — `getClientApiBaseUrl()` no longer defaults to localhost. It throws with an actionable message when the value is missing or blank.
- The fallback is removed from **both** branches, server and `window`. Only swapping `??` for `||` in the layout would have left `process.env.API_BASE_URL || 'http://localhost:8080'` on the server branch and re-created the identical bug one layer down, so both had to go.
- `apps/frontend/src/app/layout.tsx` — `window.__ENV__` is now injected by a plain inline `<script id="rhesis-runtime-env" dangerouslySetInnerHTML={...} />` in `<head>`, directly above the pre-existing `rhesis-theme-mode` script that already uses this exact pattern. This replaces `next/script` with `strategy="beforeInteractive"` in `<body>`, and drops the `import Script from 'next/script'` — the only use of `next/script` in the repo.
- `apps/frontend/src/app/layout.tsx` — `process.env.API_BASE_URL ?? 'http://localhost:8080'` becomes `process.env.API_BASE_URL || ''`, so a blank value stays blank and reaches the throw rather than being papered over.
- `apps/frontend/src/utils/__tests__/url-resolver.test.ts` — the "falls back to default" case becomes "throws when runtime config is not set", plus a new case for `apiBaseUrl: ''`, which is what an environment that declares the variable but leaves it empty actually ships.

## Additional Context

**This is a behaviour change and deserves a deliberate decision, not just a skim.** A previously silent misconfiguration now throws. That is the intent — the whole point is that an unset `API_BASE_URL` should be loud — but any deployment currently working by accident on the implicit `localhost:8080` default will surface an error after this lands instead of quietly misrouting auth traffic. Every environment in the repo does set a real value, so nothing here should be affected: `charts/rhesis/values-dev.yaml`, `values-stg.yaml` and `values-prd.yaml` all set a real host, and so do `docker-compose.yml`, `scripts/rh/dev.sh`, `scripts/rh/quickstart.sh`, `scripts/rh/worktree.sh`, `apps/frontend/jest.setup.js` and `apps/frontend/playwright.config.ts`. The gap is only the chart's own default and anything deriving from it.

On the throw's safety: all 8 files that call `getClientApiBaseUrl()` are `'use client'` files, and every call happens inside an event handler or an effect, never during render. The one that looks like a render-path call, `WebSocketContext.tsx:55`, is reached from `getWebSocketUrl()` inside a `useEffect`. So the throw cannot break an SSR render.

Not done here, worth separate tickets:

- `charts/rhesis/templates/configmap.yaml:36` could use Helm's `required "config.apiBaseUrl must be set"` so a misconfigured install fails at install time rather than at first auth request.
- `apps/frontend/src/utils/validateEnv.ts` is dead code. It lists `API_BASE_URL` among required variables and has its own test file, but nothing in the app ever calls it — the only references are its own definition and its test.
- `brandPrimaryColor`, `brandFaviconUrl` and `brandProductName` are injected into `__ENV__` and typed in `src/types/env.d.ts`, but no code reads them off `window`. They are deliberately threaded as props instead, per the comments in `src/types/navigation.ts` and `src/styles/theme.ts`, so the `__ENV__` copies look vestigial.

## Testing

Verified against the dev stack running from this worktree (frontend on 3020, backend on 8100).

The runtime env script is now a real inline tag in the initial HTML, and the deferred queue is gone:

```
$ curl -s http://localhost:3020/ | grep -o 'rhesis-runtime-env' | wc -l
2
$ curl -s http://localhost:3020/ | grep -c '__next_s'
0
$ curl -s http://localhost:3020/ | grep -o '<script id="rhesis-runtime-env">[^<]*'
<script id="rhesis-runtime-env">window.__ENV__={"apiBaseUrl":"http://localhost:8100", ...};
```

Byte offsets confirm placement: the real `<script>` tag sits at offset 3058 with `</head>` at 16038, so it is inside `<head>` and in the initial HTML. The second `rhesis-runtime-env` match is only the RSC flight payload, which is expected.

Automated checks, all run after rebasing onto `origin/main`:

```
$ npx tsc --noEmit          # clean, exit 0
$ npx eslint <the 3 changed files>   # clean, exit 0
$ npx prettier --check <the 3 changed files>   # unchanged
$ npx jest --ci
Test Suites: 211 passed, 211 total
Tests:       1949 passed, 1949 total
```

To check the fix by hand: unset `API_BASE_URL` for the frontend and load `/auth/forgot-password`, then submit. Before this change the request went to `http://localhost:8080`; now it raises a clear error naming `API_BASE_URL`.
