### PR TITLE
Scope connector-invoked endpoints to a local test identity

### DIFF
--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -316,6 +316,30 @@ Web browsers handle this automatically.
     return description
 
 
+def _validate_test_identity_override(db) -> None:
+    """Fail startup loudly if RHESIS_TEST_ORGANIZATION_ID/RHESIS_TEST_USER_ID
+    are set but don't resolve to a local organization/user.
+
+    See ``app/utils/observability.py:_build_test_identity_override`` for why
+    this override exists. Without this check, a typo'd id would surface as
+    an opaque FK/RLS error deep inside the first connector-invoked endpoint
+    call instead of at startup.
+    """
+    organization_id = os.getenv("RHESIS_TEST_ORGANIZATION_ID") or None
+    user_id = os.getenv("RHESIS_TEST_USER_ID") or None
+    if not organization_id or not user_id:
+        return
+
+    from rhesis.backend.app import models
+
+    if not db.query(models.Organization).filter(models.Organization.id == organization_id).first():
+        raise RuntimeError(
+            f"RHESIS_TEST_ORGANIZATION_ID={organization_id} does not match any local organization."
+        )
+    if not db.query(models.User).filter(models.User.id == user_id).first():
+        raise RuntimeError(f"RHESIS_TEST_USER_ID={user_id} does not match any local user.")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """
@@ -370,6 +394,7 @@ async def lifespan(app: FastAPI):
     with get_db() as db:
         initialize_local_environment(db)
         run_startup_hooks(db)
+        _validate_test_identity_override(db)
 
     # Pre-fetch exchange rate on startup (non-blocking async)
     from rhesis.backend.app.services.exchange_rate import get_usd_to_eur_rate_async

--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -336,8 +336,14 @@ def _validate_test_identity_override(db) -> None:
         raise RuntimeError(
             f"RHESIS_TEST_ORGANIZATION_ID={organization_id} does not match any local organization."
         )
-    if not db.query(models.User).filter(models.User.id == user_id).first():
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if not user:
         raise RuntimeError(f"RHESIS_TEST_USER_ID={user_id} does not match any local user.")
+    if str(user.organization_id) != organization_id:
+        raise RuntimeError(
+            f"RHESIS_TEST_USER_ID={user_id} belongs to organization {user.organization_id}, "
+            f"not RHESIS_TEST_ORGANIZATION_ID={organization_id}."
+        )
 
 
 @asynccontextmanager

--- a/apps/backend/src/rhesis/backend/app/utils/observability.py
+++ b/apps/backend/src/rhesis/backend/app/utils/observability.py
@@ -1,14 +1,50 @@
 """Observability utilities for Rhesis backend."""
 
 import logging
+import os
 
 from rhesis.sdk.clients import RhesisClient
 
 logger = logging.getLogger(__name__)
 
+
+def _build_test_identity_override():
+    """Build the local identity to use for connector-invoked endpoints.
+
+    When this backend's own ``@endpoint`` functions (e.g. the architect) are
+    triggered by a *remote* Rhesis instance over the SDK connector — for
+    testing this backend as a connected endpoint of dev/stg/prod — the
+    remote instance's organization/user identity would otherwise flow into
+    local DB scoping, where it doesn't exist. Setting both
+    RHESIS_TEST_ORGANIZATION_ID and RHESIS_TEST_USER_ID substitutes a local
+    identity instead. RHESIS_TEST_PROJECT_ID is optional; unset means
+    unscoped locally. Existence of these ids is checked once at startup in
+    ``main.py``'s lifespan.
+    """
+    organization_id = os.getenv("RHESIS_TEST_ORGANIZATION_ID") or None
+    user_id = os.getenv("RHESIS_TEST_USER_ID") or None
+    if not organization_id or not user_id:
+        return None
+
+    from rhesis.sdk.context import EndpointContext
+
+    logger.warning(
+        "RHESIS_TEST_ORGANIZATION_ID/RHESIS_TEST_USER_ID set — connector-invoked "
+        "endpoints will run as organization=%s, user=%s instead of the identity "
+        "sent by the remote backend.",
+        organization_id,
+        user_id,
+    )
+    return EndpointContext(
+        organization_id=organization_id,
+        user_id=user_id,
+        project_id=os.getenv("RHESIS_TEST_PROJECT_ID") or "",
+    )
+
+
 # Initialize RhesisClient at module import time (required for @endpoint decorators)
 try:
-    rhesis_client = RhesisClient.from_environment()
+    rhesis_client = RhesisClient.from_environment(identity_override=_build_test_identity_override())
     if rhesis_client and not getattr(rhesis_client, "project_id", None):
         logger.info("No project_id found, defaulting to DisabledClient")
         from rhesis.sdk.clients import DisabledClient

--- a/sdk/src/rhesis/sdk/clients/rhesis.py
+++ b/sdk/src/rhesis/sdk/clients/rhesis.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 # Check if connector should be disabled
 # Accept common truthy values: true, 1, yes, on (case-insensitive)
@@ -114,6 +114,7 @@ class RhesisClient:
         base_url: Optional[str] = None,
         project_id: Optional[str] = None,
         environment: Optional[str] = None,
+        identity_override: Optional[Any] = None,
     ):
         """
         Initialize the Rhesis observability client.
