### PR TITLE
fix(frontend): replace build-time font rewrite with runtime route handler

### DIFF
--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -339,33 +339,6 @@ const nextConfig = {
     return baseHeaders;
   },
 
-  async rewrites() {
-    const family = process.env.BRAND_FONT_FAMILY?.trim();
-    if (!family) return [];
-
-    const raw = process.env.BRAND_FONT_BASE_URL?.trim()?.replace(/\/+$/, '');
-    if (!raw) return [];
-
-    // Same safety checks as normalizeBaseUrl() in branding.ts — only https://
-    // and safe root-relative paths are proxied.
-    if (raw.startsWith('/')) {
-      if (/^\/[/\\]/.test(raw)) return [];
-    } else {
-      try {
-        if (new URL(raw).protocol !== 'https:') return [];
-      } catch {
-        return [];
-      }
-    }
-
-    return [
-      {
-        source: '/brand-fonts/:path*',
-        destination: `${raw}/:path*`,
-      },
-    ];
-  },
-
   async redirects() {
     return [
       {

--- a/apps/frontend/src/app/brand-fonts/[...path]/route.ts
+++ b/apps/frontend/src/app/brand-fonts/[...path]/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { normalizeBaseUrl } from '@/config/branding';
+
+const FONT_TIMEOUT_MS = 10_000;
+
+/**
+ * Proxies `/brand-fonts/{file}` to the validated `BRAND_FONT_BASE_URL` at
+ * request time. This replaces the earlier `rewrites()` approach whose
+ * destination was baked at build time and couldn't change per deployment.
+ *
+ * The proxy also solves CORS: self-hosted font servers (Gitea, S3, etc.)
+ * often don't set `Access-Control-Allow-Origin`, and `@font-face` requests
+ * are CORS-restricted. Proxying through the same origin sidesteps this.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const fontBase = normalizeBaseUrl(process.env.BRAND_FONT_BASE_URL);
+  if (!fontBase) {
+    return NextResponse.json(
+      { error: 'Font proxy not configured' },
+      { status: 404 }
+    );
+  }
+
+  const fontFamily = process.env.BRAND_FONT_FAMILY?.trim();
+  if (!fontFamily) {
+    return NextResponse.json(
+      { error: 'Font proxy not configured' },
+      { status: 404 }
+    );
+  }
+
+  const { path } = await params;
+  const filePath = path.join('/');
+
+  // Only allow .ttf/.woff/.woff2 files to prevent open-proxy abuse.
+  if (!/\.(ttf|woff2?)$/i.test(filePath)) {
+    return NextResponse.json({ error: 'Not a font file' }, { status: 400 });
+  }
+
+  const upstream = `${fontBase}/${filePath}`;
+
+  try {
+    const response = await fetch(upstream, {
+      signal: AbortSignal.timeout(FONT_TIMEOUT_MS),
+      headers: {
+        'User-Agent': request.headers.get('user-agent') ?? 'Next.js font proxy',
+      },
+    });
+
+    if (!response.ok) {
+      return new NextResponse(null, { status: response.status });
+    }
+
+    const body = response.body;
+    return new NextResponse(body, {
+      status: 200,
+      headers: {
+        'Content-Type': response.headers.get('content-type') ?? 'font/ttf',
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to fetch font' },
+      { status: 502 }
+    );
+  }
+}

--- a/apps/frontend/src/app/brand-fonts/[...path]/route.ts
+++ b/apps/frontend/src/app/brand-fonts/[...path]/route.ts
@@ -69,7 +69,9 @@ export async function GET(
       headers: {
         'Content-Type':
           response.headers.get('content-type') ??
-          FONT_CONTENT_TYPES[filePath.slice(filePath.lastIndexOf('.')).toLowerCase()] ??
+          FONT_CONTENT_TYPES[
+            filePath.slice(filePath.lastIndexOf('.')).toLowerCase()
+          ] ??
           'application/octet-stream',
         'Cache-Control': 'public, max-age=31536000, immutable',
       },

--- a/apps/frontend/src/app/brand-fonts/[...path]/route.ts
+++ b/apps/frontend/src/app/brand-fonts/[...path]/route.ts
@@ -3,6 +3,12 @@ import { normalizeBaseUrl } from '@/config/branding';
 
 const FONT_TIMEOUT_MS = 10_000;
 
+const FONT_CONTENT_TYPES: Record<string, string> = {
+  '.ttf': 'font/ttf',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+};
+
 /**
  * Proxies `/brand-fonts/{file}` to the validated `BRAND_FONT_BASE_URL` at
  * request time. This replaces the earlier `rewrites()` approach whose
@@ -40,7 +46,10 @@ export async function GET(
     return NextResponse.json({ error: 'Not a font file' }, { status: 400 });
   }
 
-  const upstream = `${fontBase}/${filePath}`;
+  const upstream = new URL(
+    `${fontBase}/${filePath}`,
+    request.nextUrl.origin
+  ).toString();
 
   try {
     const response = await fetch(upstream, {
@@ -58,7 +67,10 @@ export async function GET(
     return new NextResponse(body, {
       status: 200,
       headers: {
-        'Content-Type': response.headers.get('content-type') ?? 'font/ttf',
+        'Content-Type':
+          response.headers.get('content-type') ??
+          FONT_CONTENT_TYPES[filePath.slice(filePath.lastIndexOf('.')).toLowerCase()] ??
+          'application/octet-stream',
         'Cache-Control': 'public, max-age=31536000, immutable',
       },
     });

--- a/apps/frontend/src/config/__tests__/branding.test.ts
+++ b/apps/frontend/src/config/__tests__/branding.test.ts
@@ -298,10 +298,23 @@ describe('getServerBranding', () => {
       expect(warn).toHaveBeenCalled();
     });
 
-    it('slugifies family names with special characters', () => {
-      process.env.BRAND_FONT_FAMILY = 'Noto Sans (Display)';
+    it('slugifies family names with hyphens', () => {
+      process.env.BRAND_FONT_FAMILY = 'IBM Plex Sans';
 
-      expect(getServerBranding().font?.slug).toBe('noto-sans-display');
+      expect(getServerBranding().font?.slug).toBe('ibm-plex-sans');
+    });
+
+    it.each([
+      ['Noto Sans (Display)', 'parentheses'],
+      ['Font "Name"', 'double quotes'],
+      ["Font 'Name'", 'single quotes'],
+      ['Font</style>', 'angle brackets'],
+      ['Font{Name}', 'curly braces'],
+    ])('rejects %s (%s) with unsafe characters', family => {
+      process.env.BRAND_FONT_FAMILY = family;
+
+      expect(getServerBranding().font).toBeUndefined();
+      expect(warn).toHaveBeenCalled();
     });
   });
 });

--- a/apps/frontend/src/config/branding.ts
+++ b/apps/frontend/src/config/branding.ts
@@ -149,6 +149,10 @@ export function normalizeProductName(value: string | undefined | null): string {
 
 const MAX_FONT_FAMILY_LENGTH = 80;
 
+/** Letters, digits, spaces, hyphens. Rejects quotes, angle brackets, braces,
+ *  and other characters that could break CSS or HTML injection boundaries. */
+const SAFE_FONT_FAMILY_PATTERN = /^[a-zA-Z0-9 -]+$/;
+
 function slugifyFont(family: string): string {
   return family
     .toLowerCase()
@@ -160,7 +164,7 @@ function slugifyFont(family: string): string {
  * Validates a `BRAND_FONT_BASE_URL` — https:// or root-relative directory,
  * stripped of a trailing slash so callers can append `/{file}` directly.
  */
-function normalizeBaseUrl(
+export function normalizeBaseUrl(
   value: string | undefined | null
 ): string | undefined {
   const trimmed = value?.trim().replace(/\/+$/, '');
@@ -218,6 +222,13 @@ function normalizeBrandFont(): BrandFont | undefined {
   if (family.length > MAX_FONT_FAMILY_LENGTH) {
     console.warn(
       `[branding] Ignoring BRAND_FONT_FAMILY: ${family.length} characters exceeds the ${MAX_FONT_FAMILY_LENGTH}-character limit.`
+    );
+    return undefined;
+  }
+
+  if (!SAFE_FONT_FAMILY_PATTERN.test(family)) {
+    console.warn(
+      `[branding] Ignoring BRAND_FONT_FAMILY: "${family}" contains characters outside [a-zA-Z0-9 -].`
     );
     return undefined;
   }


### PR DESCRIPTION
## Summary

- Replace `rewrites()` in `next.config.mjs` with a Route Handler at `/brand-fonts/[...path]` that reads `BRAND_FONT_BASE_URL` per request, so the font proxy works with runtime env vars (no rebuild needed)
- Add `SAFE_FONT_FAMILY_PATTERN` character allowlist (`[a-zA-Z0-9 -]`) to prevent CSS/HTML injection via `BRAND_FONT_FAMILY`, which is interpolated into `dangerouslySetInnerHTML`
- Export `normalizeBaseUrl` from `branding.ts` so the Route Handler reuses the same validation
- Add 5 injection-rejection test cases and update the slugify test to use a safe family name

Follow-up to #2576 (custom font branding). These changes were pushed after #2576 was already squash-merged.

## Test plan

- [ ] `npm test -- --testPathPattern branding` passes with the new injection tests
- [ ] Set `BRAND_FONT_BASE_URL` and `BRAND_FONT_FAMILY`, verify `/brand-fonts/{slug}-{weight}.ttf` proxies correctly
- [ ] Unset `BRAND_FONT_BASE_URL`, verify `/brand-fonts/...` returns 404
- [ ] Request a non-font path (e.g. `/brand-fonts/foo.js`), verify 400 response