### PR TITLE
Fix connector TLS failures on interpreters with no CA bundle

### DIFF
--- a/sdk/src/rhesis/sdk/connector/connection.py
+++ b/sdk/src/rhesis/sdk/connector/connection.py
@@ -169,7 +169,7 @@ def _default_trust_store_is_usable() -> bool:
     return bool(paths.capath and os.path.isdir(paths.capath))
 
 
-def _fallback_ssl_context() -> ssl.SSLContext | None:
+def _fallback_ssl_context(url: str) -> ssl.SSLContext | None:
     """A certifi-backed context, but only when the interpreter has no trust store of its own.
 
     Some builds ship a CA path that does not exist -- a python.org macOS install whose
@@ -178,8 +178,13 @@ def _fallback_ssl_context() -> ssl.SSLContext | None:
     connector alone fails TLS and it reads like a platform outage.
 
     Returns ``None`` whenever the default store works, so healthy machines keep their system and
-    corporate roots and a genuine verification error still surfaces.
+    corporate roots and a genuine verification error still surfaces. Also ``None`` for a plain
+    ``ws://`` URL: there is no TLS to verify, and ``websockets`` raises ``ValueError`` on an
+    ``ssl`` argument for a non-TLS URI, which would break local development on exactly the
+    interpreters this is meant to rescue.
     """
+    if not url.lower().startswith("wss://"):
+        return None
     if _default_trust_store_is_usable():
         return None
     try:
@@ -420,7 +425,7 @@ class WebSocketConnection:
         logger.debug(f"Attempting WebSocket connection to {self.url}")
         # Omit the kwarg entirely when the default store works, so healthy machines keep
         # websockets' own context untouched.
