### PR TITLE
Fix Redis reconnect on dropped connections

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/connector/redis_client.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/redis_client.py
@@ -4,6 +4,10 @@ import logging
 import time
 
 import redis.asyncio as redis
+from redis.asyncio.retry import Retry
+from redis.backoff import ExponentialBackoff
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from rhesis.backend.app.config.settings import get_redis_settings
 
@@ -13,6 +17,13 @@ logger = logging.getLogger(__name__)
 # Prevents hammering Redis during an outage while ensuring self-healing
 # once the service recovers (closes #2272).
 _RETRY_COOLDOWN_SECONDS = 30
+
+# Ping a pooled connection that has been idle this long before reusing it,
+# so a connection the server already dropped is replaced instead of used.
+_HEALTH_CHECK_INTERVAL_SECONDS = 30
+
+# Per-command reconnect attempts on a dropped connection.
+_COMMAND_RETRIES = 3
 
 
 class RedisConnectionManager:
@@ -47,6 +58,13 @@ class RedisConnectionManager:
                 decode_responses=True,
                 encoding="utf-8",
                 max_connections=3,
+                health_check_interval=_HEALTH_CHECK_INTERVAL_SECONDS,
+                socket_keepalive=True,
+                retry=Retry(ExponentialBackoff(cap=1.0, base=0.05), _COMMAND_RETRIES),
+                # Without retry_on_error redis-py raises a dropped connection at the
+                # call site instead of reconnecting, which floods the RPC listener's
+                # blpop loop with ConnectionError (closes #1695).
+                retry_on_error=[RedisConnectionError, RedisTimeoutError],
             )
             # Actually test the connection - from_url() doesn't connect until first use
             await self._client.ping()

--- a/tests/backend/services/connector/test_redis_client_retry.py
+++ b/tests/backend/services/connector/test_redis_client_retry.py
@@ -161,3 +161,55 @@ class TestRedisRetryCooldown:
             await redis_manager.initialize()
 
         assert not redis_manager.is_available
+
+
+class TestRedisConnectionResilience:
+    """Verify the client is built so redis-py reconnects on its own (closes #1695)."""
+
+    @pytest.mark.asyncio
+    async def test_dropped_connection_is_retried_not_raised(
+        self, redis_manager, mock_redis_settings
+    ):
+        """A dropped connection must reconnect instead of surfacing to the caller.
+
+        Asserted against a real redis-py connection built from the same kwargs, so this
+        catches an option being dropped or renamed — not just "from_url got a dict".
+        """
+        import redis.asyncio as real_redis
+        from redis.exceptions import ConnectionError as RedisConnectionError
+        from redis.exceptions import TimeoutError as RedisTimeoutError
+
+        recorded = {}
+
+        async def _capture(url, **kwargs):
+            recorded["url"] = url
+            recorded["kwargs"] = kwargs
+            client = AsyncMock()
+            client.ping = AsyncMock(return_value=True)
+            return client
+
+        with patch(
+            "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
+            return_value=mock_redis_settings,
+        ), patch(
+            "rhesis.backend.app.services.connector.redis_client.redis.from_url",
+            side_effect=_capture,
+        ):
+            await redis_manager.initialize()
+
+        assert redis_manager.is_available
+
+        # from_url() does not open a socket, so this is safe without a Redis server.
+        connection = real_redis.from_url(
+            recorded["url"], **recorded["kwargs"]
+        ).connection_pool.make_connection()
+
+        # Zero retries or an empty retry_on_error is what made blpop raise instead of reconnect.
+        assert connection.retry._retries > 0
+        assert RedisConnectionError in connection.retry_on_error
+        assert RedisTimeoutError in connection.retry_on_error
+        assert RedisConnectionError in connection.retry._supported_errors
+
+        # Keeps an idle pooled connection from being handed out already dead.
+        assert connection.health_check_interval > 0
+        assert connection.socket_keepalive is True


### PR DESCRIPTION
## Purpose

