### PR TITLE
Add a frontend health route for container probes

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -138,7 +138,7 @@ EXPOSE 3000
 
 # Add a health check that uses the PORT env var with fallback
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
-  CMD curl -f http://localhost:${PORT:-3000}/ || exit 1
+  CMD curl -f http://localhost:${PORT:-3000}/api/health || exit 1
 
 # server.js does process.chdir(__dirname) so PORT env var drives the port.
 # Run from /app; server.js is at apps/frontend/server.js inside the standalone output.

--- a/apps/frontend/src/app/api/health/__tests__/route.test.ts
+++ b/apps/frontend/src/app/api/health/__tests__/route.test.ts
@@ -1,0 +1,16 @@
+/**
+ * next/server needs the WHATWG Request/Response globals, which the default
+ * jsdom environment does not provide.
+ *
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/health/route';
+
+describe('GET /api/health', () => {
+  it('returns 200 with an ok status', async () => {
+    const response = GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: 'ok' });
+  });
+});

--- a/apps/frontend/src/app/api/health/route.ts
+++ b/apps/frontend/src/app/api/health/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+
+// Static so probes never render a page or fetch anything — they used to hit `/` every 10s.
+export const dynamic = 'force-static';
+
+export function GET() {
+  return NextResponse.json({ status: 'ok' });
+}

--- a/charts/rhesis/templates/frontend/deployment.yaml
+++ b/charts/rhesis/templates/frontend/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/health
               port: {{ .Values.frontend.service.targetPort }}
             initialDelaySeconds: 60
             periodSeconds: 30
@@ -56,7 +56,7 @@ spec:
             failureThreshold: 5
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/health
               port: {{ .Values.frontend.service.targetPort }}
             initialDelaySeconds: 30
             periodSeconds: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,7 +208,7 @@ services:
       - rhesis-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/api/auth/session"]
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Purpose

The frontend's liveness and readiness probes point at `/`, the app's root page. Every probe renders the real page — data fetching, auth, log lines — and readiness runs every 10 seconds. That's the frontend half of the same noise #2565 fixed on the backend.

## What Changed

- Add `apps/frontend/src/app/api/health/route.ts` — returns `{"status":"ok"}` and nothing else. Marked `dynamic = 'force-static'`, so no auth, no backend call, no data fetching.
- Point the k8s `livenessProbe` and `readinessProbe` in `charts/rhesis/templates/frontend/deployment.yaml` at `/api/health` instead of `/`.
- Point the `HEALTHCHECK` in `apps/frontend/Dockerfile` at `/api/health` instead of `/`.
- Point the `frontend` service healthcheck in `docker-compose.yml` at `/api/health`. It was hitting `/api/auth/session`, which pulled in the whole auth stack on every poll.
- Add a route-handler test following the existing `architect-help` pattern.

No middleware change was needed: the matcher in `apps/frontend/src/proxy.ts` already excludes `api`, so `/api/health` never reaches the auth check.

## Additional Context

- Backend counterpart: #2565.
- The frontend chart template hardcodes its probe paths, unlike the backend/worker/polyphemus templates which read them from values. Left as is — making the chart consistent is a separate change.
- `playwright.config.ts` still waits on `/` for dev-server readiness. That's a one-shot startup wait, not a repeating probe, so it's untouched.
- Noticed in passing: `PUBLIC_PATHS` in `apps/frontend/src/constants/paths.ts` has a stale `/api/warmup` entry for a route that no longer exists. Not touched here.

## Testing

```bash
cd apps/frontend
npx jest src/app/api/health   # 1 passed
npx tsc --noEmit              # clean
npx eslint src/app/api/health --ext .ts
```

Rendered probe paths:

```bash
helm template rhesis charts/rhesis --show-only templates/frontend/deployment.yaml \
  --set existingSecret=dummy --set externalDatabase.host=x --set externalAnalyticsDatabase.host=x
```

Both probes render as `path: /api/health` on port 3000.

Manually: start the frontend and `curl -i localhost:3000/api/health` → `200` with `{"status":"ok"}`, and no page-render log line.
