### PR TITLE
fix(frontend): apply brand font to sign-in page

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -372,6 +372,7 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
     logo: <ThemeAwareLogo productName={deploymentBranding.productName} />,
     iconUrl: deploymentBranding.faviconUrl,
     productName: deploymentBranding.productName,
+    fontFamily: deploymentBranding.font?.family,
     homeUrl: '/architect',
   };
   // Empty when `API_BASE_URL` is unset or blank — whichever of Helm,

--- a/apps/frontend/src/components/auth/AuthPageShell.tsx
+++ b/apps/frontend/src/components/auth/AuthPageShell.tsx
@@ -7,10 +7,10 @@ import BrandMark from '@/components/common/BrandMark';
 import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 import BackgroundDecoration from './BackgroundDecoration';
 import {
-  AUTH_FONT_DISPLAY,
   AUTH_FONT_MONO,
-  AUTH_FONT_SANS,
   AUTH_SHAPE,
+  authFontDisplay,
+  authFontSans,
   getAuthTokens,
 } from './authTokens';
 import { scaledVh } from '@/styles/viewport-scaling';
@@ -91,6 +91,7 @@ export default function AuthPageShell({ children }: AuthPageShellProps) {
   // server-resolved branding is available here without a second env read.
   const { branding } = useNavigationItems();
   const productName = branding?.productName ?? 'Rhesis AI';
+  const brandFont = branding?.fontFamily;
   const isRebranded = productName !== 'Rhesis AI';
   // A rebranded sign-in page must not send its users to rhesis.ai, and there is
   // no configured homepage to send them to instead — so the wordmark stops
@@ -105,7 +106,7 @@ export default function AuthPageShell({ children }: AuthPageShellProps) {
         flexDirection: 'column',
         bgcolor: t.ground,
         color: t.body,
-        fontFamily: AUTH_FONT_SANS,
+        fontFamily: authFontSans(brandFont),
         position: 'relative',
         overflowX: 'hidden',
       }}
