### PR TITLE
Stop id/nano_id from being client-settable on create/update

### DIFF
--- a/apps/backend/src/rhesis/backend/app/schemas/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/__init__.py
@@ -1,3 +1,5 @@
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
+
 from .architect import (
     ArchitectMessage,
     ArchitectMessageCreate,
@@ -5,14 +7,6 @@ from .architect import (
     ArchitectSessionCreate,
     ArchitectSessionDetail,
     ArchitectSessionUpdate,
-)
-from .base import Base
-from .requirement import (
-    Requirement,
-    RequirementBase,
-    RequirementCreate,
-    RequirementDetail,
-    RequirementUpdate,
 )
 from .category import Category, CategoryBase, CategoryCreate, CategoryDetail, CategoryUpdate
 from .chunk import Chunk, ChunkBase, ChunkCreate
@@ -100,6 +94,13 @@ from .prompt_template import (
     PromptTemplateCreate,
     PromptTemplateUpdate,
 )
+from .requirement import (
+    Requirement,
+    RequirementBase,
+    RequirementCreate,
+    RequirementDetail,
+    RequirementUpdate,
+)
 from .source import Source, SourceBase, SourceCreate, SourceUpdate, SourceWithContent
 from .status import Status, StatusBase, StatusCreate, StatusDetail, StatusUpdate
 from .tag import Tag, TagBase, TagCreate, TagUpdate
@@ -171,6 +172,7 @@ from .user import User, UserBase, UserCreate, UserUpdate
 
 __all__ = [
     "Base",
+    "ServerIdentity",
     "ArchitectSession",
     "ArchitectSessionCreate",
     "ArchitectSessionUpdate",

--- a/apps/backend/src/rhesis/backend/app/schemas/architect.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/architect.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import UUID4, ConfigDict
 
-from .base import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
 class ArchitectMessageBase(Base):
@@ -22,7 +22,7 @@ class ArchitectMessageCreate(ArchitectMessageBase):
     session_id: Optional[UUID4] = None
 
 
-class ArchitectMessage(ArchitectMessageBase):
+class ArchitectMessage(ArchitectMessageBase, ServerIdentity):
     session_id: UUID4
 
     model_config = ConfigDict(from_attributes=True)
@@ -49,7 +49,7 @@ class ArchitectSessionUpdate(ArchitectSessionBase):
     agent_state: Optional[Dict[str, Any]] = None
 
 
-class ArchitectSession(ArchitectSessionBase):
+class ArchitectSession(ArchitectSessionBase, ServerIdentity):
     project_id: Optional[UUID4] = None
     plan_data: Optional[Dict[str, Any]] = None
     agent_state: Optional[Dict[str, Any]] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/base.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/base.py
@@ -15,8 +15,15 @@ from pydantic import UUID4, BaseModel, ConfigDict, field_serializer
 
 
 class Base(BaseModel):
-    id: Optional[UUID4] = None
-    nano_id: Optional[str] = None
+    """Shared base for read *and* write schemas, so it carries no server-owned identity.
+
+    ``id`` and ``nano_id`` are assigned by the backend and must never be settable from a
+    request body. Because every entity's ``<Entity>Base`` is inherited by both its
+    ``Create``/``Update`` schemas and its response schemas, any field declared here leaks
+    into write payloads. Read schemas therefore pick identity up from
+    :class:`ServerIdentity` instead. Enforced by ``tests/backend/schemas/test_server_identity.py``.
+    """
+
     project_id: Optional[UUID4] = None
     model_config = ConfigDict(from_attributes=True, use_enum_values=True)
 
@@ -25,3 +32,15 @@ class Base(BaseModel):
         if isinstance(value, datetime.datetime):
             return value.isoformat()
         return value
+
+
+class ServerIdentity(BaseModel):
+    """Server-assigned identity, for response schemas only.
+
+    Mix into a read schema to expose ``id``/``nano_id``. Never mix into a ``Create`` or
+    ``Update`` schema: the backend owns both values. ``id`` stays optional here because
+    response schemas that require it redeclare it as ``id: UUID4``.
+    """
+
+    id: Optional[UUID4] = None
+    nano_id: Optional[str] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/category.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/category.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from pydantic import UUID4
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
 # Category schemas
@@ -24,7 +24,7 @@ class CategoryUpdate(CategoryBase):
     name: Optional[str] = None
 
 
-class Category(CategoryBase):
+class Category(CategoryBase, ServerIdentity):
     pass
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/comment.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/comment.py
@@ -6,9 +6,9 @@ from pydantic import UUID4, BaseModel, ConfigDict, Field
 
 from rhesis.backend.app.auth.capabilities import ResourceType
 from rhesis.backend.app.constants import EntityType
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 from .affordances import WithPermittedActions
-from .base import Base
 from .emoji_reaction import EmojiReaction
 from .user import UserReference
 
@@ -58,7 +58,7 @@ class CommentUpdate(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-class Comment(CommentBase, WithPermittedActions):
+class Comment(CommentBase, WithPermittedActions, ServerIdentity):
     """Full Comment schema with all fields.
 
     ``permitted_actions`` (server-resolved object-level affordances) is filled

--- a/apps/backend/src/rhesis/backend/app/schemas/embedding.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/embedding.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import UUID4, Field
 
-from rhesis.backend.app.schemas.base import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
 class EmbeddingBase(Base):
@@ -38,7 +38,7 @@ class EmbeddingUpdate(EmbeddingBase):
     status_id: Optional[UUID4] = None
 
 
-class Embedding(EmbeddingBase):
+class Embedding(EmbeddingBase, ServerIdentity):
     embedding: Optional[List[float]] = None
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
@@ -10,7 +10,7 @@ from rhesis.backend.app.models.enums import (
     EndpointEnvironment,
     EndpointResponseFormat,
 )
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.references import ProjectReference, StatusReference
 from rhesis.backend.app.schemas.user import UserReference
 
@@ -141,7 +141,7 @@ class EndpointMappingTestRequest(Base):
     response_format: Optional[EndpointResponseFormat] = None
 
 
-class Endpoint(Base):
+class Endpoint(Base, ServerIdentity):
     """Response schema - excludes sensitive write-only fields"""
 
     id: UUID4

--- a/apps/backend/src/rhesis/backend/app/schemas/file.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/file.py
@@ -4,7 +4,7 @@ from typing import Optional, Union
 
 from pydantic import UUID4, BaseModel, ConfigDict
 
-from .base import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
 class FileEntityType(str, Enum):
@@ -14,7 +14,7 @@ class FileEntityType(str, Enum):
     ARCHITECT_SESSION = "ArchitectSession"
 
 
-class FileResponse(Base):
+class FileResponse(Base, ServerIdentity):
     """File metadata response — never includes raw content or storage_path."""
 
     filename: str

--- a/apps/backend/src/rhesis/backend/app/schemas/metric.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/metric.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from pydantic import UUID4, ConfigDict, Field, field_validator, model_validator
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.metric_types import ScoreType, ThresholdOperator
 from rhesis.backend.app.schemas.references import RequirementReference
 from rhesis.backend.app.schemas.tag import Tag
@@ -92,7 +92,7 @@ class MetricUpdate(MetricBase):
         return v
 
 
-class Metric(MetricBase):
+class Metric(MetricBase, ServerIdentity):
     id: UUID4
     tags: Optional[List[Tag]] = []
     # Override string fields with relationship objects for response
@@ -102,7 +102,7 @@ class Metric(MetricBase):
     model_config = ConfigDict(from_attributes=True)
 
 
-class ModelReference(Base):
+class ModelReference(Base, ServerIdentity):
     id: UUID4
     name: Optional[str] = None
     description: Optional[str] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/model.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/model.py
@@ -9,7 +9,8 @@ from typing import Literal, Optional
 
 from pydantic import UUID4, BaseModel, ConfigDict, Field, field_validator
 
-from .base import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
+
 from .references import StatusReference, TypeLookupReference
 from .status import Status
 from .type_lookup import TypeLookup
@@ -72,7 +73,7 @@ class ModelUpdate(ModelBaseFields):
     assignee_id: Optional[UUID4] = None
 
 
-class ModelRead(ModelBaseFields):
+class ModelRead(ModelBaseFields, ServerIdentity):
     """Schema for reading Model (excludes API key for security)"""
 
     id: UUID4
@@ -89,7 +90,7 @@ class ModelRead(ModelBaseFields):
     model_config = ConfigDict(from_attributes=True)
 
 
-class Model(ModelBase):
+class Model(ModelBase, ServerIdentity):
     """Complete Model schema with relationships (includes key - internal use only)"""
 
     id: UUID4

--- a/apps/backend/src/rhesis/backend/app/schemas/notification.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/notification.py
@@ -4,10 +4,10 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from .base import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
-class NotificationRead(Base):
+class NotificationRead(Base, ServerIdentity):
     """A single notification, as returned by the API and carried in the
     websocket ``NOTIFICATION`` event payload."""
 

--- a/apps/backend/src/rhesis/backend/app/schemas/organization.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/organization.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from pydantic import UUID4, field_validator
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 _SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,48}[a-z0-9]$")
 # Public alias used by the SSO router and other modules that need the same pattern.
@@ -59,5 +59,5 @@ class OrganizationUpdate(OrganizationBase):
     email: Optional[str] = None
 
 
-class Organization(OrganizationBase):
+class Organization(OrganizationBase, ServerIdentity):
     pass

--- a/apps/backend/src/rhesis/backend/app/schemas/project.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/project.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import UUID4
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.tag import TagRead
 from rhesis.backend.app.schemas.user import UserReference
 
@@ -28,7 +28,7 @@ class ProjectUpdate(ProjectBase):
     name: Optional[str] = None
 
 
-class Project(ProjectBase):
+class Project(ProjectBase, ServerIdentity):
     id: UUID4
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/prompt.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/prompt.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from pydantic import UUID4
 
-from rhesis.backend.app.schemas.base import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
 # Base Prompt Schema
@@ -30,5 +30,5 @@ class PromptUpdate(PromptBase):
 
 
 # Read schema (optional, if it contains extra fields)
-class Prompt(PromptBase):
+class Prompt(PromptBase, ServerIdentity):
     pass

--- a/apps/backend/src/rhesis/backend/app/schemas/prompt_template.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/prompt_template.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from pydantic import UUID4
 
-from rhesis.backend.app.schemas.base import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.tag import Tag
 
 
@@ -30,5 +30,5 @@ class PromptTemplateUpdate(PromptTemplateBase):
     language_code: Optional[str] = None
 
 
-class PromptTemplate(PromptTemplateBase):
+class PromptTemplate(PromptTemplateBase, ServerIdentity):
     pass

--- a/apps/backend/src/rhesis/backend/app/schemas/references.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/references.py
@@ -14,11 +14,11 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import UUID4, ConfigDict
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.tag import TagRead
 
 
-class StatusReference(Base):
+class StatusReference(Base, ServerIdentity):
     id: UUID4
     name: Optional[str] = None
     description: Optional[str] = None
@@ -28,7 +28,7 @@ class StatusReference(Base):
     model_config = ConfigDict(from_attributes=True)
 
 
-class ProjectReference(Base):
+class ProjectReference(Base, ServerIdentity):
     id: UUID4
     name: Optional[str] = None
     description: Optional[str] = None
@@ -42,7 +42,7 @@ class ProjectReference(Base):
     model_config = ConfigDict(from_attributes=True)
 
 
-class OrganizationReference(Base):
+class OrganizationReference(Base, ServerIdentity):
     id: UUID4
     name: Optional[str] = None
     description: Optional[str] = None
@@ -53,7 +53,7 @@ class OrganizationReference(Base):
     model_config = ConfigDict(from_attributes=True)
 
 
-class TypeLookupReference(Base):
+class TypeLookupReference(Base, ServerIdentity):
     id: UUID4
     description: Optional[str] = None
     type_name: Optional[str] = None
@@ -64,7 +64,7 @@ class TypeLookupReference(Base):
     model_config = ConfigDict(from_attributes=True)
 
 
-class CategoryReference(Base):
+class CategoryReference(Base, ServerIdentity):
     id: UUID4
     name: Optional[str] = None
     description: Optional[str] = None
@@ -76,7 +76,7 @@ class CategoryReference(Base):
     model_config = ConfigDict(from_attributes=True)
 
 
-class TopicReference(Base):
+class TopicReference(Base, ServerIdentity):
     id: UUID4
     name: Optional[str] = None
     description: Optional[str] = None
@@ -87,7 +87,7 @@ class TopicReference(Base):
     model_config = ConfigDict(from_attributes=True)
 
 
-class RequirementReference(Base):
+class RequirementReference(Base, ServerIdentity):
     id: UUID4
     name: Optional[str] = None
     description: Optional[str] = None
@@ -100,7 +100,7 @@ class RequirementReference(Base):
     model_config = ConfigDict(from_attributes=True)
 
 
-class PromptReference(Base):
+class PromptReference(Base, ServerIdentity):
     id: UUID4
     content: Optional[str] = None
     expected_response: Optional[str] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/requirement.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/requirement.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 
 from pydantic import UUID4, Field
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.tag import Tag, TagRead
 from rhesis.backend.app.schemas.user import UserReference
 
@@ -24,7 +24,7 @@ class RequirementUpdate(RequirementBase):
     name: Optional[str] = None
 
 
-class Requirement(RequirementBase):
+class Requirement(RequirementBase, ServerIdentity):
     tags: List[Tag] = Field(default_factory=list)
     created_at: Optional[Union[datetime, str]] = None
     user: Optional[UserReference] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/source.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/source.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import UUID4, ConfigDict
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.tag import Tag
 from rhesis.backend.app.schemas.type_lookup import TypeLookup
 from rhesis.backend.app.schemas.user import User
@@ -55,7 +55,7 @@ class SourceUpdate(SourceBase):
 
 
 # Schema for returning a Source (content field is deferred in the model for performance)
-class Source(SourceBase):
+class Source(SourceBase, ServerIdentity):
     id: UUID4
     created_at: Union[datetime, str]
     updated_at: Union[datetime, str]

--- a/apps/backend/src/rhesis/backend/app/schemas/status.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/status.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from pydantic import UUID4
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
 # Status schemas
@@ -22,7 +22,7 @@ class StatusUpdate(StatusBase):
     name: Optional[str] = None
 
 
-class Status(StatusBase):
+class Status(StatusBase, ServerIdentity):
     pass
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/subscription.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/subscription.py
@@ -4,7 +4,8 @@ from typing import List, Optional
 from pydantic import UUID4
 
 from rhesis.backend.app.models import SubscriptionPlan
-from rhesis.backend.app.schemas import Base, Tag
+from rhesis.backend.app.schemas import Tag
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
 # Risk schemas
@@ -33,5 +34,5 @@ class SubscriptionUpdate(SubscriptionBase):
     is_active: Optional[bool] = None
 
 
-class Subscription(SubscriptionBase):
+class Subscription(SubscriptionBase, ServerIdentity):
     pass

--- a/apps/backend/src/rhesis/backend/app/schemas/tag.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/tag.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from pydantic import UUID4
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
 # Tag schemas
@@ -40,11 +40,11 @@ class EntityType(str, Enum):
     TRACE = "Trace"
 
 
-class TagRead(Base):
+class TagRead(Base, ServerIdentity):
     id: UUID4
     name: str
     icon_unicode: Optional[str] = None
 
 
-class Tag(TagBase):
+class Tag(TagBase, ServerIdentity):
     pass

--- a/apps/backend/src/rhesis/backend/app/schemas/task_management.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/task_management.py
@@ -4,9 +4,9 @@ from typing import Dict, List, Optional
 from pydantic import UUID4, BaseModel, ConfigDict
 
 from rhesis.backend.app.auth.capabilities import ResourceType
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 from .affordances import WithPermittedActions
-from .base import Base
 from .references import (
     StatusReference,
     TypeLookupReference,
@@ -58,7 +58,7 @@ class TaskUpdate(BaseModel):
     task_metadata: Optional[Dict] = None
 
 
-class Task(Base, WithPermittedActions):
+class Task(Base, WithPermittedActions, ServerIdentity):
     """Schema for Task with relationships and auto-generated fields.
 
     ``permitted_actions`` (server-resolved object-level affordances) is filled

--- a/apps/backend/src/rhesis/backend/app/schemas/test.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import UUID4, BaseModel, ConfigDict, field_validator
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.references import (
     RequirementReference,
     CategoryReference,
@@ -15,7 +15,7 @@ from rhesis.backend.app.schemas.references import (
 from rhesis.backend.app.schemas.user import UserReference
 
 
-class TestTag(Base):
+class TestTag(Base, ServerIdentity):
     id: UUID4
     name: str
 
@@ -91,7 +91,7 @@ class TestUpdate(TestBase):
         return validate_test_config_content(v)
 
 
-class Test(TestBase):
+class Test(TestBase, ServerIdentity):
     id: UUID4
     created_at: Union[datetime, str]
     updated_at: Union[datetime, str]

--- a/apps/backend/src/rhesis/backend/app/schemas/test_configuration.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_configuration.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from pydantic import UUID4, BaseModel, Field
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
 # TestConfiguration schemas
@@ -26,7 +26,7 @@ class TestConfigurationUpdate(TestConfigurationBase):
     endpoint_id: Optional[UUID4] = None
 
 
-class TestConfiguration(TestConfigurationBase):
+class TestConfiguration(TestConfigurationBase, ServerIdentity):
     pass
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/test_result.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_result.py
@@ -8,7 +8,7 @@ from rhesis.backend.app.constants import (
     REVIEW_TARGET_TEST_RESULT,
     ReviewTarget,
 )
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.affordances import WithPermittedActions
 from rhesis.backend.app.schemas.references import (
     RequirementReference,
@@ -45,7 +45,7 @@ class TestResultUpdate(TestResultBase):
     test_configuration_id: Optional[UUID4] = None
 
 
-class TestResult(TestResultBase, WithPermittedActions):
+class TestResult(TestResultBase, WithPermittedActions, ServerIdentity):
     """Full TestResult response with server-resolved object-level affordances.
 
     ``permitted_actions`` is populated automatically during serialization for
@@ -62,7 +62,7 @@ class TestResult(TestResultBase, WithPermittedActions):
     model_config = ConfigDict(from_attributes=True)
 
 
-class TestReference(Base):
+class TestReference(Base, ServerIdentity):
     id: UUID4
     prompt: Optional[PromptReference] = None
     requirement: Optional[RequirementReference] = None
@@ -70,7 +70,7 @@ class TestReference(Base):
     model_config = ConfigDict(from_attributes=True)
 
 
-class TestRunReference(Base):
+class TestRunReference(Base, ServerIdentity):
     id: UUID4
     name: Optional[str] = None
 

--- a/apps/backend/src/rhesis/backend/app/schemas/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_run.py
@@ -3,8 +3,8 @@ from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import UUID4, ConfigDict
 
 from rhesis.backend.app.auth.capabilities import ResourceType
-from rhesis.backend.app.schemas import Base
 from rhesis.backend.app.schemas.affordances import WithPermittedActions
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.references import (
     ProjectReference,
     StatusReference,
@@ -37,7 +37,7 @@ class TestRunUpdate(TestRunBase):
     pass
 
 
-class TestRun(TestRunBase, WithPermittedActions):
+class TestRun(TestRunBase, WithPermittedActions, ServerIdentity):
     """Full TestRun response with server-resolved object-level affordances.
 
     ``permitted_actions`` is populated automatically during serialization for
@@ -50,7 +50,7 @@ class TestRun(TestRunBase, WithPermittedActions):
     model_config = ConfigDict(from_attributes=True)
 
 
-class EndpointReference(Base):
+class EndpointReference(Base, ServerIdentity):
     id: UUID4
     name: Optional[str] = None
     description: Optional[str] = None
@@ -63,7 +63,7 @@ class EndpointReference(Base):
     model_config = ConfigDict(from_attributes=True)
 
 
-class TestSetReference(Base):
+class TestSetReference(Base, ServerIdentity):
     id: UUID4
     name: Optional[str] = None
     user_id: Optional[UUID4] = None
@@ -75,7 +75,7 @@ class TestSetReference(Base):
     model_config = ConfigDict(from_attributes=True)
 
 
-class TestConfigurationReference(Base):
+class TestConfigurationReference(Base, ServerIdentity):
     id: UUID4
     attributes: Optional[Dict[str, Any]] = None
     endpoint: Optional[EndpointReference] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_set.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 from pydantic import UUID4, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from rhesis.backend.app.constants import TestSetType, TestType
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.references import StatusReference, TypeLookupReference
 from rhesis.backend.app.schemas.tag import Tag, TagRead
 from rhesis.backend.app.schemas.user import UserReference
@@ -51,7 +51,7 @@ class TestSetUpdate(TestSetBase):
     name: str = None
 
 
-class TestSet(TestSetBase):
+class TestSet(TestSetBase, ServerIdentity):
     id: UUID4
     created_at: Union[datetime, str]
     updated_at: Union[datetime, str]

--- a/apps/backend/src/rhesis/backend/app/schemas/token.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/token.py
@@ -3,7 +3,7 @@ from typing import ClassVar, List, Optional, Set
 
 from pydantic import UUID4
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
 class TokenBase(Base):
@@ -51,7 +51,7 @@ class TokenUpdate(TokenBase):
 
 
 # For list and detail views - excludes the actual token value
-class TokenRead(TokenBase):
+class TokenRead(TokenBase, ServerIdentity):
     id: UUID4
     token_obfuscated: Optional[str] = None
     last_used_at: Optional[datetime] = None
@@ -70,7 +70,7 @@ class TokenInfoResponse(Base):
 
 
 # Special response schema for token creation that includes the actual token value
-class TokenCreateResponse(Base):
+class TokenCreateResponse(Base, ServerIdentity):
     id: UUID4  # Add ID field for consistency
     access_token: str
     token_obfuscated: str

--- a/apps/backend/src/rhesis/backend/app/schemas/tool.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/tool.py
@@ -4,7 +4,8 @@ from typing import Any, Dict, Optional, Union
 
 from pydantic import UUID4, ConfigDict, field_serializer
 
-from .base import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
+
 from .references import TypeLookupReference
 from .type_lookup import TypeLookup
 
@@ -50,7 +51,7 @@ class ToolUpdate(ToolBase):
         return json.dumps(value)
 
 
-class Tool(Base):
+class Tool(Base, ServerIdentity):
     """
     Complete Tool schema with relationships.
 
@@ -79,7 +80,7 @@ class Tool(Base):
 
 # Extends ToolBase, not Tool -- Tool declares status/user as full relationship
 # objects, which would leak back in through inheritance if this extended it instead.
-class ToolDetail(ToolBase):
+class ToolDetail(ToolBase, ServerIdentity):
     id: UUID4
     created_at: Union[datetime, str]
     updated_at: Union[datetime, str]

--- a/apps/backend/src/rhesis/backend/app/schemas/topic.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/topic.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from pydantic import UUID4
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
 # Topic schemas
@@ -24,7 +24,7 @@ class TopicUpdate(TopicBase):
     name: Optional[str] = None
 
 
-class Topic(TopicBase):
+class Topic(TopicBase, ServerIdentity):
     pass
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/type_lookup.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/type_lookup.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from pydantic import UUID4
 
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
 # Category schemas
@@ -23,5 +23,5 @@ class TypeLookupUpdate(TypeLookupBase):
     type_value: Optional[str] = None
 
 
-class TypeLookup(TypeLookupBase):
+class TypeLookup(TypeLookupBase, ServerIdentity):
     pass

--- a/apps/backend/src/rhesis/backend/app/schemas/user.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/user.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 from pydantic import UUID4, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from rhesis.backend.app.auth.constants import AuthProviderType
-from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
 
 # User Settings schemas - use BaseModel instead of Base since these are not DB models
@@ -242,7 +242,7 @@ class UserUpdate(UserBase):
     email: Optional[str] = None
 
 
-class User(UserBase):
+class User(UserBase, ServerIdentity):
     user_settings: Optional[UserSettingsOutput] = Field(
         default_factory=lambda: UserSettingsOutput(version=1),
         description="User preferences and settings",
@@ -250,7 +250,7 @@ class User(UserBase):
 
 
 # For use in responses where we need minimal user info
-class UserReference(Base):
+class UserReference(Base, ServerIdentity):
     id: UUID4
     name: Optional[str] = ""  # Default to empty string to avoid validation errors
     given_name: Optional[str] = ""  # Default to empty string to avoid validation errors

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -150,9 +150,14 @@ def _prepare_item_data(
 
     # nano_id is server-owned: nothing in the backend ever writes one, so drop it here as
     # well as at the schema layer. This covers the dict-based callers that skip Pydantic.
-    # `id` is deliberately NOT dropped -- FileCreate pre-generates its primary key so the
-    # storage path and the test_output JSONB marker can embed it before the row exists.
     data.pop("nano_id", None)
+
+    # id is server-owned too, with one exception: File pre-generates its primary key so the
+    # storage path and the test_output JSONB marker can embed it before the row exists
+    # (routers/file.py, tasks/execution/executors/results.py). Every other model's id is
+    # dropped here, so a dict-based caller that skips Pydantic validation can't squat a UUID.
+    if getattr(model, "__name__", None) != "File":
+        data.pop("id", None)
 
     # Drop keys that have no corresponding ORM column on this model.
     # This handles schema fields (e.g. project_id on Base) that are absent from

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -148,6 +148,12 @@ def _prepare_item_data(
     # Convert Pydantic to dict
     data = _convert_pydantic_to_dict(item_data)
 
+    # nano_id is server-owned: nothing in the backend ever writes one, so drop it here as
+    # well as at the schema layer. This covers the dict-based callers that skip Pydantic.
+    # `id` is deliberately NOT dropped -- FileCreate pre-generates its primary key so the
+    # storage path and the test_output JSONB marker can embed it before the row exists.
+    data.pop("nano_id", None)
+
     # Drop keys that have no corresponding ORM column on this model.
     # This handles schema fields (e.g. project_id on Base) that are absent from
     # models like Organization, User, and Project itself.
@@ -186,6 +192,12 @@ def _prepare_update_data(
     # project_id is immutable — silently strip it from update payloads so callers
     # cannot accidentally (or maliciously) change the project scope of a record.
     data.pop("project_id", None)
+
+    # Identity is immutable. Unlike creates (where FileCreate legitimately pre-generates
+    # its primary key), no update path may ever rebind id or nano_id: update_item applies
+    # every remaining key, so leaving these in would let a PUT repoint a row's identity.
+    data.pop("id", None)
+    data.pop("nano_id", None)
 
     # Token scopes are mint-time-only: the SP9 "scopes ⊆ issuer" + chained-mint
     # guard runs only at creation (routers/token.py). Stripping scopes here makes

--- a/apps/frontend/src/utils/api-client/interfaces/endpoint.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/endpoint.ts
@@ -78,8 +78,13 @@ export interface Endpoint {
   // They can be set during create/update but are never returned in responses
 }
 
-// Type for editing endpoints - includes write-only fields
-export interface EndpointEditData extends Partial<Endpoint> {
+// Type for editing endpoints - includes write-only fields.
+// id/nano_id are assigned by the backend and ignored in request bodies, so they are
+// omitted here to stop callers from spreading a fetched entity straight into an update.
+export interface EndpointEditData extends Omit<
+  Partial<Endpoint>,
+  'id' | 'nano_id'
+> {
   // null clears the stored token; undefined leaves it untouched
   auth_token?: string | null;
   client_secret?: string;

--- a/apps/frontend/src/utils/api-client/organizations-client.ts
+++ b/apps/frontend/src/utils/api-client/organizations-client.ts
@@ -52,7 +52,9 @@ export class OrganizationsClient extends BaseApiClient {
 
   async updateOrganization(
     id: UUID | string,
-    data: Partial<Organization>
+    // id/nano_id are backend-assigned and ignored in request bodies; the organization is
+    // addressed by the id path param instead.
+    data: Omit<Partial<Organization>, 'id' | 'nano_id'>
   ): Promise<Organization> {
     return this.fetch<Organization>(`${API_ENDPOINTS.organizations}/${id}`, {
       method: 'PUT',

--- a/sdk/src/rhesis/sdk/entities/base_entity.py
+++ b/sdk/src/rhesis/sdk/entities/base_entity.py
@@ -142,9 +142,12 @@ class BaseEntity(BaseModel):
             if field in data and data[field] is None:
                 del data[field]
 
-        if "id" in data and data["id"] is not None:
-            response = self._update(data["id"], data)
+        # id is server-owned: it addresses the resource in the URL, never in the body.
+        entity_id = data.pop("id", None)
+        data.pop("nano_id", None)
 
+        if entity_id is not None:
+            response = self._update(entity_id, data)
         else:
             response = self._create(data)
             self.id = response["id"]

--- a/sdk/src/rhesis/sdk/entities/model.py
+++ b/sdk/src/rhesis/sdk/entities/model.py
@@ -129,8 +129,12 @@ class Model(BaseEntity):
         if self.provider:
             data["icon"] = self.provider.lower()
 
-        if "id" in data and data["id"] is not None:
-            response = self._update(data["id"], data)
+        # id is server-owned: it addresses the resource in the URL, never in the body.
+        entity_id = data.pop("id", None)
+        data.pop("nano_id", None)
+
+        if entity_id is not None:
+            response = self._update(entity_id, data)
         else:
             response = self._create(data)
             self.id = response["id"]

--- a/sdk/src/rhesis/sdk/metrics/utils.py
+++ b/sdk/src/rhesis/sdk/metrics/utils.py
@@ -13,6 +13,12 @@ logger = logging.getLogger(__name__)
 
 
 def sdk_config_to_backend_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    # id/nano_id are server-owned. MetricConfig always carries id (it's a dataclass field, so
+    # asdict emits it), but the backend assigns it; the update path addresses the metric by
+    # id in the URL instead.
+    config.pop("id", None)
+    config.pop("nano_id", None)
+
     if config.get("passing_categories"):
         config["reference_score"] = config.get("passing_categories")[0]
     else:

--- a/tests/backend/routes/test_server_owned_identity.py
+++ b/tests/backend/routes/test_server_owned_identity.py
@@ -1,0 +1,64 @@
+"""API-level behavior for issue #744: id/nano_id are server-assigned, not client-settable.
+
+Verifies what actually happens at the HTTP boundary (the schema-level and route-introspection
+guarantees live in tests/backend/schemas/test_server_identity.py): a client-supplied id/nano_id
+in a create or update body is silently ignored -- Pydantic's default extra="ignore" drops the
+unrecognized key before it ever reaches the CRUD layer, so the response comes back with the
+backend's own values, not the caller's.
+
+Uses the category endpoint as a representative CRUD entity; the same Base-derived schema
+pattern applies to every other entity covered by tests/backend/schemas/test_server_identity.py.
+"""
+
+import uuid
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from .endpoints import APIEndpoints
+from .faker_utils import generate_category_data
+
+
+@pytest.mark.unit
+class TestServerOwnedIdentityIgnoredOnWrite:
+    def test_create_ignores_client_supplied_id_and_nano_id(self, authenticated_client: TestClient):
+        data = generate_category_data()
+        data.pop("status_id", None)
+        data.pop("entity_type_id", None)
+        spoofed_id = str(uuid.uuid4())
+        data["id"] = spoofed_id
+        data["nano_id"] = "attacker-chosen"
+
+        response = authenticated_client.post(APIEndpoints.CATEGORIES.create, json=data)
+
+        assert response.status_code == status.HTTP_200_OK
+        created = response.json()
+        assert created["id"] != spoofed_id
+        assert created["nano_id"] != "attacker-chosen"
+        assert created["nano_id"]  # server still assigned one
+
+    def test_update_ignores_client_supplied_id_and_nano_id(self, authenticated_client: TestClient):
+        data = generate_category_data()
+        data.pop("status_id", None)
+        data.pop("entity_type_id", None)
+        created = authenticated_client.post(APIEndpoints.CATEGORIES.create, json=data).json()
+
+        real_id = created["id"]
+        real_nano_id = created["nano_id"]
+        other_id = str(uuid.uuid4())
+
+        response = authenticated_client.put(
+            APIEndpoints.CATEGORIES.put(real_id),
+            json={"name": "renamed", "id": other_id, "nano_id": "attacker-chosen"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        updated = response.json()
+        assert updated["id"] == real_id
+        assert updated["nano_id"] == real_nano_id
+        assert updated["name"] == "renamed"
+
+        # Nothing was created or repointed under the spoofed id.
+        other_lookup = authenticated_client.get(APIEndpoints.CATEGORIES.get(other_id))
+        assert other_lookup.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/backend/schemas/test_server_identity.py
+++ b/tests/backend/schemas/test_server_identity.py
@@ -1,0 +1,164 @@
+"""Drift guard: ``id``/``nano_id`` are server-owned and must never be accepted in a request body.
+
+Both values are assigned by the backend (``id`` via the ``gen_random_uuid()`` server default,
+``nano_id`` via the python-side default on ``models.base.Base``). Accepting them from a client
+lets a caller squat a UUID, inject a predictable short id, or -- on update -- repoint an existing
+row's identity.
+
+The structural fix is that ``schemas.base.Base`` carries neither field, because it is inherited by
+both write and read schemas. Read schemas opt back in via ``schemas.base.ServerIdentity``. These
+tests pin both halves of that arrangement:
+
+1. no request body model exposes ``id``/``nano_id`` (the security invariant, derived from the
+   live route table so new endpoints are covered automatically), and
+2. the response models whose ``nano_id`` clients actually consume still expose it (the
+   regression guard -- dropping it degrades silently rather than erroring, because callers
+   fall back to ``nano_id || id``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.routing import APIRoute
+from pydantic import BaseModel
+
+from rhesis.backend.app import schemas
+from rhesis.backend.app.main import app
+from rhesis.backend.app.schemas.base import Base, ServerIdentity
+
+SERVER_OWNED_FIELDS = ("id", "nano_id")
+
+# Legitimate exceptions to the "no id/nano_id in a request body" rule:
+#
+# - FileCreate pre-generates its primary key so the storage path and the
+#   ``__file_attached__`` marker in test_output JSONB can embed the id before the row
+#   exists (routers/file.py, tasks/execution/executors/results.py). It deliberately
+#   derives from BaseModel rather than Base, and carries no nano_id.
+# - ExtractToolRequest.id is not an entity primary key at all: it is a caller-supplied
+#   reference to an item *inside* an external tool (e.g. a Jira ticket id, a Confluence
+#   page id) that the caller wants extracted (routers/tools.py, POST
+#   /tools/{tool_id}/extract). The field name collides with our heuristic, not with the
+#   thing the heuristic is protecting.
+BODY_MODEL_ALLOWLIST = {"FileCreate", "ExtractToolRequest"}
+
+# Response models whose nano_id is read by the frontend or the SDK. Verified consumers:
+# frontend detail links and list captions (RunDrawer, TraceDrawer, compare page, explorer
+# identifier resolution) and the SDK's metric pull filter.
+NANO_ID_RESPONSE_CONTRACT = [
+    schemas.Test,
+    schemas.TestDetail,
+    schemas.TestSet,
+    schemas.TestSetDetail,
+    schemas.TestRun,
+    schemas.TestRunDetail,
+    schemas.TestResult,
+    schemas.TestResultDetail,
+    schemas.Endpoint,
+    schemas.EndpointDetail,
+    schemas.Metric,
+    schemas.MetricDetail,
+    schemas.Project,
+    schemas.ProjectDetail,
+    schemas.Prompt,
+    schemas.ModelRead,
+    schemas.Task,
+    schemas.TaskDetail,
+]
+
+
+def _nested_models(annotation) -> list[type[BaseModel]]:
+    """Pull every BaseModel subclass out of an annotation (unwrapping List/Optional/Union)."""
+    found, stack = [], [annotation]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, type) and issubclass(current, BaseModel):
+            found.append(current)
+        stack.extend(getattr(current, "__args__", ()) or ())
+    return found
+
+
+def _request_body_models() -> dict[type[BaseModel], set[str]]:
+    """Map each top-level request body model to the routes that accept it.
+
+    Only the top-level body model is inspected. A nested ``id`` is often a legitimate
+    reference to an existing row (e.g. ``ExecutionMetric.id`` inside a test set execution
+    request), whereas a top-level one would set the identity of the row being written.
+    """
+    models: dict[type[BaseModel], set[str]] = {}
+    for route in app.router.routes:
+        if not isinstance(route, APIRoute) or route.body_field is None:
+            continue
+        annotation = getattr(route.body_field, "type_", None)
+        if annotation is None:
+            annotation = route.body_field.field_info.annotation
+        for model in _nested_models(annotation):
+            label = f"{','.join(sorted(route.methods))} {route.path}"
+            models.setdefault(model, set()).add(label)
+    return models
+
+
+class TestWriteSchemasRejectServerIdentity:
+    """No request body may carry server-owned identity."""
+
+    def test_base_schema_carries_no_identity(self):
+        """``Base`` is shared by read and write schemas, so identity must not live on it."""
+        for field in SERVER_OWNED_FIELDS:
+            assert field not in Base.model_fields, (
+                f"schemas.base.Base must not declare {field!r}: every <Entity>Base inherits it, "
+                "so the field would leak into every Create/Update payload. Put it on "
+                "ServerIdentity and mix that into the response schema instead."
+            )
+
+    def test_server_identity_mixin_provides_both_fields(self):
+        for field in SERVER_OWNED_FIELDS:
+            assert field in ServerIdentity.model_fields
+
+    def test_no_request_body_accepts_server_owned_identity(self):
+        """Derived from the live route table, so a new endpoint is covered automatically."""
+        offenders: list[str] = []
+        for model, routes in sorted(_request_body_models().items(), key=lambda kv: kv[0].__name__):
+            if model.__name__ in BODY_MODEL_ALLOWLIST:
+                continue
+            present = [f for f in SERVER_OWNED_FIELDS if f in model.model_fields]
+            if present:
+                where = "; ".join(sorted(routes))
+                offenders.append(f"{model.__module__}.{model.__name__} accepts {present} ({where})")
+
+        assert not offenders, (
+            "These request body schemas accept server-owned identity fields:\n  "
+            + "\n  ".join(offenders)
+            + "\n\nFix by removing the field from the write schema (do not inherit "
+            "ServerIdentity on a Create/Update model). If a pre-generated id is genuinely "
+            "required, add the schema to BODY_MODEL_ALLOWLIST with a justification."
+        )
+
+    @pytest.mark.parametrize(
+        "schema",
+        [s for s in dir(schemas) if s.endswith(("Create", "Update"))],
+    )
+    def test_create_and_update_schemas_have_no_identity(self, schema):
+        """Belt-and-braces over the exported schema surface, including unrouted schemas."""
+        model = getattr(schemas, schema)
+        if not (isinstance(model, type) and issubclass(model, BaseModel)):
+            pytest.skip(f"{schema} is not a pydantic model")
+        if schema in BODY_MODEL_ALLOWLIST:
+            pytest.skip(f"{schema} is an allowlisted pre-generated-id schema")
+
+        present = [f for f in SERVER_OWNED_FIELDS if f in model.model_fields]
+        assert not present, f"schemas.{schema} must not accept {present}"
+
+
+class TestResponseSchemasKeepNanoId:
+    """nano_id must stay on the responses that clients read it from."""
+
+    @pytest.mark.parametrize("schema", NANO_ID_RESPONSE_CONTRACT, ids=lambda s: s.__name__)
+    def test_response_schema_exposes_nano_id(self, schema):
+        assert "nano_id" in schema.model_fields, (
+            f"{schema.__name__} lost nano_id. The frontend builds detail links as "
+            "`nano_id || id`, so this degrades silently instead of failing. Mix in "
+            "schemas.base.ServerIdentity."
+        )
+
+    @pytest.mark.parametrize("schema", NANO_ID_RESPONSE_CONTRACT, ids=lambda s: s.__name__)
+    def test_response_schema_exposes_id(self, schema):
+        assert "id" in schema.model_fields

--- a/tests/sdk/entities/test_base_entity.py
+++ b/tests/sdk/entities/test_base_entity.py
@@ -70,6 +70,7 @@ def test_delete_by_id(mock_request, test_entity):
 
 @patch("requests.request")
 def test_push_with_id(mock_request, test_entity):
+    """id addresses the resource in the URL and is left out of the body — the backend owns it."""
     test_entity.push()
     mock_request.assert_called_once_with(
         method="PUT",
@@ -78,7 +79,7 @@ def test_push_with_id(mock_request, test_entity):
             "Authorization": "Bearer rh-test-token",
             "Content-Type": "application/json",
         },
-        json={"name": "Test", "description": "Test", "id": 1},
+        json={"name": "Test", "description": "Test"},
         params=None,
     )
 


### PR DESCRIPTION
## Purpose

API endpoints for creating and updating entities currently accept `id` and `nano_id` fields in request bodies. Both are backend-assigned: `id` via a Postgres `gen_random_uuid()` server default, `nano_id` via a Python-side default on the SQLAlchemy base model. A client could set its own `id` (UUID squatting) on create, or repoint either field on an existing row via update, since the CRUD layer only stripped `project_id`. Closes #744.

## What Changed

- `apps/backend/.../schemas/base.py`: split the shared `Base` schema (no identity fields, inherited by both write and read schemas today) from a new `ServerIdentity` mixin holding `id`/`nano_id`. `ServerIdentity` is added only to response schemas that need it — never to a `Create`/`Update` schema. This makes new entities safe by default: forgetting to mix in `ServerIdentity` on a future entity only costs a display convenience, never reopens the vulnerability, unlike stripping the fields the other way (opt-out on write) would.
- `apps/backend/.../utils/crud_utils.py`: defense-in-depth for callers that bypass Pydantic validation — strips `nano_id` on create (no internal writer ever sets one) and `id`+`nano_id` on update (identity is immutable; `FileCreate`'s pre-generated `id` is a create-only, deliberate exception documented in its schema).
- `sdk/`: `BaseEntity.push()`, `Model.push()`, and native metric sync were sending `id`/`nano_id` in write bodies (one already asserted by an SDK test as expected behavior). Updated to pop both before building the request body.
- `apps/frontend/`: tightened two type-level holes (`EndpointEditData`, `updateOrganization`) that accepted `id`/`nano_id` via `Partial<Entity>`, though no current caller sends them.
- `tests/backend/schemas/test_server_identity.py`: route-introspection guardrail derived from the live FastAPI route table — fails if any request body schema exposes `id`/`nano_id`, and pins that the response schemas consumers actually read `nano_id` from keep exposing it.
- `tests/backend/routes/test_server_owned_identity.py`: behavioral test — POST/PUT with spoofed `id`/`nano_id` get ignored; the server's own values come back in the response.

## Additional Context

- Closes #744.
- Deliberate deviation from the issue's stated acceptance criteria, explained in [this comment](https://github.com/rhesis-ai/rhesis/issues/744#issuecomment-5371006421): the fix makes the backend *ignore* `id`/`nano_id` rather than return a 422. Our own SDK sends these fields in write bodies today, and a hard rejection would break any already-released SDK version for no security benefit — the fields already have no effect on the write, since the backend assigns its own values regardless of what's sent. This also matches how Stripe/GitHub handle unrecognized fields on write.
- No documentation changes needed: the fields simply no longer appear in the generated OpenAPI schema for `Create`/`Update` bodies.

## Testing

- `cd apps/backend && uv run pytest ../../tests/backend/schemas/ ../../tests/backend/crud/ ../../tests/backend/routes/ ../../tests/backend/security/` — 3198 passed, 40 pre-existing skips, 0 failures.
- `cd sdk && uv run pytest ../tests/sdk/entities/test_base_entity.py ../tests/sdk/entities/test_model.py ../tests/sdk/metrics/test_metric_scope.py` — 26 passed.
- `cd apps/frontend && npx tsc --noEmit && npx eslint src/utils/api-client/interfaces/endpoint.ts src/utils/api-client/organizations-client.ts` — clean.
- New tests specifically exercise: a POST/PUT to `/categories` with spoofed `id`/`nano_id` in the body, asserting the response reflects the server's own values, not the caller's.