### PR TITLE
feat(frontend): custom font branding via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,12 @@ SESSION_SECRET_KEY=
 # BRAND_SECONDARY_COLOR=#C2185B
 # BRAND_FAVICON_URL=https://www.example.com/favicon.png
 # BRAND_PRODUCT_NAME=Acme
+# BRAND_FONT_FAMILY overrides the default "Be Vietnam Pro" typeface.
+# When set alone, the font is loaded from Google Fonts. To self-host the files
+# instead, also set BRAND_FONT_BASE_URL — the app loads
+# {base_url}/{slug}-{300,400,700}.ttf (e.g. inria-sans-300.ttf).
+# BRAND_FONT_FAMILY=Inria Sans
+# BRAND_FONT_BASE_URL=https://example.com/assets/fonts
 
 # =============================================================================
 # DATABASE

--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -340,7 +340,10 @@ const nextConfig = {
   },
 
   async rewrites() {
-    const fontBase = process.env.BRAND_FONT_BASE_URL?.trim()?.replace(/\/+$/, '');
+    const fontBase = process.env.BRAND_FONT_BASE_URL?.trim()?.replace(
+      /\/+$/,
+      ''
+    );
     if (!fontBase) return [];
     return [
       {

--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -339,6 +339,17 @@ const nextConfig = {
     return baseHeaders;
   },
 
+  async rewrites() {
+    const fontBase = process.env.BRAND_FONT_BASE_URL?.trim()?.replace(/\/+$/, '');
+    if (!fontBase) return [];
+    return [
+      {
+        source: '/brand-fonts/:path*',
+        destination: `${fontBase}/:path*`,
+      },
+    ];
+  },
+
   async redirects() {
     return [
       {

--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -340,15 +340,28 @@ const nextConfig = {
   },
 
   async rewrites() {
-    const fontBase = process.env.BRAND_FONT_BASE_URL?.trim()?.replace(
-      /\/+$/,
-      ''
-    );
-    if (!fontBase) return [];
+    const family = process.env.BRAND_FONT_FAMILY?.trim();
+    if (!family) return [];
+
+    const raw = process.env.BRAND_FONT_BASE_URL?.trim()?.replace(/\/+$/, '');
+    if (!raw) return [];
+
+    // Same safety checks as normalizeBaseUrl() in branding.ts — only https://
+    // and safe root-relative paths are proxied.
+    if (raw.startsWith('/')) {
+      if (/^\/[/\\]/.test(raw)) return [];
+    } else {
+      try {
+        if (new URL(raw).protocol !== 'https:') return [];
+      } catch {
+        return [];
+      }
+    }
+
     return [
       {
         source: '/brand-fonts/:path*',
-        destination: `${fontBase}/:path*`,
+        destination: `${raw}/:path*`,
       },
     ];
   },

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -51,7 +51,7 @@ import { type Organization } from '../utils/api-client/interfaces/organization';
 import { type UserSettings } from '../utils/api-client/interfaces/user';
 import { type Session } from 'next-auth';
 import ThemeContextProvider from '../components/providers/ThemeProvider';
-import { getServerBranding } from '../config/branding';
+import { getServerBranding, type BrandFont } from '../config/branding';
 import { BACKGROUND_DEFAULT } from '../styles/theme-background';
 import { Capability } from '../constants/capabilities';
 
@@ -93,6 +93,16 @@ const THEME_MODE_STYLE = (['dark', 'light'] as const)
 html[data-theme-mode='${mode}'],html[data-theme-mode='${mode}'] body{background-color:${BACKGROUND_DEFAULT[mode]}}`
   )
   .join('\n');
+
+function buildFontFaceCss(font: BrandFont): string {
+  const weights = ['300', '400', '700'];
+  return weights
+    .map(
+      w =>
+        `@font-face{font-family:"${font.family}";font-weight:${w};font-style:normal;font-display:swap;src:url("/brand-fonts/${font.slug}-${w}.ttf") format("truetype")}`
+    )
+    .join('\n');
+}
 
 // This function will be used to get navigation items with dynamic data
 async function getNavigationItems(
@@ -445,6 +455,21 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
           id="rhesis-theme-mode-paint"
           dangerouslySetInnerHTML={{ __html: THEME_MODE_STYLE }}
         />
+        {deploymentBranding.font?.source === 'google' && (
+          <link
+            rel="stylesheet"
+            href={deploymentBranding.font.googleHref}
+            crossOrigin="anonymous"
+          />
+        )}
+        {deploymentBranding.font?.source === 'custom' && (
+          <style
+            id="rhesis-brand-font"
+            dangerouslySetInnerHTML={{
+              __html: buildFontFaceCss(deploymentBranding.font),
+            }}
+          />
+        )}
       </head>
       <body suppressHydrationWarning>
         <ThemeContextProvider
@@ -453,6 +478,7 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
           brandColors={{
             primary: deploymentBranding.primaryColor,
             secondary: deploymentBranding.secondaryColor,
+            fontFamily: deploymentBranding.font?.family,
           }}
         >
           <LayoutContent

--- a/apps/frontend/src/components/providers/ThemeProvider.tsx
+++ b/apps/frontend/src/components/providers/ThemeProvider.tsx
@@ -120,15 +120,17 @@ export default function ThemeContextProvider({
   // otherwise rebuild the whole theme on every render.
   const brandPrimary = brandColors?.primary;
   const brandSecondary = brandColors?.secondary;
+  const brandFont = brandColors?.fontFamily;
   const theme = React.useMemo(
     () =>
       createTheme(
         getDesignTokens(mode, {
           primary: brandPrimary,
           secondary: brandSecondary,
+          fontFamily: brandFont,
         })
       ),
-    [mode, brandPrimary, brandSecondary]
+    [mode, brandPrimary, brandSecondary, brandFont]
   );
 
   return (

--- a/apps/frontend/src/config/__tests__/branding.test.ts
+++ b/apps/frontend/src/config/__tests__/branding.test.ts
@@ -131,6 +131,8 @@ describe('getServerBranding', () => {
     secondary: process.env.BRAND_SECONDARY_COLOR,
     favicon: process.env.BRAND_FAVICON_URL,
     product: process.env.BRAND_PRODUCT_NAME,
+    fontFamily: process.env.BRAND_FONT_FAMILY,
+    fontBaseUrl: process.env.BRAND_FONT_BASE_URL,
   };
 
   // Assigning `undefined` to a process.env key stores the *string* "undefined"
@@ -146,6 +148,8 @@ describe('getServerBranding', () => {
     restore('BRAND_SECONDARY_COLOR', original.secondary);
     restore('BRAND_FAVICON_URL', original.favicon);
     restore('BRAND_PRODUCT_NAME', original.product);
+    restore('BRAND_FONT_FAMILY', original.fontFamily);
+    restore('BRAND_FONT_BASE_URL', original.fontBaseUrl);
   });
 
   it('reads every variable from the environment', () => {
@@ -160,6 +164,7 @@ describe('getServerBranding', () => {
       faviconUrl: 'https://example.com/fav.png',
       productName: 'Acme',
       isDefaultProductName: false,
+      font: undefined,
     });
   });
 
@@ -195,6 +200,7 @@ describe('getServerBranding', () => {
       faviconUrl: DEFAULT_FAVICON_URL,
       productName: DEFAULT_PRODUCT_NAME,
       isDefaultProductName: true,
+      font: undefined,
     });
   });
 
@@ -203,5 +209,99 @@ describe('getServerBranding', () => {
     // to what it already was.
     process.env.BRAND_PRODUCT_NAME = 'Rhesis AI';
     expect(getServerBranding().isDefaultProductName).toBe(true);
+  });
+
+  describe('font', () => {
+    let warn: jest.SpyInstance;
+
+    beforeEach(() => {
+      warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      delete process.env.BRAND_FONT_FAMILY;
+      delete process.env.BRAND_FONT_BASE_URL;
+    });
+
+    afterEach(() => {
+      warn.mockRestore();
+    });
+
+    it('returns google source with correct href when only family is set', () => {
+      process.env.BRAND_FONT_FAMILY = 'Inria Sans';
+
+      const font = getServerBranding().font;
+      expect(font).toEqual({
+        family: 'Inria Sans',
+        source: 'google',
+        googleHref:
+          'https://fonts.googleapis.com/css2?family=Inria%20Sans:wght@300;400;700&display=swap',
+        slug: 'inria-sans',
+      });
+    });
+
+    it('returns custom source when family and base URL are set', () => {
+      process.env.BRAND_FONT_FAMILY = 'Inria Sans';
+      process.env.BRAND_FONT_BASE_URL = 'https://gitea.example.com/fonts';
+
+      const font = getServerBranding().font;
+      expect(font).toEqual({
+        family: 'Inria Sans',
+        source: 'custom',
+        baseUrl: 'https://gitea.example.com/fonts',
+        slug: 'inria-sans',
+      });
+    });
+
+    it('strips trailing slashes from the base URL', () => {
+      process.env.BRAND_FONT_FAMILY = 'Fira Code';
+      process.env.BRAND_FONT_BASE_URL = 'https://cdn.example.com/fonts///';
+
+      expect(getServerBranding().font?.baseUrl).toBe(
+        'https://cdn.example.com/fonts'
+      );
+    });
+
+    it('accepts root-relative base URL', () => {
+      process.env.BRAND_FONT_FAMILY = 'Fira Code';
+      process.env.BRAND_FONT_BASE_URL = '/static/fonts';
+
+      const font = getServerBranding().font;
+      expect(font?.source).toBe('custom');
+      expect(font?.baseUrl).toBe('/static/fonts');
+    });
+
+    it('ignores invalid base URL and falls back to google', () => {
+      process.env.BRAND_FONT_FAMILY = 'Fira Code';
+      process.env.BRAND_FONT_BASE_URL = 'http://insecure.example.com/fonts';
+
+      const font = getServerBranding().font;
+      expect(font?.source).toBe('google');
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it('rejects protocol-relative base URL', () => {
+      process.env.BRAND_FONT_FAMILY = 'Fira Code';
+      process.env.BRAND_FONT_BASE_URL = '//cdn.example.com/fonts';
+
+      const font = getServerBranding().font;
+      expect(font?.source).toBe('google');
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it('returns undefined when family is unset', () => {
+      expect(getServerBranding().font).toBeUndefined();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('rejects an overlong family name', () => {
+      process.env.BRAND_FONT_FAMILY = 'A'.repeat(81);
+
+      expect(getServerBranding().font).toBeUndefined();
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it('slugifies family names with special characters', () => {
+      process.env.BRAND_FONT_FAMILY = 'Noto Sans (Display)';
+
+      expect(getServerBranding().font?.slug).toBe('noto-sans-display');
+    });
   });
 });

--- a/apps/frontend/src/config/branding.ts
+++ b/apps/frontend/src/config/branding.ts
@@ -150,7 +150,10 @@ export function normalizeProductName(value: string | undefined | null): string {
 const MAX_FONT_FAMILY_LENGTH = 80;
 
 function slugifyFont(family: string): string {
-  return family.toLowerCase().replace(/\s+/g, '-');
+  return family
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
 }
 
 /**

--- a/apps/frontend/src/config/branding.ts
+++ b/apps/frontend/src/config/branding.ts
@@ -27,7 +27,7 @@ const MAX_PRODUCT_NAME_LENGTH = 60;
  * 3-digit form would silently widen what deployments can put in a values file. */
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 
-/** Font weights the theme uses: light, regular, bold. */
+/** Font weights loaded for brand fonts: light, regular, bold. */
 const FONT_WEIGHTS = ['300', '400', '700'] as const;
 
 export interface BrandFont {

--- a/apps/frontend/src/config/branding.ts
+++ b/apps/frontend/src/config/branding.ts
@@ -27,6 +27,20 @@ const MAX_PRODUCT_NAME_LENGTH = 60;
  * 3-digit form would silently widen what deployments can put in a values file. */
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 
+/** Font weights the theme uses: light, regular, bold. */
+const FONT_WEIGHTS = ['300', '400', '700'] as const;
+
+export interface BrandFont {
+  family: string;
+  source: 'google' | 'custom';
+  /** Google Fonts stylesheet URL (source === 'google'). */
+  googleHref?: string;
+  /** Base URL for self-hosted .ttf files (source === 'custom'). */
+  baseUrl?: string;
+  /** Slug used to build filenames: "Inria Sans" → "inria-sans". */
+  slug: string;
+}
+
 export interface Branding {
   /** Undefined means "use the built-in Rhesis palette", not "no colour". */
   primaryColor?: string;
@@ -38,6 +52,8 @@ export interface Branding {
   /** True when `productName` is the Rhesis default, so callers can keep
    * Rhesis-specific copy (the marketing description) out of a branded build. */
   isDefaultProductName: boolean;
+  /** Custom font override. Undefined means "use Be Vietnam Pro". */
+  font?: BrandFont;
 }
 
 /**
@@ -131,6 +147,93 @@ export function normalizeProductName(value: string | undefined | null): string {
   return trimmed;
 }
 
+const MAX_FONT_FAMILY_LENGTH = 80;
+
+function slugifyFont(family: string): string {
+  return family.toLowerCase().replace(/\s+/g, '-');
+}
+
+/**
+ * Validates a `BRAND_FONT_BASE_URL` — https:// or root-relative directory,
+ * stripped of a trailing slash so callers can append `/{file}` directly.
+ */
+function normalizeBaseUrl(
+  value: string | undefined | null
+): string | undefined {
+  const trimmed = value?.trim().replace(/\/+$/, '');
+  if (!trimmed) return undefined;
+
+  if (trimmed.startsWith('/')) {
+    if (/^\/[/\\]/.test(trimmed)) {
+      console.warn(
+        `[branding] Ignoring BRAND_FONT_BASE_URL "${trimmed}": protocol-relative URLs are not allowed.`
+      );
+      return undefined;
+    }
+    return trimmed;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    console.warn(
+      `[branding] Ignoring BRAND_FONT_BASE_URL "${trimmed}": not a valid URL.`
+    );
+    return undefined;
+  }
+
+  if (parsed.protocol !== 'https:') {
+    console.warn(
+      `[branding] Ignoring BRAND_FONT_BASE_URL "${trimmed}": only https:// URLs and root-relative paths are allowed.`
+    );
+    return undefined;
+  }
+
+  return parsed.toString().replace(/\/+$/, '');
+}
+
+function buildGoogleFontsHref(family: string): string {
+  const weights = FONT_WEIGHTS.join(';');
+  const encoded = encodeURIComponent(family);
+  return `https://fonts.googleapis.com/css2?family=${encoded}:wght@${weights}&display=swap`;
+}
+
+/**
+ * Reads `BRAND_FONT_FAMILY` (required) and `BRAND_FONT_BASE_URL` (optional)
+ * from the environment.
+ *
+ * When only the family is set, the font is loaded from Google Fonts. When a
+ * base URL is also provided, `@font-face` rules are generated from
+ * `{baseUrl}/{slug}-{weight}.ttf` instead — for air-gapped or self-hosted
+ * deployments that can't reach Google.
+ */
+function normalizeBrandFont(): BrandFont | undefined {
+  const family = process.env.BRAND_FONT_FAMILY?.trim();
+  if (!family) return undefined;
+
+  if (family.length > MAX_FONT_FAMILY_LENGTH) {
+    console.warn(
+      `[branding] Ignoring BRAND_FONT_FAMILY: ${family.length} characters exceeds the ${MAX_FONT_FAMILY_LENGTH}-character limit.`
+    );
+    return undefined;
+  }
+
+  const slug = slugifyFont(family);
+  const baseUrl = normalizeBaseUrl(process.env.BRAND_FONT_BASE_URL);
+
+  if (baseUrl) {
+    return { family, source: 'custom', baseUrl, slug };
+  }
+
+  return {
+    family,
+    source: 'google',
+    googleHref: buildGoogleFontsHref(family),
+    slug,
+  };
+}
+
 /**
  * Reads branding from the environment. Server-side only — the env vars carry no
  * `NEXT_PUBLIC_` prefix, so in a client bundle every read compiles to
@@ -148,5 +251,6 @@ export function getServerBranding(): Branding {
     faviconUrl: normalizeFaviconUrl(process.env.BRAND_FAVICON_URL),
     productName,
     isDefaultProductName: productName === DEFAULT_PRODUCT_NAME,
+    font: normalizeBrandFont(),
   };
 }

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -45,6 +45,13 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
   const ff = brand.fontFamily
     ? `"${brand.fontFamily}", "${DEFAULT_FONT}", sans-serif`
     : `"${DEFAULT_FONT}", sans-serif`;
+  // Brand fonts typically ship 300/400/700. Remap the intermediate weights
+  // the theme uses (500, 600, 800) so they land on loaded weights instead of
+  // triggering faux-bold synthesis. The default font has all weights, so no
+  // remapping needed there.
+  const w500 = brand.fontFamily ? 400 : 500;
+  const w600 = brand.fontFamily ? 700 : 600;
+  const w800 = brand.fontFamily ? 700 : 800;
   const brandColor = brand.primary;
   const brandPrimary = brandColor
     ? deriveBrandPrimary(brandColor, mode)
@@ -160,21 +167,21 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
         '"SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace',
       h1: {
         fontFamily: ff,
-        fontWeight: 800,
+        fontWeight: w800,
         fontSize: '3rem', // 48px
         lineHeight: '57.6px',
         color: gs.title,
       },
       h2: {
         fontFamily: ff,
-        fontWeight: 800,
+        fontWeight: w800,
         fontSize: '2.5rem', // 40px
         lineHeight: '48px',
         color: gs.title,
       },
       h3: {
         fontFamily: ff,
-        fontWeight: 800,
+        fontWeight: w800,
         fontSize: '2.0625rem', // 33px
         lineHeight: '39.6px',
         color: gs.title,
@@ -195,7 +202,7 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
       },
       h6: {
         fontFamily: ff,
-        fontWeight: 600,
+        fontWeight: w600,
         fontSize: '1.25rem', // 20px
         lineHeight: '24px',
         color: gs.title,
@@ -216,7 +223,7 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
       },
       button: {
         fontFamily: ff,
-        fontWeight: 600,
+        fontWeight: w600,
         textTransform: 'none' as const,
         fontSize: '0.875rem', // 14px
       },
@@ -229,21 +236,21 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
       },
       subtitle1: {
         fontFamily: ff,
-        fontWeight: 500,
+        fontWeight: w500,
         fontSize: '1rem',
         lineHeight: 1.75,
         color: mode === 'light' ? '#3D3D3D' : '#E6EDF3',
       },
       subtitle2: {
         fontFamily: ff,
-        fontWeight: 500,
+        fontWeight: w500,
         fontSize: '0.875rem',
         lineHeight: 1.57,
         color: mode === 'light' ? '#3D3D3D' : '#E6EDF3',
       },
       overline: {
         fontFamily: ff,
-        fontWeight: 600,
+        fontWeight: w600,
         fontSize: '0.75rem',
         lineHeight: '18px',
         letterSpacing: '0.04em',
@@ -281,7 +288,7 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
       },
       captionBold: {
         fontFamily: ff,
-        fontWeight: 600,
+        fontWeight: w600,
         fontSize: '0.75rem', // 12px
         lineHeight: '18px',
         color: gs.body,
@@ -380,7 +387,7 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
         styleOverrides: {
           root: {
             fontFamily: ff,
-            fontWeight: 600,
+            fontWeight: w600,
             borderRadius: 8,
             '&.MuiButton-containedPrimary': {
               backgroundColor: accent.main,
@@ -432,7 +439,7 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
             style: {
               borderRadius: 999,
               textTransform: 'none',
-              fontWeight: 600,
+              fontWeight: w600,
               fontSize: '0.875rem',
               lineHeight: '22px',
               paddingLeft: '16px',
@@ -460,7 +467,7 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
         styleOverrides: {
           root: {
             fontFamily: ff,
-            fontWeight: 500,
+            fontWeight: w500,
             // Tags and interactive chips stay rectangular; use GridBadge for pill badges.
             borderRadius: 4,
             fontSize: '0.75rem',
@@ -554,7 +561,7 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
               mode === 'light'
                 ? GREYSCALE.light.surface1
                 : GREYSCALE.dark.surface1,
-            fontWeight: 600,
+            fontWeight: w600,
             color:
               mode === 'light' ? GREYSCALE.light.body : GREYSCALE.dark.body,
             height: '48px',

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -23,10 +23,11 @@ import {
 } from './brand-palette';
 export { GREYSCALE, BORDER_RADIUS, BACKDROP_COLORS, ELEVATION, FAB_GROUP_GAP };
 
-/** Deployment brand colours (`BRAND_PRIMARY_COLOR`, `BRAND_SECONDARY_COLOR`). */
+/** Deployment brand overrides (`BRAND_PRIMARY_COLOR`, `BRAND_SECONDARY_COLOR`, `BRAND_FONT_FAMILY`). */
 export interface BrandColors {
   primary?: string;
   secondary?: string;
+  fontFamily?: string;
 }
 
 /**
@@ -37,8 +38,13 @@ export interface BrandColors {
  * its own. When a colour is omitted every token below is the literal Figma
  * value, so the default Rhesis theme is unaffected by this parameter existing.
  */
+const DEFAULT_FONT = 'Be Vietnam Pro';
+
 const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
   const gs = mode === 'light' ? GREYSCALE.light : GREYSCALE.dark;
+  const ff = brand.fontFamily
+    ? `"${brand.fontFamily}", "${DEFAULT_FONT}", sans-serif`
+    : `"${DEFAULT_FONT}", sans-serif`;
   const brandColor = brand.primary;
   const brandPrimary = brandColor
     ? deriveBrandPrimary(brandColor, mode)
@@ -149,95 +155,94 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
       circular: '50%',
     },
     typography: {
-      fontFamily:
-        '"Be Vietnam Pro", "Roboto", "Helvetica", "Arial", sans-serif',
+      fontFamily: ff,
       fontFamilyCode:
         '"SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace',
       h1: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 800,
         fontSize: '3rem', // 48px
         lineHeight: '57.6px',
         color: gs.title,
       },
       h2: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 800,
         fontSize: '2.5rem', // 40px
         lineHeight: '48px',
         color: gs.title,
       },
       h3: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 800,
         fontSize: '2.0625rem', // 33px
         lineHeight: '39.6px',
         color: gs.title,
       },
       h4: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 700,
         fontSize: '1.75rem', // 28px – Figma H4/Bold
         lineHeight: '33.6px',
         color: gs.title,
       },
       h5: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 700,
         fontSize: '1.4375rem', // 23px
         lineHeight: '27.6px',
         color: gs.title,
       },
       h6: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 600,
         fontSize: '1.25rem', // 20px
         lineHeight: '24px',
         color: gs.title,
       },
       body1: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 400,
         fontSize: '1rem', // 16px
         lineHeight: '24px',
         color: mode === 'light' ? '#3D3D3D' : '#E6EDF3',
       },
       body2: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 400,
         fontSize: '0.875rem', // 14px
         lineHeight: '22px',
         color: mode === 'light' ? '#3D3D3D' : '#E6EDF3',
       },
       button: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 600,
         textTransform: 'none' as const,
         fontSize: '0.875rem', // 14px
       },
       caption: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 400,
         fontSize: '0.75rem', // 12px
         lineHeight: '18px',
         color: gs.subtitle,
       },
       subtitle1: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 500,
         fontSize: '1rem',
         lineHeight: 1.75,
         color: mode === 'light' ? '#3D3D3D' : '#E6EDF3',
       },
       subtitle2: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 500,
         fontSize: '0.875rem',
         lineHeight: 1.57,
         color: mode === 'light' ? '#3D3D3D' : '#E6EDF3',
       },
       overline: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 600,
         fontSize: '0.75rem',
         lineHeight: '18px',