@@ -127,6 +128,10 @@ class RhesisClient:
                        will try to get from RHESIS_PROJECT_ID environment variable.
             environment: Optional environment name. If not provided, will try to get
                         from RHESIS_ENVIRONMENT environment variable (default: "development").
+            identity_override: Optional ``EndpointContext`` to use for
+                connector-invoked endpoints in place of the org/user identity
+                sent by the remote backend on connect. See
+                ``ConnectorManager.__init__``.
         """
         from rhesis.sdk.config import get_api_key, get_base_url
 
@@ -137,6 +142,7 @@ class RhesisClient:
         # Observability configuration
         self.project_id = project_id or os.getenv("RHESIS_PROJECT_ID")
         self.environment = environment or os.getenv("RHESIS_ENVIRONMENT", "development")
+        self._identity_override = identity_override
 
         # Resolve project_id from token when not explicitly provided
         if not self.project_id and self.api_key:
@@ -181,7 +187,9 @@ class RhesisClient:
             logger.debug(f"Token introspection failed: {e}")
 
     @classmethod
-    def from_environment(cls) -> Union["RhesisClient", DisabledClient]:
+    def from_environment(
+        cls, identity_override: Optional[Any] = None
+    ) -> Union["RhesisClient", DisabledClient]:
         """
         Create a RhesisClient from environment variables.
 
@@ -195,6 +203,10 @@ class RhesisClient:
             RHESIS_API_KEY: Required API key
             RHESIS_ENVIRONMENT: Optional, defaults to 'development'
             RHESIS_BASE_URL: Optional, defaults to 'http://localhost:8080'
+
+        Args:
+            identity_override: Optional ``EndpointContext``, see
+                ``RhesisClient.__init__``.
 
         Returns:
             RhesisClient or DisabledClient instance
@@ -224,6 +236,7 @@ class RhesisClient:
             api_key=api_key,
             environment=os.getenv("RHESIS_ENVIRONMENT") or "development",
             base_url=os.getenv("RHESIS_BASE_URL") or "http://localhost:8080",
+            identity_override=identity_override,
         )
 
     def _init_telemetry(self) -> None:
@@ -319,6 +332,7 @@ class RhesisClient:
                 project_id=self.project_id,
                 environment=self.environment,
                 base_url=self._base_url,
+                identity_override=self._identity_override,
             )
             self._connector_manager.initialize()
         return self._connector_manager

--- a/sdk/src/rhesis/sdk/connector/manager.py
+++ b/sdk/src/rhesis/sdk/connector/manager.py
@@ -54,6 +54,7 @@ class ConnectorManager:
 
         Raises:
             ValueError: If environment is not valid
+            TypeError: If identity_override is set but isn't an EndpointContext
         """
         environment = environment.lower()
 
@@ -62,6 +63,15 @@ class ConnectorManager:
                 f"Invalid environment: '{environment}'. "
                 f"Valid environments: {', '.join(Environment.ALL)}"
             )
+
+        if identity_override is not None:
+            from rhesis.sdk.context import EndpointContext
+
+            if not isinstance(identity_override, EndpointContext):
+                raise TypeError(
+                    "identity_override must be an EndpointContext, got "
+                    f"{type(identity_override).__name__}"
+                )
 
         self.api_key = api_key
         self.project_id = project_id

--- a/sdk/src/rhesis/sdk/connector/manager.py
+++ b/sdk/src/rhesis/sdk/connector/manager.py
@@ -36,6 +36,7 @@ class ConnectorManager:
         project_id: str | None = None,
         environment: str = "development",
         base_url: str = "ws://localhost:8080",
+        identity_override: Any | None = None,
     ):
         """
         Initialize connector manager.
@@ -45,6 +46,11 @@ class ConnectorManager:
             project_id: Project identifier (optional for metrics-only)
             environment: Environment name (default: "development")
             base_url: Base URL for WebSocket connection
+            identity_override: Optional ``EndpointContext`` to use in place of
+                the organization/user identity the server sends on connect.
+                For running this process's own endpoints against a remote
+                Rhesis instance, where the remote identity would otherwise
+                be applied to this process's local data.
 
         Raises:
             ValueError: If environment is not valid
