### PR TITLE
fix(backend): serialize concurrent migrations with a Postgres advisory lock

### DIFF
--- a/apps/backend/migrate.sh
+++ b/apps/backend/migrate.sh
@@ -65,6 +65,11 @@ maybe_wait_for_database() {
 
 # Function to run migrations
 #
+# Concurrent replicas are serialized by a Postgres advisory lock acquired in
+# alembic's env.py (see MIGRATION_ADVISORY_LOCK_KEY there), so simultaneous
+# Cloud Run Job instances wait for each other instead of racing through the
+# upgrade. The wait is logged by Alembic; tune it with ALEMBIC_LOCK_TIMEOUT.
+#
 # We use `psql` (not `alembic current`) to read the revision before and after
 # the upgrade. Each `alembic` invocation costs ~5-6s of Python cold-start +
 # SDK/model imports inside the Cloud Run Job, so two diagnostic calls used to

--- a/apps/backend/src/rhesis/backend/alembic/env.py
+++ b/apps/backend/src/rhesis/backend/alembic/env.py
@@ -1,8 +1,11 @@
+import logging
+import os
+import time
 from logging.config import fileConfig
 
 from alembic import context
 from dotenv import load_dotenv
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 
 from rhesis.backend.app.config.settings import get_database_settings
 from rhesis.backend.app.models import Base
@@ -37,6 +40,89 @@ fileConfig(config.config_file_name)
 
 # Import your models here to ensure they are known to Alembic
 target_metadata = Base.metadata
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+# Session-scoped Postgres advisory lock that serializes concurrent schema
+# upgrades across replicas (every backend replica runs ``migrate.sh`` at
+# container start). Without it, simultaneous rollouts rely on row-level lock
+# serialization inside Postgres plus idempotent migration guards to avoid
+# corrupting each other.
+#
+# The key is a fixed constant so every replica agrees on the same lock; it is
+# derived from crc32(b"rhesis-backend-migrations") = 1260693429 and must not
+# change once deployments exist.
+MIGRATION_ADVISORY_LOCK_KEY = 1260693429
+
+# How long a process waits for another replica's upgrade before failing.
+MIGRATION_LOCK_TIMEOUT_SECONDS = float(os.environ.get("ALEMBIC_LOCK_TIMEOUT", "600"))
+LOCK_POLL_INTERVAL_SECONDS = 1.0
+
+
+def _try_acquire_migration_advisory_lock(connection) -> bool:
+    """Attempt a non-blocking acquisition of the migration advisory lock."""
+    return bool(
+        connection.execute(
+            text("SELECT pg_try_advisory_lock(:key)"),
+            {"key": MIGRATION_ADVISORY_LOCK_KEY},
+        ).scalar_one()
+    )
+
+
+def _acquire_migration_advisory_lock(connectable):
+    """Hold a Postgres advisory lock for the duration of an online upgrade.
+
+    Uses a dedicated autocommit connection so the session-scoped lock stays
+    held while Alembic runs its own transactions on the migration connection.
+
+    Returns the connection holding the lock, or None when locking does not
+    apply (non-PostgreSQL database). Raises RuntimeError if another holder
+    keeps the lock beyond ``ALEMBIC_LOCK_TIMEOUT`` seconds so orchestrators
+    can retry instead of racing through an upgrade.
+    """
+    lock_connection = connectable.connect().execution_options(isolation_level="AUTOCOMMIT")
+    if lock_connection.dialect.name != "postgresql":
+        lock_connection.close()
+        return None
+
+    deadline = time.monotonic() + MIGRATION_LOCK_TIMEOUT_SECONDS
+    waited = False
+    while True:
+        if _try_acquire_migration_advisory_lock(lock_connection):
+            if waited:
+                logger.info("Migration advisory lock acquired")
+            return lock_connection
+
+        if not waited:
+            waited = True
+            logger.warning(
+                "Another replica is running migrations; waiting up to %ss "
+                "for the migration advisory lock",
+                MIGRATION_LOCK_TIMEOUT_SECONDS,
+            )
+        if time.monotonic() >= deadline:
+            lock_connection.close()
+            raise RuntimeError(
+                "Timed out waiting for the migration advisory lock "
+                f"({MIGRATION_LOCK_TIMEOUT_SECONDS}s). Another upgrade may be "
+                "stuck; inspect pg_locks for the holder or raise "
+                "ALEMBIC_LOCK_TIMEOUT."
+            )
+        time.sleep(LOCK_POLL_INTERVAL_SECONDS)
+
+
+def _release_migration_advisory_lock(lock_connection):
+    """Release the migration advisory lock if we hold one."""
+    if lock_connection is None:
+        return
+    try:
+        lock_connection.execute(
+            text("SELECT pg_advisory_unlock(:key)"),
+            {"key": MIGRATION_ADVISORY_LOCK_KEY},
+        )
+    finally:
+        lock_connection.close()
+
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:
@@ -85,22 +171,30 @@ def run_migrations_online():
     In this scenario we need to create an Engine
     and associate a connection with the context.
 
+    Concurrent replicas are serialized with a Postgres advisory lock so only
+    one process performs the upgrade while the rest wait and then find the
+    database already at head.
+
     """
     url = get_database_settings().admin_url
 
     connectable = create_engine(url)
 
-    with connectable.connect() as connection:
-        context.configure(
-            connection=connection,
-            target_metadata=target_metadata,
-            compare_type=True,
-            compare_server_default=False,
-            include_object=include_object,
-        )
+    lock_connection = _acquire_migration_advisory_lock(connectable)
+    try:
+        with connectable.connect() as connection:
+            context.configure(
+                connection=connection,
+                target_metadata=target_metadata,
+                compare_type=True,
+                compare_server_default=False,
+                include_object=include_object,
+            )
 
-        with context.begin_transaction():
-            context.run_migrations()
+            with context.begin_transaction():
+                context.run_migrations()
+    finally:
+        _release_migration_advisory_lock(lock_connection)
 
 
 if context.is_offline_mode():

--- a/apps/backend/src/rhesis/backend/alembic/env.py
+++ b/apps/backend/src/rhesis/backend/alembic/env.py
@@ -80,10 +80,14 @@ def _acquire_migration_advisory_lock(connectable):
     keeps the lock beyond ``ALEMBIC_LOCK_TIMEOUT`` seconds so orchestrators
     can retry instead of racing through an upgrade.
     """
-    lock_connection = connectable.connect().execution_options(isolation_level="AUTOCOMMIT")
-    if lock_connection.dialect.name != "postgresql":
-        lock_connection.close()
+    # Check the dialect at engine level before opening the lock connection:
+    # applying AUTOCOMMIT isolation via execution_options may be rejected on
+    # dialects other than PostgreSQL, and non-PG setups must skip locking
+    # entirely rather than fail while trying to skip it.
+    if connectable.dialect.name != "postgresql":
         return None
+
+    lock_connection = connectable.connect().execution_options(isolation_level="AUTOCOMMIT")
 
     deadline = time.monotonic() + MIGRATION_LOCK_TIMEOUT_SECONDS
     waited = False

--- a/apps/backend/src/rhesis/backend/alembic/env.py
+++ b/apps/backend/src/rhesis/backend/alembic/env.py
@@ -91,28 +91,34 @@ def _acquire_migration_advisory_lock(connectable):
 
     deadline = time.monotonic() + MIGRATION_LOCK_TIMEOUT_SECONDS
     waited = False
-    while True:
-        if _try_acquire_migration_advisory_lock(lock_connection):
-            if waited:
-                logger.info("Migration advisory lock acquired")
-            return lock_connection
+    try:
+        while True:
+            if _try_acquire_migration_advisory_lock(lock_connection):
+                if waited:
+                    logger.info("Migration advisory lock acquired")
+                return lock_connection
 
-        if not waited:
-            waited = True
-            logger.warning(
-                "Another replica is running migrations; waiting up to %ss "
-                "for the migration advisory lock",
-                MIGRATION_LOCK_TIMEOUT_SECONDS,
-            )
-        if time.monotonic() >= deadline:
-            lock_connection.close()
-            raise RuntimeError(
-                "Timed out waiting for the migration advisory lock "
-                f"({MIGRATION_LOCK_TIMEOUT_SECONDS}s). Another upgrade may be "
-                "stuck; inspect pg_locks for the holder or raise "
-                "ALEMBIC_LOCK_TIMEOUT."
-            )
-        time.sleep(LOCK_POLL_INTERVAL_SECONDS)
+            if not waited:
+                waited = True
+                logger.warning(
+                    "Another replica is running migrations; waiting up to %ss "
+                    "for the migration advisory lock",
+                    MIGRATION_LOCK_TIMEOUT_SECONDS,
+                )
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    "Timed out waiting for the migration advisory lock "
+                    f"({MIGRATION_LOCK_TIMEOUT_SECONDS}s). Another upgrade may be "
+                    "stuck; inspect pg_locks for the holder or raise "
+                    "ALEMBIC_LOCK_TIMEOUT."
+                )
+            time.sleep(LOCK_POLL_INTERVAL_SECONDS)
+    except BaseException:
+        # Any failure while polling (e.g. the connection dropping mid-poll)
+        # must not leak the dedicated lock connection; the timeout path raises
+        # through here as well.
+        lock_connection.close()
+        raise
 
 
 def _release_migration_advisory_lock(lock_connection):
