### PR TITLE
Fix project metadata card edit mode layout and save handling

### DIFF
--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMetadataCard.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMetadataCard.tsx
@@ -79,14 +79,14 @@ export default function ProjectMetadataCard({
     [project]
   );
 
-  const handleSave = async (draft: MetadataDraft) => {
-    await onSave({
+  // Returning the result keeps the card in edit mode when the update fails.
+  const handleSave = (draft: MetadataDraft) =>
+    onSave({
       name: draft.name.trim(),
       description: draft.description,
       is_active: draft.is_active,
       owner_id: draft.owner_id || undefined,
     });
-  };
 
   const ownerFromProject =
     project.owner?.name || project.owner?.email || 'Not assigned';

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMetadataCard.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMetadataCard.tsx
@@ -109,11 +109,11 @@ export default function ProjectMetadataCard({
         return (
           <Grid
             container
-            columnSpacing={isEditing ? 2 : '30px'}
-            rowSpacing={isEditing ? 2 : '20px'}
+            columnSpacing="30px"
+            rowSpacing="20px"
             alignItems="flex-start"
           >
-            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <Grid size={{ xs: 12, sm: 6, md: 6 }}>
               {isEditing ? (
                 <TextField
                   fullWidth
@@ -156,11 +156,14 @@ export default function ProjectMetadataCard({
               )}
             </Grid>
 
-            <Grid size={{ xs: 12, md: 6 }}>
+            <Grid size={{ xs: 12, md: 3 }}>
               {isEditing ? (
                 <FormControl fullWidth>
-                  <InputLabel>Owner</InputLabel>
+                  {/* `displayEmpty` + `shrink` keep the label floated when no
+                      owner is set, so "Not assigned" shows in the value slot. */}
+                  <InputLabel shrink>Owner</InputLabel>
                   <Select
+                    displayEmpty
                     value={draft.owner_id}
                     label="Owner"
                     onChange={e =>

--- a/apps/frontend/src/components/common/ViewField.tsx
+++ b/apps/frontend/src/components/common/ViewField.tsx
@@ -60,7 +60,6 @@ export default function ViewField({
           pl: '16px',
           pr: '12px',
           py: '16px',
-          alignItems: multiline ? 'flex-start' : 'center',
         }}
       >
         {children ?? (


### PR DESCRIPTION
## Purpose

The project detail page's metadata card rendered its edit mode with a different layout from its display mode, so clicking Edit visibly rearranged the card instead of just swapping text for inputs. Three separate causes: the Name column was `md: 3` while Owner took `md: 6`, so the longest field got the narrowest column; `columnSpacing`/`rowSpacing` switched on `isEditing` (`2` vs `'30px'`/`'20px'`), which changed every column's width at the same time; and the Owner `Select` had no `displayEmpty`, so a project with no owner rendered the label inside an apparently empty field. Fixing the card also turned up a save bug that is not in the issue but is arguably the most valuable change here, described below.

## What Changed

- Name and Owner swap grid widths — Name goes `md: 3` to `md: 6`, Owner `md: 6` to `md: 3`. At a 1554px container this takes the Name column from 366px to 762px, which is what the field actually needs.
- `columnSpacing` and `rowSpacing` no longer switch on `isEditing`. Both modes now use the display-mode `'30px'`/`'20px'`, so column widths and positions are identical between modes at every width.
- The Owner `Select` gets `displayEmpty` and its `InputLabel` gets `shrink`. Without them, a project with no owner rendered a zero-width space as the select's value and left the label sitting unshrunk inside the field, so the existing `'Not assigned'` fallback never appeared.
- `handleSave` now returns the `onSave` result instead of `undefined`. This is outside the issue's scope but worth reviewing closely: `EditableSection` treats any non-`false` return as success (`if (ok !== false)` at `EditableSection.tsx:90`), and `handleUpdateProject` returns `false` on failure, so with `handleSave` swallowing that value the card left edit mode and looked saved even when the update had failed and an error toast was on screen. The user lost their input.
- Removed a dead `alignItems` from `ViewField`'s `Box`, which has no `display: flex`, so the property never had any effect. It is a no-op by construction, which is why touching this shared component cannot affect the other 17 `EditableSection` call sites.

## Additional Context

Fixes #2399

A known limitation remains and is deliberately out of scope: entering edit mode still shifts rows by about 28px, because `ViewField` puts its label above the box (84px tall) while MUI's outlined `TextField` puts the label on the border (56px tall). That cannot be fixed inside one card — it needs a design decision about which of the two label positions wins, and it touches all 18 `EditableSection` call sites. A follow-up issue is planned for it.

Be aware the grid-spacing part of this is a modest fix, not a dramatic one. The sideways column slide it removes was only 3-7px; the more noticeable effect was every column changing width by roughly 11px at the same moment. Both are gone now, but nobody should expect a large visual difference from that hunk alone.

The same `columnSpacing={isEditing ? 2 : '30px'}` pattern still exists in `TaskDetailsCard.tsx`, `TestMetadataCard.tsx`, `TestTechnicalCard.tsx`, `TestSetDetailsCard.tsx`, `endpoint-overview-utils.ts`, `OrganizationDetailsForm.tsx` and `ContactInformationForm.tsx`, each carrying the same latent shift. Left alone on purpose to keep this PR scoped to the card the issue is about.

## Testing

Automated checks, all clean on this branch after rebasing onto `main`: `npm run type-check`, `npx eslint --max-warnings 0` on both changed files, `npx prettier --check` on both, `node scripts/check-hardcoded-styles.js` on both, and the full jest suite at 211 suites / 1949 tests passing. Note honestly that jest proves nothing about this change specifically — there are no unit tests covering `ProjectMetadataCard`, `EditableSection` or `ViewField`, so the behavioural verification below was done by driving a real dev stack with Playwright.

To reproduce manually you need two projects: one with an owner set and one with no owner, both with names long enough to strain the Name column (35-40 characters works). The no-owner project is the important one — a project that already has an owner never exercises the Owner-label defect. Note the route requires a UUID: `/projects/<uuid>` works, and passing a `nano_id` returns 422 because the backend's `GET /{project_id}` is typed `uuid.UUID`.

Measured on a running dev stack at viewport widths 1920, 1512, 1100 and 950, light theme. Grid spacing is now identical between display and edit mode at every width (`columnGap: 30px`, `rowGap: 20px` in both). The Owner field on the no-owner project reads `Not assigned` in display mode, and in edit mode the label is shrunk and floated above the border with the select's text reading `Not assigned` as real characters rather than a zero-width space. The Name column measures 762px at 1920, 588px at 1512, 352px at 1100 and 277px at 950.

One caveat on the clipping fix, since the issue frames it as clipping: widening the column removes clipping at wide viewports but does not eliminate it everywhere. A 40-character name still overflows its input at 1100px (scrollWidth 374 vs clientWidth 352) and at 950px (374 vs 277), and long names still wrap to three lines in display mode at those widths. The column is twice as wide as before, which is a clear improvement, but a reviewer should not read this as "long names now always fit".

The save fix was verified by intercepting the project update request and forcing a 500. With the fix the card stays in edit mode, keeps all three inputs mounted, and shows the `API error: 500` toast rather than silently closing as if the save had worked.