-        ssl_context = _fallback_ssl_context()
+        ssl_context = _fallback_ssl_context(self.url)
         extra = {"ssl": ssl_context} if ssl_context else {}
         async with websockets.connect(
             self.url,

--- a/sdk/src/rhesis/sdk/connector/connection.py
+++ b/sdk/src/rhesis/sdk/connector/connection.py
@@ -3,7 +3,9 @@
 import asyncio
 import json
 import logging
+import os
 import re
+import ssl
 from collections.abc import Coroutine
 from typing import Any, Callable, Dict, Optional
 
@@ -72,6 +74,27 @@ def _classify_by_close_code(exception: Exception) -> tuple[bool, str] | None:
     return None
 
 
+def _classify_by_exception_type(exception: Exception) -> tuple[bool, str] | None:
+    """
+    Classify error by exception type.
+
+    Returns:
+        Tuple of (is_retryable, error_message) or None if not applicable
+    """
+    # A trust-store failure never fixes itself. Without this it falls through to the transient
+    # default below and retries forever, because the message carries no HTTP status and none of
+    # the TRANSIENT_KEYWORDS.
+    if isinstance(exception, ssl.SSLCertVerificationError):
+        return False, (
+            f"TLS certificate verification failed: {exception}\n"
+            "The server certificate could not be verified against any trusted CA. Check:\n"
+            "  - SSL_CERT_FILE / SSL_CERT_DIR, if you set either\n"
+            "  - a corporate proxy re-signing TLS traffic (add its root CA)\n"
+            "  - your system clock"
+        )
+    return None
+
+
 def _classify_by_http_status(error_str: str) -> tuple[bool, str] | None:
     """
     Classify error by HTTP status code.
@@ -120,12 +143,56 @@ def classify_websocket_error(exception: Exception) -> tuple[bool, str]:
     if result := _classify_by_http_status(error_str):
         return result
 
+    # Try classification by exception type
+    if result := _classify_by_exception_type(exception):
+        return result
+
     # Check for transient keywords in error message
     if any(kw in error_str.lower() for kw in ErrorClassification.TRANSIENT_KEYWORDS):
         return True, f"Network error: {error_str}. Retrying..."
 
     # Default: treat as transient
     return True, f"Connection error: {error_str}. Retrying..."
+
+
+def _default_trust_store_is_usable() -> bool:
+    """Whether this interpreter can verify TLS with its default trust store.
+
+    ``cafile`` is the resolved bundle -- ``SSL_CERT_FILE`` if that path exists, else the
+    compiled-in default if *that* exists, else ``None``. ``openssl_cafile`` is the compiled-in
+    path whether or not anything is there, so testing it would report success on exactly the
+    broken installs this guards against.
+    """
+    paths = ssl.get_default_verify_paths()
+    if paths.cafile:
+        return True
+    return bool(paths.capath and os.path.isdir(paths.capath))
+
+
+def _fallback_ssl_context() -> ssl.SSLContext | None:
+    """A certifi-backed context, but only when the interpreter has no trust store of its own.
+
+    Some builds ship a CA path that does not exist -- a python.org macOS install whose
+    ``Install Certificates.command`` was never run is the common case. Trace export survives it
+    because ``requests`` bundles certifi, while ``websockets`` uses the default context, so the
+    connector alone fails TLS and it reads like a platform outage.
+
+    Returns ``None`` whenever the default store works, so healthy machines keep their system and
+    corporate roots and a genuine verification error still surfaces.
+    """
+    if _default_trust_store_is_usable():
+        return None
+    try:
+        import certifi
+    except ImportError:  # pragma: no cover - certifi ships with requests, a hard dependency
+        return None
+
+    logger.warning(
+        "This interpreter has no usable default CA bundle (%s does not exist); "
+        "verifying the connector's TLS connection with certifi instead.",
+        ssl.get_default_verify_paths().openssl_cafile,
+    )
+    return ssl.create_default_context(cafile=certifi.where())
 
 
 class WebSocketConnection:
@@ -284,7 +351,7 @@ class WebSocketConnection:
                             if not is_retryable:
                                 # Permanent error - don't retry
                                 logger.error(f"Permanent connection failure:\n{error_message}")
-                                logger.error("Not retrying authentication/authorization failures.")
+                                logger.error("Not retrying: this will not resolve on its own.")
                                 self._log_state_change(ConnectionState.FAILED, "permanent error")
                                 self._failure_reason = error_message
 
@@ -351,11 +418,16 @@ class WebSocketConnection:
     async def _attempt_single_connection(self) -> None:
         """Attempt a single WebSocket connection."""
         logger.debug(f"Attempting WebSocket connection to {self.url}")
+        # Omit the kwarg entirely when the default store works, so healthy machines keep
+        # websockets' own context untouched.
+        ssl_context = _fallback_ssl_context()
+        extra = {"ssl": ssl_context} if ssl_context else {}
         async with websockets.connect(
             self.url,
             additional_headers=self.headers,
             ping_interval=self.ping_interval,
             ping_timeout=self.ping_timeout,
+            **extra,
         ) as websocket:
             self.websocket = websocket
             self._log_state_change(ConnectionState.CONNECTED, "websocket established")

--- a/tests/sdk/connector/test_connection_errors.py
+++ b/tests/sdk/connector/test_connection_errors.py
@@ -1,13 +1,17 @@
 """Tests for WebSocket connection error handling and retry logic."""
 
 import asyncio
+import ssl
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+import certifi
 import pytest
 from websockets.exceptions import InvalidStatus
 
 from rhesis.sdk.connector.connection import (
     WebSocketConnection,
+    _default_trust_store_is_usable,
+    _fallback_ssl_context,
     classify_websocket_error,
 )
 from rhesis.sdk.connector.types import ConnectionState, RetryConfig
@@ -152,6 +156,105 @@ class TestErrorClassification:
         assert is_retryable
         assert "Connection error" in message
 
+    def test_classify_ssl_cert_error_is_permanent(self):
+        """A trust-store failure must not be retried -- it can never succeed.
+
+        The message carries no HTTP status and none of the TRANSIENT_KEYWORDS, so without an
+        explicit rule it falls through to the retryable default and loops forever.
+        """
+        error = ssl.SSLCertVerificationError(
+            1,
+            "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: "
+            "unable to get local issuer certificate (_ssl.c:1028)",
+        )
+        is_retryable, message = classify_websocket_error(error)
+
+        assert not is_retryable
+        assert "TLS certificate verification failed" in message
+        assert "SSL_CERT_FILE" in message
+
+
+class TestTrustStoreFallback:
+    """The connector must still verify TLS on interpreters with no usable CA bundle."""
+
+    def _paths(self, cafile, capath):
+        return ssl.DefaultVerifyPaths(
+            cafile=cafile,
+            capath=capath,
+            openssl_cafile_env="SSL_CERT_FILE",
+            openssl_cafile="/nonexistent/cert.pem",
+            openssl_capath_env="SSL_CERT_DIR",
+            openssl_capath="/nonexistent/certs",
+        )
+
+    def test_healthy_store_builds_no_context(self, monkeypatch):
+        """A working default store is left alone, so system and corporate roots still apply."""
+        monkeypatch.setattr(
+            ssl, "get_default_verify_paths", lambda: self._paths("/etc/ssl/cert.pem", None)
+        )
+        assert _default_trust_store_is_usable() is True
+        assert _fallback_ssl_context() is None
+
+    def test_capath_directory_counts_as_usable(self, monkeypatch, tmp_path):
+        """A cafile-less interpreter is still fine when it has a real capath directory."""
+        monkeypatch.setattr(
+            ssl, "get_default_verify_paths", lambda: self._paths(None, str(tmp_path))
+        )
+        assert _default_trust_store_is_usable() is True
+        assert _fallback_ssl_context() is None
+
+    def test_unusable_store_falls_back_to_certifi(self, monkeypatch):
+        """No cafile and no capath directory -- the python.org-without-certificates case."""
+        monkeypatch.setattr(
+            ssl, "get_default_verify_paths", lambda: self._paths(None, "/nonexistent/certs")
+        )
+        assert _default_trust_store_is_usable() is False
+
+        built = {}
+        real_create = ssl.create_default_context
+
+        def spy(*args, **kwargs):
+            built.update(kwargs)
+            return real_create(*args, **kwargs)
+
+        monkeypatch.setattr(ssl, "create_default_context", spy)
+
+        context = _fallback_ssl_context()
+
+        assert isinstance(context, ssl.SSLContext)
+        assert built["cafile"] == certifi.where()
+
+    @pytest.mark.asyncio
+    async def test_connect_omits_ssl_kwarg_on_healthy_store(self, monkeypatch):
+        """The kwarg is absent entirely when no fallback is needed, not passed as None."""
+        monkeypatch.setattr("rhesis.sdk.connector.connection._fallback_ssl_context", lambda: None)
+        connection = WebSocketConnection(
+            url="wss://test.example.com/ws", headers={}, on_message=AsyncMock()
+        )
+        with patch("rhesis.sdk.connector.connection.websockets.connect") as mock_connect:
+            mock_connect.side_effect = RuntimeError("stop here")
+            with pytest.raises(RuntimeError, match="stop here"):
+                await connection._attempt_single_connection()
+
+        assert "ssl" not in mock_connect.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_connect_passes_fallback_context(self, monkeypatch):
+        """When a fallback context exists it reaches websockets.connect."""
+        sentinel = ssl.create_default_context()
+        monkeypatch.setattr(
+            "rhesis.sdk.connector.connection._fallback_ssl_context", lambda: sentinel
+        )
+        connection = WebSocketConnection(
+            url="wss://test.example.com/ws", headers={}, on_message=AsyncMock()
+        )
+        with patch("rhesis.sdk.connector.connection.websockets.connect") as mock_connect:
+            mock_connect.side_effect = RuntimeError("stop here")
+            with pytest.raises(RuntimeError, match="stop here"):
+                await connection._attempt_single_connection()
+
+        assert mock_connect.call_args.kwargs["ssl"] is sentinel
+
 
 class TestWebSocketConnectionRetry:
     """Test WebSocket connection retry logic."""
@@ -216,6 +319,26 @@ class TestWebSocketConnectionRetry:
             assert "Authorization failed" in call_args
 
             # Cleanup
+            await connection.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_ssl_cert_error_no_retry(self, connection, mock_on_connection_failed):
+        """A TLS trust failure stops the maintenance loop instead of retrying for minutes."""
+        with patch("rhesis.sdk.connector.connection.websockets.connect") as mock_connect:
+            mock_connect.side_effect = ssl.SSLCertVerificationError(
+                1, "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed"
+            )
+
+            await connection.connect()
+            await asyncio.sleep(0.2)
+
+            assert mock_connect.call_count == 1
+            assert connection.state == ConnectionState.FAILED
+            assert mock_on_connection_failed.called
+            assert (
+                "TLS certificate verification failed" in (mock_on_connection_failed.call_args[0][0])
+            )
+
             await connection.disconnect()
 
     @pytest.mark.asyncio

--- a/tests/sdk/connector/test_connection_errors.py
+++ b/tests/sdk/connector/test_connection_errors.py
@@ -193,7 +193,7 @@ class TestTrustStoreFallback:
             ssl, "get_default_verify_paths", lambda: self._paths("/etc/ssl/cert.pem", None)
         )
         assert _default_trust_store_is_usable() is True
-        assert _fallback_ssl_context() is None
+        assert _fallback_ssl_context("wss://test.example.com/ws") is None
 
     def test_capath_directory_counts_as_usable(self, monkeypatch, tmp_path):
         """A cafile-less interpreter is still fine when it has a real capath directory."""
@@ -201,7 +201,7 @@ class TestTrustStoreFallback:
             ssl, "get_default_verify_paths", lambda: self._paths(None, str(tmp_path))
         )
         assert _default_trust_store_is_usable() is True
-        assert _fallback_ssl_context() is None
+        assert _fallback_ssl_context("wss://test.example.com/ws") is None
 
     def test_unusable_store_falls_back_to_certifi(self, monkeypatch):
         """No cafile and no capath directory -- the python.org-without-certificates case."""
@@ -219,15 +219,31 @@ class TestTrustStoreFallback:
 
         monkeypatch.setattr(ssl, "create_default_context", spy)
 
-        context = _fallback_ssl_context()
+        context = _fallback_ssl_context("wss://test.example.com/ws")
 
         assert isinstance(context, ssl.SSLContext)
         assert built["cafile"] == certifi.where()
 
+    def test_plain_ws_url_never_gets_a_context(self, monkeypatch):
+        """A ws:// URL must not receive an ssl kwarg, even with no usable trust store.
+
+        websockets raises ValueError on an ssl argument for a non-TLS URI, and that ValueError
+        classifies as retryable -- so it would put local development against
+        ws://localhost:8080 into the exact infinite retry loop this change exists to remove,
+        on precisely the interpreters the certifi fallback is meant to rescue.
+        """
+        monkeypatch.setattr(
+            ssl, "get_default_verify_paths", lambda: self._paths(None, "/nonexistent/certs")
+        )
+        assert _default_trust_store_is_usable() is False
+        assert _fallback_ssl_context("ws://localhost:8080/connector/ws") is None
+
     @pytest.mark.asyncio
     async def test_connect_omits_ssl_kwarg_on_healthy_store(self, monkeypatch):
         """The kwarg is absent entirely when no fallback is needed, not passed as None."""
-        monkeypatch.setattr("rhesis.sdk.connector.connection._fallback_ssl_context", lambda: None)
+        monkeypatch.setattr(
+            "rhesis.sdk.connector.connection._fallback_ssl_context", lambda _url: None
+        )
         connection = WebSocketConnection(
             url="wss://test.example.com/ws", headers={}, on_message=AsyncMock()
         )
@@ -243,7 +259,7 @@ class TestTrustStoreFallback:
         """When a fallback context exists it reaches websockets.connect."""
         sentinel = ssl.create_default_context()
         monkeypatch.setattr(
-            "rhesis.sdk.connector.connection._fallback_ssl_context", lambda: sentinel
+            "rhesis.sdk.connector.connection._fallback_ssl_context", lambda _url: sentinel
         )
         connection = WebSocketConnection(
             url="wss://test.example.com/ws", headers={}, on_message=AsyncMock()


### PR DESCRIPTION
## Purpose

Two TLS problems in the connector's WebSocket path, both of which make a local setup issue look like a platform outage.

First, some interpreters ship a compiled-in CA path that does not exist — a python.org macOS install whose `Install Certificates.command` was never run is the common case. Trace export survives this because `requests` bundles certifi, but `websockets` uses the interpreter's default context, so the connector alone fails TLS. You get traces arriving and no connector, which points suspicion at the backend rather than at the machine.

Second, when that happens the failure is retried forever. `classify_websocket_error` checks close codes, then an `HTTP \d{3}` pattern, then a list of transient keywords. `CERTIFICATE_VERIFY_FAILED` matches none of them, so it falls through to `# Default: treat as transient` — ten attempts with exponential backoff, then a 60 second sleep, then the whole cycle again, until the process is killed. A permanent trust failure produces no actionable output at any point.

## What Changed

- Supply a certifi-backed SSL context to `websockets.connect`, but only when the interpreter has no usable trust store — neither a resolved `cafile` nor a real `capath` directory. On a healthy machine no `ssl` kwarg is passed at all, so behaviour is unchanged and system and corporate roots still apply.
- Classify `ssl.SSLCertVerificationError` as permanent, with a message pointing at `SSL_CERT_FILE`/`SSL_CERT_DIR`, a TLS-inspecting proxy, and the system clock. `_maintain_connection` already handles permanent errors correctly, so this needed no new machinery.
- Generalised the follow-up log line, which hardcoded "Not retrying authentication/authorization failures" and became wrong once TLS reached that branch.

## Additional Context

The usability check is deliberately on `cafile`/`capath` and not `openssl_cafile`. `openssl_cafile` reports the compiled-in path whether or not anything exists there, so testing it would report success on precisely the broken installs this is meant to catch. Verified experimentally before settling on it.

`certifi` is imported lazily inside the fallback branch rather than declared as a dependency. `requests` is already a hard SDK dependency and itself requires `certifi>=2023.5.7`, so it is always installed; adding it to `sdk/pyproject.toml` would churn `uv.lock` across every consumer in the monorepo for no benefit, and lock churn is the one way a change like this could disturb unrelated agent runs.

This does not weaken verification anywhere. The fallback only ever adds a CA bundle to an interpreter that has none — it never overrides a working trust store, and a genuine verification failure still surfaces, now as one clear message instead of an endless retry.

Independent of #2582 (no overlapping files); either can merge first.

## Testing

`cd sdk && uv run pytest ../tests/sdk/test_client.py ../tests/sdk/connector -q` → 351 passed, up from 344 on `main`.

Coverage is by unit test in both directions: a usable `cafile` or a real `capath` passes no `ssl` kwarg, an interpreter with neither builds a context from `certifi.where()`, and an `SSLCertVerificationError` drives the maintenance loop to `FAILED` with the failure callback fired once rather than retrying.

Worth stating plainly: I could not reproduce the original failure on my machine, whose trust store is healthy — `cafile` resolves and both `api.rhesis.ai` and `stg-api.rhesis.ai` verify under a default context. The bug was diagnosed from a colleague's failing run and confirmed by feeding the exception straight to the classifier. Forcing `SSL_CERT_FILE=/nonexistent` is no longer a live repro either, since the certifi fallback now absorbs it — which is the intended behaviour.
