### PR TITLE
fix(dev): make Grafana Google OIDC config survive ArgoCD resyncs

### DIFF
--- a/kubernetes/base/grafana-resources/grafana-instance.yaml
+++ b/kubernetes/base/grafana-resources/grafana-instance.yaml
@@ -60,8 +60,26 @@ spec:
                   value: PLACEHOLDER
                 - name: GF_SMTP_FROM_NAME
                   value: "Rhesis Alerts"
+                # Declared here (not clicked through the UI) so it survives ArgoCD's
+                # selfHeal instead of being wiped on the next sync. See
+                # grafana-google-oidc-credentials.yaml in each cluster's grafana-resources
+                # overlay for the client id/secret.
+                - name: GF_AUTH_GOOGLE_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-google-oidc-credentials
+                      key: client-id
+                - name: GF_AUTH_GOOGLE_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-google-oidc-credentials
+                      key: client-secret
   config:
     server:
       root_url: PLACEHOLDER
     auth.anonymous:
       enabled: "false"
+    auth.google:
+      enabled: "true"
+      allow_sign_up: "true"
+      allowed_domains: rhesis.ai

--- a/kubernetes/clusters/dev/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/dev/external-secrets/rhesis-app-secrets.yaml
@@ -299,6 +299,14 @@ spec:
       remoteRef:
         key: grafana-datasource-password
 
+    - secretKey: GF_AUTH_GOOGLE_CLIENT_ID
+      remoteRef:
+        key: dev-grafana-google-oidc-client-id
+
+    - secretKey: GF_AUTH_GOOGLE_CLIENT_SECRET
+      remoteRef:
+        key: dev-grafana-google-oidc-client-secret
+
 ##--------------------------------------------------------
 ## Rhesis license
 ##--------------------------------------------------------

--- a/kubernetes/clusters/dev/grafana-resources/grafana-google-oidc-credentials.yaml
+++ b/kubernetes/clusters/dev/grafana-resources/grafana-google-oidc-credentials.yaml
@@ -1,0 +1,26 @@
+# Google OAuth client for "Sign in with Google", so it survives ArgoCD's selfHeal instead
+# of resetting on every sync. dev has its own client id/secret (see also
+# external-secrets/rhesis-app-secrets.yaml, which syncs the same GSM keys into the
+# rhesis namespace); synced separately here since a Secret can't be read across namespaces.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-google-oidc-credentials
+  namespace: monitoring
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: grafana-google-oidc-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: client-id
+      remoteRef:
+        key: dev-grafana-google-oidc-client-id
+    - secretKey: client-secret
+      remoteRef:
+        key: dev-grafana-google-oidc-client-secret

--- a/kubernetes/clusters/dev/grafana-resources/kustomization.yaml
+++ b/kubernetes/clusters/dev/grafana-resources/kustomization.yaml
@@ -11,6 +11,9 @@ resources:
   # them lives in base/grafana-resources (shared identically by dev/stg/prd).
   - discord-webhook-secret.yaml
   - grafana-smtp-credentials.yaml
+  # Google OIDC client id/secret consumed by the auth.google config in
+  # base/grafana-resources/grafana-instance.yaml.
+  - grafana-google-oidc-credentials.yaml
 
 configMapGenerator:
   - name: grafana-config

--- a/kubernetes/clusters/prd/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/prd/external-secrets/rhesis-app-secrets.yaml
@@ -274,6 +274,14 @@ spec:
       remoteRef:
         key: grafana-datasource-password
 
+    - secretKey: GF_AUTH_GOOGLE_CLIENT_ID
+      remoteRef:
+        key: prd-grafana-google-oidc-client-id
+
+    - secretKey: GF_AUTH_GOOGLE_CLIENT_SECRET
+      remoteRef:
+        key: prd-grafana-google-oidc-client-secret
+
 ##--------------------------------------------------------
 ## Rhesis license
 ##--------------------------------------------------------

--- a/kubernetes/clusters/prd/grafana-resources/grafana-google-oidc-credentials.yaml
+++ b/kubernetes/clusters/prd/grafana-resources/grafana-google-oidc-credentials.yaml
@@ -1,0 +1,26 @@
+# Google OAuth client for "Sign in with Google", so it survives ArgoCD's selfHeal instead
+# of resetting on every sync. prd has its own client id/secret (see also
+# external-secrets/rhesis-app-secrets.yaml, which syncs the same GSM keys into the
+# rhesis namespace); synced separately here since a Secret can't be read across namespaces.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-google-oidc-credentials
+  namespace: monitoring
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: grafana-google-oidc-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: client-id
+      remoteRef:
+        key: prd-grafana-google-oidc-client-id
+    - secretKey: client-secret
+      remoteRef:
+        key: prd-grafana-google-oidc-client-secret