@@ -61,6 +67,7 @@ class ConnectorManager:
         self.project_id = project_id
         self.environment = environment
         self.base_url = base_url
+        self._identity_override = identity_override
 
         self._registry = FunctionRegistry()
         self._metric_registry = MetricRegistry()
@@ -117,11 +124,16 @@ class ConnectorManager:
         return self._connection_id
 
     def _build_endpoint_context(self):
-        """Build an ``EndpointContext`` from the connection's identity.
+        """Build the ``EndpointContext`` for an incoming execute-test request.
 
-        Returns ``None`` if the server has not yet sent identity fields
-        (e.g. connecting to an older backend).
+        Returns ``identity_override`` when one was configured. Otherwise
+        builds one from the connection's identity, or ``None`` if the
+        server has not yet sent identity fields (e.g. connecting to an
+        older backend).
         """
+        if self._identity_override is not None:
+            return self._identity_override
+
         if not self._organization_id or not self._user_id:
             return None
         from rhesis.sdk.context import EndpointContext

--- a/tests/backend/app/test_connector_test_identity.py
+++ b/tests/backend/app/test_connector_test_identity.py
@@ -1,0 +1,45 @@
+"""Tests for the RHESIS_TEST_ORGANIZATION_ID/RHESIS_TEST_USER_ID startup guard.
+
+See ``app/utils/observability.py:_build_test_identity_override`` for why this
+override exists: it lets this backend run its own connector-invoked
+endpoints (currently just the architect) under a local identity when the
+process is connected to a remote Rhesis instance as a test endpoint.
+"""
+
+import uuid
+
+import pytest
+
+from rhesis.backend.app.main import _validate_test_identity_override
+
+
+def test_noop_when_env_vars_unset(test_db, monkeypatch):
+    monkeypatch.delenv("RHESIS_TEST_ORGANIZATION_ID", raising=False)
+    monkeypatch.delenv("RHESIS_TEST_USER_ID", raising=False)
+
+    _validate_test_identity_override(test_db)
+
+
+def test_passes_for_existing_local_org_and_user(
+    test_db, test_org_id, authenticated_user_id, monkeypatch
+):
+    monkeypatch.setenv("RHESIS_TEST_ORGANIZATION_ID", test_org_id)
+    monkeypatch.setenv("RHESIS_TEST_USER_ID", authenticated_user_id)
+
+    _validate_test_identity_override(test_db)
+
+
+def test_raises_for_unknown_organization_id(test_db, authenticated_user_id, monkeypatch):
+    monkeypatch.setenv("RHESIS_TEST_ORGANIZATION_ID", str(uuid.uuid4()))
+    monkeypatch.setenv("RHESIS_TEST_USER_ID", authenticated_user_id)
+
+    with pytest.raises(RuntimeError, match="RHESIS_TEST_ORGANIZATION_ID"):
+        _validate_test_identity_override(test_db)
+
+
+def test_raises_for_unknown_user_id(test_db, test_org_id, monkeypatch):
+    monkeypatch.setenv("RHESIS_TEST_ORGANIZATION_ID", test_org_id)
+    monkeypatch.setenv("RHESIS_TEST_USER_ID", str(uuid.uuid4()))
+
+    with pytest.raises(RuntimeError, match="RHESIS_TEST_USER_ID"):
+        _validate_test_identity_override(test_db)

--- a/tests/backend/app/test_connector_test_identity.py
+++ b/tests/backend/app/test_connector_test_identity.py
@@ -43,3 +43,27 @@ def test_raises_for_unknown_user_id(test_db, test_org_id, monkeypatch):
 
     with pytest.raises(RuntimeError, match="RHESIS_TEST_USER_ID"):
         _validate_test_identity_override(test_db)
+
+
+def test_raises_for_user_in_a_different_organization(test_db, test_org_id, monkeypatch):
+    """A user that exists but belongs to a different org must not pass."""
+    from rhesis.backend.app import models
+
+    other_org = models.Organization(name=f"other-org-{uuid.uuid4().hex[:8]}")
+    test_db.add(other_org)
+    test_db.flush()
+
+    other_user = models.User(
+        email=f"other-{uuid.uuid4().hex[:8]}@rhesis-test.com",
+        name="Other Org User",
+        is_active=True,
+        organization_id=other_org.id,
+    )
+    test_db.add(other_user)
+    test_db.flush()
+
+    monkeypatch.setenv("RHESIS_TEST_ORGANIZATION_ID", test_org_id)
+    monkeypatch.setenv("RHESIS_TEST_USER_ID", str(other_user.id))
+
+    with pytest.raises(RuntimeError, match="belongs to organization"):
+        _validate_test_identity_override(test_db)

--- a/tests/sdk/connector/test_manager.py
+++ b/tests/sdk/connector/test_manager.py
@@ -70,6 +70,40 @@ def test_manager_uses_telemetry_tracer(manager):
     assert isinstance(manager._tracer, Tracer)
 
 
+def test_build_endpoint_context_uses_handshake_identity_by_default(manager):
+    """Without an override, context comes from the server's connect message."""
+    manager._organization_id = "remote-org"
+    manager._user_id = "remote-user"
+
+    ctx = manager._build_endpoint_context()
+
+    assert ctx.organization_id == "remote-org"
+    assert ctx.user_id == "remote-user"
+
+
+def test_build_endpoint_context_none_without_handshake_identity(manager):
+    """No handshake identity and no override means no context."""
+    assert manager._build_endpoint_context() is None
+
+
+def test_build_endpoint_context_prefers_identity_override():
+    """An identity_override wins even when the server sent its own identity."""
+    from rhesis.sdk.context import EndpointContext
+
+    override = EndpointContext(organization_id="local-org", user_id="local-user")
+    manager = ConnectorManager(
+        api_key="test-api-key",
+        project_id="test-project",
+        environment="development",
+        base_url="http://localhost:8080",
+        identity_override=override,
+    )
+    manager._organization_id = "remote-org"
+    manager._user_id = "remote-user"
+
+    assert manager._build_endpoint_context() is override
+
+
 @patch("rhesis.sdk.connector.manager.WebSocketConnection")
 @patch("asyncio.get_running_loop")
 def test_initialize(mock_get_loop, mock_ws_class, manager):