@@ -124,6 +130,13 @@ def _release_migration_advisory_lock(lock_connection):
             text("SELECT pg_advisory_unlock(:key)"),
             {"key": MIGRATION_ADVISORY_LOCK_KEY},
         )
+    except Exception:
+        # This runs in a ``finally`` after the migration itself: when the same
+        # database problem failed the migration, the unlock fails too, and a
+        # propagating unlock error would replace the original migration error.
+        # Closing the connection releases the session-scoped lock anyway, so
+        # the explicit unlock is belt-and-suspenders only.
+        logger.warning("Failed to release migration advisory lock", exc_info=True)
     finally:
         lock_connection.close()
 


### PR DESCRIPTION
Fixes #2545

## Problem

Every backend replica runs `migrate.sh` at container start, so rolling out a new version with multiple Cloud Run Job instances fires `alembic upgrade head` against the same database simultaneously. As reported in #2545, during the v0.13.0 rollout three backend pods ran the 582-line org migration concurrently and only avoided corruption because Postgres row-level locks serialized the writes and the migration guards happened to be idempotent.

## Solution

Acquire a session-scoped `pg_advisory_lock` in Alembic's `env.py` (online mode) so exactly one process performs the upgrade while any other replica waits, then finds the database already at head:

- **Dedicated autocommit connection** holds the session-scoped lock for the whole upgrade; Alembic keeps using its own connection/transactions untouched.
- **Crash-safe**: the lock auto-releases if a holder dies mid-upgrade (session end).
- **Bounded wait**: `pg_try_advisory_lock` polling with `ALEMBIC_LOCK_TIMEOUT` (default 600s); on timeout it raises a clear RuntimeError instead of hanging replicas forever or racing through the upgrade.
- **Non-PostgreSQL databases**: locking is skipped entirely (dialect guard), so community/non-PG setups are unaffected.
- **Covers every entry point**: since the lock lives in `env.py`, manual `alembic upgrade`, CI jobs, and `migrate.sh` are all serialized — not just the shell script path.
- `migrate.sh` got a short comment pointing at the mechanism for discoverability.

Lock key is the fixed constant `crc32(b"rhesis-backend-migrations") = 1260693429`.

## Testing

Verified against Postgres 16 (local Docker, full `alembic upgrade head` from an empty DB to head with the change active):

| Scenario | Result |
|---|---|
| Fresh DB, single upgrade | ✅ migrates to head, lock released after (0 rows in `pg_locks`) |
| External holder + `ALEMBIC_LOCK_TIMEOUT=6` | ✅ logs "Another replica is running migrations; waiting up to 6.0s", times out with clear RuntimeError, exit 1 |
| External holder releases mid-wait (`ALEMBIC_LOCK_TIMEOUT=60`) | ✅ warning → "Migration advisory lock acquired" → completes at head, exit 0 |
| Re-run at head | ✅ no-op |

```
WARNI [alembic.runtime.migration] Another replica is running migrations; waiting up to 6.0s for the migration advisory lock
INFO  [alembic.runtime.migration] Migration advisory lock acquired
```

Also: `ruff check` + `ruff format --check` clean, `bash -n migrate.sh` clean.

> [!NOTE]
> LLM-assisted contribution, per repo guidelines.