@@ -247,35 +252,35 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
       },
       // ── Figma-aligned custom variants ──────────────────────────────────
       bodyLReg: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 400,
         fontSize: '1rem', // 16px
         lineHeight: '24px',
         color: gs.body,
       },
       bodyMReg: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 400,
         fontSize: '0.875rem', // 14px
         lineHeight: '22px',
         color: gs.body,
       },
       bodyMBold: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 700,
         fontSize: '0.875rem', // 14px
         lineHeight: '22px',
         color: gs.body,
       },
       bodySReg: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 400,
         fontSize: '0.75rem', // 12px
         lineHeight: '18px',
         color: gs.body,
       },
       captionBold: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 600,
         fontSize: '0.75rem', // 12px
         lineHeight: '18px',
@@ -283,21 +288,21 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
       },
       // ── Legacy custom variants (kept for backwards-compat) ──────────────
       chartLabel: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 400,
         fontSize: '0.75rem',
         lineHeight: 1.5,
         color: mode === 'light' ? '#3D3D3D' : '#FFFFFF',
       },
       chartTick: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 400,
         fontSize: '0.625rem',
         lineHeight: 1.4,
         color: mode === 'light' ? '#3D3D3D' : '#FFFFFF',
       },
       helperText: {
-        fontFamily: '"Be Vietnam Pro", sans-serif',
+        fontFamily: ff,
         fontWeight: 400,
         fontSize: '0.875rem',
         lineHeight: 1.43,
@@ -374,7 +379,7 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
       MuiButton: {
         styleOverrides: {
           root: {
-            fontFamily: '"Be Vietnam Pro", sans-serif',
+            fontFamily: ff,
             fontWeight: 600,
             borderRadius: 8,
             '&.MuiButton-containedPrimary': {
@@ -454,7 +459,7 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
       MuiChip: {
         styleOverrides: {
           root: {
-            fontFamily: '"Be Vietnam Pro", sans-serif',
+            fontFamily: ff,
             fontWeight: 500,
             // Tags and interactive chips stay rectangular; use GridBadge for pill badges.
             borderRadius: 4,
@@ -511,7 +516,7 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
       MuiTooltip: {
         styleOverrides: {
           tooltip: {
-            fontFamily: '"Be Vietnam Pro", sans-serif',
+            fontFamily: ff,
             fontSize: '0.75rem', // 12px
             lineHeight: 1.4,
             padding: '6px 10px',
@@ -537,7 +542,7 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
         styleOverrides: {
           root: {
             borderBottom: `1px solid ${mode === 'light' ? GREYSCALE.light.border : GREYSCALE.dark.border}`,
-            fontFamily: '"Be Vietnam Pro", sans-serif',
+            fontFamily: ff,
             fontSize: '0.875rem', // 14px
             color:
               mode === 'light' ? GREYSCALE.light.body : GREYSCALE.dark.body,

--- a/docs/content/docs/deployment/environment-variables.mdx
+++ b/docs/content/docs/deployment/environment-variables.mdx
@@ -58,6 +58,18 @@ One difference between the two colours: the built-in secondary uses a different 
 lighten/darken ramp instead, so secondary buttons brighten on hover within your own hue rather than
 shifting to another colour.
 
+### Custom font
+
+| Variable | Description | Default |
+|---|---|---|
+| `BRAND_FONT_FAMILY` | CSS font-family name, e.g. `Inria Sans`. Replaces the built-in Be Vietnam Pro typeface across all UI text | *(unset — Be Vietnam Pro)* |
+| `BRAND_FONT_BASE_URL` | Base URL for self-hosted font files (https:// or root-relative). The app loads `\{base\}/\{slug\}-300.ttf`, `-400.ttf` and `-700.ttf`, where the slug is the lowercased, hyphenated family name | *(unset — Google Fonts)* |
+
+When only `BRAND_FONT_FAMILY` is set, the font is loaded from Google Fonts. Add
+`BRAND_FONT_BASE_URL` for deployments that cannot reach Google (air-gapped, on-prem) or prefer to
+serve the files themselves. Name the .ttf files `\{slug\}-\{weight\}.ttf` (e.g. `inria-sans-300.ttf`,
+`inria-sans-400.ttf`, `inria-sans-700.ttf`).
+
 Setting `BRAND_PRODUCT_NAME` also drops the Rhesis tagline from the page description and stops the
 sign-in wordmark linking to rhesis.ai.
 


### PR DESCRIPTION
## Summary

- Adds `BRAND_FONT_FAMILY` and `BRAND_FONT_BASE_URL` env vars for white-label font customization
- When only the family name is set, fonts load from Google Fonts. When a base URL is also set, fonts are proxied same-origin via a Next.js rewrite to avoid CORS issues with external hosts
- Replaces all 25 hardcoded `"Be Vietnam Pro"` font-family strings in `theme.ts` with a single variable that falls back to the default when no brand font is configured
- Documents the new vars in the deployment environment variables page

## Test plan

- [ ] Set `BRAND_FONT_FAMILY=Inria Sans` alone, verify font loads from Google Fonts
- [ ] Set `BRAND_FONT_FAMILY=Inria Sans` with `BRAND_FONT_BASE_URL=https://...`, verify font loads via `/brand-fonts/` proxy
- [ ] Leave both unset, verify Be Vietnam Pro renders as before
- [ ] Set an invalid `BRAND_FONT_FAMILY` (>80 chars), verify warning logged and default applied
- [ ] Existing branding tests pass (`npx jest src/config/__tests__/branding.test.ts`)