### PR TITLE
Fix two broken backend tests from #2500

### DIFF
--- a/tests/backend/services/test_test.py
+++ b/tests/backend/services/test_test.py
@@ -227,9 +227,15 @@ class TestBulkCreateTests:
         test_db.add(multi_turn_type)
         test_db.flush()
 
+        # test_set.organization_id is a non-null FK to organization.id, so the
+        # other org has to exist before a set can point at it.
+        other_org = models.Organization(id=uuid.uuid4(), name="Other Org")
+        test_db.add(other_org)
+        test_db.flush()
+
         other_org_set = models.TestSet(
             name="Other org multi-turn set",
-            organization_id=uuid.uuid4(),
+            organization_id=other_org.id,
             user_id=authenticated_user_id,
             test_set_type_id=multi_turn_type.id,
         )

--- a/tests/backend/services/test_test_set.py
+++ b/tests/backend/services/test_test_set.py
@@ -754,7 +754,9 @@ class TestBulkCreateEnforcesUniformTestType:
                 )
             ],
         )
-        assert payload.tests[0].test_configuration == {"goal": "multi turn"}
+        # TestData normalises a goal-bearing config through MultiTurnTestConfig,
+        # whose max_turns defaults to 10 — so it is always present on the way out.
+        assert payload.tests[0].test_configuration == {"goal": "multi turn", "max_turns": 10}
 
     def test_effective_type_precedence_is_shared(self):
         base = {


### PR DESCRIPTION
## Purpose

Two backend tests added in #2500 fail on `main`, so the backend test job is red for everyone. Both failures are in the tests themselves, not in the code under test.

## What Changed

- `tests/backend/services/test_test.py::test_bulk_create_tests_rejects_cross_org_test_set_id` built a `TestSet` with a random `organization_id`. That column is a non-null FK to `organization.id`, so the insert failed with `ForeignKeyViolation` before the assertion was ever reached. The test now creates the other organization first and points the set at it.
- `tests/backend/services/test_test_set.py::test_uniform_multi_turn_payload_is_accepted` expected the raw config back as `{"goal": "multi turn"}`. `TestData` normalises a goal-bearing config through `MultiTurnTestConfig`, whose `max_turns` defaults to `10`, so that key is always present on the way out. The expectation now includes it.

## Additional Context

- Follow-up to #2500; no production code changes.

## Testing

Ran the exact CI command from `.github/workflows/backend-test.yml`:

```bash
cd apps/backend
uv run --extra cpu --extra ee pytest ../../tests/backend --ignore=../../tests/backend/integration -n 4 --timeout=120 --timeout-method=thread --reruns=1
```

Result: 7382 passed, 47 skipped, 1 xfailed. The community-boundary job (`pytest tests/backend/test_ee_boundary.py --noconftest`) passes too. Reverting either edit reproduces its failure.
