### PR TITLE
Fix noisy health-probe access logs in backend

### DIFF
--- a/apps/backend/src/rhesis/backend/logging/logging_config.py
+++ b/apps/backend/src/rhesis/backend/logging/logging_config.py
@@ -302,6 +302,38 @@ class _WorkerContextFilter(logging.Filter):
         return True
 
 
+#: Infra paths whose *successful* access lines are pure noise. Kubelet hits
+#: /health every 10-15s per pod (charts/rhesis/values-prd.yaml), which is the
+#: only access traffic an idle pod produces. Failures still log -- a 503 from a
+#: probe is the signal worth having. Same idea as EXCLUDED_PREFIXES in
+#: telemetry/middleware.py, applied to access logs instead of spans.
+_QUIET_ACCESS_PATHS = frozenset({"/health", "/healthz"})
+
+
+class _QuietProbeAccessFilter(logging.Filter):
+    """Drop 2xx/3xx ``uvicorn.access`` lines for infra probe paths.
+
+    Filtering here rather than by log level: uvicorn writes every access line at
+    INFO whatever the status (``h11_impl.RequestResponseCycle.send``), so no
+    level keeps the errors and drops the probes. ``--no-access-log`` is no help
+    either -- it clears the logger's handlers at Config init, and set_logger
+    runs later and re-propagates, which turns access logging back on.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        # uvicorn logs '%s - "%s %s HTTP/%s" %d' with
+        # (client_addr, method, path_with_query, http_version, status). Matching
+        # on the args rather than the formatted message keeps this cheap, and
+        # means a uvicorn format change degrades to "log everything".
+        args = record.args
+        if not isinstance(args, tuple) or len(args) != 5:
+            return True
+        path, status = args[2], args[4]
+        if not isinstance(path, str) or not isinstance(status, int) or status >= 400:
+            return True
+        return path.split("?", 1)[0] not in _QUIET_ACCESS_PATHS
+
+
 class ColorFormatter(logging.Formatter):
     """Formatter that adds ANSI color codes to log level names for terminal output."""
 
@@ -385,6 +417,8 @@ def set_logger(worker_role: str | None = None):
         logger = logging.getLogger(name)
         logger.handlers.clear()
         logger.propagate = True
+
+    logging.getLogger("uvicorn.access").addFilter(_QuietProbeAccessFilter())
 
     # Suppress verbose Celery-internal loggers that emit misleading task-signature
     # dumps and other low-signal debug chatter at the DEBUG level.

--- a/tests/backend/app/test_access_log_filter.py
+++ b/tests/backend/app/test_access_log_filter.py
@@ -1,0 +1,62 @@
+"""Tests for the uvicorn access-log probe filter."""
+
+import logging
+
+import pytest
+
+from rhesis.backend.logging.logging_config import _QuietProbeAccessFilter
+
+
+def _access_record(path: str, status: int, method: str = "GET") -> logging.LogRecord:
+    """A record shaped the way uvicorn emits access lines."""
+    return logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("10.3.3.1:52048", method, path, "1.1", status),
+        exc_info=None,
+    )
+
+
+class TestQuietProbeAccessFilter:
+    @pytest.fixture
+    def probe_filter(self) -> _QuietProbeAccessFilter:
+        return _QuietProbeAccessFilter()
+
+    @pytest.mark.parametrize("path", ["/health", "/healthz"])
+    @pytest.mark.parametrize("status", [200, 204, 301])
+    def test_drops_successful_probes(self, probe_filter, path, status):
+        assert probe_filter.filter(_access_record(path, status)) is False
+
+    @pytest.mark.parametrize("status", [404, 500, 503])
+    def test_keeps_failing_probes(self, probe_filter, status):
+        """A probe that fails is the signal the filter exists to preserve."""
+        assert probe_filter.filter(_access_record("/health", status)) is True
+
+    @pytest.mark.parametrize("path", ["/tests", "/auth/providers", "/health/basic"])
+    def test_keeps_other_paths(self, probe_filter, path):
+        assert probe_filter.filter(_access_record(path, 200)) is True
+
+    def test_drops_probe_with_query_string(self, probe_filter):
+        assert probe_filter.filter(_access_record("/health?verbose=1", 200)) is False
+
+    def test_keeps_non_access_records(self, probe_filter):
+        """Only uvicorn's 5-arg access line is understood; anything else passes."""
+        record = logging.LogRecord(
+            name="rhesis.backend.app.main",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="Health check called for /health",
+            args=None,
+            exc_info=None,
+        )
+        assert probe_filter.filter(record) is True
+
+    def test_keeps_record_with_unexpected_arg_shape(self, probe_filter):
+        """A uvicorn format change must degrade to logging everything."""
+        record = _access_record("/health", 200)
+        record.args = ("10.3.3.1:52048", "GET", "/health", "1.1", 200, "0.5ms")
+        assert probe_filter.filter(record) is True


