### PR TITLE
Enforce disposable email screening on dev, stg and prd

### DIFF
--- a/charts/rhesis/values-dev.yaml
+++ b/charts/rhesis/values-dev.yaml
@@ -37,9 +37,9 @@ config:
   rhesisBaseUrl: "https://dev-api.rhesis.ai"
   frontendUrl: "https://dev-app.rhesis.ai"
   backendUrl: "http://backend:8080"
-  # Disposable-email screening: off | log | enforce. Starts at log so the
-  # community list's false-positive rate can be measured before it rejects.
-  authBlockDisposableEmails: "log"
+  # Disposable-email screening: off | log | enforce. Ran as log from #2511 so the
+  # community list's false-positive rate could be measured; enforcing since 2026-08-21.
+  authBlockDisposableEmails: "enforce"
   authDisposableEmailExtraDomains: ""
 
   # GCP

--- a/charts/rhesis/values-prd.yaml
+++ b/charts/rhesis/values-prd.yaml
@@ -46,9 +46,9 @@ config:
   rhesisBaseUrl: "https://api.rhesis.ai"
   frontendUrl: "https://app.rhesis.ai"
   backendUrl: "http://backend:8080"
-  # Disposable-email screening: off | log | enforce. Starts at log so the
-  # community list's false-positive rate can be measured before it rejects.
-  authBlockDisposableEmails: "log"
+  # Disposable-email screening: off | log | enforce. Ran as log from #2511 so the
+  # community list's false-positive rate could be measured; enforcing since 2026-08-21.
+  authBlockDisposableEmails: "enforce"
   authDisposableEmailExtraDomains: ""
 
   # GCP

--- a/charts/rhesis/values-stg.yaml
+++ b/charts/rhesis/values-stg.yaml
@@ -42,9 +42,9 @@ config:
   rhesisBaseUrl: "https://stg-api.rhesis.ai"
   frontendUrl: "https://stg-app.rhesis.ai"
   backendUrl: "http://backend:8080"
-  # Disposable-email screening: off | log | enforce. Starts at log so the
-  # community list's false-positive rate can be measured before it rejects.
-  authBlockDisposableEmails: "log"
+  # Disposable-email screening: off | log | enforce. Ran as log from #2511 so the
+  # community list's false-positive rate could be measured; enforcing since 2026-08-21.
+  authBlockDisposableEmails: "enforce"
   authDisposableEmailExtraDomains: ""
 
   # GCP


### PR DESCRIPTION
## Purpose

Disposable-email screening shipped in #2511 (v0.13.0) deliberately started in `log` mode so the community blocklist's false-positive rate could be measured on real traffic before it started rejecting anyone. That observation window is done — matches show up in Loki as `Disposable sign-up domain matched` warnings from `rhesis.backend.app.auth.disposable_email`, and signups on listed domains are still going through. This flips the switch so they get a 400 instead.

## What Changed

- `authBlockDisposableEmails: "log"` → `"enforce"` in `values-dev.yaml`, `values-stg.yaml` and `values-prd.yaml`, which sets `AUTH_BLOCK_DISPOSABLE_EMAILS` in the app ConfigMap.
- Updated the comment above each to say why it is `enforce` now instead of why it starts at `log`.
- `charts/rhesis/values.yaml` — the chart default self-hosters get — stays `log` on purpose. The issue flagged default-`enforce` as a surprise for deployments running internal mail domains, and they have no operator watching the logs to notice a false positive.

## Additional Context

- Refs #2418, follows #2511.
- Screening is creation-only: all three call sites sit inside the "no user found" branch (`auth/user_utils.py:96`, `routers/auth.py:947`, `auth/providers/email.py:224`). Existing accounts on a listed domain keep logging in. Nobody gets locked out by this flip.
- Admin invites via `POST /users/` and EE SSO JIT are not screened, unchanged here.
- Rollout timing differs per environment. Dev and stg track `main`, so this lands as soon as it merges. Prd's ArgoCD Application pins `targetRevision` to a commit SHA (`kubernetes/clusters/prd/rhesis/rhesis-application.yaml`), so prd only picks it up when `publish-release.yml` promotes the next release.
- `AUTH_DISPOSABLE_EMAIL_EXTRA_DOMAINS` is the escape hatch if a domain needs blocking before the upstream package catches up; there is no per-env allowlist override, so a false positive means flipping the env back to `log` while a fix ships.

## Testing

No code change, so the existing suites in `tests/backend/auth/test_disposable_email.py` and `tests/backend/routes/test_auth.py::TestDisposableEmailSignup` already cover `enforce` behaviour on all three signup paths.

Render the ConfigMap to confirm the value lands:

```bash
helm template rhesis charts/rhesis -f charts/rhesis/values.yaml -f charts/rhesis/values-prd.yaml \
  | grep -A1 AUTH_BLOCK_DISPOSABLE_EMAILS
```

After it syncs to dev, `POST https://dev-api.rhesis.ai/auth/magic-link` with an `@mailinator.com` address should return 400 with "Disposable email addresses are not accepted", create no user, and send no email. A signup on a normal domain should be unaffected.
