### PR TITLE
Keep architect tool data across turns, show reviews in full

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/architect/runner.py
+++ b/apps/backend/src/rhesis/backend/app/services/architect/runner.py
@@ -155,6 +155,7 @@ async def build_agent(
         plan_data=session_data["plan_data"],
         max_iterations=agent_state.get("max_iterations", 15),
         pending_tasks=agent_state.get("pending_tasks") or [],
+        carried_tool_results=agent_state.get("carried_tool_results") or [],
     )
 
     tool_provider = LocalToolProvider(fastapi_app, delegation_token, project_id=project_id)
@@ -270,6 +271,10 @@ async def persist_state(
             "guard_state": snapshot.guard_state,
             "pending_tasks": snapshot.pending_tasks,
             "id_to_name": snapshot.id_to_name,
+            # Rendered tool data from this and earlier turns. Execution
+            # history itself dies with the Celery task, so without this a
+            # follow-up question has only the agent's own prose to go on.
+            "carried_tool_results": snapshot.carried_tool_results,
         }
         if root_trace_id:
             # Read on the next turn by ``architect_chat_task`` and bound via

--- a/sdk/src/rhesis/sdk/agents/architect/agent.py
+++ b/sdk/src/rhesis/sdk/agents/architect/agent.py
@@ -40,6 +40,13 @@ from .workflow import WorkflowPath, resolve_workflow_path_update
 
 logger = logging.getLogger(__name__)
 
+# Pseudo-tools that stand for agent control flow, not fetched data.
+_INTERNAL_TOOL_NAMES: FrozenSet[str] = frozenset(t.value for t in InternalTool)
+
+# Floor on an unnamed record's share of the summary budget. Below this a
+# record is too clipped to be worth showing as a record at all.
+_MIN_RECORD_CHARS = 400
+
 
 # ── helpers ──────────────────────────────────────────────────────
 
