### PR TITLE
Add bulk-delete endpoints for remaining grid entities

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/crud/endpoint.py
@@ -1,0 +1,34 @@
+"""CRUD operations for endpoints.
+
+Part of the incremental split of the ``crud`` monolith: ``crud/__init__.py`` still holds
+the single-item endpoint CRUD functions, and new code goes into modules like this one
+instead of growing the monolith further -- see ``apps/backend/AGENTS.md``'s crud-layout rule.
+"""
+
+import uuid
+from typing import Dict, List
+
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.utils.crud_utils import bulk_delete_by_ids
+
+
+def bulk_delete_endpoints(
+    db: Session,
+    endpoint_ids: List[uuid.UUID],
+    organization_id: str,
+    user_id: str,
+) -> Dict[str, List[str]]:
+    """Soft delete multiple endpoints in one transaction.
+
+    No owner-only rule on endpoint delete, so this is a direct wrapper around
+    the generic bulk helper.
+    """
+    return bulk_delete_by_ids(
+        db,
+        models.Endpoint,
+        endpoint_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+    )

--- a/apps/backend/src/rhesis/backend/app/crud/source.py
+++ b/apps/backend/src/rhesis/backend/app/crud/source.py
@@ -19,12 +19,13 @@ were never used and were removed rather than carried over in the split.
 """
 
 import uuid
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models, schemas
 from rhesis.backend.app.utils.crud_utils import (
+    bulk_delete_by_ids,
     create_item,
     delete_item,
     get_item_detail,
@@ -134,6 +135,26 @@ def delete_source(
 ) -> Optional[models.Source]:
     """Delete source."""
     return delete_item(db, models.Source, source_id, organization_id, user_id)
+
+
+def bulk_delete_sources(
+    db: Session,
+    source_ids: List[uuid.UUID],
+    organization_id: str,
+    user_id: str,
+) -> Dict[str, List[str]]:
+    """Soft delete multiple sources in one transaction.
+
+    No owner-only rule on source delete, so this is a direct wrapper around
+    the generic bulk helper.
+    """
+    return bulk_delete_by_ids(
+        db,
+        models.Source,
+        source_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
 
 
 def create_chunk(

--- a/apps/backend/src/rhesis/backend/app/crud/task.py
+++ b/apps/backend/src/rhesis/backend/app/crud/task.py
@@ -28,12 +28,13 @@ leaves no orphaned reference behind.
 
 import uuid
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models, schemas
 from rhesis.backend.app.utils.crud_utils import (
+    bulk_delete_by_ids,
     create_item,
     delete_item,
     get_item_detail,
@@ -152,3 +153,25 @@ def delete_task(db: Session, task_id: uuid.UUID, organization_id: str, user_id: 
     """Delete a task"""
     result = delete_item(db, models.Task, task_id, organization_id=organization_id, user_id=user_id)
     return result is not None
+
+
+def bulk_delete_tasks(
+    db: Session,
+    task_ids: List[uuid.UUID],
+    organization_id: str,
+    user_id: str,
+) -> Dict[str, List[str]]:
+    """
+    Soft delete multiple tasks in one transaction, enforcing the same owner-only
+    rule as the single-item delete route: only the creator may delete their task.
+    Ids that exist but belong to someone else are reported in "forbidden_ids"
+    rather than silently skipped or deleted.
+    """
+    return bulk_delete_by_ids(
+        db,
+        models.Task,
+        task_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+        owner_attr="user_id",
+    )

--- a/apps/backend/src/rhesis/backend/app/crud/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/crud/test_run.py
@@ -21,13 +21,14 @@ the cascade to test results is driven by ``config/cascade_config.py`` inside
 
 import logging
 import uuid
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
 from rhesis.backend.app import models, schemas
 from rhesis.backend.app.utils.crud_utils import (
+    bulk_delete_by_ids,
     create_item,
     delete_item,
     get_item_detail,
@@ -334,3 +335,53 @@ def delete_test_run(
     return delete_item(
         db, models.TestRun, test_run_id, organization_id=organization_id, user_id=user_id
     )
+
+
+def bulk_delete_test_runs(
+    db: Session,
+    test_run_ids: List[uuid.UUID],
+    organization_id: str,
+    user_id: str,
+) -> Dict[str, List[str]]:
+    """
+    Soft delete multiple test runs in one transaction, enforcing the same
+    owner-only rule as the single-item delete route: only the creator may
+    delete their own test run. Ids that exist but belong to someone else are
+    reported in "forbidden_ids" rather than silently skipped or deleted.
+    """
+    return bulk_delete_by_ids(
+        db,
+        models.TestRun,
+        test_run_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+        owner_attr="user_id",
+    )
+
+
+def get_test_run_task_ids(
+    db: Session,
+    test_run_ids: List[uuid.UUID],
+    organization_id: str,
+    user_id: str,
+) -> Dict[uuid.UUID, Tuple[Optional[str], Optional[str]]]:
+    """Map ids in ``test_run_ids`` to (status_name, task_id).
+
+    Used by the bulk-delete route to find active runs among the ones it's
+    about to soft-delete, so their Celery task can be revoked -- same as the
+    single-item delete route does per-run. Deciding which status counts as
+    "active" is left to the caller (RunStatus lives in tasks/, which this
+    module must not import -- see AGENTS.md's tasks-layout rule).
+    """
+    rows = (
+        QueryBuilder(db, models.TestRun)
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .with_related(include(models.TestRun.status))
+        .with_custom_filter(lambda q: q.filter(models.TestRun.id.in_(test_run_ids)))
+        .all()
+    )
+    return {
+        row.id: (row.status.name if row.status else None, (row.attributes or {}).get("task_id"))
+        for row in rows
+    }

--- a/apps/backend/src/rhesis/backend/app/crud/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/crud/test_run.py
@@ -372,6 +372,11 @@ def get_test_run_task_ids(
     single-item delete route does per-run. Deciding which status counts as
     "active" is left to the caller (RunStatus lives in tasks/, which this
     module must not import -- see AGENTS.md's tasks-layout rule).
+
+    Scoped to ``user_id``'s own runs, matching bulk_delete_test_runs's
+    owner_attr check: the caller only ever consults this for ids that end up
+    in "deleted_ids", so fetching runs that would land in "forbidden_ids"
+    (visible in-org but not owned) would just be discarded work.
     """
     rows = (
         QueryBuilder(db, models.TestRun)
@@ -379,6 +384,7 @@ def get_test_run_task_ids(
         .with_visibility_filter(user_id)
         .with_related(include(models.TestRun.status))
         .with_custom_filter(lambda q: q.filter(models.TestRun.id.in_(test_run_ids)))
+        .with_custom_filter(lambda q: q.filter(models.TestRun.user_id == user_id))
         .all()
     )
     return {

--- a/apps/backend/src/rhesis/backend/app/crud/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/crud/test_set.py
@@ -1,0 +1,36 @@
+"""CRUD operations for test sets.
+
+Part of the incremental split of the ``crud`` monolith: ``crud/__init__.py`` still holds
+most test-set functions, and new code goes into modules like this one instead of growing
+the monolith further -- see ``apps/backend/AGENTS.md``'s crud-layout rule.
+"""
+
+import uuid
+from typing import Dict, List
+
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.utils.crud_utils import bulk_delete_by_ids
+
+
+def bulk_delete_test_sets(
+    db: Session,
+    test_set_ids: List[uuid.UUID],
+    organization_id: str,
+    user_id: str,
+) -> Dict[str, List[str]]:
+    """
+    Soft delete multiple test sets in one transaction.
+
+    TestSet's ``visibility`` column is the only ownership gate on delete --
+    unlike TestRun, there's no owner-only ":own" rule layered on top -- so
+    this is a direct wrapper around the generic bulk helper.
+    """
+    return bulk_delete_by_ids(
+        db,
+        models.TestSet,
+        test_set_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+    )

--- a/apps/backend/src/rhesis/backend/app/crud/token.py
+++ b/apps/backend/src/rhesis/backend/app/crud/token.py
@@ -18,12 +18,13 @@ compared as a guard against hash collisions.
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models, schemas
 from rhesis.backend.app.utils.crud_utils import (
+    bulk_delete_by_ids,
     create_item,
     delete_item,
     get_item,
@@ -174,6 +175,26 @@ def revoke_token(
 ) -> Optional[models.Token]:
     """Delete token."""
     return delete_item(db, models.Token, token_id, organization_id, user_id)
+
+
+def bulk_revoke_tokens(
+    db: Session,
+    token_ids: List[uuid.UUID],
+    organization_id: str = None,
+    user_id: str = None,
+) -> Dict[str, List[str]]:
+    """Soft delete (revoke) multiple tokens in one transaction.
+
+    No owner-only rule on token delete, so this is a direct wrapper around
+    the generic bulk helper.
+    """
+    return bulk_delete_by_ids(
+        db,
+        models.Token,
+        token_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
 
 
 def revoke_user_tokens(db: Session, user_id: uuid.UUID, organization_id: str = None) -> int:

--- a/apps/backend/src/rhesis/backend/app/routers/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/routers/endpoint.py
@@ -11,6 +11,7 @@ from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.quota_gates import require_quota
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
+from rhesis.backend.app.crud import endpoint as endpoint_crud
 from rhesis.backend.app.database import no_project_scope_hint
 from rhesis.backend.app.dependencies import (
     get_endpoint_service,
@@ -233,6 +234,28 @@ def get_endpoint_schema(endpoint_service: EndpointService = Depends(get_endpoint
         Dict containing the input and output schema definitions
     """
     return endpoint_service.get_schema()
+
+
+@router.delete("/bulk", response_model=schemas.EndpointBulkDeleteResponse)
+def bulk_delete_endpoints(
+    request: schemas.EndpointBulkDeleteRequest,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Delete multiple endpoints at once.
+
+    Registered before /{endpoint_id} below -- FastAPI matches routes in
+    registration order, so a literal /bulk path must come first or a
+    /{endpoint_id}-shaped route would swallow it (treating "bulk" as an id).
+    """
+    organization_id, user_id = tenant_context
+    return endpoint_crud.bulk_delete_endpoints(
+        db=db,
+        endpoint_ids=request.endpoint_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
 
 
 # --- Routes with path parameters must come AFTER static routes ---

--- a/apps/backend/src/rhesis/backend/app/routers/source.py
+++ b/apps/backend/src/rhesis/backend/app/routers/source.py
@@ -121,6 +121,28 @@ def read_source(
     return db_source
 
 
+@router.delete("/bulk", response_model=schemas.SourceBulkDeleteResponse)
+def bulk_delete_sources(
+    request: schemas.SourceBulkDeleteRequest,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Delete multiple sources at once.
+
+    Registered before /{source_id} below -- FastAPI matches routes in
+    registration order, so a literal /bulk path must come first or a
+    /{source_id}-shaped route would swallow it (treating "bulk" as an id).
+    """
+    organization_id, user_id = tenant_context
+    return source_crud.bulk_delete_sources(
+        db=db,
+        source_ids=request.source_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+
+
 @router.delete("/{source_id}")
 def delete_source(
     source_id: uuid.UUID,

--- a/apps/backend/src/rhesis/backend/app/routers/task_management.py
+++ b/apps/backend/src/rhesis/backend/app/routers/task_management.py
@@ -290,12 +290,18 @@ def bulk_delete_tasks(
     """
     organization_id = str(current_user.organization_id)
     user_id = str(current_user.id)
-    return task_crud.bulk_delete_tasks(
+    result = task_crud.bulk_delete_tasks(
         db=db,
         task_ids=request.task_ids,
         organization_id=organization_id,
         user_id=user_id,
     )
+
+    track_feature_usage(
+        feature_name="task", action="bulk_deleted", count=len(result["deleted_ids"])
+    )
+
+    return result
 
 
 @router.delete("/{task_id}")

--- a/apps/backend/src/rhesis/backend/app/routers/task_management.py
+++ b/apps/backend/src/rhesis/backend/app/routers/task_management.py
@@ -272,6 +272,32 @@ def update_task(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+@router.delete("/bulk", response_model=schemas.TaskBulkDeleteResponse)
+def bulk_delete_tasks(
+    request: schemas.TaskBulkDeleteRequest,
+    db: Session = Depends(get_tenant_db_session),
+    current_user=Depends(require_current_user_or_token),
+):
+    """Delete multiple tasks at once.
+
+    Only the creator of a task may delete it -- ids that exist but belong to
+    someone else land in "forbidden_ids", not silently skipped or deleted,
+    same rule as the single-item delete route below.
+
+    Registered before /{task_id} below -- FastAPI matches routes in
+    registration order, so a literal /bulk path must come first or a
+    /{task_id}-shaped route would swallow it (treating "bulk" as an id).
+    """
+    organization_id = str(current_user.organization_id)
+    user_id = str(current_user.id)
+    return task_crud.bulk_delete_tasks(
+        db=db,
+        task_ids=request.task_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+
+
 @router.delete("/{task_id}")
 def delete_task(
     task_id: uuid.UUID,

--- a/apps/backend/src/rhesis/backend/app/routers/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_run.py
@@ -211,6 +211,47 @@ def update_test_run(
     )
 
 
+@router.delete("/bulk", response_model=schemas.TestRunBulkDeleteResponse)
+def bulk_delete_test_runs(
+    request: schemas.TestRunBulkDeleteRequest,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Delete multiple test runs at once.
+
+    Only the creator of a test run may delete it -- ids that exist but belong
+    to someone else land in "forbidden_ids", not silently skipped or deleted,
+    same rule as the single-item delete route below. Active runs (Queued or
+    Progress) among the ones actually deleted have their Celery task revoked.
+
+    Registered before /{test_run_id} below -- FastAPI matches routes in
+    registration order, so a literal /bulk path must come first or a
+    /{test_run_id}-shaped route would swallow it (treating "bulk" as an id).
+    """
+    from rhesis.backend.celery.core import app as celery_app
+
+    organization_id, user_id = tenant_context
+    active_statuses = {RunStatus.QUEUED.value, RunStatus.PROGRESS.value}
+    task_ids_by_run = test_run_crud.get_test_run_task_ids(
+        db, request.test_run_ids, organization_id=organization_id, user_id=user_id
+    )
+
+    result = test_run_crud.bulk_delete_test_runs(
+        db=db,
+        test_run_ids=request.test_run_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+
+    for deleted_id in result["deleted_ids"]:
+        status_name, task_id = task_ids_by_run.get(UUID(deleted_id), (None, None))
+        if status_name in active_statuses and task_id:
+            celery_app.control.revoke(task_id)
+
+    return result
+
+
 @router.delete("/{test_run_id}", response_model=schemas.TestRun)
 def delete_test_run(
     test_run_id: UUID,

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -13,6 +13,7 @@ from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.quota_gates import require_quota
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.crud import metric as metric_crud
+from rhesis.backend.app.crud import test_set as test_set_crud
 from rhesis.backend.app.dependencies import (
     get_project_context,
     get_tenant_context,
@@ -385,6 +386,28 @@ def read_test_set(
 ):
     organization_id, user_id = tenant_context
     return resolve_test_set_or_raise(test_set_identifier, db, organization_id)
+
+
+@router.delete("/bulk", response_model=schemas.TestSetBulkDeleteResponse)
+def bulk_delete_test_sets(
+    request: schemas.TestSetBulkDeleteRequest,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Delete multiple test sets at once.
+
+    Registered before /{test_set_id} below -- FastAPI matches routes in
+    registration order, so a literal /bulk path must come first or a
+    /{test_set_id}-shaped route would swallow it (treating "bulk" as an id).
+    """
+    organization_id, user_id = tenant_context
+    return test_set_crud.bulk_delete_test_sets(
+        db=db,
+        test_set_ids=request.test_set_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
 
 
 @router.delete("/{test_set_id}", response_model=schemas.TestSet)

--- a/apps/backend/src/rhesis/backend/app/routers/token.py
+++ b/apps/backend/src/rhesis/backend/app/routers/token.py
@@ -24,6 +24,8 @@ from rhesis.backend.app.dependencies import (
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.token import (
+    TokenBulkDeleteRequest,
+    TokenBulkDeleteResponse,
     TokenCreate,
     TokenCreateResponse,
     TokenInfoResponse,
@@ -253,6 +255,28 @@ def read_token(
     if db_token is None:
         raise HTTPException(status_code=404, detail="Token not found")
     return db_token
+
+
+@router.delete("/bulk", response_model=TokenBulkDeleteResponse)
+def bulk_delete_tokens(
+    request: TokenBulkDeleteRequest,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Delete (revoke) multiple tokens at once.
+
+    Registered before /{token_id} below -- FastAPI matches routes in
+    registration order, so a literal /bulk path must come first or a
+    /{token_id}-shaped route would swallow it (treating "bulk" as an id).
+    """
+    organization_id, user_id = tenant_context
+    return token_crud.bulk_revoke_tokens(
+        db=db,
+        token_ids=request.token_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
 
 
 @router.delete("/{token_id}", response_model=TokenRead)

--- a/apps/backend/src/rhesis/backend/app/schemas/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/__init__.py
@@ -114,7 +114,15 @@ from .source import (
 )
 from .status import Status, StatusBase, StatusCreate, StatusDetail, StatusUpdate
 from .tag import Tag, TagBase, TagCreate, TagUpdate
-from .task_management import Task, TaskBase, TaskCreate, TaskDetail, TaskUpdate
+from .task_management import (
+    Task,
+    TaskBase,
+    TaskBulkDeleteRequest,
+    TaskBulkDeleteResponse,
+    TaskCreate,
+    TaskDetail,
+    TaskUpdate,
+)
 from .test import (
     ConversationMessage,
     ConversationTestExtractionResponse,
@@ -328,6 +336,8 @@ __all__ = [
     "TaskCreate",
     "TaskDetail",
     "TaskUpdate",
+    "TaskBulkDeleteRequest",
+    "TaskBulkDeleteResponse",
     "TokenBase",
     "TokenCreate",
     "TokenUpdate",

--- a/apps/backend/src/rhesis/backend/app/schemas/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/__init__.py
@@ -145,7 +145,15 @@ from .test_result import (
     TestResultDetail,
     TestResultUpdate,
 )
-from .test_run import TestRun, TestRunBase, TestRunCreate, TestRunDetail, TestRunUpdate
+from .test_run import (
+    TestRun,
+    TestRunBase,
+    TestRunBulkDeleteRequest,
+    TestRunBulkDeleteResponse,
+    TestRunCreate,
+    TestRunDetail,
+    TestRunUpdate,
+)
 from .test_set import (
     ExplorerTestSetCreate,
     TestData,
@@ -156,6 +164,8 @@ from .test_set import (
     TestSetBulkAssociateRequest,
     TestSetBulkAssociateResponse,
     TestSetBulkCreate,
+    TestSetBulkDeleteRequest,
+    TestSetBulkDeleteResponse,
     TestSetBulkDisassociateRequest,
     TestSetBulkDisassociateResponse,
     TestSetBulkResponse,
@@ -259,11 +269,15 @@ __all__ = [
     "TestRunRescoreRequest",
     "TestSetBulkDisassociateResponse",
     "TestSetBulkDisassociateRequest",
+    "TestSetBulkDeleteRequest",
+    "TestSetBulkDeleteResponse",
     "TestRun",
     "TestRunBase",
     "TestRunCreate",
     "TestRunDetail",
     "TestRunUpdate",
+    "TestRunBulkDeleteRequest",
+    "TestRunBulkDeleteResponse",
     "Status",
     "StatusBase",
     "StatusCreate",

--- a/apps/backend/src/rhesis/backend/app/schemas/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/__init__.py
@@ -25,6 +25,8 @@ from .emoji_reaction import CommentEmojis, EmojiReaction
 from .endpoint import (
     Endpoint,
     EndpointBase,
+    EndpointBulkDeleteRequest,
+    EndpointBulkDeleteResponse,
     EndpointCreate,
     EndpointDetail,
     EndpointTestRequest,
@@ -221,6 +223,8 @@ __all__ = [
     "EndpointDetail",
     "EndpointTestRequest",
     "EndpointUpdate",
+    "EndpointBulkDeleteRequest",
+    "EndpointBulkDeleteResponse",
     "Model",
     "ModelBase",
     "ModelCreate",

--- a/apps/backend/src/rhesis/backend/app/schemas/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/__init__.py
@@ -103,7 +103,15 @@ from .requirement import (
     RequirementDetail,
     RequirementUpdate,
 )
-from .source import Source, SourceBase, SourceCreate, SourceUpdate, SourceWithContent
+from .source import (
+    Source,
+    SourceBase,
+    SourceBulkDeleteRequest,
+    SourceBulkDeleteResponse,
+    SourceCreate,
+    SourceUpdate,
+    SourceWithContent,
+)
 from .status import Status, StatusBase, StatusCreate, StatusDetail, StatusUpdate
 from .tag import Tag, TagBase, TagCreate, TagUpdate
 from .task_management import Task, TaskBase, TaskCreate, TaskDetail, TaskUpdate
@@ -292,6 +300,8 @@ __all__ = [
     "SourceCreate",
     "SourceUpdate",
     "SourceWithContent",
+    "SourceBulkDeleteRequest",
+    "SourceBulkDeleteResponse",
     "Topic",
     "TopicBase",
     "TopicCreate",

--- a/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
@@ -203,6 +203,15 @@ class EndpointDetail(Endpoint):
     project: Optional[ProjectReference] = None
 
 
+class EndpointBulkDeleteRequest(BaseModel):
+    endpoint_ids: List[UUID4]
+
+
+class EndpointBulkDeleteResponse(BaseModel):
+    deleted_ids: List[str]
+    not_found_ids: List[str]
+
+
 # Auto-configure schemas — use BaseModel (not Base) since these are
 # transient DTOs that should not carry id/nano_id UUID fields.
 

--- a/apps/backend/src/rhesis/backend/app/schemas/source.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/source.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import UUID4, ConfigDict
+from pydantic import UUID4, BaseModel, ConfigDict
 
 from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.tag import Tag
@@ -73,3 +73,12 @@ class SourceWithContent(Source):
     content: Optional[str] = None  # Raw text content from source, extracted
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class SourceBulkDeleteRequest(BaseModel):
+    source_ids: List[UUID4]
+
+
+class SourceBulkDeleteResponse(BaseModel):
+    deleted_ids: List[str]
+    not_found_ids: List[str]

--- a/apps/backend/src/rhesis/backend/app/schemas/task_management.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/task_management.py
@@ -110,3 +110,13 @@ class TaskDetail(Task):
     assignee: Optional[UserReference] = None
     status: Optional[StatusReference] = None
     priority: Optional[TypeLookupReference] = None
+
+
+class TaskBulkDeleteRequest(BaseModel):
+    task_ids: List[UUID4]
+
+
+class TaskBulkDeleteResponse(BaseModel):
+    deleted_ids: List[str]
+    not_found_ids: List[str]
+    forbidden_ids: List[str]

--- a/apps/backend/src/rhesis/backend/app/schemas/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_run.py
@@ -1,6 +1,6 @@
 from typing import Any, ClassVar, Dict, List, Optional
 
-from pydantic import UUID4, ConfigDict
+from pydantic import UUID4, BaseModel, ConfigDict
 
 from rhesis.backend.app.auth.capabilities import ResourceType
 from rhesis.backend.app.schemas.affordances import WithPermittedActions
@@ -48,6 +48,16 @@ class TestRun(TestRunBase, WithPermittedActions, ServerIdentity):
     # __owner_attr__ defaults to "user_id", which is the creator column on TestRun.
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class TestRunBulkDeleteRequest(BaseModel):
+    test_run_ids: List[UUID4]
+
+
+class TestRunBulkDeleteResponse(BaseModel):
+    deleted_ids: List[str]
+    not_found_ids: List[str]
+    forbidden_ids: List[str]
 
 
 class EndpointReference(Base, ServerIdentity):

--- a/apps/backend/src/rhesis/backend/app/schemas/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_set.py
@@ -269,6 +269,15 @@ class TestSetBulkDisassociateResponse(BaseModel):
     message: str
 
 
+class TestSetBulkDeleteRequest(BaseModel):
+    test_set_ids: List[UUID4]
+
+
+class TestSetBulkDeleteResponse(BaseModel):
+    deleted_ids: List[str]
+    not_found_ids: List[str]
+
+
 class ExecutionMetric(BaseModel):
     """Metric specification for execution-time metric override.
 

--- a/apps/backend/src/rhesis/backend/app/schemas/token.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/token.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import ClassVar, List, Optional, Set
 
-from pydantic import UUID4
+from pydantic import UUID4, BaseModel
 
 from rhesis.backend.app.schemas.base import Base, ServerIdentity
 
@@ -79,3 +79,12 @@ class TokenCreateResponse(Base, ServerIdentity):
     name: str
     project_id: Optional[UUID4] = None
     last_refreshed_at: Optional[datetime] = None  # For refresh operations
+
+
+class TokenBulkDeleteRequest(BaseModel):
+    token_ids: List[UUID4]
+
+
+class TokenBulkDeleteResponse(BaseModel):
+    deleted_ids: List[str]
+    not_found_ids: List[str]

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -716,6 +716,7 @@ def bulk_delete_by_ids(
     item_ids: List[uuid.UUID],
     organization_id: str = None,
     user_id: str = None,
+    owner_attr: Optional[str] = None,
     on_deleted: Optional[Callable[[List[uuid.UUID]], None]] = None,
 ) -> Dict[str, List[str]]:
     """
@@ -734,6 +735,13 @@ def bulk_delete_by_ids(
         item_ids: IDs of items to delete
         organization_id: Organization ID for tenant filtering
         user_id: User ID for visibility filtering
+        owner_attr: When set, additionally restricts deletion to rows where
+            this column equals ``user_id`` -- for models with an owner-only
+            (":own") delete rule that a ``visibility`` column can't express
+            (e.g. TestRun: no visibility column, but only the creator may
+            delete it). Ids that exist and are visible but fail this check
+            are reported in "forbidden_ids" rather than silently skipped or
+            deleted.
         on_deleted: Optional callback invoked once, after commit, with the
             list of ids actually deleted. Use this for bespoke post-delete
             side effects that should run once per batch rather than once per
@@ -741,14 +749,18 @@ def bulk_delete_by_ids(
             *distinct* affected test sets, not by each deleted test).
 
     Returns:
-        Dict with "deleted_ids" and "not_found_ids" (both lists of str ids).
+        Dict with "deleted_ids" and "not_found_ids" (both lists of str ids),
+        plus "forbidden_ids" when ``owner_attr`` is given.
     """
     from rhesis.backend.app.services import cascade as cascade_service
 
     if not item_ids:
-        return {"deleted_ids": [], "not_found_ids": []}
+        result = {"deleted_ids": [], "not_found_ids": []}
+        if owner_attr:
+            result["forbidden_ids"] = []
+        return result
 
-    existing_ids = {
+    visible_ids = {
         row.id
         for row in QueryBuilder(db, model)
         .with_organization_filter(organization_id)
@@ -756,8 +768,23 @@ def bulk_delete_by_ids(
         .with_custom_filter(lambda q: q.filter(model.id.in_(item_ids)))
         .all()
     }
-    deleted_ids = [i for i in item_ids if i in existing_ids]
-    not_found_ids = [i for i in item_ids if i not in existing_ids]
+    not_found_ids = [i for i in item_ids if i not in visible_ids]
+
+    forbidden_ids = None
+    if owner_attr:
+        owned_ids = {
+            row.id
+            for row in QueryBuilder(db, model)
+            .with_organization_filter(organization_id)
+            .with_visibility_filter(user_id)
+            .with_custom_filter(lambda q: q.filter(model.id.in_(item_ids)))
+            .with_custom_filter(lambda q: q.filter(getattr(model, owner_attr) == user_id))
+            .all()
+        }
+        deleted_ids = [i for i in item_ids if i in owned_ids]
+        forbidden_ids = [i for i in item_ids if i in visible_ids and i not in owned_ids]
+    else:
+        deleted_ids = [i for i in item_ids if i in visible_ids]
 
     if deleted_ids:
         try:
@@ -780,10 +807,13 @@ def bulk_delete_by_ids(
         if on_deleted:
             on_deleted(deleted_ids)
 
-    return {
+    result = {
         "deleted_ids": [str(i) for i in deleted_ids],
         "not_found_ids": [str(i) for i in not_found_ids],
     }
+    if owner_attr:
+        result["forbidden_ids"] = [str(i) for i in forbidden_ids]
+    return result
 
 
 def get_deleted_items(

--- a/tests/backend/routes/test_endpoint_bulk_delete.py
+++ b/tests/backend/routes/test_endpoint_bulk_delete.py
@@ -1,0 +1,71 @@
+"""
+Tests for DELETE /endpoints/bulk endpoint.
+
+Registered before /{endpoint_id} in routers/endpoint.py -- these tests exist mainly to
+guard against that route-ordering regression (a /{endpoint_id}-shaped route
+registered first would swallow "/endpoints/bulk", treating "bulk" as an id).
+"""
+
+import uuid
+
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.database import without_soft_delete_filter
+from rhesis.backend.app.models.endpoint import Endpoint
+
+
+class TestBulkDeleteEndpointsEndpoint:
+    """Tests for DELETE /endpoints/bulk"""
+
+    def test_bulk_delete_returns_deleted_and_not_found_ids(
+        self, authenticated_client: TestClient, db_endpoint_minimal
+    ):
+        fake_id = str(uuid.uuid4())
+
+        response = authenticated_client.request(
+            "DELETE",
+            "/endpoints/bulk",
+            json={"endpoint_ids": [str(db_endpoint_minimal.id), fake_id]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["deleted_ids"] == [str(db_endpoint_minimal.id)]
+        assert data["not_found_ids"] == [fake_id]
+
+    def test_bulk_delete_bumps_updated_at(
+        self, authenticated_client: TestClient, db_endpoint_minimal, test_db: Session
+    ):
+        """bulk_delete_by_ids soft-deletes via a Core-level query.update(),
+        which bypasses the ORM flush path that applies column onupdate for a
+        single-row soft_delete() -- without setting updated_at explicitly,
+        it stays stale after a bulk delete even though deleted_at is correct.
+        """
+        original_updated_at = db_endpoint_minimal.updated_at
+        test_db.commit()
+
+        response = authenticated_client.request(
+            "DELETE",
+            "/endpoints/bulk",
+            json={"endpoint_ids": [str(db_endpoint_minimal.id)]},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        test_db.expire_all()
+        with without_soft_delete_filter():
+            deleted_endpoint = (
+                test_db.query(Endpoint).filter(Endpoint.id == db_endpoint_minimal.id).first()
+            )
+        assert deleted_endpoint is not None
+        assert deleted_endpoint.updated_at > original_updated_at
+
+    def test_bulk_delete_unauthenticated(self, client: TestClient):
+        response = client.request(
+            "DELETE", "/endpoints/bulk", json={"endpoint_ids": [str(uuid.uuid4())]}
+        )
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]

--- a/tests/backend/routes/test_source_bulk_delete.py
+++ b/tests/backend/routes/test_source_bulk_delete.py
@@ -1,0 +1,94 @@
+"""
+Tests for DELETE /sources/bulk endpoint.
+
+Registered before /{source_id} in routers/source.py -- these tests exist mainly to
+guard against that route-ordering regression (a /{source_id}-shaped route
+registered first would swallow "/sources/bulk", treating "bulk" as an id).
+"""
+
+import uuid
+
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.database import without_soft_delete_filter
+from rhesis.backend.app.models.source import Source
+
+
+class TestBulkDeleteSourcesEndpoint:
+    """Tests for DELETE /sources/bulk"""
+
+    def test_bulk_delete_returns_deleted_and_not_found_ids(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_organization,
+        authenticated_user_id: str,
+    ):
+        source = Source(
+            title="Bulk-delete source",
+            organization_id=test_organization.id,
+            user_id=authenticated_user_id,
+        )
+        test_db.add(source)
+        test_db.flush()
+        test_db.refresh(source)
+
+        fake_id = str(uuid.uuid4())
+
+        response = authenticated_client.request(
+            "DELETE",
+            "/sources/bulk",
+            json={"source_ids": [str(source.id), fake_id]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["deleted_ids"] == [str(source.id)]
+        assert data["not_found_ids"] == [fake_id]
+
+    def test_bulk_delete_bumps_updated_at(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_organization,
+        authenticated_user_id: str,
+    ):
+        """bulk_delete_by_ids soft-deletes via a Core-level query.update(),
+        which bypasses the ORM flush path that applies column onupdate for a
+        single-row soft_delete() -- without setting updated_at explicitly,
+        it stays stale after a bulk delete even though deleted_at is correct.
+        """
+        source = Source(
+            title="Bulk-delete source",
+            organization_id=test_organization.id,
+            user_id=authenticated_user_id,
+        )
+        test_db.add(source)
+        test_db.flush()
+        test_db.refresh(source)
+        original_updated_at = source.updated_at
+        test_db.commit()
+
+        response = authenticated_client.request(
+            "DELETE",
+            "/sources/bulk",
+            json={"source_ids": [str(source.id)]},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        test_db.expire_all()
+        with without_soft_delete_filter():
+            deleted_source = test_db.query(Source).filter(Source.id == source.id).first()
+        assert deleted_source is not None
+        assert deleted_source.updated_at > original_updated_at
+
+    def test_bulk_delete_unauthenticated(self, client: TestClient):
+        response = client.request(
+            "DELETE", "/sources/bulk", json={"source_ids": [str(uuid.uuid4())]}
+        )
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]

--- a/tests/backend/routes/test_task_bulk_delete.py
+++ b/tests/backend/routes/test_task_bulk_delete.py
@@ -1,0 +1,84 @@
+"""
+Tests for DELETE /tasks/bulk endpoint.
+
+Registered before /{task_id} in routers/task_management.py -- these tests guard
+against that route-ordering regression, and against the owner-only delete
+rule (only the creator may delete a task) being silently dropped for the
+bulk path the way a naive bulk_delete_by_ids() call would: Task has no
+visibility column, so without the owner_attr filter any org member could
+bulk-delete anyone's tasks.
+"""
+
+import uuid
+
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.database import without_soft_delete_filter
+from rhesis.backend.app.models.task import Task
+
+
+class TestBulkDeleteTasksEndpoint:
+    """Tests for DELETE /tasks/bulk"""
+
+    def test_bulk_delete_buckets_owned_forbidden_and_not_found_ids(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_organization,
+        authenticated_user_id: str,
+        db_status,
+        db_user,
+    ):
+        """One id owned by the caller, one owned by someone else (same org),
+        and one that doesn't exist -- each must land in exactly one bucket.
+        ``db_user`` is a different user than the caller, so a task created
+        for them doubles as the "forbidden" case here.
+        """
+        owned_task = Task(
+            title="Caller's task",
+            user_id=authenticated_user_id,
+            organization_id=test_organization.id,
+            status_id=db_status.id,
+        )
+        foreign_task = Task(
+            title="Someone else's task",
+            user_id=db_user.id,
+            organization_id=test_organization.id,
+            status_id=db_status.id,
+        )
+        test_db.add_all([owned_task, foreign_task])
+        test_db.flush()
+        test_db.refresh(owned_task)
+        test_db.refresh(foreign_task)
+
+        fake_id = str(uuid.uuid4())
+
+        response = authenticated_client.request(
+            "DELETE",
+            "/tasks/bulk",
+            json={"task_ids": [str(owned_task.id), str(foreign_task.id), fake_id]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["deleted_ids"] == [str(owned_task.id)]
+        assert data["forbidden_ids"] == [str(foreign_task.id)]
+        assert data["not_found_ids"] == [fake_id]
+
+        test_db.expire_all()
+        with without_soft_delete_filter():
+            still_present = test_db.query(Task).filter(Task.id == foreign_task.id).first()
+        # Forbidden id must not be deleted, unlike not_found ids which never existed.
+        assert still_present is not None
+        assert still_present.deleted_at is None
+
+    def test_bulk_delete_unauthenticated(self, client: TestClient):
+        response = client.request(
+            "DELETE", "/tasks/bulk", json={"task_ids": [str(uuid.uuid4())]}
+        )
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]

--- a/tests/backend/routes/test_test_run_bulk_delete.py
+++ b/tests/backend/routes/test_test_run_bulk_delete.py
@@ -1,0 +1,81 @@
+"""
+Tests for DELETE /test_runs/bulk endpoint.
+
+Registered before /{test_run_id} in routers/test_run.py -- these tests guard
+against that route-ordering regression, and against the owner-only delete
+rule (only the creator may delete a test run) being silently dropped for the
+bulk path the way a naive bulk_delete_by_ids() call would: TestRun has no
+visibility column, so without the owner_attr filter any org member could
+bulk-delete anyone's test runs.
+"""
+
+import uuid
+
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.database import without_soft_delete_filter
+from rhesis.backend.app.models.test_run import TestRun
+
+
+class TestBulkDeleteTestRunsEndpoint:
+    """Tests for DELETE /test_runs/bulk"""
+
+    def test_bulk_delete_buckets_owned_forbidden_and_not_found_ids(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_organization,
+        authenticated_user_id: str,
+        db_status,
+        db_test_configuration,
+        db_test_run,
+    ):
+        """One id owned by the caller, one owned by someone else (same org),
+        and one that doesn't exist -- each must land in exactly one bucket.
+        ``db_test_run`` is created for a different user than the caller (see
+        its fixture), so it doubles as the "forbidden" case here.
+        """
+        owned_run = TestRun(
+            name="Caller's run",
+            user_id=authenticated_user_id,
+            organization_id=test_organization.id,
+            status_id=db_status.id,
+            test_configuration_id=db_test_configuration.id,
+        )
+        test_db.add(owned_run)
+        test_db.flush()
+        test_db.refresh(owned_run)
+
+        fake_id = str(uuid.uuid4())
+
+        response = authenticated_client.request(
+            "DELETE",
+            "/test_runs/bulk",
+            json={"test_run_ids": [str(owned_run.id), str(db_test_run.id), fake_id]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["deleted_ids"] == [str(owned_run.id)]
+        assert data["forbidden_ids"] == [str(db_test_run.id)]
+        assert data["not_found_ids"] == [fake_id]
+
+        test_db.expire_all()
+        with without_soft_delete_filter():
+            still_present = (
+                test_db.query(TestRun).filter(TestRun.id == db_test_run.id).first()
+            )
+        # Forbidden id must not be deleted, unlike not_found ids which never existed.
+        assert still_present is not None
+        assert still_present.deleted_at is None
+
+    def test_bulk_delete_unauthenticated(self, client: TestClient):
+        response = client.request(
+            "DELETE", "/test_runs/bulk", json={"test_run_ids": [str(uuid.uuid4())]}
+        )
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]

--- a/tests/backend/routes/test_test_set_bulk_delete.py
+++ b/tests/backend/routes/test_test_set_bulk_delete.py
@@ -1,0 +1,71 @@
+"""
+Tests for DELETE /test_sets/bulk endpoint.
+
+Registered before /{test_set_id} in routers/test_set.py -- these tests exist mainly to
+guard against that route-ordering regression (a /{test_set_id}-shaped route
+registered first would swallow "/test_sets/bulk", treating "bulk" as an id).
+"""
+
+import uuid
+
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.database import without_soft_delete_filter
+from rhesis.backend.app.models.test_set import TestSet
+
+
+class TestBulkDeleteTestSetsEndpoint:
+    """Tests for DELETE /test_sets/bulk"""
+
+    def test_bulk_delete_returns_deleted_and_not_found_ids(
+        self, authenticated_client: TestClient, db_test_set
+    ):
+        fake_id = str(uuid.uuid4())
+
+        response = authenticated_client.request(
+            "DELETE",
+            "/test_sets/bulk",
+            json={"test_set_ids": [str(db_test_set.id), fake_id]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["deleted_ids"] == [str(db_test_set.id)]
+        assert data["not_found_ids"] == [fake_id]
+
+    def test_bulk_delete_bumps_updated_at(
+        self, authenticated_client: TestClient, db_test_set, test_db: Session
+    ):
+        """bulk_delete_by_ids soft-deletes via a Core-level query.update(),
+        which bypasses the ORM flush path that applies column onupdate for a
+        single-row soft_delete() -- without setting updated_at explicitly,
+        it stays stale after a bulk delete even though deleted_at is correct.
+        """
+        original_updated_at = db_test_set.updated_at
+        test_db.commit()
+
+        response = authenticated_client.request(
+            "DELETE",
+            "/test_sets/bulk",
+            json={"test_set_ids": [str(db_test_set.id)]},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        test_db.expire_all()
+        with without_soft_delete_filter():
+            deleted_test_set = (
+                test_db.query(TestSet).filter(TestSet.id == db_test_set.id).first()
+            )
+        assert deleted_test_set is not None
+        assert deleted_test_set.updated_at > original_updated_at
+
+    def test_bulk_delete_unauthenticated(self, client: TestClient):
+        response = client.request(
+            "DELETE", "/test_sets/bulk", json={"test_set_ids": [str(uuid.uuid4())]}
+        )
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]

--- a/tests/backend/routes/test_token_bulk_delete.py
+++ b/tests/backend/routes/test_token_bulk_delete.py
@@ -1,0 +1,95 @@
+"""
+Tests for DELETE /tokens/bulk endpoint.
+
+Registered before /{token_id} in routers/token.py -- these tests exist mainly to
+guard against that route-ordering regression (a /{token_id}-shaped route
+registered first would swallow "/tokens/bulk", treating "bulk" as an id).
+"""
+
+import uuid
+
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.database import without_soft_delete_filter
+from rhesis.backend.app.models.token import Token
+
+
+def _make_token(test_db, test_organization, user_id) -> Token:
+    unique = uuid.uuid4().hex
+    token = Token(
+        name="Bulk-delete token",
+        token=f"tok_{unique}",
+        token_hash=unique,
+        token_type="bearer",
+        user_id=user_id,
+        organization_id=test_organization.id,
+    )
+    test_db.add(token)
+    test_db.flush()
+    test_db.refresh(token)
+    return token
+
+
+class TestBulkDeleteTokensEndpoint:
+    """Tests for DELETE /tokens/bulk"""
+
+    def test_bulk_delete_returns_deleted_and_not_found_ids(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_organization,
+        authenticated_user_id: str,
+    ):
+        token = _make_token(test_db, test_organization, authenticated_user_id)
+        fake_id = str(uuid.uuid4())
+
+        response = authenticated_client.request(
+            "DELETE",
+            "/tokens/bulk",
+            json={"token_ids": [str(token.id), fake_id]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["deleted_ids"] == [str(token.id)]
+        assert data["not_found_ids"] == [fake_id]
+
+    def test_bulk_delete_bumps_updated_at(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_organization,
+        authenticated_user_id: str,
+    ):
+        """bulk_delete_by_ids soft-deletes via a Core-level query.update(),
+        which bypasses the ORM flush path that applies column onupdate for a
+        single-row soft_delete() -- without setting updated_at explicitly,
+        it stays stale after a bulk delete even though deleted_at is correct.
+        """
+        token = _make_token(test_db, test_organization, authenticated_user_id)
+        original_updated_at = token.updated_at
+        test_db.commit()
+
+        response = authenticated_client.request(
+            "DELETE",
+            "/tokens/bulk",
+            json={"token_ids": [str(token.id)]},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        test_db.expire_all()
+        with without_soft_delete_filter():
+            deleted_token = test_db.query(Token).filter(Token.id == token.id).first()
+        assert deleted_token is not None
+        assert deleted_token.updated_at > original_updated_at
+
+    def test_bulk_delete_unauthenticated(self, client: TestClient):
+        response = client.request(
+            "DELETE", "/tokens/bulk", json={"token_ids": [str(uuid.uuid4())]}
+        )
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]


### PR DESCRIPTION
## Purpose

Add bulk-select delete support to every backend entity that has a grid in the frontend. This covers the backend half of #2261 (Test Runs and Test Sets) and extends the same pattern to Endpoints, Sources, Tokens, and Tasks. Two of these entities (Test Run, Task) have an owner-only delete rule that the existing generic bulk-delete helper didn't understand, so this also extends that helper to support it safely instead of letting any org member bulk-delete rows they don't own.

## What Changed

- `bulk_delete_by_ids()` gained an optional `owner_attr` parameter: when set, only rows owned by the caller are deleted, and ids that exist but belong to someone else are reported in a new `forbidden_ids` field instead of being silently skipped or deleted.
- Added `DELETE /test_runs/bulk`, respecting the existing creator-only delete rule (also revokes the Celery task for any active run among the ones actually deleted).
- Added `DELETE /test_sets/bulk`, replacing the one-row-at-a-time delete loop the frontend used before.
- Added `DELETE /endpoints/bulk`, `DELETE /sources/bulk`, and `DELETE /tokens/bulk` — none of these have an owner-only rule, so each is a direct wrapper around the existing bulk-delete helper.
- Added `DELETE /tasks/bulk`, respecting the existing creator-only delete rule, same treatment as test runs.

## Additional Context

Closes the backend half of #2261. Team Members and account-level User deletion were intentionally left out of this batch — Team Members isn't backed by a real data grid today, and deleting another user's account carries different risk than deleting a resource like a test or endpoint. The frontend wiring (selection UI, bulk-action bars, API client methods) is a separate PR.

## Testing

Added a route-level test file per entity under `tests/backend/routes/`, covering the deleted/not-found split for every entity and the deleted/forbidden/not-found split for Test Run and Task specifically. Ran the full set of new tests together with the existing Tests bulk-delete suite and the object-level authorization suite to confirm no regressions; all 36 tests pass.