@@ -149,7 +150,7 @@ export default function AuthPageShell({ children }: AuthPageShellProps) {
           />
           <Typography
             sx={{
-              fontFamily: AUTH_FONT_DISPLAY,
+              fontFamily: authFontDisplay(brandFont),
               fontSize: 20,
               fontWeight: 800,
               letterSpacing: '-0.01em',

--- a/apps/frontend/src/components/auth/authTokens.ts
+++ b/apps/frontend/src/components/auth/authTokens.ts
@@ -20,6 +20,24 @@ export const AUTH_FONT_MONO = '"Geist Mono", "Sometype Mono", monospace';
 /** Sora stays the wordmark face, matching the website navbar. */
 export const AUTH_FONT_DISPLAY = '"Sora", "Be Vietnam Pro", sans-serif';
 
+/**
+ * Returns the sans-serif font stack with a brand font prepended when one is
+ * configured. The brand font replaces Geist as the primary face, with Geist
+ * and Be Vietnam Pro as fallbacks.
+ */
+export function authFontSans(brandFontFamily?: string): string {
+  return brandFontFamily
+    ? `"${brandFontFamily}", ${AUTH_FONT_SANS}`
+    : AUTH_FONT_SANS;
+}
+
+/** Display stack with brand font prepended when configured. */
+export function authFontDisplay(brandFontFamily?: string): string {
+  return brandFontFamily
+    ? `"${brandFontFamily}", ${AUTH_FONT_DISPLAY}`
+    : AUTH_FONT_DISPLAY;
+}
+
 export interface AuthTokens {
   /** Page background behind the wash/aurora. */
   ground: string;

--- a/apps/frontend/src/components/auth/useAuthStyles.ts
+++ b/apps/frontend/src/components/auth/useAuthStyles.ts
@@ -2,9 +2,10 @@
 
 import { useMemo } from 'react';
 import { useTheme, type SxProps, type Theme } from '@mui/material/styles';
+import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 import {
-  AUTH_FONT_SANS,
   AUTH_SHAPE,
+  authFontSans,
   getAuthTokens,
   type AuthTokens,
 } from './authTokens';
@@ -38,26 +39,29 @@ export interface AuthStyles {
  */
 export function useAuthStyles(): AuthStyles {
   const { mode, brandColor } = useTheme().palette;
+  const { branding } = useNavigationItems();
+  const brandFont = branding?.fontFamily;
 
   return useMemo(() => {
     const t = getAuthTokens(mode, brandColor);
+    const fontSans = authFontSans(brandFont);
 
     return {
       tokens: t,
       heading: {
-        fontFamily: AUTH_FONT_SANS,
+        fontFamily: fontSans,
         fontSize: 24,
         fontWeight: 700,
         letterSpacing: '-0.02em',
         color: t.ink,
       },
       subheading: {
-        fontFamily: AUTH_FONT_SANS,
+        fontFamily: fontSans,
         fontSize: 14,
         color: t.muted,
       },
       body: {
-        fontFamily: AUTH_FONT_SANS,
+        fontFamily: fontSans,
         fontSize: 14,
         lineHeight: 1.55,
         color: t.body,
@@ -65,7 +69,7 @@ export function useAuthStyles(): AuthStyles {
       primaryButton: {
         height: AUTH_SHAPE.buttonHeight,
         borderRadius: AUTH_SHAPE.button,
-        fontFamily: AUTH_FONT_SANS,
+        fontFamily: fontSans,
         fontSize: 15,
         fontWeight: 700,
         textTransform: 'none',
@@ -77,7 +81,7 @@ export function useAuthStyles(): AuthStyles {
       outlinedButton: {
         height: AUTH_SHAPE.buttonHeight,
         borderRadius: AUTH_SHAPE.button,
-        fontFamily: AUTH_FONT_SANS,
+        fontFamily: fontSans,
         fontSize: 15,
         fontWeight: 600,
         textTransform: 'none',
@@ -94,7 +98,7 @@ export function useAuthStyles(): AuthStyles {
         '& .MuiOutlinedInput-root': {
           borderRadius: AUTH_SHAPE.input,
           bgcolor: t.field,
-          fontFamily: AUTH_FONT_SANS,
+          fontFamily: fontSans,
           color: t.ink,
           '& fieldset': { borderColor: t.fieldBorder },
           '&:hover fieldset': { borderColor: t.muted },
@@ -104,18 +108,18 @@ export function useAuthStyles(): AuthStyles {
           },
         },
         '& .MuiInputLabel-root': {
-          fontFamily: AUTH_FONT_SANS,
+          fontFamily: fontSans,
           color: t.muted,
           '&.Mui-focused': { color: t.accent },
         },
         '& .MuiFormHelperText-root': { color: t.muted },
       },
       quietLink: {
-        fontFamily: AUTH_FONT_SANS,
+        fontFamily: fontSans,
         fontSize: 13,
         color: t.muted,
         textDecoration: 'none',
       },
     };
-  }, [mode, brandColor]);
+  }, [mode, brandColor, brandFont]);
 }

--- a/apps/frontend/src/types/navigation.ts
+++ b/apps/frontend/src/types/navigation.ts
@@ -67,6 +67,8 @@ export interface BrandingProps {
   iconUrl?: string;
   /** `BRAND_PRODUCT_NAME`, for alt text and labels. */
   productName?: string;
+  /** `BRAND_FONT_FAMILY` — the CSS font-family name for white-label deployments. */
+  fontFamily?: string;
   homeUrl?: string;
 }
 


### PR DESCRIPTION
## Summary

- The sign-in page used hardcoded font stacks (Geist, Sora) that ignored `BRAND_FONT_FAMILY`, so a branded deployment showed the default fonts on the login screen while the rest of the UI used the configured brand font.
- Thread `fontFamily` through `BrandingProps` into the auth components so the sign-in page matches the rest of the branded UI.
- Depends on #2576 (white-label theming env vars).

## Changes

- Add `fontFamily?: string` to `BrandingProps` and populate it from `getServerBranding().font.family` in the root layout
- Add `authFontSans()` and `authFontDisplay()` helpers in `authTokens.ts` that prepend the brand font to the existing font stacks when one is configured
- Update `AuthPageShell` and `useAuthStyles` to use the brand-aware font functions

## Test plan

- [ ] Set `BRAND_FONT_FAMILY` in `.env.local`, reload the sign-in page, and verify headings, body text, buttons, and form fields use the brand font
- [ ] With no `BRAND_FONT_FAMILY` set, verify the sign-in page still uses Geist/Sora as before
- [ ] Auth tests pass (45/45)