--- a/tests/sdk/connector/test_manager.py
+++ b/tests/sdk/connector/test_manager.py
@@ -104,6 +104,18 @@ def test_build_endpoint_context_prefers_identity_override():
     assert manager._build_endpoint_context() is override
 
 
+def test_identity_override_rejects_wrong_type():
+    """A non-EndpointContext identity_override fails fast at construction."""
+    with pytest.raises(TypeError, match="EndpointContext"):
+        ConnectorManager(
+            api_key="test-api-key",
+            project_id="test-project",
+            environment="development",
+            base_url="http://localhost:8080",
+            identity_override={"organization_id": "local-org", "user_id": "local-user"},
+        )
+
+
 @patch("rhesis.sdk.connector.manager.WebSocketConnection")
 @patch("asyncio.get_running_loop")
 def test_initialize(mock_get_loop, mock_ws_class, manager):


### PR DESCRIPTION
## Purpose

Testing this backend as a connected endpoint of another Rhesis instance (dev/stg/prod) means the remote instance's org/user identity arrives on the SDK connector handshake and gets applied to local DB scoping via `EndpointContext`, where those ids don't exist. This breaks the architect (and any future connector-invoked endpoint) with an opaque FK/RLS failure four layers deep in the DB, rather than a clear error close to the cause.

## What Changed

- `ConnectorManager` (SDK) accepts an `identity_override` and returns it from `_build_endpoint_context()` ahead of the identity sent by the remote on connect. `RhesisClient` threads the same parameter through `__init__`, `from_environment`, and `_ensure_connector`.
- The backend's observability bootstrap reads `RHESIS_TEST_ORGANIZATION_ID` / `RHESIS_TEST_USER_ID` / `RHESIS_TEST_PROJECT_ID` and builds the override from them, logging loudly whenever it's active.
- A startup check in `main.py`'s lifespan resolves the configured org/user against the local DB once and raises if either doesn't exist, so a bad id fails at boot instead of during the first connector-invoked call.
- Unit tests for both the SDK override precedence and the backend startup guard (happy path, missing env, unknown org, unknown user).

## Additional Context

- This only takes effect when both `RHESIS_TEST_ORGANIZATION_ID` and `RHESIS_TEST_USER_ID` are set — absent by default, no behavior change otherwise. Same pattern as the existing `RHESIS_DISABLE_SCOPE_LISTENER` / `QUICK_START` dev-only knobs.
- Only one `@endpoint`-registered function exists in the backend today (`run_architect_turn`), so the override's scope is effectively architect-only right now, though it applies to any future one in the same process.
- Verified live against a real backend restart: a correct override logs the warning and starts cleanly; a nonexistent org id raises `RuntimeError` at startup and the process exits before serving traffic.

## Testing

```bash
cd apps/backend && uv run pytest ../../tests/backend/app/test_connector_test_identity.py -v
cd sdk && uv run pytest ../tests/sdk/connector/test_manager.py ../tests/sdk/test_client.py -v
```

Manual: set `QUICK_START=true`, start the backend once to seed `Local Org`/`admin@local.dev`, set `RHESIS_TEST_ORGANIZATION_ID`/`RHESIS_TEST_USER_ID` to the seeded ids, restart — startup logs the override warning and completes. Set either to a random UUID and restart — startup raises and exits before serving.