@@ -87,10 +94,11 @@ def _unwrap_list_envelope(data: Any) -> Tuple[Optional[List[Any]], Dict[str, Any
 
 
 def _trim_for_summary(value: Any, max_chars: int) -> Any:
-    """Drop empty values and clip long strings, recursively.
+    """Drop empty values and clip runaway strings, recursively.
 
-    Keeps an unnamed record readable in a prompt without dumping the
-    whole payload.
+    ``max_chars`` is a backstop against one pathological field, not a
+    summary width — an unnamed record is the only place its content is
+    ever shown, so it has to arrive whole.
     """
     if isinstance(value, str):
         return value[:max_chars].rstrip() + "…" if len(value) > max_chars else value
@@ -225,6 +233,14 @@ class ArchitectAgent(BaseAgent):
         # Per-turn attachments (mentions + file text)
         self._attachments: Optional[Dict[str, Any]] = None
 
+        # Tool data from earlier turns, already rendered. The backend
+        # builds a fresh agent per user message, so _execution_history is
+        # empty on every follow-up; this is what survives.
+        self._carried_tool_results: List[str] = []
+        # Index into _execution_history where the current turn starts, so
+        # the streaming prompt can show this turn's data as this turn's.
+        self._turn_start_step: int = 0
+
     # ── public API ───────────────────────────────────────────────
 
     def chat(
@@ -266,6 +282,7 @@ class ArchitectAgent(BaseAgent):
             # leak into a later finish (e.g. an auto-resumed
             # [TASK_COMPLETED] summary).
             self._blocked_this_turn = False
+            self._turn_start_step = len(self._execution_history)
             self._conversation_history.append({"role": Role.USER, "content": message})
             self._maybe_update_workflow_path(message)
 
@@ -430,6 +447,8 @@ class ArchitectAgent(BaseAgent):
         self._attachments = None
         self._discovery_state = _default_discovery_state()
         self._id_to_name.clear()
+        self._carried_tool_results.clear()
+        self._turn_start_step = 0
         self._requirement_id_names.clear()
         self._metric_id_names.clear()
         self._linked_pairs.clear()
@@ -1193,6 +1212,8 @@ class ArchitectAgent(BaseAgent):
         content: str,
         max_items: int = 50,
         desc_chars: int = 80,
+        record_chars: int = 4_000,
+        record_block_chars: int = 20_000,
     ) -> Optional[str]:
         """Render a list/paginated-list tool result as a compact summary.
 
@@ -1202,6 +1223,16 @@ class ArchitectAgent(BaseAgent):
         emits one line per item (id, name, short description, key
         attributes) so every item in the page is visible to the LLM in a
         fraction of the bytes.
+
+        Two separate budgets, because the two item shapes are not the same
+        problem. A named entity gets ``desc_chars`` of its description —
+        the rest is one ``get_*`` call away. An unnamed record (an
+        annotation, a test result) is dumped whole: this rendering is the
+        only place its content is ever shown, so clipping it to a preview
+        width leaves the LLM completing a human's half-sentence. Those
+        records are bounded per field by ``record_chars`` and in aggregate
+        by ``record_block_chars``, both large enough that real data passes
+        through intact.
 
         Returns ``None`` when ``content`` is not a recognised list shape,
         so callers can fall back to plain truncation.
@@ -1247,19 +1278,35 @@ class ArchitectAgent(BaseAgent):
             return "\n".join(lines)
 
         shown = data[:max_items]
+        # Share the block budget across the unnamed records on this page, so a
+        # page of small records (annotations) is never clipped at all and a page
+        # of fat ones (test results) degrades in detail instead of losing rows.
+        # Dropping rows would read as "there were only four", which is the same
+        # lie as the bare "- ?" this renderer exists to prevent.
+        unnamed_count = sum(1 for item in shown if not (item.get("name") or item.get("title")))
+        allowance = record_chars
+        if unnamed_count:
+            allowance = min(
+                record_chars, max(_MIN_RECORD_CHARS, record_block_chars // unnamed_count)
+            )
+
         for item in shown:
             name = item.get("name") or item.get("title")
             if not name:
                 # Annotations, test results and anything else without a label
                 # would render as a bare "- ?", hiding every field from the
-                # LLM — which then invents the content. Keep the record.
+                # LLM — which then invents the content. Keep the record whole:
+                # a review comment clipped to a preview width is a half
+                # sentence the LLM finishes on the human's behalf.
                 # ensure_ascii=False so non-ASCII review text stays readable
                 # rather than arriving at the LLM as \uXXXX escapes.
                 compact_item = json.dumps(
-                    _trim_for_summary(item, desc_chars),
+                    _trim_for_summary(item, allowance),
                     default=str,
                     ensure_ascii=False,
                 )
+                if len(compact_item) > allowance:
+                    compact_item = compact_item[:allowance].rstrip() + "… [record truncated]"
                 lines.append(f"  - {compact_item}")
                 continue
             eid = item.get("id", "")
@@ -1284,7 +1331,6 @@ class ArchitectAgent(BaseAgent):
             lines.append(
                 f"  … and {len(data) - len(shown)} more item(s) on this page (omitted from summary)"
             )
-
         return "\n".join(lines)
 
     @staticmethod
@@ -1383,6 +1429,7 @@ class ArchitectAgent(BaseAgent):
             plan_data=plan_data,
             max_iterations=self.max_iterations,
             pending_tasks=list(self._pending_tasks),
+            carried_tool_results=self._build_carried_tool_results(),
         )
 
     def restore_state(self, snapshot: ArchitectAgentStateSnapshot) -> None:
@@ -1416,6 +1463,8 @@ class ArchitectAgent(BaseAgent):
 
         if snapshot.id_to_name:
             self._id_to_name = dict(snapshot.id_to_name)
+
+        self._carried_tool_results = list(snapshot.carried_tool_results)
 
         if snapshot.plan_data:
             try:
@@ -1664,13 +1713,72 @@ class ArchitectAgent(BaseAgent):
             return f"{prefix} Error: {tr.error}"
         return None
 
-    def _format_tool_results_for_streaming(self) -> str:
-        """Format tool results from the current turn."""
-        if not self._execution_history:
+    _CARRIED_RESULTS_HEADER = (
+        "Data already collected earlier in this conversation. Quote from it "
+        "instead of recalling it from your own previous answers. It may be "
+        "stale — call the tool again if the user needs current state."
+    )
+
+    def _build_carried_tool_results(self) -> List[str]:
+        """Render this session's tool data into lines that outlive the turn.
+
+        The backend builds a fresh agent per user message, so
+        ``_execution_history`` is empty on every follow-up. Without this, a
+        question about something already fetched — the exact words of a
+        review, who left it — is answered from the agent's own earlier
+        prose, and the missing detail gets invented.
+
+        Failures and the internal pseudo-tools are dropped: an error is not
+        data, and a ``finish`` result is the answer text, which is already
+        in the conversation history.
+        """
+        cfg = self._cfg
+        fresh: List[str] = []
+        for step in self._execution_history:
+            for tr in step.tool_results:
+                if tr.tool_name in _INTERNAL_TOOL_NAMES or not (tr.success and tr.content):
+                    continue
+                rendered = self._render_tool_result(
+                    tr,
+                    prefix=f"[{tr.tool_name}]",
+                    preview=cfg.tool_result_preview_chars,
+                )
+                if rendered:
+                    fresh.append(rendered)
+
+        # Newest first so recent data wins the budget, then back to
+        # chronological order for the prompt.
+        selected: List[str] = []
+        used = 0
+        for rendered in reversed([*self._carried_tool_results, *fresh]):
+            if len(selected) >= cfg.carried_result_max_entries:
+                break
+            if used + len(rendered) > cfg.carried_result_max_chars:
+                break
+            selected.append(rendered)
+            used += len(rendered)
+        selected.reverse()
+        return selected
+
+    def _format_carried_tool_results(self) -> str:
+        """Render the earlier-turn digest as one labelled prompt block."""
+        if not self._carried_tool_results:
             return ""
+        return "\n\n".join([self._CARRIED_RESULTS_HEADER, *self._carried_tool_results])
+
+    def _format_tool_results_for_streaming(self) -> str:
+        """Format tool data available to the response writer.
+
+        Earlier turns come first as a labelled block, then this turn's
+        results. The slice matters: without it a third-turn response is
+        handed turn one's results as freshly collected data.
+        """
         cfg = self._cfg
         parts: List[str] = []
-        for step in self._execution_history:
+        carried = self._format_carried_tool_results()
+        if carried:
+            parts.append(carried)
+        for step in self._execution_history[self._turn_start_step :]:
             if step.tool_results:
                 for tr in step.tool_results:
                     rendered = self._render_tool_result(
@@ -1701,6 +1809,10 @@ class ArchitectAgent(BaseAgent):
             if len(content) > max_chars:
                 content = content[:max_chars] + "..."
             parts.append(f"{role}: {content}")
+
+        carried = self._format_carried_tool_results()
+        if carried:
+            parts.append(carried)
 
         exec_window = self._execution_history[-self._history_window :]
         if len(self._execution_history) > self._history_window:

--- a/sdk/src/rhesis/sdk/agents/architect/agent.py
+++ b/sdk/src/rhesis/sdk/agents/architect/agent.py
@@ -1753,8 +1753,18 @@ class ArchitectAgent(BaseAgent):
         for rendered in reversed([*self._carried_tool_results, *fresh]):
             if len(selected) >= cfg.carried_result_max_entries:
                 break
-            if used + len(rendered) > cfg.carried_result_max_chars:
-                break
+            room = cfg.carried_result_max_chars - used
+            if len(rendered) > room:
+                marker = f"… [truncated, {len(rendered)} chars total]"
+                # Degrade detail instead of stopping: a compacted 50-row page
+                # runs past this whole budget on its own, and stopping there
+                # returned an empty digest — losing the data this exists to
+                # carry. Half the budget at most, so one fat page cannot
+                # starve the older entries behind it.
+                keep = min(room, cfg.carried_result_max_chars // 2)
+                if keep <= len(marker):
+                    continue
+                rendered = rendered[: keep - len(marker)].rstrip() + marker
             selected.append(rendered)
             used += len(rendered)
         selected.reverse()

--- a/sdk/src/rhesis/sdk/agents/architect/config.py
+++ b/sdk/src/rhesis/sdk/agents/architect/config.py
@@ -47,6 +47,12 @@ class ArchitectConfig:
     # how often the agent gets a call wrong.
     failed_args_preview_chars: int = 1_500
 
+    # ── tool data carried between turns ───────────────────────────
+    # The backend builds a fresh agent per user message, so execution
+    # history dies with the turn. These bound the digest that survives.
+    carried_result_max_entries: int = 12
+    carried_result_max_chars: int = 12_000
+
     # ── HTTP methods treated as read-only ─────────────────────────
     readonly_http_methods: frozenset = field(
         default_factory=lambda: frozenset({"GET", "HEAD", "OPTIONS"})

--- a/sdk/src/rhesis/sdk/agents/architect/state.py
+++ b/sdk/src/rhesis/sdk/agents/architect/state.py
@@ -29,3 +29,6 @@ class ArchitectAgentStateSnapshot(BaseModel):
     plan_data: Optional[Dict[str, Any]] = None
     max_iterations: int = 15
     pending_tasks: List[Dict[str, Any]] = Field(default_factory=list)
+    # Rendered tool results from earlier turns. Execution history itself is
+    # not portable — this is the readable digest the next turn quotes from.
+    carried_tool_results: List[str] = Field(default_factory=list)

--- a/tests/backend/tasks/architect/test_chat.py
+++ b/tests/backend/tasks/architect/test_chat.py
@@ -199,6 +199,52 @@ async def test_persist_state_omits_trace_id_when_tracing_disabled():
     assert "conversation_trace_id" not in session_update.agent_state
 
 
+# ── persist_state carries tool data forward ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_persist_state_stores_carried_tool_results():
+    """Execution history dies with the Celery task, so the rendered tool
+    data has to reach ``agent_state`` or the next turn answers a question
+    about it from the agent's own prose."""
+    agent = MagicMock()
+    agent.dump_state.return_value = MagicMock(
+        mode="discovery",
+        max_iterations=15,
+        discovery_state={},
+        guard_state={},
+        pending_tasks=[],
+        id_to_name={},
+        plan_data=None,
+        carried_tool_results=["[list_annotations]: one Fail review from Nicolai Bohn"],
+    )
+
+    with (
+        patch("rhesis.telemetry.context.get_root_trace_id", return_value=None),
+        patch(
+            "rhesis.backend.app.services.architect.runner.get_db_with_tenant_variables"
+        ) as mock_db_ctx,
+        patch("rhesis.backend.app.crud.create_architect_message"),
+        patch("rhesis.backend.app.crud.update_architect_session") as mock_update,
+    ):
+        mock_db_ctx.return_value.__enter__.return_value = MagicMock()
+
+        await persist_state(
+            agent=agent,
+            response="reply",
+            session_id=_VALID_SESSION_ID,
+            organization_id="org",
+            user_id="user",
+            session_has_title=True,
+            user_message="hi",
+        )
+
+    session_update = mock_update.call_args.kwargs["session"]
+    assert session_update.agent_state["carried_tool_results"] == [
+        "[list_annotations]: one Fail review from Nicolai Bohn"
+    ]
+
+
 # ── _conversation_telemetry_context lifecycle ───────────────────────
 
 

--- a/tests/sdk/agents/test_architect.py
+++ b/tests/sdk/agents/test_architect.py
@@ -2649,6 +2649,37 @@ class TestCarriedToolResults:
         assert sum(len(entry) for entry in digest) <= agent._cfg.carried_result_max_chars
         assert len(digest) < 6
 
+    # A page of unnamed records is the shape that outgrows the digest budget:
+    # each one is dumped whole, so 50 of them render far past it.
+    @staticmethod
+    def _fat_page(rows: int = 50, width: int = 600) -> str:
+        return json.dumps([{"id": f"row-{i}", "content": "y" * width} for i in range(rows)])
+
+    def test_an_oversized_page_is_truncated_not_dropped(self):
+        """A page bigger than the whole budget used to return an empty digest."""
+        agent = _make_agent(_mock_model())
+        agent._execution_history.append(
+            _tool_step(1, "list_annotations", content=self._fat_page())
+        )
+
+        digest = agent._build_carried_tool_results()
+
+        assert digest
+        assert "truncated" in digest[0]
+        assert sum(len(entry) for entry in digest) <= agent._cfg.carried_result_max_chars
+
+    def test_an_oversized_page_does_not_wipe_earlier_entries(self):
+        agent = _make_agent(_mock_model())
+        agent._carried_tool_results = ["[list_annotations]: one review, from Nicolai."]
+        agent._execution_history.append(
+            _tool_step(1, "list_annotations", content=self._fat_page())
+        )
+
+        digest = agent._build_carried_tool_results()
+
+        assert any("one review, from Nicolai." in entry for entry in digest)
+        assert sum(len(entry) for entry in digest) <= agent._cfg.carried_result_max_chars
+
     def test_earlier_carried_data_survives_a_turn_that_fetched_nothing(self):
         first = _make_agent(_mock_model())
         first._execution_history.append(_tool_step(1, "list_annotations", content=_ANNOTATION_PAGE))

--- a/tests/sdk/agents/test_architect.py
+++ b/tests/sdk/agents/test_architect.py
@@ -2421,15 +2421,57 @@ class TestCompactUnnamedListResults:
         assert out is not None
         assert "nano_id" not in out
 
-    def test_long_comment_is_clipped(self):
+    def test_long_comment_survives_whole(self):
+        """A review comment is only ever shown here — it must arrive intact.
+
+        Clipping it to a preview width leaves the LLM holding half a
+        sentence, which it finishes on the reviewer's behalf.
+        """
+        comment = (
+            "The agent quoted a refund of 240 EUR that appears nowhere in the policy, "
+            "then repeated it with a made-up section number when challenged. The metric "
+            "passed it, so the judge is scoring fluency rather than groundedness."
+        )
         item = self._annotation(1)
-        item["comments"] = "z" * 500
+        item["comments"] = comment
+        out = ArchitectAgent._compact_list_result_for_history(json.dumps([item]))
+        assert out is not None
+        assert comment in out
+
+    def test_runaway_field_is_still_bounded(self):
+        """``record_chars`` is a backstop against one pathological field."""
+        item = self._annotation(1)
+        item["comments"] = "z" * 9_000
         out = ArchitectAgent._compact_list_result_for_history(
-            json.dumps([item]), desc_chars=100
+            json.dumps([item]), record_chars=2_000
         )
         assert out is not None
-        assert "z" * 500 not in out
+        assert "z" * 9_000 not in out
         assert "…" in out
+
+    def test_fat_page_keeps_every_row_and_marks_the_clipping(self):
+        """Detail degrades; rows do not disappear.
+
+        Dropping records to fit a budget reads as "there were only four",
+        which is the same lie as the bare "- ?".
+        """
+        items = []
+        for idx in range(20):
+            item = self._annotation(idx)
+            item["comments"] = f"review {idx} " + "lorem ipsum dolor sit amet " * 200
+            items.append(item)
+        payload = {
+            "results": items,
+            "_pagination": {"returned": 20, "has_more": False},
+        }
+        out = ArchitectAgent._compact_list_result_for_history(json.dumps(payload))
+        assert out is not None
+        rows = [line for line in out.splitlines() if line.startswith("  - ")]
+        assert len(rows) == 20
+        assert all("[record truncated]" in row for row in rows)
+        # Every review is still identifiable even where its text is cut.
+        for idx in range(20):
+            assert f"review {idx} " in out
 
     def test_named_items_keep_the_compact_form(self):
         """Entities with names are unaffected — no raw JSON for them."""
@@ -2499,6 +2541,152 @@ class TestToolResultTruncationMarker:
         assert rendered is not None
         assert "truncated" not in rendered
         assert "Passed" in rendered
+
+
+# ── carried tool-result tests ─────────────────────────────────────
+
+_ANNOTATION_PAGE = json.dumps(
+    {
+        "results": [
+            {
+                "id": None,
+                "review_id": "e87b6bc0-1111",
+                "comments": "Quoted a refund figure that is nowhere in the policy.",
+                "status": {"name": "Fail"},
+                "user": {"name": "Nicolai Bohn"},
+                "target": {"type": "turn", "turn_index": 3},
+            }
+        ],
+        "_pagination": {"returned": 1, "has_more": False},
+    }
+)
+
+
+def _tool_step(iteration, tool_name, *, content=None, error=None):
+    """One execution step carrying a single tool result."""
+    return ExecutionStep(
+        iteration=iteration,
+        reasoning=f"step {iteration}",
+        action="call_tool",
+        tool_calls=[],
+        tool_results=[
+            ToolResult(
+                tool_name=tool_name,
+                success=error is None,
+                content=content or "",
+                error=error,
+            )
+        ],
+    )
+
+
+@pytest.mark.unit
+class TestCarriedToolResults:
+    """Tool data has to outlive the turn that fetched it.
+
+    The backend builds a fresh agent per user message, so a follow-up
+    question ("who left that review?") otherwise has nothing but the
+    agent's own earlier prose to answer from — and fills the gaps.
+    """
+
+    def test_digest_reaches_a_fresh_agent(self):
+        first = _make_agent(_mock_model())
+        first._execution_history.append(_tool_step(1, "list_annotations", content=_ANNOTATION_PAGE))
+
+        second = _make_agent(_mock_model())
+        second.restore_state(first.dump_state())
+
+        assert not second._execution_history
+        for prompt in (second._format_history(), second._format_tool_results_for_streaming()):
+            assert "Quoted a refund figure" in prompt
+            assert "Nicolai Bohn" in prompt
+            assert "turn_index" in prompt
+
+    def test_carried_block_is_labelled_as_earlier_data(self):
+        agent = _make_agent(_mock_model())
+        agent._carried_tool_results = ["[list_annotations]: one review"]
+
+        assert "already collected earlier" in agent._format_history()
+
+    def test_failed_calls_and_finish_results_excluded(self):
+        agent = _make_agent(_mock_model())
+        agent._execution_history.extend(
+            [
+                _tool_step(1, "list_annotations", content=_ANNOTATION_PAGE),
+                _tool_step(2, "get_test_set", error="404 not found"),
+                _tool_step(3, "finish", content="One review, from Nicolai."),
+            ]
+        )
+
+        digest = agent._build_carried_tool_results()
+
+        # An error is not data, and the finish text is already the
+        # assistant message in conversation history.
+        assert len(digest) == 1
+        assert "list_annotations" in digest[0]
+
+    def test_newest_entries_win_the_entry_cap(self):
+        agent = _make_agent(_mock_model())
+        for i in range(20):
+            agent._execution_history.append(
+                _tool_step(i, "list_metrics", content=json.dumps({"marker": f"call-{i}"}))
+            )
+
+        digest = agent._build_carried_tool_results()
+
+        assert len(digest) == agent._cfg.carried_result_max_entries
+        assert "call-19" in digest[-1]
+        assert not any("call-0" in entry for entry in digest)
+
+    def test_char_budget_drops_the_oldest(self):
+        agent = _make_agent(_mock_model())
+        for i in range(6):
+            bulky = json.dumps({"marker": i, "pad": "x" * 3000})
+            agent._execution_history.append(_tool_step(i, "get_test_result", content=bulky))
+
+        digest = agent._build_carried_tool_results()
+
+        assert sum(len(entry) for entry in digest) <= agent._cfg.carried_result_max_chars
+        assert len(digest) < 6
+
+    def test_earlier_carried_data_survives_a_turn_that_fetched_nothing(self):
+        first = _make_agent(_mock_model())
+        first._execution_history.append(_tool_step(1, "list_annotations", content=_ANNOTATION_PAGE))
+
+        second = _make_agent(_mock_model())
+        second.restore_state(first.dump_state())
+        third = _make_agent(_mock_model())
+        third.restore_state(second.dump_state())
+
+        assert "Quoted a refund figure" in third._format_history()
+
+    def test_streaming_shows_only_this_turns_results_as_current(self):
+        agent = _make_agent(_mock_model())
+        agent._execution_history.append(
+            _tool_step(1, "list_metrics", content=json.dumps({"marker": "old-turn"}))
+        )
+        agent._turn_start_step = len(agent._execution_history)
+        agent._execution_history.append(
+            _tool_step(2, "list_requirements", content=json.dumps({"marker": "this-turn"}))
+        )
+
+        streaming = agent._format_tool_results_for_streaming()
+
+        # Stale data presented as freshly collected is its own hallucination
+        # source — the previous turn's results belong in the carried block.
+        assert "this-turn" in streaming
+        assert "old-turn" not in streaming
+
+    def test_reset_clears_the_digest(self):
+        agent = _make_agent(_mock_model())
+        agent._carried_tool_results = ["[list_annotations]: one review"]
+        agent._turn_start_step = 3
+
+        agent.reset()
+
+        assert agent._carried_tool_results == []
+        assert agent._turn_start_step == 0
+        assert agent._format_tool_results_for_streaming() == ""
 
 
 # ── Mapping completion tests ─────────────────────────────────────


### PR DESCRIPTION
## Purpose

#2427 stopped annotations arriving at the LLM as a column of `- ?`, but it did not stop the architect inventing review content. Two paths were left open, and both are data starvation rather than creativity — the agent is told reviews exist, shown nothing usable, and asked to report on them.

**Tool results died with the turn.** `prepare_and_load_session` rehydrates only `conversation_history` from the DB, so every user message builds a fresh agent with an empty `_execution_history`. A follow-up question about something already fetched — the exact words of a review, who left it, which turn it was on — had nothing but the agent's own earlier prose to answer from, and older messages are cut to 500 chars. This is the likeliest source of invented reviewer names and turn numbers in a real conversation, and #2427 does not touch it.

**Review comments arrived clipped to 80 characters.** `desc_chars` is a summary width for a *named* entity's description, where the untruncated version is one `get_*` call away. Since #2427 it was also the clip width for every string inside an *unnamed* record, where this rendering is the only place the content is ever shown. A reviewer's comment reached the model as half a sentence ending in `…`, next to an instruction to "expand on the seed with appropriate detail" — the setup for finishing someone else's sentence and presenting it as their review. Arguably worse than the bare `- ?` it replaced, because a partial quote reads as a real one.

## What Changed

### Tool data survives the turn

- `dump_state` emits `carried_tool_results`: the rendered tool results from this and earlier turns, newest-first within two caps, then back in chronological order. `restore_state` loads it; `persist_state` stores it on `agent_state` and `build_agent` reads it back. No migration — the key is additive and existing sessions fall back to `[]`.
- The digest goes into both prompts (`_format_history` for the reasoning call, `_format_tool_results_for_streaming` for the response writer) under a header that tells the agent to quote from it rather than recall it, and to re-read the tool if the user needs current state.
- Failures and the internal pseudo-tools are excluded. An error is not data, and a `finish` result is the answer text, which is already the assistant message in conversation history.
- Bounded by `carried_result_max_entries` (12) and `carried_result_max_chars` (12_000). One review costs about 415 bytes of JSONB.

### Unnamed records are shown whole

- `_compact_list_result_for_history` now takes `record_chars` (4_000) and `record_block_chars` (20_000) separately from `desc_chars`, which keeps its 80 for named entities. An annotation, a test result, anything without a label is dumped in full.
- The block budget is **shared across the unnamed records on the page**, so a page of small records is never clipped at all and a page of fat ones degrades in detail instead of losing rows. Dropping rows to fit would read as "there were only four", which is the same lie as the `- ?`. Anything actually cut carries a `… [record truncated]` marker.

Measured across three page shapes:

| page | raw | rendered | rows kept | full comment kept |
|---|---|---|---|---|
| 1 annotation | 553 | 534 | 1 | yes |
| 20 annotations, ~440-char comments | 9,865 | 9,675 | 20 | yes |
| 20 test results with full outputs | 88,825 | 20,555 | 20 | n/a — all 20 marked truncated |

### Incidental

- `_format_tool_results_for_streaming` now slices from `_turn_start_step`. Execution history accumulates in-process, so a third-turn response was handed turn one's results under the heading "Tool Results (data you collected)" as if freshly fetched. Stale data presented as current is its own fabrication source. No effect on the backend path, where the agent is fresh each turn, but it is required for correctness now that data crosses turns at all.

## Additional Context

- Refs #2402. Follows #2374 (made annotations reachable) and #2427 (stopped them rendering as `- ?`).
- `test_long_comment_is_clipped` asserted exactly the behaviour this removes, so it is replaced by three tests covering the new contract.
- **Not addressed here**, from the same analysis of #2402: `streaming_response.j2` still instructs the model to "expand on the seed with appropriate detail" with no grounding rule for quoted human text; `get_test_result` still returns `test_reviews` inline as an undocumented second shape for the same reviews; blank `comments`/`user` fields still have no vocabulary, so "no comment left" cannot be said; and `total_count` is returned as an `X-Total-Count` header, so the tool payload cannot state a real total. Each is a separate change.
- Also noticed, unrelated and untouched: `workflow_path` is in the snapshot and emitted by `dump_state`, but `persist_state` never writes it and `build_agent` never reads it, so it resets to `unset` every turn.
- There is still no eval that asserts what the model *says* matches what the tool *returned*. That is what would have caught #2374 not working, and it also covers #2516.

## Testing

```bash
cd sdk && uv run pytest ../tests/sdk/agents/
cd apps/backend && uv run pytest ../../tests/backend/tasks/architect/ ../../tests/backend/services/architect/
```

443 SDK tests and 100 backend tests pass. Docker must be running for the backend suite.

New coverage:

- A two-turn round trip: turn 1 fetches annotations, the digest goes through `json.dumps`/`loads` the way the JSONB column does, and turn 2 — a fresh agent with an empty execution history — has the reviewer, the verbatim comment and the turn index in its prompt.
- Failed calls and `finish` results stay out of the digest; both caps keep the newest entries; earlier data survives a turn that fetched nothing; `reset()` clears it.
- The streaming prompt shows this turn's results and not the previous turn's.
- A long review comment survives whole; a runaway field is still bounded by `record_chars`; a 20-row page of fat records keeps all 20 rows with the clipping marked and every review still identifiable.

Worth a manual check: open the architect on a run with reviews, ask what people flagged, then ask a follow-up about one specific review without naming it again. The follow-up should quote the real comment rather than paraphrasing from its own previous answer.
