### PR TITLE
fix(dev): drop email alert receiver for dev and stg grafana

### DIFF
--- a/kubernetes/clusters/dev/grafana-resources/contact-point.yaml
+++ b/kubernetes/clusters/dev/grafana-resources/contact-point.yaml
@@ -1,0 +1,19 @@
+# Discord only for dev — no need to spam email for a dev-cluster alert.
+# To bring email back, delete this patch (and the matching one in stg/grafana-resources)
+# and remove it from kustomization.yaml's patches list.
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaContactPoint
+metadata:
+  name: default-notifications
+  namespace: monitoring
+spec:
+  receivers:
+    - type: discord
+      settings:
+        use_discord_username: true
+      valuesFrom:
+        - targetPath: url
+          valueFrom:
+            secretKeyRef:
+              name: grafana-discord-webhook
+              key: url

--- a/kubernetes/clusters/dev/grafana-resources/kustomization.yaml
+++ b/kubernetes/clusters/dev/grafana-resources/kustomization.yaml
@@ -15,6 +15,10 @@ resources:
   # base/grafana-resources/grafana-instance.yaml.
   - grafana-google-oidc-credentials.yaml
 
+patches:
+  # Drop the email receiver for dev — Discord alone is enough here.
+  - path: contact-point.yaml
+
 configMapGenerator:
   - name: grafana-config
     literals:

--- a/kubernetes/clusters/stg/grafana-resources/contact-point.yaml
+++ b/kubernetes/clusters/stg/grafana-resources/contact-point.yaml
@@ -1,0 +1,19 @@
+# Discord only for stg — no need to spam email for a staging-cluster alert.
+# To bring email back, delete this patch (and the matching one in dev/grafana-resources)
+# and remove it from kustomization.yaml's patches list.
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaContactPoint
+metadata:
+  name: default-notifications
+  namespace: monitoring
+spec:
+  receivers:
+    - type: discord
+      settings:
+        use_discord_username: true
+      valuesFrom:
+        - targetPath: url
+          valueFrom:
+            secretKeyRef:
+              name: grafana-discord-webhook
+              key: url

--- a/kubernetes/clusters/stg/grafana-resources/kustomization.yaml
+++ b/kubernetes/clusters/stg/grafana-resources/kustomization.yaml
@@ -15,6 +15,10 @@ resources:
   # base/grafana-resources/grafana-instance.yaml.
   - grafana-google-oidc-credentials.yaml
 
+patches:
+  # Drop the email receiver for stg — Discord alone is enough here.
+  - path: contact-point.yaml
+
 configMapGenerator:
   - name: grafana-config
     literals:


### PR DESCRIPTION
## Purpose

Dev and stg alerts were emailing on top of the Discord notification, which is noise nobody needs for non-prod alerts — Discord alone is enough there. Prod keeps email as-is since that's where it actually matters.

## What Changed

- Added a kustomize patch (`contact-point.yaml`) in `kubernetes/clusters/dev/grafana-resources` and `kubernetes/clusters/stg/grafana-resources` that overrides the shared `GrafanaContactPoint`'s `spec.receivers` to Discord only.
- Wired each patch into that cluster's `kustomization.yaml` via `patches:`.
- `kubernetes/base/grafana-resources/contact-point.yaml` (shared by all three clusters) and the prod overlay are untouched, so prod still gets both Discord and email.

## Additional Context

Grafana's contact point CRD has no per-receiver enable/disable flag, so this is done by patching the receivers list per cluster instead. To re-enable email for dev or stg later, delete that cluster's `contact-point.yaml` and remove the `patches:` block from its `kustomization.yaml`.

## Testing

Rendered both overlays locally with `kubectl kustomize` to confirm dev and stg produce a Discord-only `GrafanaContactPoint` while prod still renders both Discord and email receivers.