### PR TITLE
Fix tenant filter gap for select() and relationship loads

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -87,8 +87,9 @@ needed.
 
 `models/scope_events.py` registers two listeners:
 
-- `auto_filter` (`Query.before_compile`) — adds `WHERE organization_id=...` (and `project_id=...`)
-  to every SELECT, UPDATE, DELETE automatically
+- `auto_filter` (`Session.do_orm_execute`) — adds `WHERE organization_id=...` (and `project_id=...`)
+  to every SELECT, UPDATE, DELETE automatically, including `db.execute(select(...))` and
+  relationship lazy/eager loads
 - `auto_stamp` (`Session.before_flush`) — fills `organization_id`, `user_id`, `project_id` on new
   ORM objects when the column is `None`
 
@@ -103,9 +104,6 @@ from rhesis.backend.app.scope import bypass_tenant_filter
 with bypass_tenant_filter():
     all_rows = db.query(SomeModel).all()  # filter skipped; stamp still active
 
-# Per-query bypass (legacy Query API only):
-query._bypass_scope = True
-
 # Background scripts / migrations (scope is unbound outside get_db_with_tenant_variables):
 from rhesis.backend.app.scope import RequestScope, bind_scope, reset_scope
 
@@ -116,13 +114,11 @@ finally:
     reset_scope(token)
 ```
 
-### Limitations (Phase 0 — document, not fix)
+### Limitations
 
-- `db.execute(select(...))` / `db.scalars(...)` (ORM 2.0 style) are **not** auto-filtered by the
-  `before_compile` listener. Use `db.query(...)` instead, or add explicit `organization_id` filters.
-  RLS (Phase 5) is the security backstop for those paths.
-- `Session.bulk_insert_mappings` / `bulk_save_objects` bypass `before_flush`; auto-stamp does **not**
-  fire. Include `organization_id`/`user_id`/`project_id` in bulk payloads manually.
+- `Session.bulk_insert_mappings` / `bulk_save_objects` bypass `before_flush` AND `do_orm_execute`;
+  neither auto-stamp nor auto-filter apply. Include `organization_id`/`user_id`/`project_id` in
+  bulk payloads manually.
 - Raw SQL `INSERT`/`UPDATE`/`DELETE` bypasses both listeners. Auth uses some intentionally; tenant-
   scoped raw SQL must add explicit `WHERE` clauses or rely on RLS.
 - Background scripts run outside `get_db_with_tenant_variables`. Bind scope explicitly or pass

--- a/apps/backend/src/rhesis/backend/app/models/scope_events.py
+++ b/apps/backend/src/rhesis/backend/app/models/scope_events.py
@@ -3,10 +3,13 @@ SQLAlchemy event listeners for automatic tenant scope filtering and stamping.
 
 TWO LISTENERS
 -------------
-1. auto_filter  (Query.before_compile)
-   PRIMARY filter. Covers db.query(...), db.query(...).update(), db.query(...).delete().
-   Fires for ALL Query-based operations including lazy-loaded relationships loaded via
-   the legacy Query API. Does NOT fire for db.execute(select(...)) / ORM 2.0 style.
+1. auto_filter  (Session.do_orm_execute)
+   Adds WHERE organization_id = ... (and project_id logic) to every SELECT, UPDATE,
+   and DELETE issued through the Session: db.query(...), db.execute(select(...)),
+   db.scalars(...), Query.update()/.delete(), and relationship lazy/eager loads.
+   Uses with_loader_criteria() so the predicate follows an entity everywhere it
+   occurs - joins, subqueries, aliases, and loader-triggered secondary queries -
+   without needing to touch every call site.
 
 2. auto_stamp  (Session.before_flush)
    Before every flush, fills organization_id / user_id / project_id from the ambient
@@ -15,16 +18,28 @@ TWO LISTENERS
 
 COVERAGE NOTES
 --------------
-This implementation uses Query.before_compile which covers the dominant db.query(...)
-pattern throughout this codebase. db.execute(select(...)) statements (ORM 2.0 style)
-are not filtered by this listener — use db.query(...) or add explicit organization_id
-filters. RLS (Phase 5) backstops all tenant tables regardless of the filtering path.
-If select()-style auto-filtering is ever needed, add a do_orm_execute listener here.
+This used to run on Query.before_compile, which only fires for the legacy db.query(...)
+API - db.execute(select(...)) went unfiltered at the ORM layer (RLS was the only
+backstop for that path). do_orm_execute fires for every Session.execute() call,
+including the internal one legacy Query.all()/.update()/.delete() issue under the
+hood (Query has been built on the unified execution path since SQLAlchemy 1.4), so
+one listener now covers all of it, plus relationship loads that before_compile could
+not reach at all.
 
-EXEMPT MODELS
--------------
-User, Organization, Token - no auto-filter applied; these must be queried
-before any tenant context is known.
+TENANT-SCOPED CLASSES
+----------------------
+The set of classes to filter is derived once, at listener-registration time, from
+the actual mapped columns (has_organization_id / has_project_id in query_utils.py) -
+not a hand-maintained per-model registry. A new model with an organization_id column
+is covered automatically the next time the process starts; nobody has to remember to
+add it anywhere. EXEMPT_TABLES is the one deliberate override: Token has a real
+organization_id column but must stay queryable by its raw value before any scope is
+known, so it is force-excluded despite otherwise matching. User and Organization
+need no override - they are excluded because they lack the column outright (User's
+organization_id is a plain FK, not something the identity lookup path filters on;
+Organization has no such column since it's the org table itself). Keeping all three
+in EXEMPT_TABLES matches the original design intent even though only Token is load
+bearing today.
 
 PRODUCTION KNOBS
 ----------------
@@ -36,16 +51,16 @@ RHESIS_DISABLE_SCOPE_LISTENER=1   Kill switch. Both filter and stamp are no-ops.
                                    database.py + re-applied by _reapply_tenant_vars);
                                    RLS remains the security backstop regardless.
 
-PER-QUERY BYPASS
-----------------
-Legacy Query API:  query._bypass_scope = True
+BYPASS
+------
+Admin / cross-org reads: bypass_tenant_filter() context manager (scope.py). Disables
+auto_filter for its block; auto_stamp is unaffected.
 
 KNOWN LIMITATIONS
 -----------------
-- db.execute(select(...)) / ORM 2.0 SELECT style is NOT filtered by this listener.
-  Use db.query(...) or explicit filters. RLS provides the security backstop.
 - Session.bulk_insert_mappings / bulk_save_objects skip before_flush; auto-stamp
-  does NOT fire. Payloads must include organization_id / user_id / project_id.
+  does NOT fire, and they also skip do_orm_execute, so auto-filter does not apply
+  either. Payloads must include organization_id / user_id / project_id.
 - Raw SQL INSERT/UPDATE/DELETE bypasses both listeners. Add explicit WHERE clauses
   or rely on RLS (Phase 5).
 - Background scripts run outside get_db_with_tenant_variables; call bind_scope()
@@ -55,22 +70,15 @@ KNOWN LIMITATIONS
 import logging
 import os
 
-from sqlalchemy import event, or_
-from sqlalchemy.orm import Query, Session
+from sqlalchemy import and_, event, or_
+from sqlalchemy.orm import Session, with_loader_criteria
 
 logger = logging.getLogger(__name__)
 
-# Tables that should never be auto-filtered (queried before any tenant context).
-#
-# This is the ORM-layer exempt set and is deliberately NARROWER than the RLS-exempt
-# set in the migrations ({token, user, organization, refresh_token, alembic_version}).
-# The two serve different layers and are not required to match:
-#   - This set: tables the ORM auto_filter/auto_stamp listeners skip because they are
-#     queried before any tenant context exists (auth/identity lookups).
-#   - RLS-exempt set: tables with no tenant policy at the database level.
-# refresh_token / alembic_version are absent here only because they have no
-# organization_id column, so the listeners already no-op on them. If you add a tenant
-# column to an auth/infra table, reconcile both lists deliberately.
+# Tables force-excluded from auto_filter despite matching column presence.
+# Rationale per table is in the module docstring (TENANT-SCOPED CLASSES) - Token
+# is the only load-bearing entry; User/Organization are already excluded by
+# column absence and are listed here defensively.
 EXEMPT_TABLES = frozenset({"user", "organization", "token"})
 
 # Tables exempt from the PROJECT predicate only (org filtering still applies).
@@ -109,21 +117,73 @@ def _scope_from_session(session):
     return current_scope()
 
 
-def _inject_filter(query: Query, condition) -> Query:
-    """
-    Append a WHERE condition to a Query, even when LIMIT or OFFSET is already set.
-
-    SQLAlchemy's public Query.filter() raises InvalidRequestError when called after
-    .limit() or .offset(). We use the supported enable_assertions(False) path to
-    bypass that Python-level guard without touching private internals. The resulting
-    SQL is correct: WHERE always precedes LIMIT/OFFSET in the generated statement.
-    """
-    return query.enable_assertions(False).filter(condition)
-
-
 def _kill_switch_active() -> bool:
     """Return True when RHESIS_DISABLE_SCOPE_LISTENER=1 is set."""
     return os.environ.get("RHESIS_DISABLE_SCOPE_LISTENER", "").lower() in ("1", "true")
+
+
+def _build_tenant_classes():
+    """
+    Enumerate mapped classes needing the org/project WHERE predicate.
+
+    Returns a list of (model_cls, needs_project_filter) tuples.
+    """
+    from rhesis.backend.app.models.base import Base
+    from rhesis.backend.app.utils.query_utils import has_organization_id, has_project_id
+
+    tenant_classes = []
+    for mapper in Base.registry.mappers:
+        model_cls = mapper.class_
+        tablename = getattr(model_cls, "__tablename__", None)
+        if tablename in EXEMPT_TABLES:
+            continue
+        if not has_organization_id(model_cls):
+            continue
+        needs_project_filter = (
+            has_project_id(model_cls) and tablename not in PROJECT_FILTER_EXEMPT_TABLES
+        )
+        tenant_classes.append((model_cls, needs_project_filter))
+    return tenant_classes
+
+
+# ----------------------------------------------------------------------------
+# Criteria builders for with_loader_criteria().
+#
+# Each returns a freshly defined, UNCONDITIONAL closure over plain scalar values
+# (never a dataclass/dict looked up inside the closure body). SQLAlchemy's lambda
+# cache keys on the closure's code object plus its captured values; a closure that
+# branches on a mutable value's *shape* at call time (e.g. "if scope.project_id")
+# risks serving a stale cached WHERE shape from an earlier call with a different
+# branch. Picking one of these three fixed-shape functions in auto_filter, instead
+# of branching inside a single shared closure, avoids that trap.
+# ----------------------------------------------------------------------------
+
+
+def _org_only_criteria(organization_id):
+    def _criteria(cls):
+        return cls.organization_id == organization_id
+
+    return _criteria
+
+
+def _org_and_active_project_criteria(organization_id, project_id):
+    def _criteria(cls):
+        return and_(
+            cls.organization_id == organization_id,
+            or_(cls.project_id == project_id, cls.project_id.is_(None)),
+        )
+
+    return _criteria
+
+
+def _org_and_null_project_criteria(organization_id):
+    def _criteria(cls):
+        return and_(
+            cls.organization_id == organization_id,
+            cls.project_id.is_(None),
+        )
+
+    return _criteria
 
 
 def setup_scope_listeners():
@@ -145,92 +205,56 @@ def setup_scope_listeners():
         )
         return
 
-    # ------------------------------------------------------------------
-    # Listener 1: Auto-filter via Query.before_compile
-    # Covers db.query(...), db.query(...).update(), db.query(...).delete()
-    # ------------------------------------------------------------------
-    @event.listens_for(Query, "before_compile", retval=True)
-    def auto_filter(query):
+    tenant_classes = _build_tenant_classes()
+
+    # Listener 1: auto_filter - see module docstring for what it covers.
+    @event.listens_for(Session, "do_orm_execute")
+    def auto_filter(orm_execute_state):
         from rhesis.backend.app.scope import is_tenant_filter_disabled
 
         if _kill_switch_active():
-            return query
+            return
         if is_tenant_filter_disabled():
-            return query
-        if getattr(query, "_bypass_scope", False):
-            return query
-        # Idempotency guard: before_compile can fire more than once for the same
-        # Query object (e.g. subquery compilation). Avoid appending duplicate
-        # predicates. Pattern mirrors _soft_delete_filter_applied in soft_delete_events.py.
-        if getattr(query, "_scope_filter_applied", False):
-            return query
+            return
 
-        # Prefer session.info so async route handlers (event-loop thread) see the
-        # same scope as the sync dep (threadpool thread) that created the session.
-        session = query.session
-        if session is not None:
-            scope = _scope_from_session(session)
-        else:
-            from rhesis.backend.app.scope import current_scope
-
-            scope = current_scope()
+        # Deliberately does not skip is_column_load / is_relationship_load to rely on
+        # with_loader_criteria's propagation instead: propagation only carries criteria
+        # from whatever SELECT loaded the parent, so an object created via
+        # session.add()+flush() (an INSERT, not a SELECT) would have its relationships
+        # load unfiltered later. Re-attaching every time costs a redundant re-attach on
+        # already-covered loads, not a correctness risk.
+        scope = _scope_from_session(orm_execute_state.session)
         if scope.organization_id is None:
-            return query
+            return
 
-        for desc in query.column_descriptions:
-            entity = desc.get("entity")
-            if entity is None:
-                continue
-            if getattr(entity, "__tablename__", None) in EXEMPT_TABLES:
-                continue
-            table = getattr(entity, "__table__", None)
-            if table is None:
-                continue
-            # Use frozenset of names to avoid triggering SQLAlchemy column operators
-            col_names = frozenset(col.name for col in table.columns)
-            if "organization_id" in col_names:
-                query = _inject_filter(query, entity.organization_id == scope.organization_id)
-            # Project filtering is fail-closed: we only reach this branch when an org
-            # scope is active (the listener returns early when organization_id is None,
-            # so org-less system/bootstrap sessions are never project-filtered).
-            #   - project set   -> rows in that project plus org-level (NULL) rows
-            #   - project unset -> org-level (NULL) rows only
-            # project_membership is exempt (org-scoped access-control table).
-            if (
-                "project_id" in col_names
-                and getattr(entity, "__tablename__", None) not in PROJECT_FILTER_EXEMPT_TABLES
-            ):
-                if scope.project_id:
-                    query = _inject_filter(
-                        query,
-                        or_(
-                            entity.project_id == scope.project_id,
-                            entity.project_id.is_(None),
-                        ),
-                    )
-                else:
-                    query = _inject_filter(query, entity.project_id.is_(None))
+        # Project filtering is fail-closed: we only reach this branch when an org
+        # scope is active (the check above returns early when organization_id is
+        # None, so org-less system/bootstrap sessions are never project-filtered).
+        #   - project set   -> rows in that project plus org-level (NULL) rows
+        #   - project unset -> org-level (NULL) rows only
+        if scope.project_id:
+            project_criteria = _org_and_active_project_criteria(
+                scope.organization_id, scope.project_id
+            )
+        else:
+            project_criteria = _org_and_null_project_criteria(scope.organization_id)
+        org_only_criteria = _org_only_criteria(scope.organization_id)
 
-        query._scope_filter_applied = True
-        return query
+        stmt = orm_execute_state.statement
+        for model_cls, needs_project_filter in tenant_classes:
+            criteria = project_criteria if needs_project_filter else org_only_criteria
+            stmt = stmt.options(with_loader_criteria(model_cls, criteria, include_aliases=True))
+        orm_execute_state.statement = stmt
 
-    # ------------------------------------------------------------------
-    # Listener 2: Auto-stamp on INSERT via Session.before_flush
+    # Listener 2: auto_stamp - see module docstring for what it fills in.
     #
-    # Session.before_flush is used instead of the mapper-level before_insert
-    # because declarative_base() does not propagate before_insert to subclasses
-    # correctly in all SQLAlchemy 2.x configurations. Session.before_flush
-    # gives direct access to session.new (pending inserts) and fires
-    # synchronously before the INSERT statements are issued.
+    # Uses Session.before_flush rather than the mapper-level before_insert because
+    # declarative_base() does not propagate before_insert to subclasses correctly in
+    # all SQLAlchemy 2.x configurations; before_flush gives direct access to
+    # session.new and fires before the INSERT statements are issued.
     #
-    # Fills organization_id / user_id / project_id from RequestScope
-    # when the column is present and the value is None.
-    # Bypass does NOT suppress stamping.
-    #
-    # NOTE: We import Base from models.base (the @as_declarative() Base), NOT
-    # from database.py (the declarative_base() Base). All application models
-    # inherit from models.base.Base.
-    # ------------------------------------------------------------------
+    # Base here is models.base.Base (the @as_declarative() one all app models
+    # inherit from), not the declarative_base() Base in database.py.
     from rhesis.backend.app.models.base import Base
 
     @event.listens_for(Session, "before_flush")

--- a/apps/backend/src/rhesis/backend/app/scope.py
+++ b/apps/backend/src/rhesis/backend/app/scope.py
@@ -35,13 +35,6 @@ Admin / cross-org reads:
         results = db.query(SomeModel).all()   # filter skipped
     Auto-stamp is NOT affected by bypass - inserts still get the caller's identity.
 
-Per-query bypass (legacy Query API only):
-    query._bypass_scope = True
-
-    Note: db.execute(select(...)) / ORM 2.0 style reads are not auto-filtered by the
-    before_compile listener at all, so no bypass is needed or available for them.
-    RLS (Phase 5) is the security backstop for those paths.
-
 Background scripts / migrations:
     Scripts run outside get_db_with_tenant_variables. Scope is unbound, auto-stamp is
     a no-op, and NOT-NULL constraints on organization_id will trip. Explicitly bind:

--- a/tests/backend/utils/test_scope_listeners.py
+++ b/tests/backend/utils/test_scope_listeners.py
@@ -2,15 +2,15 @@
 Tests for the ambient request scope listeners (scope_events.py).
 
 The shipped implementation uses two listeners:
-  auto_filter  - Query.before_compile  (covers db.query(...), not db.execute(select(...)))
-  auto_stamp   - Session.before_flush  (covers all ORM pending inserts, not bulk operations)
+  auto_filter  - Session.do_orm_execute  (covers db.query(...), db.execute(select(...)),
+                 Query.update()/.delete(), and relationship loads)
+  auto_stamp   - Session.before_flush    (covers all ORM pending inserts, not bulk operations)
 
 Coverage:
 - Auto-filter no-ops when scope is unbound (isolate_request_scope fixture)
-- Auto-filter applies org_id predicate when scope is bound (before_compile)
+- Auto-filter applies org_id predicate when scope is bound (do_orm_execute)
 - Auto-filter is idempotent with explicit filter + bound scope
 - bypass_tenant_filter() suppresses auto-filter
-- query._bypass_scope = True suppresses auto-filter (per-query bypass)
 - Kill switch (RHESIS_DISABLE_SCOPE_LISTENER=1) checked at query time by both listeners
 - Auto-stamp fires when scope is bound and column is None
 - Auto-stamp does NOT overwrite explicit values
@@ -41,8 +41,9 @@ from rhesis.backend.app.scope import (
 )
 from rhesis.backend.app.utils import crud_utils
 from tests.backend.routes.fixtures.data_factories import (
-    RequirementDataFactory,
     ProjectDataFactory,
+    PromptDataFactory,
+    RequirementDataFactory,
 )
 
 
@@ -187,11 +188,75 @@ class TestAutoFilterWhenBound:
         assert b1.id in ids
         assert b2.id not in ids
 
+    def test_bound_scope_filters_select_style_query(
+        self, test_db: Session, test_org_id, test_org2_id, bound_scope
+    ):
+        """db.execute(select(...)) is filtered too - the gap the before_compile listener had."""
+        from sqlalchemy import select
+
+        b1 = crud_utils.create_item(
+            test_db,
+            models.Requirement,
+            RequirementDataFactory.sample_data(),
+            organization_id=test_org_id,
+        )
+        b2 = crud_utils.create_item(
+            test_db,
+            models.Requirement,
+            RequirementDataFactory.sample_data(),
+            organization_id=test_org2_id,
+        )
+
+        with bound_scope(organization_id=test_org_id):
+            results = test_db.execute(select(models.Requirement)).scalars().all()
+
+        ids = {b.id for b in results}
+        assert b1.id in ids
+        assert b2.id not in ids
+
+    def test_bound_scope_filters_relationship_lazy_load(
+        self, test_db: Session, test_org_id, test_org2_id, bound_scope
+    ):
+        """
+        Lazy-loading a relationship is filtered too - another gap the before_compile
+        listener had, since it never fired for the secondary SELECT a lazy load issues.
+        """
+        from rhesis.backend.app.utils.crud_utils import create_item
+
+        requirement = create_item(
+            test_db,
+            models.Requirement,
+            RequirementDataFactory.sample_data(),
+            organization_id=test_org_id,
+        )
+        own_org_prompt = create_item(
+            test_db,
+            models.Prompt,
+            {**PromptDataFactory.minimal_data(), "requirement_id": requirement.id},
+            organization_id=test_org_id,
+        )
+        # Deliberately stamped with a different org than its parent requirement, to
+        # prove the relationship load is filtered by the ACTIVE scope, not merely by
+        # whatever the FK join happens to return.
+        create_item(
+            test_db,
+            models.Prompt,
+            {**PromptDataFactory.minimal_data(), "requirement_id": requirement.id},
+            organization_id=test_org2_id,
+        )
+
+        with bound_scope(organization_id=test_org_id):
+            test_db.expire(requirement, ["prompts"])
+            loaded_prompt_ids = {p.id for p in requirement.prompts}
+
+        assert own_org_prompt.id in loaded_prompt_ids
+        assert len(loaded_prompt_ids) == 1
+
 
 @pytest.mark.unit
 @pytest.mark.utils
 class TestBypassFiltering:
-    """bypass_tenant_filter() and per-query bypasses suppress the listener."""
+    """bypass_tenant_filter() suppresses the listener."""
 
     def test_bypass_context_manager_skips_filter(
         self, test_db: Session, test_org_id, test_org2_id, bound_scope
@@ -217,24 +282,6 @@ class TestBypassFiltering:
         ids = {b.id for b in results}
         assert b1.id in ids
         assert b2.id in ids
-
-    def test_legacy_per_query_bypass(
-        self, test_db: Session, test_org_id, test_org2_id, bound_scope
-    ):
-        """query._bypass_scope = True suppresses the legacy before_compile listener."""
-        b2 = crud_utils.create_item(
-            test_db,
-            models.Requirement,
-            RequirementDataFactory.sample_data(),
-            organization_id=test_org2_id,
-        )
-
-        with bound_scope(organization_id=test_org_id):
-            q = test_db.query(models.Requirement)
-            q._bypass_scope = True
-            results = q.all()
-
-        assert any(b.id == b2.id for b in results)
 
 
 @pytest.mark.unit
@@ -432,7 +479,7 @@ class TestKillSwitch:
     ):
         """
         RHESIS_DISABLE_SCOPE_LISTENER=1 is re-checked at call time by both listeners:
-        auto_filter (before_compile) and auto_stamp (before_flush) both call
+        auto_filter (do_orm_execute) and auto_stamp (before_flush) both call
         _kill_switch_active() on every invocation, so setting the env var at runtime
         disables filtering for subsequent queries even in the same process.
         """


### PR DESCRIPTION
## Purpose

The automatic tenant/org scope filter only ever hooked into SQLAlchemy's legacy `Query` API via `Query.before_compile`, so anything written the modern way — `db.execute(select(...))`, `Query.update()`/`.delete()`, and relationship lazy/eager loads — ran completely unfiltered at the ORM layer, with Postgres RLS as the only backstop. This closes that gap so multi-tenant isolation no longer depends on which query style a call site happens to use. Tracked in #1846.

## What Changed

- Replaced the `Query.before_compile` listener with a single `Session.do_orm_execute` listener using `with_loader_criteria`, covering `db.query(...)`, `db.execute(select(...))`, `Query.update()`/`.delete()`, and relationship lazy/eager loads through one mechanism.
- The list of tenant-scoped model classes is now derived automatically from each model's actual `organization_id`/`project_id` columns at startup, instead of a hand-maintained registry — a new model is covered without anyone remembering to register it.
- Removed the `query._bypass_scope` per-query escape hatch; it had no real callers anywhere in the codebase.
- Added regression tests proving `db.execute(select(...))` queries and relationship loads are correctly filtered by the active org/project scope — the exact gap this closes.

## Additional Context

- Closes #1846.
- Testing surfaced a real gap during development: an object created via `session.add()` + flush (an INSERT, not a SELECT) never had filter criteria to propagate from, so relying purely on `with_loader_criteria`'s propagation left its later relationship loads unfiltered. The listener now re-attaches criteria on every call instead of skipping relationship/column loads, which closes that.

## Testing

```
cd apps/backend
uv run pytest ../../tests/backend/utils/test_scope_listeners.py ../../tests/backend/utils/test_project_querybuilder.py -v
```

Also ran the full backend suite (6800 passed); the 2 failures there were confirmed pre-existing and unrelated by reproducing them against unmodified `main` with this change stashed out.