### PR DESCRIPTION
## Purpose

An idle backend pod's logs are entirely infrastructure probes. Kubelet hits `/health` every 10-15s per pod (readiness 10s + liveness 15s in `values-prd.yaml`), which works out to roughly 26k access lines per pod per day with zero real traffic behind them. That noise makes the logs hard to scan and costs money to store.

The obvious levers don't work here. Lowering `LOG_LEVEL` isn't an option because uvicorn writes every access line at INFO regardless of status (`h11_impl.RequestResponseCycle.send`), so there is no level that keeps errors and drops probes — and since the app shares the same root level, it would silence our own INFO logs too. `--no-access-log` looks like the right flag but is silently defeated in this codebase: it clears the logger's handlers and sets `propagate = False` at `Config.__init__`, then `set_logger()` runs later in the FastAPI lifespan and re-propagates `uvicorn.access`, at which point uvicorn's `hasHandlers()` check finds the root handler and turns access logging back on.

Detaching `uvicorn.access` from the root logger was also considered and rejected. Propagation is what gives access lines the JSON formatting, GCP severity, the `request_id` prefix that ties them to the app's own log lines for the same request, and secret redaction — the last of which matters because uvicorn logs the path *with* its query string.

## What Changed

- Added `_QuietProbeAccessFilter` to `logging_config.py`, attached to the `uvicorn.access` logger in `set_logger()`. It drops access lines for `/health` and `/healthz` when the status is under 400, and passes everything else through.
- Failing probes still log. A 503 from a readiness check is the signal worth keeping, so only successes are dropped.
- The filter matches on `record.args` (uvicorn's 5-tuple of client, method, path, version, status) rather than the formatted message. That keeps it cheap — no string is built for a line about to be discarded — and means a future uvicorn format change degrades to "log everything" instead of silently swallowing records.
- Only `/health` and `/healthz` are on the list. Matching is exact rather than by prefix, so `/health/basic` (the Docker `HEALTHCHECK` path) is unaffected.

## Additional Context

- Mirrors the existing `EXCLUDED_PREFIXES` pattern in `telemetry/middleware.py`, which excludes the same class of high-frequency infra paths from OTel spans.
- Real request logging is deliberately untouched. The OTel middleware only creates spans for authenticated requests (`if user:`), so access logs remain the only record of 401s, rate-limited calls and anonymous traffic — and self-hosted deployments have no ingress access log to fall back on.
- Not addressed here: `/auth/providers` is hit every 10s because the frontend's liveness/readiness probes target `path: /`, which server-renders the root layout and calls the backend from `fetchQuickStartEnabledServer()`. That one is worth fixing at the source (a cheap probe route) rather than filtering, since it also removes a wasted render and round-trip. Left for a separate change.
- `/telemetry/traces` and `/files/` are candidates for the same treatment if their volume in production turns out to justify it, but were left alone without numbers to back it up.

## Testing

New unit tests in `tests/backend/app/test_access_log_filter.py` — 15 cases covering successful probes dropped (200/204/301 on both paths), failing probes kept (404/500/503), other paths kept including `/health/basic`, query strings stripped before matching, and both non-access records and an unexpected arg shape passing through untouched.

```bash
cd apps/backend
uv run pytest ../../tests/backend/app/test_access_log_filter.py -v
```

All 15 pass. To check it end to end, run the backend and hit `/health` — the request succeeds and returns normally, with no `uvicorn.access` line; any other path still logs as before.
