### PR TITLE
Guard the active project from deletion and fix the post-delete flow

### DIFF
--- a/apps/frontend/src/app/(protected)/projects/[identifier]/__tests__/client-wrapper.test.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/__tests__/client-wrapper.test.tsx
@@ -244,4 +244,33 @@ describe('Project detail ClientWrapper active-project guard', () => {
 
     expect(editFab()).toBeEnabled();
   });
+
+  it('refuses the delete when the project became active while the dialog was open', async () => {
+    // No active-project cookie yet, so the FAB renders enabled.
+    mockActiveProject = null;
+    const { rerender } = render(
+      <ClientWrapper project={makeProject()} projectId="proj-1" />
+    );
+
+    await openDeleteModal();
+
+    // ActiveProjectContext resolves and auto-selects this project.
+    mockActiveProject = { id: 'proj-1', name: 'My Project' } as Project;
+    rerender(<ClientWrapper project={makeProject()} projectId="proj-1" />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /confirm delete/i })
+    );
+
+    expect(mockDeleteProject).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument()
+    );
+    // The dialog must not just vanish with no explanation.
+    expect(mockShow).toHaveBeenCalledWith(
+      ACTIVE_PROJECT_DELETE_BLOCKED,
+      expect.objectContaining({ severity: 'warning' })
+    );
+  });
 });

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/__tests__/client-wrapper.test.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/__tests__/client-wrapper.test.tsx
@@ -4,14 +4,21 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import ClientWrapper from '../client-wrapper';
 import type { Project } from '@/utils/api-client/interfaces/project';
+import { ACTIVE_PROJECT_DELETE_BLOCKED } from '../../constants';
 
-const mockPush = jest.fn();
+const mockReplace = jest.fn();
 const mockDeleteProject = jest.fn();
 const mockShow = jest.fn();
 const mockSyncProject = jest.fn();
+const mockRefreshActiveProjects = jest.fn();
+let mockActiveProject: Project | null = null;
 
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush, refresh: jest.fn() }),
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: mockReplace,
+    refresh: jest.fn(),
+  }),
   useParams: () => ({ identifier: 'my-project' }),
   useSearchParams: () => new URLSearchParams(),
   usePathname: () => '/projects/my-project',
@@ -22,7 +29,12 @@ jest.mock('@/hooks/useOnboardingTour', () => ({
 }));
 
 jest.mock('@/contexts/ActiveProjectContext', () => ({
-  useActiveProject: () => ({ syncProject: mockSyncProject }),
+  useActiveProject: () => ({
+    syncProject: mockSyncProject,
+    activeProject: mockActiveProject,
+    projects: [],
+    refresh: mockRefreshActiveProjects,
+  }),
 }));
 
 jest.mock('@/components/common/NotificationContext', () => ({
@@ -103,10 +115,20 @@ const makeProject = (): Project =>
     owner: { id: 'user-1', name: 'Alice', email: 'alice@example.com' },
   }) as Project;
 
+function deleteFab() {
+  return within(screen.getByTestId('page-actions')).getByRole('button', {
+    name: 'Delete project',
+  });
+}
+
+function editFab() {
+  return within(screen.getByTestId('page-actions')).getByRole('button', {
+    name: 'Edit project',
+  });
+}
+
 async function openDeleteModal() {
-  const actions = screen.getByTestId('page-actions');
-  const fabButtons = within(actions).getAllByRole('button');
-  await userEvent.click(fabButtons[1]);
+  await userEvent.click(deleteFab());
   expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
 }
 
@@ -114,6 +136,8 @@ describe('Project detail ClientWrapper delete flow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDeleteProject.mockResolvedValue(undefined);
+    mockRefreshActiveProjects.mockResolvedValue(undefined);
+    mockActiveProject = null;
   });
 
   it('closes the delete modal after a successful delete', async () => {
@@ -130,10 +154,29 @@ describe('Project detail ClientWrapper delete flow', () => {
     await waitFor(() =>
       expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument()
     );
-    expect(mockPush).toHaveBeenCalledWith('/projects');
+    expect(mockRefreshActiveProjects).toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledWith('/projects');
     expect(mockShow).toHaveBeenCalledWith(
       'Project deleted successfully',
       expect.objectContaining({ severity: 'success' })
+    );
+  });
+
+  it('unmounts the detail body once the project is gone', async () => {
+    render(<ClientWrapper project={makeProject()} projectId="proj-1" />);
+    expect(screen.getByTestId('project-detail-tabs')).toBeInTheDocument();
+
+    await openDeleteModal();
+    await userEvent.click(
+      screen.getByRole('button', { name: /confirm delete/i })
+    );
+
+    // The empty detail shell must never be shown between the DELETE and the
+    // navigation landing.
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('project-detail-tabs')
+      ).not.toBeInTheDocument()
     );
   });
 