The SDK RPC listener logs `redis.ConnectionError: Connection closed by server` intermittently (#1695). The client in `services/connector/redis_client.py` was built with only `decode_responses`, `encoding` and `max_connections` — none of redis-py's resilience options. That left it with zero retries and an empty `retry_on_error` list, so a dropped connection was guaranteed to surface at the call site instead of being reconnected transparently.

The pool holds three connections shared between the listener's `blpop` and the `setex` writes for `ws:routing:*` and RPC replies. The `blpop(timeout=1)` loop is never idle for long, so it isn't the listener's own connection that ages out — it's the other pooled connections. The server reaps one while idle, the pool has no way to know, and it hands the dead connection to the next `blpop`. Not an outage: `manager.py` catches the exception and continues the loop, so the impact was log noise. Fixing it removes a recurring false alarm from the logs.

## What Changed

- `services/connector/redis_client.py`: added `health_check_interval=30`, `socket_keepalive=True`, `retry=Retry(ExponentialBackoff(cap=1.0, base=0.05), 3)` and `retry_on_error=[ConnectionError, TimeoutError]` to the `from_url` call, with two named constants for the interval and retry count.
- `tests/backend/services/connector/test_redis_client_retry.py`: new `TestRedisConnectionResilience` case.

Both `retry` and `retry_on_error` are required, which is the non-obvious part. `Redis._disconnect_raise` (`redis/asyncio/client.py:622`) decides whether to reconnect by checking `conn.retry_on_error` — not `retry._supported_errors`. A retry policy passed on its own is never consulted, so the naive one-argument fix compiles, reads correctly and changes nothing.

`retry_on_timeout=True` was deliberately avoided: the async `Redis.__init__` appends to the caller's list when that flag is set, which mutates a shared list across repeated `initialize()` calls. `TimeoutError` is passed explicitly in a freshly built list instead.

Layered on purpose — keepalive and health checks keep most dead connections out of circulation, and the retry covers whatever still slips through.

## Additional Context

- Closes #1695.
- redis-py is pinned `>=5.0.0,<6.0.0` and resolves to 5.3.1; the argument shapes above are the 5.x API and were confirmed against the installed version rather than from docs.
- The issue's traceback points at `manager.py:906`; that `blpop` now lives at `manager.py:1077`. Same call, code moved.
- Ten other call sites construct Redis clients with the same gap and are **not** touched here: `connector/rpc_client.py:53`, `websocket/redis_pubsub.py:128`, `websocket/publisher.py:69,79`, `garak/cache.py:73,93`, `services/cache.py:62,80`, `tasks/architect/monitor.py:43`. Eleven sites hand-rolling the same five kwargs is how one gets missed — a shared factory is the right end state, as separate work.
- Unrelated finding while working here: running the backend suite rewrites `apps/backend/uv.lock`. `tests/backend/conftest.py:331` shells out to `uv run alembic upgrade heads`, and the lock carries a relative `exclude-newer-span = "P1W"`, so any `uv` invocation re-resolves it. Anyone running backend tests picks up an unrelated lockfile change in their working tree. Worth its own issue; the lockfile is deliberately excluded from this PR.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/services/connector/ ../../tests/backend/routes/test_connector.py -p no:randomly -q
```

`124 passed` on this branch, rebased on `main`.

The new test is red on unfixed code and green with the fix — verified in both directions, with the source reverted in place:

```
>       assert connection.retry._retries > 0
E       assert 0 > 0
1 failed
```

It avoids asserting on the mock's call arguments, which would only restate the source line and would pass just as happily with `retry` set and `retry_on_error` missing — the exact bug. Instead it captures the real kwargs, feeds them to a genuine `redis.asyncio.from_url` (which opens no socket, so no server is needed), and asserts on the resulting `Connection`: retry count above zero, `ConnectionError` present in `retry_on_error`, health check interval set, keepalive on. That exercises redis-py's own combination logic, so a 6.x upgrade changing these semantics fails loudly instead of silently.
