### PR TITLE
Fix SDK connector never connecting from a web app

### DIFF
--- a/docs/content/docs/endpoints/sdk-endpoints.mdx
+++ b/docs/content/docs/endpoints/sdk-endpoints.mdx
@@ -14,12 +14,16 @@ the SDK handles registration, mapping, and synchronization automatically.
 
 ## How It Works
 
-The SDK connector establishes a WebSocket connection to the Rhesis backend. When
-your application starts, the SDK:
+The SDK connector establishes a WebSocket connection to the Rhesis backend:
 
-1. Discovers all functions decorated with `@endpoint`
-2. Registers them as endpoints in your Rhesis project
-3. Keeps the connection alive for remote invocation during tests
+1. Importing your module discovers all functions decorated with `@endpoint`
+2. Starting the connector opens the WebSocket and registers them as endpoints in your project
+3. The connection is kept alive for remote invocation during tests
+
+Step 2 needs a running event loop. A script gets one from `client.connect()`; a web app must call
+`client.start_connector()` from its startup hook, because the module is imported before the loop
+exists. Skip it and the SDK logs a warning and your endpoint never appears in the dashboard — see
+[Running the connector](/sdk/connector#running-the-connector).
 
 When Rhesis runs tests against an SDK endpoint, it sends the test input over the
 WebSocket connection, the SDK calls your function locally, and returns the result

--- a/docs/content/sdk/connector/index.mdx
+++ b/docs/content/sdk/connector/index.mdx
@@ -66,7 +66,34 @@ if __name__ == "__main__":
     client.connect()`}
 </CodeBlock>
 
-If you already have a running event loop (e.g. in an async REPL or Jupyter), do not call `connect()`. Run the connector as a task in that loop instead.
+If you already have a running event loop, do not call `connect()` — it raises. Call
+`client.start_connector()` instead, from wherever that loop starts.
+
+For a web app this is not optional. `@endpoint` registers your function when the module is
+*imported*, and uvicorn imports it before it creates the event loop, so the connector has no loop
+to dial from and defers the connection. Nothing retries afterwards: the SDK logs a warning and your
+endpoint never reaches the platform. Start it from a FastAPI `lifespan`:
+
+<CodeBlock filename="app.py" language="python">
+{`from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from rhesis.sdk import RhesisClient, endpoint
+
+client = RhesisClient.from_environment()
+
+@endpoint()
+async def chat(input: str, conversation_id: str = None) -> dict:
+    return {"output": "Echo: " + input, "conversation_id": conversation_id or "default"}
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # The loop exists by now, so the connector can dial out.
+    client.start_connector()
+    yield
+
+app = FastAPI(lifespan=lifespan)`}
+</CodeBlock>
 
 ## Platform context with `EndpointContext`
 

--- a/sdk/src/rhesis/sdk/clients/rhesis.py
+++ b/sdk/src/rhesis/sdk/clients/rhesis.py
@@ -337,6 +337,18 @@ class RhesisClient:
             self._connector_manager.initialize()
         return self._connector_manager
 
+    def start_connector(self) -> None:
+        """Start the connector's WebSocket from inside an already-running event loop.
+
+        Registration normally dials out on its own, but only when a loop is already running.
+        Under a web server it usually is not: uvicorn imports the app module from
+        ``uvicorn.main.run`` -- before ``asyncio.run`` -- so the ``@endpoint`` decorators run
+        with no loop and the connection is deferred. Call this from a startup hook (FastAPI
+        ``lifespan``) to pick it up; without it the app never appears in the platform and the
+        playground cannot reach it. Idempotent, and a no-op if no loop is running.
+        """
+        self._ensure_connector()._ensure_connection()
+
     def register_endpoint(self, name: str, func, metadata: dict) -> None:
         """
         Register a function as a remotely callable endpoint.

--- a/sdk/src/rhesis/sdk/connector/manager.py
+++ b/sdk/src/rhesis/sdk/connector/manager.py
@@ -120,7 +120,15 @@ class ConnectorManager:
             asyncio.get_running_loop()
             asyncio.create_task(self._connection.connect())
         except RuntimeError:
-            logger.debug("No event loop running, connection will be established later")
+            # Nothing re-checks this later, so the connector stays offline until someone starts
+            # it from inside a loop. Warn rather than debug: a web server registers endpoints at
+            # import time, which uvicorn does before asyncio.run(), and a silent miss here looks
+            # exactly like success -- the endpoint never reaches the platform.
+            logger.warning(
+                "Connector registered with no running event loop, so it is not connected. "
+                "Web apps: call client.start_connector() from a startup hook "
+                "(FastAPI lifespan). Sync scripts: call client.connect()."
+            )
 
         self._initialized = True
         msg = "Connector initialized"

--- a/tests/sdk/connector/test_manager.py
+++ b/tests/sdk/connector/test_manager.py
@@ -1,6 +1,7 @@
 """Tests for ConnectorManager."""
 
 import inspect
+import logging
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -137,6 +138,36 @@ def test_initialize(mock_get_loop, mock_ws_class, manager):
     assert manager._connection is not None
     mock_ws_class.assert_called_once()
     mock_create_task.assert_called_once()
+
+
+@patch("rhesis.sdk.connector.manager.WebSocketConnection")
+@patch("asyncio.get_running_loop", side_effect=RuntimeError("no running event loop"))
+def test_initialize_without_event_loop_warns(mock_get_loop, mock_ws_class, manager, caplog):
+    """No loop at registration time leaves the connector offline, and says so.
+
+    This is the web-server case: uvicorn imports the app module from ``uvicorn.main.run``, before
+    ``asyncio.run``, so ``@endpoint`` registers with no loop. Nothing re-checks afterwards, so a
+    quiet log here is indistinguishable from a working connector.
+    """
+    mock_ws_instance = Mock()
+    mock_ws_instance.connect = AsyncMock()
+    mock_ws_class.return_value = mock_ws_instance
+
+    mock_create_task, _mock_task = _make_create_task_mock()
+
+    with caplog.at_level(logging.WARNING, logger="rhesis.sdk.connector.manager"):
+        with patch("asyncio.create_task", mock_create_task):
+            manager.initialize()
+
+    mock_create_task.assert_not_called()
+    assert manager._initialized
+    assert manager._connection is not None
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1, "the deferred connection must warn exactly once"
+    message = warnings[0].getMessage()
+    assert "start_connector()" in message
+    assert "connect()" in message
 
 
 @patch("asyncio.get_running_loop")

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import requests
@@ -355,6 +355,48 @@ async def test_connect_raises_when_event_loop_running(monkeypatch):
         client.connect()
 
     importlib.reload(rhesis.sdk.clients.rhesis)
+
+
+@pytest.mark.asyncio
+async def test_start_connector_connects_inside_running_loop(monkeypatch):
+    """start_connector() dials the socket from a loop that already exists.
+
+    This is the call a web app makes from its startup hook, after @endpoint registered at import
+    time with no loop available.
+    """
+    import importlib
+
+    import rhesis.sdk.clients.rhesis
+
+    monkeypatch.setenv("RHESIS_API_KEY", "test_key")
+    monkeypatch.setenv("RHESIS_BASE_URL", "http://localhost:8080")
+    monkeypatch.setenv("RHESIS_PROJECT_ID", "test_project")
+    importlib.reload(rhesis.sdk.clients.rhesis)
+
+    from rhesis.sdk.clients.rhesis import RhesisClient
+
+    client = RhesisClient.from_environment()
+
+    manager = MagicMock()
+    client._connector_manager = manager
+
+    client.start_connector()
+    manager._ensure_connection.assert_called_once()
+
+    # Idempotent: the manager's own guard is what suppresses a second dial, so the client must
+    # keep delegating rather than tracking state itself.
+    client.start_connector()
+    assert manager._ensure_connection.call_count == 2
+
+    importlib.reload(rhesis.sdk.clients.rhesis)
+
+
+def test_start_connector_is_noop_on_disabled_client():
+    """DisabledClient absorbs start_connector() via __getattr__, so apps need no guard."""
+    from rhesis.sdk.clients.rhesis import DisabledClient
+
+    client = DisabledClient()
+    assert client.start_connector() is None
 
 
 def test_disabled_client_connect_returns_immediately():


### PR DESCRIPTION
## Purpose

An SDK endpoint registered from a web app never reached the platform, and nothing said so. `@endpoint` runs at import time, and uvicorn imports the app module from `uvicorn.main.run` — before `asyncio.run` — so `ConnectorManager.initialize()` finds no event loop, catches the `RuntimeError`, and defers the connection. Nothing re-checks it afterwards. The deferral was logged at debug level with a message promising the connection would be established later, so at the default log level the startup sequence reads as a success: `Connector initialized`, `Registered function: ...`, `Application startup complete` — with no WebSocket, no endpoint row, and a Playground that has nothing to invoke.

Two of us lost time to this independently before finding the cause, which is what makes the silence the real defect rather than the missing connection.

## What Changed

- `RhesisClient.start_connector()` — public, idempotent, no-op without a running loop, and absorbed by `DisabledClient` via `__getattr__` so callers need no guard.
- The deferred connection now logs at warning level and names the fix for both cases: `start_connector()` for anything that already owns a loop, `connect()` for sync scripts.
- Tests for both, including the no-loop path in `test_manager.py` that had no coverage at all — `test_initialize` only patched `get_running_loop` to succeed, which is why this went unnoticed.
- Docs now cover the web-server case on both the connector page and the SDK endpoints page.

## Additional Context

The connector deliberately still does not start itself. A background thread with its own loop would be fully automatic, but `connector/executor.py` awaits endpoint coroutines on whichever loop the connector runs on, and agents hold loop-bound state — visit-prep caches per-conversation `asyncio.Lock` objects, and a lock bound to one loop raises when awaited on another. So the connector has to share the app's loop, which makes an explicit call from the app's startup hook the correct shape. The job of this PR is to make forgetting loud and to provide the one-line call, not to guess.

The docs were actively misleading here: the connector page documented only `client.connect()` and told anyone with a running loop to "run the connector as a task in that loop" without saying how, while the SDK endpoints page claimed the SDK "keeps the connection alive for remote invocation" on its own.

Two follow-ups are stacked on this branch: a TLS trust-store fix in the same subsystem, and adoption of `start_connector()` across the three agents in `agents/`.

## Testing

`cd sdk && uv run pytest ../tests/sdk/test_client.py ../tests/sdk/connector -q` → 347 passed, up from 344 on `main`.

Verified live against `api.rhesis.ai`, which is what confirms the fix rather than the tests: with the agent-side call in place the log now shows the warning at import, then `disconnected -> connecting`, `connected (websocket established)`, and `Sent registration for 1 function(s)`, and the endpoint appears in the project. Server startup alone creates no traces, so this was verified without adding any.