@@ -156,6 +199,49 @@ describe('Project detail ClientWrapper delete flow', () => {
     await waitFor(() =>
       expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument()
     );
-    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(screen.getByTestId('project-detail-tabs')).toBeInTheDocument();
+  });
+});
+
+describe('Project detail ClientWrapper active-project guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDeleteProject.mockResolvedValue(undefined);
+    mockRefreshActiveProjects.mockResolvedValue(undefined);
+    mockActiveProject = null;
+  });
+
+  it('disables delete with a reason when viewing the active project', async () => {
+    mockActiveProject = { id: 'proj-1', name: 'My Project' } as Project;
+
+    render(<ClientWrapper project={makeProject()} projectId="proj-1" />);
+
+    const fab = deleteFab();
+    expect(fab).toBeDisabled();
+
+    // Hover the span wrapper: the disabled button itself has pointer-events: none.
+    await userEvent.hover(fab.parentElement as HTMLElement);
+    expect(
+      await screen.findByRole('tooltip', {
+        name: ACTIVE_PROJECT_DELETE_BLOCKED,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('leaves delete enabled when a different project is active', () => {
+    mockActiveProject = { id: 'proj-2', name: 'Other Project' } as Project;
+
+    render(<ClientWrapper project={makeProject()} projectId="proj-1" />);
+
+    expect(deleteFab()).toBeEnabled();
+  });
+
+  it('keeps edit available on the active project', () => {
+    mockActiveProject = { id: 'proj-1', name: 'My Project' } as Project;
+
+    render(<ClientWrapper project={makeProject()} projectId="proj-1" />);
+
+    expect(editFab()).toBeEnabled();
   });
 });

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
@@ -120,6 +120,17 @@ export default function ClientWrapper({
   );
 
   const handleDeleteConfirm = async () => {
+    // The FAB is guarded at render time, but activeProject can resolve after this
+    // page rendered — a session with no active-project cookie and a single project
+    // auto-selects it client-side — so the FAB may have been enabled when the
+    // dialog opened. Re-check before the DELETE, as the list page does.
+    if (isActiveProject) {
+      notifications.show(ACTIVE_PROJECT_DELETE_BLOCKED, {
+        severity: 'warning',
+      });
+      setDeleteConfirmOpen(false);
+      return;
+    }
     setIsDeleting(true);
     try {
       const apiFactory = new ApiClientFactory();

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
@@ -18,6 +18,11 @@ import { DeleteModal } from '@/components/common/DeleteModal';
 import { Can } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import PageLoadingState from '@/components/common/PageLoadingState';
+import {
+  ACTIVE_PROJECT_DELETE_BLOCKED,
+  PROJECT_DELETE_WARNING,
+} from '../constants';
 import ProjectEditDrawer from './edit-drawer';
 import ProjectDetailTabs from './components/ProjectDetailTabs';
 import { format } from 'date-fns';
@@ -41,9 +46,19 @@ export default function ClientWrapper({
   const [currentProject, setCurrentProject] = useState<Project>(project);
   const [isUpdating, setIsUpdating] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isDeleted, setIsDeleted] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const notifications = useNotifications();
-  const { syncProject } = useActiveProject();
+  const {
+    activeProject,
+    refresh: refreshActiveProjects,
+    syncProject,
+  } = useActiveProject();
+
+  // Deleting the project that scopes the whole app would leave every other view
+  // pointing at something that no longer exists. Switch away from it first.
+  const isActiveProject =
+    !!activeProject && String(activeProject.id) === String(projectId);
 
   const title = currentProject.name || `Project ${params.identifier}`;
   const breadcrumbs: BreadcrumbItem[] = [
@@ -110,16 +125,27 @@ export default function ClientWrapper({
       const apiFactory = new ApiClientFactory();
       const projectsClient = apiFactory.getProjectsClient();
       await projectsClient.deleteProject(projectId);
+      // Unmount the detail body on this same render: the tabs below fire their
+      // own project-scoped requests, and the refresh and navigation each take a
+      // round trip. Without this the user watches the deleted project's tabs
+      // fail one by one.
+      setIsDeleted(true);
+      setDeleteConfirmOpen(false);
       notifications.show('Project deleted successfully', {
         severity: 'success',
       });
-      router.push('/projects');
+      // The sidebar and switcher read ActiveProjectProvider state seeded by the
+      // root layout, which router.refresh() does not re-run — so this is the only
+      // way to drop the project from them without a full reload. It also clears
+      // the active-project cookie when the deleted project was the active one.
+      await refreshActiveProjects();
+      // replace, not push: the deleted project's URL must not come back on Back.
+      router.replace('/projects');
     } catch (error) {
       notifications.show(
         error instanceof Error ? error.message : 'Failed to delete project',
         { severity: 'error' }
       );
-    } finally {
       setDeleteConfirmOpen(false);
       setIsDeleting(false);
     }
@@ -131,6 +157,7 @@ export default function ClientWrapper({
         <Fab
           icon={<EditIcon sx={{ fontSize: 28 }} />}
           tooltip="Edit project"
+          aria-label="Edit project"
           onClick={() => setIsDrawerOpen(true)}
           disabled={isUpdating || isDeleting}
         />
@@ -138,14 +165,21 @@ export default function ClientWrapper({
       <Can capability={Capability.Project.UPDATE}>
         <Fab
           icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
-          tooltip="Delete project"
+          tooltip={
+            isActiveProject ? ACTIVE_PROJECT_DELETE_BLOCKED : 'Delete project'
+          }
+          aria-label="Delete project"
           onClick={() => setDeleteConfirmOpen(true)}
           loading={isDeleting}
-          disabled={isUpdating}
+          disabled={isUpdating || isActiveProject}
         />
       </Can>
     </FabGroup>
   );
+
+  // The project is gone; hold a neutral state until router.replace() lands rather
+  // than rendering a detail page with nothing behind it.
+  if (isDeleted) return <PageLoadingState />;
 
   return (
     <PageLayout
@@ -175,6 +209,14 @@ export default function ClientWrapper({
         itemType="project"
         itemName={currentProject.name}
         title="Delete Project"
+        warningMessage={PROJECT_DELETE_WARNING}
+        message={
+          <>
+            Are you sure you want to delete{' '}
+            <strong>{currentProject.name}</strong>? This action cannot be
+            undone.
+          </>
+        }
       />
     </PageLayout>
   );

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/page.tsx
@@ -1,5 +1,8 @@
+import { notFound } from 'next/navigation';
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
+import type { Project } from '@/utils/api-client/interfaces/project';
 import ClientWrapper from './client-wrapper';
 
 interface PageProps {
@@ -17,7 +20,19 @@ export default async function ProjectDetailPage({ params }: PageProps) {
   const apiFactory = await createServerApiFactory();
   const projectsClient = apiFactory.getProjectsClient();
   const resolvedParams = await params;
-  const project = await projectsClient.getProject(resolvedParams.identifier);
+
+  let project: Project;
+  try {
+    project = await projectsClient.getProject(resolvedParams.identifier);
+  } catch (error) {
+    // Projects deviate from the repo's 404-only notFoundIfEntityMissing pattern on
+    // purpose. A deleted project comes back as 410 with a restore offer, but deleting
+    // a project hard-drops every project_membership row and restoring does not
+    // re-enroll anyone — so a restored project would be invisible to everyone. Treat
+    // gone and missing the same way.
+    if (isNotFoundApiError(error)) notFound();
+    throw error;
+  }
 
   return <ClientWrapper project={project} projectId={project.id} />;
 }

--- a/apps/frontend/src/app/(protected)/projects/components/ProjectCard.tsx
+++ b/apps/frontend/src/app/(protected)/projects/components/ProjectCard.tsx
@@ -104,10 +104,17 @@ interface ProjectCardProps {
   project: Project;
   isLoading?: boolean;
   onDelete?: () => void;
+  /** When set, the trash can renders disabled with this as its tooltip. */
+  deleteDisabledReason?: string;
 }
 
 const ProjectCard = React.memo(
-  ({ project, isLoading = false, onDelete }: ProjectCardProps) => {
+  ({
+    project,
+    isLoading = false,
+    onDelete,
+    deleteDisabledReason,
+  }: ProjectCardProps) => {
     const router = useRouter();
 
     if (isLoading) {
@@ -149,6 +156,8 @@ const ProjectCard = React.memo(
         description={project.description}
         onClick={() => router.push(`/projects/${project.id}`)}
         onDelete={onDelete}
+        deleteDisabledReason={deleteDisabledReason}
+        deleteLabel="Delete project"
         userAvatar={project.owner?.picture}
         userName={project.owner?.name}
         chipSections={chipSections}

--- a/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material';
 import { useSession } from 'next-auth/react';
 import { DeleteModal } from '@/components/common/DeleteModal';
+import { useNotifications } from '@/components/common/NotificationContext';
 import { Project, ProjectCreate } from '@/utils/api-client/interfaces/project';
 import ProjectCard from './ProjectCard';
 import ProjectCreateDrawer from './ProjectCreateDrawer';
@@ -37,6 +38,10 @@ import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import {
+  ACTIVE_PROJECT_DELETE_BLOCKED,
+  PROJECT_DELETE_WARNING,
+} from '../constants';
 
 type StatusFilter = 'all' | 'active' | 'inactive';
 
@@ -68,7 +73,9 @@ export default function ProjectsClientWrapper() {
   const [rowsPerPage, setRowsPerPage] = useState(25);
 
   const { markStepComplete, progress, activeTour } = useOnboarding();
-  const { refresh: refreshActiveProjects } = useActiveProject();
+  const { activeProject, refresh: refreshActiveProjects } = useActiveProject();
+  const notifications = useNotifications();
+  const activeProjectId = activeProject ? String(activeProject.id) : null;
   const isOnProjectTour = activeTour === 'project';
   const isProjectButtonDisabled = activeTour !== null && !isOnProjectTour;
 
@@ -110,18 +117,31 @@ export default function ProjectsClientWrapper() {
 
   const confirmDelete = useCallback(async () => {
     if (!deleteTarget) return;
+    // The active project can only become known after the card rendered (no
+    // cookie yet, or a single project being auto-selected mid-flight), so a
+    // click can slip through the disabled trash can. Re-check before the DELETE.
+    if (activeProjectId !== null && deleteTarget.id === activeProjectId) {
+      setDeleteTarget(null);
+      return;
+    }
     try {
       const factory = new ApiClientFactory();
       const client = factory.getProjectsClient();
       await client.deleteProject(deleteTarget.id);
       setProjects(prev => prev.filter(p => p.id !== deleteTarget.id));
       await refreshActiveProjects();
+      notifications.show('Project deleted successfully', {
+        severity: 'success',
+      });
     } catch (error) {
-      console.error('Failed to delete project:', error);
+      notifications.show(
+        error instanceof Error ? error.message : 'Failed to delete project',
+        { severity: 'error' }
+      );
     } finally {
       setDeleteTarget(null);
     }
-  }, [deleteTarget, refreshActiveProjects]);
+  }, [deleteTarget, activeProjectId, refreshActiveProjects, notifications]);
 
   // Mark onboarding step complete when projects are loaded
   useEffect(() => {
@@ -323,6 +343,11 @@ export default function ProjectsClientWrapper() {
                           })
                       : undefined
                   }
+                  deleteDisabledReason={
+                    String(project.id) === activeProjectId
+                      ? ACTIVE_PROJECT_DELETE_BLOCKED
+                      : undefined
+                  }
                 />
               ))}
             </Box>
@@ -366,6 +391,7 @@ export default function ProjectsClientWrapper() {
         onClose={() => setDeleteTarget(null)}
         onConfirm={confirmDelete}
         title="Delete project?"
+        warningMessage={PROJECT_DELETE_WARNING}
         message={
           <>
             Are you sure you want to delete{' '}

--- a/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
@@ -121,6 +121,9 @@ export default function ProjectsClientWrapper() {
     // cookie yet, or a single project being auto-selected mid-flight), so a
     // click can slip through the disabled trash can. Re-check before the DELETE.
     if (activeProjectId !== null && deleteTarget.id === activeProjectId) {
+      notifications.show(ACTIVE_PROJECT_DELETE_BLOCKED, {
+        severity: 'warning',
+      });
       setDeleteTarget(null);
       return;
     }

--- a/apps/frontend/src/app/(protected)/projects/components/__tests__/ProjectsClientWrapper.test.tsx
+++ b/apps/frontend/src/app/(protected)/projects/components/__tests__/ProjectsClientWrapper.test.tsx
@@ -189,6 +189,11 @@ describe('ProjectsClientWrapper active-project delete guard', () => {
       expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument()
     );
     expect(mockDeleteProject).not.toHaveBeenCalled();
+    // The dialog must not just vanish with no explanation.
+    expect(mockShow).toHaveBeenCalledWith(
+      ACTIVE_PROJECT_DELETE_BLOCKED,
+      expect.objectContaining({ severity: 'warning' })
+    );
   });
 
   it('surfaces a failed delete instead of failing silently', async () => {

--- a/apps/frontend/src/app/(protected)/projects/components/__tests__/ProjectsClientWrapper.test.tsx
+++ b/apps/frontend/src/app/(protected)/projects/components/__tests__/ProjectsClientWrapper.test.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import ProjectsClientWrapper from '../ProjectsClientWrapper';
+import { ACTIVE_PROJECT_DELETE_BLOCKED } from '../../constants';
+import type { Project } from '@/utils/api-client/interfaces/project';
+
+const mockGetAllProjects = jest.fn();
+const mockDeleteProject = jest.fn();
+const mockRefreshActiveProjects = jest.fn();
+const mockShow = jest.fn();
+let mockActiveProject: Project | null = null;
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { user: { id: 'user-1' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    refresh: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
+jest.mock('@/contexts/ActiveProjectContext', () => ({
+  useActiveProject: () => ({
+    activeProject: mockActiveProject,
+    projects: [],
+    loading: false,
+    refresh: mockRefreshActiveProjects,
+    syncProject: jest.fn(),
+    setActiveProject: jest.fn(),
+  }),
+}));
+
+jest.mock('@/contexts/OnboardingContext', () => ({
+  useOnboarding: () => ({
+    markStepComplete: jest.fn(),
+    progress: { projectCreated: true },
+    activeTour: null,
+  }),
+}));
+
+jest.mock('@/hooks/useOnboardingTour', () => ({
+  useOnboardingTour: jest.fn(),
+}));
+
+jest.mock('@/components/common/NotificationContext', () => ({
+  useNotifications: () => ({ show: mockShow, close: jest.fn() }),
+}));
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getProjectsClient: () => ({
+      getAllProjects: mockGetAllProjects,
+      deleteProject: mockDeleteProject,
+      createProject: jest.fn(),
+    }),
+  })),
+}));
+
+jest.mock('@/components/layout/PageLayout', () => ({
+  PageLayout: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+jest.mock('../ProjectCreateDrawer', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../ProjectFilterDrawer', () => ({
+  __esModule: true,
+  default: () => null,
+  EMPTY_FILTERS: { activeStatus: null, environments: [] },
+  hasActiveProjectFilters: () => false,
+  countActiveProjectFilters: () => 0,
+}));
+
+jest.mock('@/components/common/DeleteModal', () => ({
+  DeleteModal: ({
+    open,
+    onConfirm,
+  }: {
+    open: boolean;
+    onConfirm: () => void;
+  }) =>
+    open ? (
+      <div data-testid="delete-modal">
+        <button onClick={onConfirm}>Confirm Delete</button>
+      </div>
+    ) : null,
+}));
+
+const ACTIVE = { id: 'proj-1', name: 'Regulatory Advisor' } as Project;
+const OTHER = { id: 'proj-2', name: 'Example Project' } as Project;
+
+function trashFor(name: string) {
+  // The card root is a ButtonBase; the trash can lives inside it.
+  const card = screen
+    .getByText(name)
+    .closest('.MuiButtonBase-root') as HTMLElement;
+  return within(card).getByRole('button', { name: 'Delete project' });
+}
+
+async function renderList() {
+  const { rerender } = render(<ProjectsClientWrapper />);
+  await waitFor(() =>
+    expect(screen.getByText('Regulatory Advisor')).toBeInTheDocument()
+  );
+  return { rerender: () => rerender(<ProjectsClientWrapper />) };
+}
+
+describe('ProjectsClientWrapper active-project delete guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAllProjects.mockResolvedValue([ACTIVE, OTHER]);
+    mockDeleteProject.mockResolvedValue(undefined);
+    mockRefreshActiveProjects.mockResolvedValue(undefined);
+    mockActiveProject = ACTIVE;
+  });
+
+  it('disables the trash can on the active project only', async () => {
+    await renderList();
+
+    expect(trashFor('Regulatory Advisor')).toBeDisabled();
+    expect(trashFor('Example Project')).toBeEnabled();
+  });
+
+  it('explains why the active project cannot be deleted', async () => {
+    await renderList();
+
+    const trash = trashFor('Regulatory Advisor');
+    // Hover the span wrapper: the disabled button has pointer-events: none.
+    await userEvent.hover(trash.parentElement as HTMLElement);
+
+    expect(
+      await screen.findByRole('tooltip', {
+        name: ACTIVE_PROJECT_DELETE_BLOCKED,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('deletes a non-active project and refreshes the sidebar list', async () => {
+    await renderList();
+
+    await userEvent.click(trashFor('Example Project'));
+    await userEvent.click(
+      screen.getByRole('button', { name: /confirm delete/i })
+    );
+
+    await waitFor(() =>
+      expect(mockDeleteProject).toHaveBeenCalledWith('proj-2')
+    );
+    expect(mockRefreshActiveProjects).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.queryByText('Example Project')).not.toBeInTheDocument()
+    );
+  });
+
+  it('refuses the delete when the target became the active project mid-flight', async () => {
+    mockActiveProject = null;
+    const { rerender } = await renderList();
+
+    await userEvent.click(trashFor('Example Project'));
+    // The active project resolves while the confirmation dialog is open — the
+    // re-render is what a real context update would trigger.
+    mockActiveProject = OTHER;
+    rerender();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /confirm delete/i })
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument()
+    );
+    expect(mockDeleteProject).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed delete instead of failing silently', async () => {
+    mockDeleteProject.mockRejectedValue(new Error('Server error'));
+    await renderList();
+
+    await userEvent.click(trashFor('Example Project'));
+    await userEvent.click(
+      screen.getByRole('button', { name: /confirm delete/i })
+    );
+
+    await waitFor(() =>
+      expect(mockShow).toHaveBeenCalledWith(
+        'Server error',
+        expect.objectContaining({ severity: 'error' })
+      )
+    );
+    expect(screen.getByText('Example Project')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/projects/constants.ts
+++ b/apps/frontend/src/app/(protected)/projects/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Why deleting is blocked on the project currently scoping the app. Shared by the
+ * card trash can and the detail-page FAB so the two can't drift apart.
+ */
+export const ACTIVE_PROJECT_DELETE_BLOCKED =
+  'Active project — cannot be deleted. Switch to another project first.';
+
+/** What a user actually loses when a project goes away. */
+export const PROJECT_DELETE_WARNING =
+  'Everyone on this project loses access. Its endpoints, tests, and results stop showing up in the app.';

--- a/apps/frontend/src/components/common/DetailNotFoundState.tsx
+++ b/apps/frontend/src/components/common/DetailNotFoundState.tsx
@@ -10,6 +10,7 @@ import EntityMessageState from '@/components/common/EntityMessageState';
 import { useCrossProjectResolve } from '@/hooks/useCrossProjectResolve';
 import {
   buildNotFoundEntityData,
+  isResolvableEntityTable,
   NotFoundEntityData,
 } from '@/utils/entity-error-handler';
 import {
@@ -52,8 +53,15 @@ export default function DetailNotFoundState({
   onRetry,
   isRetrying = false,
 }: DetailNotFoundStateProps) {
+  // Skip the resolve for entities the backend can't resolve across projects —
+  // otherwise its rejection reads as "we couldn't check right now, try again",
+  // which hides the real answer: the thing is gone.
   const { crossProjectData, isResolving, resolveError, retryResolve } =
-    useCrossProjectResolve(entityTableName, entityId);
+    useCrossProjectResolve(
+      entityTableName,
+      entityId,
+      isResolvableEntityTable(entityTableName)
+    );
 
   const entityData = useMemo(
     () =>

--- a/apps/frontend/src/components/common/EntityCard.tsx
+++ b/apps/frontend/src/components/common/EntityCard.tsx
@@ -2,7 +2,14 @@
 
 import React from 'react';
 import { alpha, useTheme, type Theme } from '@mui/material/styles';
-import { Box, ButtonBase, Typography, Avatar, IconButton } from '@mui/material';
+import {
+  Box,
+  ButtonBase,
+  Typography,
+  Avatar,
+  IconButton,
+  Tooltip,
+} from '@mui/material';
 import { DeleteIcon } from '@/components/icons';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import GridBadge from '@/components/common/GridBadge';
@@ -30,6 +37,10 @@ export interface EntityCardProps {
   description?: string;
   onClick?: () => void;
   onDelete?: () => void;
+  /** When set, the delete button renders disabled with this as its tooltip. */
+  deleteDisabledReason?: string;
+  /** Accessible name for the delete button, and its tooltip when enabled. */
+  deleteLabel?: string;
   userAvatar?: string;
   userName?: string;
   status?: 'active' | 'inactive' | string;
@@ -99,6 +110,8 @@ export default function EntityCard({
   description,
   onClick,
   onDelete,
+  deleteDisabledReason,
+  deleteLabel = 'Delete',
   userAvatar,
   userName,
   status,
@@ -167,20 +180,35 @@ export default function EntityCard({
         >
           {topRightActions}
           {onDelete && (
-            <IconButton
-              size="small"
-              onClick={e => {
-                e.stopPropagation();
-                onDelete();
-              }}
-              sx={{
-                color: 'primary.dark',
-                padding: '2px',
-                '& .MuiSvgIcon-root': { fontSize: 20 },
-              }}
-            >
-              <DeleteIcon />
-            </IconButton>
+            <Tooltip title={deleteDisabledReason || deleteLabel}>
+              {/* The span keeps the tooltip working on a disabled button, and
+                  carries the cursor — MUI sets pointer-events: none on the
+                  button itself once disabled. */}
+              <Box
+                component="span"
+                sx={{
+                  display: 'inline-flex',
+                  cursor: deleteDisabledReason ? 'not-allowed' : undefined,
+                }}
+              >
+                <IconButton
+                  size="small"
+                  aria-label={deleteLabel}
+                  disabled={!!deleteDisabledReason}
+                  onClick={e => {
+                    e.stopPropagation();
+                    onDelete();
+                  }}
+                  sx={{
+                    color: 'primary.dark',
+                    padding: '2px',
+                    '& .MuiSvgIcon-root': { fontSize: 20 },
+                  }}
+                >
+                  <DeleteIcon />
+                </IconButton>
+              </Box>
+            </Tooltip>
           )}
         </Box>
       )}

--- a/apps/frontend/src/components/common/__tests__/EntityCard.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/EntityCard.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import EntityCard from '../EntityCard';
 
 const defaultProps = {
@@ -120,6 +121,88 @@ describe('EntityCard', () => {
       screen.getByText('My Entity').closest('.MuiButtonBase-root')
     ).toHaveStyle({
       justifyContent: 'flex-start',
+    });
+  });
+  describe('delete button', () => {
+    it('names the delete button and fires onDelete when enabled', async () => {
+      const onDelete = jest.fn();
+      render(<EntityCard {...defaultProps} onDelete={onDelete} />);
+
+      const button = screen.getByRole('button', { name: 'Delete' });
+      expect(button).toBeEnabled();
+
+      await userEvent.click(button);
+      expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses deleteLabel as the accessible name', () => {
+      render(
+        <EntityCard
+          {...defaultProps}
+          onDelete={jest.fn()}
+          deleteLabel="Delete project"
+        />
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'Delete project' })
+      ).toBeInTheDocument();
+    });
+
+    it('disables the delete button and swallows clicks when a reason is given', async () => {
+      const onDelete = jest.fn();
+      render(
+        <EntityCard
+          {...defaultProps}
+          onDelete={onDelete}
+          deleteDisabledReason="Active project — cannot be deleted."
+        />
+      );
+
+      const button = screen.getByRole('button', { name: 'Delete' });
+      expect(button).toBeDisabled();
+      // MUI puts pointer-events: none on a disabled button, so a real click never
+      // reaches it — the span wrapper absorbs it.
+      expect(button).toHaveStyle({ pointerEvents: 'none' });
+
+      await userEvent.click(button.parentElement as HTMLElement);
+      expect(onDelete).not.toHaveBeenCalled();
+    });
+
+    it('shows the reason as the tooltip on the disabled delete button', async () => {
+      render(
+        <EntityCard
+          {...defaultProps}
+          onDelete={jest.fn()}
+          deleteDisabledReason="Active project — cannot be deleted."
+        />
+      );
+
+      // Hovering the wrapper, not the button: MUI sets pointer-events: none on a
+      // disabled button, which is exactly why the span wrapper exists.
+      const wrapper = screen.getByRole('button', { name: 'Delete' })
+        .parentElement as HTMLElement;
+      await userEvent.hover(wrapper);
+
+      expect(
+        await screen.findByRole('tooltip', {
+          name: 'Active project — cannot be deleted.',
+        })
+      ).toBeInTheDocument();
+    });
+
+    it('keeps the title clear of the top-right slot when delete is disabled', () => {
+      render(
+        <EntityCard
+          {...defaultProps}
+          onDelete={jest.fn()}
+          deleteDisabledReason="Nope"
+        />
+      );
+
+      expect(screen.getByText('My Entity')).toHaveStyle({
+        paddingRight: '36px',
+      });
     });
   });
 });

--- a/apps/frontend/src/contexts/OnboardingContext.tsx
+++ b/apps/frontend/src/contexts/OnboardingContext.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/utils/onboarding-service';
 import { getTourSteps, driverConfig } from '@/config/onboarding-tours';
 import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
+import { useActiveProject } from '@/contexts/ActiveProjectContext';
 
 const OnboardingContext = createContext<OnboardingContextValue | undefined>(
   undefined
@@ -54,6 +55,9 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
   const { data: session, status } = useSession();
   const queryClient = useQueryClient();
   const userScope = useUserScope();
+  // Mounted inside ActiveProjectProvider (see LayoutContent), so the live project
+  // list is available here — used to keep `projectCreated` honest below.
+  const { projects, loading: projectsLoading } = useActiveProject();
   // Initialize with localStorage data immediately to avoid flash
   const [progress, setProgress] = useState<OnboardingProgress>(() => {
     // Load synchronously during initialization to prevent flash
@@ -401,11 +405,21 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
     status,
   ]);
 
-  const isComplete = isOnboardingComplete(progress);
-  const completionPercentage = calculateCompletionPercentage(progress);
+  // A stored `projectCreated` can outlive the project — another member deletes it,
+  // or the API does — leaving the checklist claiming a step with no project behind
+  // it. Derive the flag from the live list instead of trusting the stored bit.
+  // Deliberately never written back: mergeProgress ORs local with remote, so an
+  // unset would be resurrected on the next load.
+  const effectiveProgress: OnboardingProgress =
+    projectsLoading || projects.length > 0 || !progress.projectCreated
+      ? progress
+      : { ...progress, projectCreated: false };
+
+  const isComplete = isOnboardingComplete(effectiveProgress);
+  const completionPercentage = calculateCompletionPercentage(effectiveProgress);
 
   const value: OnboardingContextValue = {
-    progress,
+    progress: effectiveProgress,
     isComplete,
     completionPercentage,
     markStepComplete,

--- a/apps/frontend/src/utils/__tests__/entity-error-handler.test.ts
+++ b/apps/frontend/src/utils/__tests__/entity-error-handler.test.ts
@@ -8,6 +8,7 @@ import {
   parseEntityFromPathname,
   urlSegmentToResolveEntityType,
   buildNotFoundEntityData,
+  isResolvableEntityTable,
 } from '../entity-error-handler';
 
 // ============================================================================
@@ -311,5 +312,28 @@ describe('buildNotFoundEntityData', () => {
     expect(result.model_name).toBe('TestSet');
     expect(result.table_name).toBe('test_set');
     expect(result.list_url).toBe('/test-sets');
+  });
+});
+
+// ============================================================================
+// isResolvableEntityTable
+// ============================================================================
+
+describe('isResolvableEntityTable', () => {
+  it.each(['endpoint', 'test_run', 'test_set', 'metric', 'task'])(
+    'resolves project-scoped entity %s',
+    table => {
+      expect(isResolvableEntityTable(table)).toBe(true);
+    }
+  );
+
+  it('does not resolve a project — it is not scoped to a project', () => {
+    expect(isResolvableEntityTable('project')).toBe(false);
+  });
+
+  it('does not resolve unknown or missing tables', () => {
+    expect(isResolvableEntityTable('organization')).toBe(false);
+    expect(isResolvableEntityTable(undefined)).toBe(false);
+    expect(isResolvableEntityTable('')).toBe(false);
   });
 });

--- a/apps/frontend/src/utils/entity-error-handler.ts
+++ b/apps/frontend/src/utils/entity-error-handler.ts
@@ -54,6 +54,31 @@ export function urlSegmentToResolveEntityType(urlSegment: string): string {
   );
 }
 
+/**
+ * Entity tables the backend can resolve across projects — mirrors
+ * ``RESOLVABLE_ENTITY_TABLES`` in ``routers/resolve.py``. Only project-scoped
+ * entities are in it: asking "is this in another project?" is meaningless for a
+ * project itself, and ``GET /resolve`` rejects anything outside this set.
+ */
+export const RESOLVABLE_ENTITY_TABLES = new Set([
+  'endpoint',
+  'experiment',
+  'metric',
+  'requirement',
+  'source',
+  'task',
+  'test',
+  'test_run',
+  'test_set',
+]);
+
+/** Whether a cross-project resolve is worth attempting for this table. */
+export function isResolvableEntityTable(
+  tableName: string | undefined
+): boolean {
+  return !!tableName && RESOLVABLE_ENTITY_TABLES.has(tableName);
+}
+
 export interface ParsedPathEntity {
   entityType: string;
   entityId: string;


### PR DESCRIPTION
## Purpose

The projects list showed a trash can on every card, including the card for the project you were currently working in — the one named in the sidebar, whose id goes out as the `X-Project-Id` header on every request. Nothing signalled that deleting it was a bad idea, and doing it left the app scoped to a project that no longer existed.

Issue #2415 reports the downstream half of the same problem: after deleting a project you stayed on its detail page, which rendered an empty shell with no title, and only manual navigation got you out.

## What Changed

- **The active project's trash can is now disabled** — dimmed, `cursor: not-allowed`, with a tooltip explaining why: *"Active project — cannot be deleted. Switch to another project first."* `EntityCard` gained a `deleteDisabledReason` prop for this; previously the delete button was all-or-nothing (rendered or absent), which is why `ModelCard` has to hide it entirely for protected models. The four other `EntityCard` call sites are unchanged. The trash can and the detail-page Delete FAB also gained accessible names, which they were missing.
- **The same guard on the detail page's Delete FAB.** The Edit FAB is untouched — editing the active project stays possible.
- **`confirmDelete` re-checks before the DELETE.** The active project can resolve after the card rendered (no cookie yet, or a single project being auto-selected mid-flight), so a click can slip through a not-yet-disabled trash can.
- **Deleting a project now lands somewhere sensible.** The detail body unmounts on the same render as the successful DELETE, so the tabs below don't fail one by one while the navigation is in flight; `router.replace` is used instead of `push` so Back can't return to the deleted URL.
- **The sidebar and switcher drop the project without a reload.** The detail page never called `useActiveProject().refresh()`, so a deleted project stayed in the switcher until a full page reload. `router.refresh()` would not have fixed this — that state is seeded by the root layout, which `router.refresh()` does not re-run.
- **A deleted project's URL renders the not-found state** instead of a blank page.
- **`projectCreated` onboarding progress is derived from the live project list** rather than a stored bit that was set once and never unset.
- **Failed deletes on the list page now surface.** The failure path only did `console.error`, so the dialog closed, the card stayed, and the user got no signal.

## Additional Context

Closes #2415.

Three things worth flagging for review:

**Projects return 410, not 404.** `crud/project.py` → `get_item_detail` → `_check_and_raise_if_deleted` raises `ItemDeletedException`, which `app/main.py:597` turns into 410 with `can_restore: true` (confirmed against a running backend). So this deliberately does *not* use the repo's `notFoundIfEntityMissing` helper, which is 404-only — that would miss the exact case the issue is about. The 410 path leads to `error.tsx`, which offers **Restore**, and that is a trap: `unenroll_all_project_members` hard-deletes every `project_membership` row and restore does not re-enroll anyone, so a restored project would be invisible to everyone including whoever restored it. "Gone" and "missing" get the same honest state.

**`DetailNotFoundState` was firing a cross-project resolve for the project itself.** A project isn't scoped to a project, so `project` isn't in the backend's `RESOLVABLE_ENTITY_TABLES` and `GET /resolve` rejects it — which made the page say *"We could not check other projects right now. Try again in a moment."*, a transient-failure message for a permanent condition. This adds a frontend mirror of that set and skips the resolve when it doesn't apply. It touches a shared component, so it fixes the same misleading copy for any other non-resolvable entity landing on a detail not-found page.

**Two acceptance criteria from the issue are not implemented, on purpose:**

- *"The zero-projects-after-delete case shows a post-delete state"* is **structurally prevented** rather than built. With the guard in place, `/projects` cannot reach zero through the UI: `ActiveProjectContext` auto-selects when there is exactly one project, the switcher never clears the selection, so the last project is always the active one and always guarded. A "you just deleted your last project" state would be dead code from day one. The guard tests are the evidence.
- The genuinely reachable zero-projects case — an admin removes you from every project — is **out of scope**. It already has its own component (`NoProjectAccess`), but `/projects` currently shows the first-run "No project yet" card instead. Changing that copy costs an E2E update (`mocked-states.spec.ts:38` asserts it) for a case unrelated to deletion.

Also note the guard is **UI-only**. `Capability.Project` has no `DELETE` — both delete paths gate on `UPDATE` — and `routers/project.py` only 404s on missing, so the backend does not reject deleting the active project. A second tab, the API, the SDK, or another member still can; the recovery path (`refresh()` clearing the active-project cookie) is what covers that.

## Testing

`npm run format`, `npm run type-check` and `npm run lint` are clean (0 errors; the 61 pre-existing warnings are all in files this PR does not touch). `npx jest` passes 212/212 suites, 1970 tests.

New and updated tests:

- `components/common/__tests__/EntityCard.test.tsx` — the enabled trash can has an accessible name and fires `onDelete`; with a reason it is disabled, carries the reason as its tooltip, and swallows clicks; the title still clears the top-right slot.
- `projects/components/__tests__/ProjectsClientWrapper.test.tsx` — new file, the list page had no test at all. The active project's trash can is disabled with its reason while the others are enabled; `confirmDelete` refuses a target that became active while the dialog was open; a failed delete surfaces.
- `projects/[identifier]/__tests__/client-wrapper.test.tsx` — moved off `getAllByRole` index lookups onto the new aria-labels; covers the FAB guard, the Edit FAB staying enabled, and the detail body unmounting before the navigation lands.
- `utils/__tests__/entity-error-handler.test.ts` — the resolvable-table set, including that `project` is not in it.

Verified end-to-end against a real backend and frontend (Playwright driving the app, not mocks):

| Check | Result |
| --- | --- |
| Active project trash can | `disabled`, `rgba(0, 0, 0, 0.26)` vs `rgb(0, 95, 130)` for the others, `cursor: not-allowed`, `pointer-events: none` |
| Tooltip on it | "Active project — cannot be deleted. Switch to another project first." |
| Clicking it | no dialog opens |
| Active project detail page | Delete FAB disabled with the same tooltip; Edit FAB enabled |
| Deleting a non-active project | lands on `/projects`; gone from the list; gone from the sidebar switcher without a reload |
| Back after the delete | does not return to the deleted URL |
| Deleted project's URL | "Project not found" with a Back to Projects action; no Restore offer |
| `GET /projects/<deleted>` | 410 (the reason for the `isNotFoundApiError` check) |

To try it manually: with two or more projects, open `/projects` and hover the trash can on the project named in the sidebar, then delete a different one from its detail page and watch the sidebar switcher.