--- a/kubernetes/clusters/prd/grafana-resources/kustomization.yaml
+++ b/kubernetes/clusters/prd/grafana-resources/kustomization.yaml
@@ -11,6 +11,9 @@ resources:
   # them lives in base/grafana-resources (shared identically by dev/stg/prd).
   - discord-webhook-secret.yaml
   - grafana-smtp-credentials.yaml
+  # Google OIDC client id/secret consumed by the auth.google config in
+  # base/grafana-resources/grafana-instance.yaml.
+  - grafana-google-oidc-credentials.yaml
 
 configMapGenerator:
   - name: grafana-config

--- a/kubernetes/clusters/stg/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/stg/external-secrets/rhesis-app-secrets.yaml
@@ -276,6 +276,14 @@ spec:
       remoteRef:
         key: grafana-datasource-password
 
+    - secretKey: GF_AUTH_GOOGLE_CLIENT_ID
+      remoteRef:
+        key: stg-grafana-google-oidc-client-id
+
+    - secretKey: GF_AUTH_GOOGLE_CLIENT_SECRET
+      remoteRef:
+        key: stg-grafana-google-oidc-client-secret
+
 ##--------------------------------------------------------
 ## Rhesis license
 ##--------------------------------------------------------

--- a/kubernetes/clusters/stg/grafana-resources/grafana-google-oidc-credentials.yaml
+++ b/kubernetes/clusters/stg/grafana-resources/grafana-google-oidc-credentials.yaml
@@ -1,0 +1,26 @@
+# Google OAuth client for "Sign in with Google", so it survives ArgoCD's selfHeal instead
+# of resetting on every sync. stg has its own client id/secret (see also
+# external-secrets/rhesis-app-secrets.yaml, which syncs the same GSM keys into the
+# rhesis namespace); synced separately here since a Secret can't be read across namespaces.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-google-oidc-credentials
+  namespace: monitoring
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: grafana-google-oidc-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: client-id
+      remoteRef:
+        key: stg-grafana-google-oidc-client-id
+    - secretKey: client-secret
+      remoteRef:
+        key: stg-grafana-google-oidc-client-secret

--- a/kubernetes/clusters/stg/grafana-resources/kustomization.yaml
+++ b/kubernetes/clusters/stg/grafana-resources/kustomization.yaml
@@ -11,6 +11,9 @@ resources:
   # them lives in base/grafana-resources (shared identically by dev/stg/prd).
   - discord-webhook-secret.yaml
   - grafana-smtp-credentials.yaml
+  # Google OIDC client id/secret consumed by the auth.google config in
+  # base/grafana-resources/grafana-instance.yaml.
+  - grafana-google-oidc-credentials.yaml
 
 configMapGenerator:
   - name: grafana-config


### PR DESCRIPTION
## Purpose

Google OIDC sign-in was being enabled by hand from the Grafana UI, but ArgoCD's `selfHeal: true` resets the `Grafana` custom resource to whatever is in git on every sync (which includes every deploy), so the UI setting kept getting wiped. This makes the config declarative so it persists.

## What Changed

- Added an `auth.google` block to the `Grafana` CR (`kubernetes/base/grafana-resources/grafana-instance.yaml`), enabling Google sign-in restricted to the `rhesis.ai` domain, with `GF_AUTH_GOOGLE_CLIENT_ID`/`_SECRET` env vars sourced from a Kubernetes secret.
- Added a `grafana-google-oidc-credentials` ExternalSecret in each cluster's `grafana-resources` overlay (dev/stg/prd), pulling per-environment client id/secret from GCP Secret Manager into the `monitoring` namespace.
- Added the same client id/secret entries to each cluster's `rhesis-app-secrets` ExternalSecret (`GF_AUTH_GOOGLE_CLIENT_ID`/`_SECRET`), next to the existing Grafana credentials, so they're synced into the `rhesis` namespace too — a Secret can't be read across namespaces, so both copies are needed.

## Additional Context

Each environment has its own Google OAuth client. Before this lands, the following GSM secrets need to be created in each environment's GCP project (and ESO granted `secretmanager.secretAccessor` on them, per the instructions already in `rhesis-app-secrets.yaml`):

- prd: `prd-grafana-google-oidc-client-id`, `prd-grafana-google-oidc-client-secret`
- stg: `stg-grafana-google-oidc-client-id`, `stg-grafana-google-oidc-client-secret`
- dev: `dev-grafana-google-oidc-client-id`, `dev-grafana-google-oidc-client-secret`

Each OAuth client also needs its environment's callback URL added as an authorized redirect URI (e.g. `https://grafana.rhesis.ai/login/google`).

## Testing

- `kubectl kustomize kubernetes/clusters/{dev,stg,prd}/grafana-resources` builds cleanly and the rendered `Grafana` CR shows the `auth.google` config and the two new env vars wired to `grafana-google-oidc-credentials`.
- `kubectl kustomize kubernetes/clusters/{dev,stg,prd}/external-secrets` builds cleanly with the new secret entries.
- Not yet verified against a live cluster — GSM secrets above need to exist first.