### PR TITLE
Fix Generate button staying enabled on incomplete OWASP form

### DIFF
--- a/apps/frontend/src/app/(protected)/test-sets/components/OwaspGenerateForm.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/OwaspGenerateForm.tsx
@@ -87,6 +87,8 @@ const EMPTY_CATEGORIES: Record<OwaspFramework, OwaspCategory[]> = {
 const MIN_TESTS = 5;
 const MAX_TESTS = 100;
 const DEFAULT_TESTS = 20;
+/** Too short a description gives the generator nothing to tailor attacks to. */
+const MIN_PURPOSE_LENGTH = 10;
 
 const categoryKey = (framework: OwaspFramework, id: string) =>
   `${framework}:${id}`;
@@ -274,8 +276,10 @@ export default function OwaspGenerateForm({
       return;
     }
 
-    if (!purpose.trim()) {
-      setError('Please describe what your system under test does');
+    if (purpose.trim().length < MIN_PURPOSE_LENGTH) {
+      setError(
+        `Please describe what your system under test does (at least ${MIN_PURPOSE_LENGTH} characters)`
+      );
       return;
     }
 
@@ -331,6 +335,10 @@ export default function OwaspGenerateForm({
     onSuccess,
   ]);
 
+  const trimmedPurposeLength = purpose.trim().length;
+  const purposeTooShort = trimmedPurposeLength < MIN_PURPOSE_LENGTH;
+  const canGenerate = selectionsByFramework.length > 0 && !purposeTooShort;
+
   const saveButtonText =
     selectionsByFramework.length > 1
       ? `Generate ${selectionsByFramework.length} Test Sets`
@@ -340,7 +348,7 @@ export default function OwaspGenerateForm({
     if (!active) return;
     onFooterChange?.({
       onSave: results ? undefined : handleGenerate,
-      saveDisabled: submitting || loadingCategories,
+      saveDisabled: submitting || loadingCategories || !canGenerate,
       saveButtonText,
       loading: submitting,
       closeButtonText: results ? 'Close' : 'Cancel',
@@ -352,6 +360,7 @@ export default function OwaspGenerateForm({
     handleGenerate,
     submitting,
     loadingCategories,
+    canGenerate,
     saveButtonText,
     onFooterChange,
   ]);
@@ -550,7 +559,12 @@ export default function OwaspGenerateForm({
           <TextField
             label="System under test"
             placeholder="e.g. Customer service chatbot for a retail bank with access to account balances and transfers"
-            helperText="Describe what the system does — attacks are tailored to this description."
+            helperText={
+              purposeTooShort
+                ? `Describe what the system does — at least ${MIN_PURPOSE_LENGTH} characters (${MIN_PURPOSE_LENGTH - trimmedPurposeLength} to go).`
+                : 'Describe what the system does — attacks are tailored to this description.'
+            }
+            error={trimmedPurposeLength > 0 && purposeTooShort}
             value={purpose}
             onChange={e => setPurpose(e.target.value)}
             fullWidth


### PR DESCRIPTION
## Purpose

In the "Generate from OWASP" drawer, the Generate button was always clickable. Clicking it with nothing selected or an empty system description just bounced back an inline error, so the validation rules were only discoverable by failing. The button now reflects whether the form is actually ready.

## What Changed

- The footer's Generate button stays disabled until at least one OWASP risk category is selected **and** the "System under test" description has at least 10 characters (trimmed).
- The "System under test" helper text shows how many characters are still needed while it's too short, and turns into an error state once the user has typed something but not enough — so the disabled button always has a visible reason.
- The click-time guard now checks the same 10-character rule instead of just non-empty, so its error message can't contradict the button state.

## Additional Context

- Only the OWASP tab is affected. The Garak tab already disabled its button when no probes were selected.
- No API or backend change — validation is purely client-side, and the backend still validates on its own.

## Testing

1. Open Test Sets → generate from a security source → OWASP tab.
2. With no risk category selected, confirm Generate is disabled even when the description is long (it may be prefilled from the active project).
3. Select a category, then clear the description: Generate goes disabled, and the helper text asks for at least 10 characters.
4. Type fewer than 10 characters: helper text shows the remaining count in red, button stays disabled.
5. Reach 10 characters with a category selected: helper text returns to normal and Generate becomes clickable; generation works as before.
