### PR TITLE
Start the connector from each agent's lifespan

### DIFF
--- a/agents/reg-advisor/src/reg_advisor/app.py
+++ b/agents/reg-advisor/src/reg_advisor/app.py
@@ -73,6 +73,11 @@ async def lifespan(_app: FastAPI):
     except RuntimeError as exc:
         logger.warning("Agent not built at startup: %s", exc)
 
+    # Dial out the connector now that uvicorn's loop is running. @endpoint registered at
+    # import time, which uvicorn does before asyncio.run(), so the connection was deferred
+    # and the Playground would never see this app. No-op under DisabledClient.
+    rhesis_client.start_connector()
+
     _startup_validated = True
     yield
     _startup_validated = False

--- a/agents/reg-advisor/tests/conftest.py
+++ b/agents/reg-advisor/tests/conftest.py
@@ -6,6 +6,16 @@ tests import from it directly.
 
 from __future__ import annotations
 
-from tests.mocks import MockLlm, build_runner_with, make_runner
+import os
+
+# Keep the suite hermetic. This agent's .env holds real Rhesis credentials, and app.py builds a
+# live RhesisClient -- which now dials the connector from its lifespan -- whenever both are set.
+# TestClient runs that lifespan, so without this the tests would open a WebSocket to the platform
+# and register an endpoint. Empty strings survive load_dotenv(), which does not override values
+# already present in the environment.
+os.environ["RHESIS_API_KEY"] = ""
+os.environ["RHESIS_PROJECT_ID"] = ""
+
+from tests.mocks import MockLlm, build_runner_with, make_runner  # noqa: E402
 
 __all__ = ["MockLlm", "build_runner_with", "make_runner"]

--- a/agents/reg-advisor/tests/test_app.py
+++ b/agents/reg-advisor/tests/test_app.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 import yaml
@@ -206,3 +207,19 @@ def test_an_unknown_attribute_still_raises() -> None:
     assert "app" in reg_advisor.__all__
     with pytest.raises(AttributeError):
         reg_advisor.no_such_thing
+
+
+def test_lifespan_starts_the_connector(monkeypatch):
+    """The lifespan dials the connector, which is what puts this app in the Playground.
+
+    ``@endpoint`` registers at import time, and uvicorn imports the app module from
+    ``uvicorn.main.run`` before ``asyncio.run``, so the connection is deferred with only a
+    warning. Nothing else picks it up, so dropping this call silently unregisters the agent.
+    """
+    fake_client = Mock()
+    monkeypatch.setattr(app_module, "rhesis_client", fake_client)
+
+    with TestClient(app_module.app):
+        pass
+
+    fake_client.start_connector.assert_called_once()

--- a/agents/travel-agent/src/travel_agent/app.py
+++ b/agents/travel-agent/src/travel_agent/app.py
@@ -67,6 +67,11 @@ async def lifespan(app: FastAPI):
     # Only the client is checked here. The workflow itself is built per turn, because its
     # shape depends on the trip brief - there is no single graph to validate up front.
     build_chat_client()
+    # Dial out the connector now that uvicorn's loop is running. @endpoint registered at
+    # import time, which uvicorn does before asyncio.run(), so the connection was deferred
+    # and the Playground would never see this app. No-op under DisabledClient.
+    rhesis_client.start_connector()
+
     _startup_validated = True
     logger.info("Travel Agent ready: trip_coordinator + 6 research specialists")
 

--- a/agents/travel-agent/tests/conftest.py
+++ b/agents/travel-agent/tests/conftest.py
@@ -3,3 +3,15 @@
 Deliberately holds no fixtures: the scripted client is constructed per test, because each
 test's script is the point of the test.
 """
+
+from __future__ import annotations
+
+import os
+
+# Keep the suite hermetic. This agent's .env holds real Rhesis credentials, and app.py builds a
+# live RhesisClient -- which now dials the connector from its lifespan -- whenever both are set.
+# TestClient runs that lifespan, so without this the tests would open a WebSocket to the platform
+# and register an endpoint. Empty strings survive load_dotenv(), which does not override values
+# already present in the environment.
+os.environ["RHESIS_API_KEY"] = ""
+os.environ["RHESIS_PROJECT_ID"] = ""

--- a/agents/travel-agent/tests/test_app.py
+++ b/agents/travel-agent/tests/test_app.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -91,3 +93,19 @@ def test_endpoint_mapping_is_shared_by_both_entry_points():
     assert "{{ response }}" == RESPONSE_MAPPING["output"]
     for key in ("phase", "handoffs", "degraded_services"):
         assert key in RESPONSE_MAPPING["metadata"]
+
+
+def test_lifespan_starts_the_connector(monkeypatch):
+    """The lifespan dials the connector, which is what puts this app in the Playground.
+
+    ``@endpoint`` registers at import time, and uvicorn imports the app module from
+    ``uvicorn.main.run`` before ``asyncio.run``, so the connection is deferred with only a
+    warning. Nothing else picks it up, so dropping this call silently unregisters the agent.
+    """
+    fake_client = Mock()
+    monkeypatch.setattr(app_module, "rhesis_client", fake_client)
+
+    with TestClient(app_module.app):
+        pass
+
+    fake_client.start_connector.assert_called_once()

--- a/agents/visit-prep/docs/architecture.md
+++ b/agents/visit-prep/docs/architecture.md
@@ -136,7 +136,7 @@ Each pair shares its harness — `chat_terminal/_traced_runner.py` and `examples
 
 `visit_prep/app_factory.py` holds the served path — `RhesisClient`, `@endpoint`, and the FastAPI wiring — and `create_app(tracing_cls)` builds it for one integration. `app.py` and `app_upstream.py` are two-line wrappers that pick one; `python -m visit_prep --tracing` selects which module uvicorn imports. The client is created before `RhesisTracing`, because the native integration reuses the provider it installs — that is what makes Haystack spans nest under the `@endpoint` span and flush with it.
 
-The FastAPI dev server registers the SDK endpoint and opens the WebSocket connector via uvicorn's event loop.
+The FastAPI dev server registers the SDK endpoint at import time and opens the WebSocket connector from its `lifespan` startup. The `lifespan` call is what makes the Playground work: uvicorn imports the app module from `uvicorn.main.run`, before `asyncio.run`, so the `@endpoint` decorator runs with no event loop and the connector defers its connection forever unless something restarts it inside the loop.
 
 ## Trace Surface
 

--- a/agents/visit-prep/src/visit_prep/app_factory.py
+++ b/agents/visit-prep/src/visit_prep/app_factory.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, Field
 
 from rhesis.sdk import RhesisClient, endpoint
 from rhesis.sdk.clients import DisabledClient
+from rhesis.sdk.decorators import get_default_client
 from visit_prep.session import default_store, run_chat_turn_async
 from visit_prep.state import Phase
 
@@ -100,6 +101,14 @@ def create_app(tracing_cls: TracingFactory) -> FastAPI:
 
         # Build the shared pipeline + generator once so per-turn requests reuse it.
         get_default_pipeline()
+
+        # Dial out the connector now that uvicorn's loop is running. @endpoint registered the
+        # function at import time, which uvicorn does before asyncio.run() -- so the connection
+        # was deferred and the Playground would never see this app.
+        client = get_default_client()
+        if client is not None:
+            client.start_connector()
+
         state["startup_validated"] = True
         logger.info("Visit-Prep ready: coordinator + history + summary + critic specialists")
         yield

--- a/agents/visit-prep/src/visit_prep/app_factory.py
+++ b/agents/visit-prep/src/visit_prep/app_factory.py
@@ -21,7 +21,6 @@ from pydantic import BaseModel, Field
 
 from rhesis.sdk import RhesisClient, endpoint
 from rhesis.sdk.clients import DisabledClient
-from rhesis.sdk.decorators import get_default_client
 from visit_prep.session import default_store, run_chat_turn_async
 from visit_prep.state import Phase
 
@@ -69,24 +68,25 @@ def create_app(tracing_cls: TracingFactory) -> FastAPI:
     :param tracing_cls: The ``RhesisTracing`` class of the integration to trace through.
     """
     # Initialise the Rhesis client so ``@endpoint`` has a registered default client to attach
-    # traces to. ``RhesisClient.__init__`` calls ``_register_default_client`` as a side effect —
-    # the local variable is never passed anywhere; ``@endpoint`` resolves it via
-    # ``get_default_client()`` at decorate time. Gate on both credentials: ``RhesisClient``
-    # eagerly installs OTEL providers and would export against an unknown project scope without
-    # ``RHESIS_PROJECT_ID``. ``DisabledClient`` keeps telemetry off when either is missing.
+    # traces to — ``RhesisClient.__init__`` calls ``_register_default_client`` as a side effect,
+    # so ``@endpoint`` finds it without being handed it. The lifespan needs the client itself to
+    # start the connector, so keep the reference rather than reaching back for the decorator
+    # module's global. Gate on both credentials: ``RhesisClient`` eagerly installs OTEL providers
+    # and would export against an unknown project scope without ``RHESIS_PROJECT_ID``.
+    # ``DisabledClient`` keeps telemetry off when either is missing.
     #
     # This must precede ``tracing_cls(...)``: the native integration reuses the provider the
     # client installs, which is what makes Haystack spans nest under the ``@endpoint`` span and
     # flush with it.
     tracing_configured = bool(os.getenv("RHESIS_API_KEY") and os.getenv("RHESIS_PROJECT_ID"))
     if tracing_configured:
-        RhesisClient.from_environment()
+        client = RhesisClient.from_environment()
     else:
         logger.info(
             "RHESIS_API_KEY/RHESIS_PROJECT_ID not set; using DisabledClient. "
             "Traces will NOT be shipped to the backend."
         )
-        DisabledClient()
+        client = DisabledClient()
 
     # The served path never opens a turn span: @endpoint already owns the conversation turn root.
     # This is here to enable Haystack tracing and to carry the conversation id onto its spans.
@@ -105,9 +105,7 @@ def create_app(tracing_cls: TracingFactory) -> FastAPI:
         # Dial out the connector now that uvicorn's loop is running. @endpoint registered the
         # function at import time, which uvicorn does before asyncio.run() -- so the connection
         # was deferred and the Playground would never see this app.
-        client = get_default_client()
-        if client is not None:
-            client.start_connector()
+        client.start_connector()
 
         state["startup_validated"] = True
         logger.info("Visit-Prep ready: coordinator + history + summary + critic specialists")

--- a/agents/visit-prep/tests/test_app.py
+++ b/agents/visit-prep/tests/test_app.py
@@ -57,17 +57,28 @@ def test_lifespan_starts_the_connector(monkeypatch):
     ``uvicorn.main.run`` before ``asyncio.run``, so the connection is deferred with only a
     warning. Nothing else picks it up, so dropping this call silently unregisters the agent.
     """
-    app_mod = _import_app_with_rhesis_disabled(monkeypatch)
+    monkeypatch.setenv("RHESIS_API_KEY", "")
+    monkeypatch.setenv("RHESIS_PROJECT_ID", "")
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
 
+    import rhesis.sdk.decorators._state as decorator_state
     import visit_prep.app_factory as factory
     import visit_prep.session as session
+    from rhesis.sdk.telemetry.integrations.haystack import RhesisTracing
 
     monkeypatch.setattr(session, "get_default_pipeline", lambda: None)
+
+    # Build the app through the factory so the lifespan closes over this client, and register it
+    # as the default so @endpoint resolves one. A Mock reports a truthy ``is_disabled``, which is
+    # what makes the decorator skip its own wiring.
     fake_client = Mock()
-    monkeypatch.setattr(factory, "get_default_client", lambda: fake_client)
+    monkeypatch.setattr(factory, "DisabledClient", lambda *_a, **_k: fake_client)
+    monkeypatch.setattr(decorator_state, "_default_client", fake_client)
+
+    app = factory.create_app(RhesisTracing)
 
     async def drive_lifespan():
-        async with app_mod.app.router.lifespan_context(app_mod.app):
+        async with app.router.lifespan_context(app):
             pass
 
     asyncio.run(drive_lifespan())

--- a/agents/visit-prep/tests/test_app.py
+++ b/agents/visit-prep/tests/test_app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import Mock
 
 from visit_prep.state import Phase
 
@@ -47,3 +48,28 @@ def test_chat_endpoint_awaits_async_run(monkeypatch):
     assert result.response == "hi"
     assert called["message"] == "hello"
     assert called["conversation_id"] == "c1"
+
+
+def test_lifespan_starts_the_connector(monkeypatch):
+    """The lifespan dials the connector, which is what puts this app in the Playground.
+
+    ``@endpoint`` registers at import time, and uvicorn imports the app module from
+    ``uvicorn.main.run`` before ``asyncio.run``, so the connection is deferred with only a
+    warning. Nothing else picks it up, so dropping this call silently unregisters the agent.
+    """
+    app_mod = _import_app_with_rhesis_disabled(monkeypatch)
+
+    import visit_prep.app_factory as factory
+    import visit_prep.session as session
+
+    monkeypatch.setattr(session, "get_default_pipeline", lambda: None)
+    fake_client = Mock()
+    monkeypatch.setattr(factory, "get_default_client", lambda: fake_client)
+
+    async def drive_lifespan():
+        async with app_mod.app.router.lifespan_context(app_mod.app):
+            pass
+
+    asyncio.run(drive_lifespan())
+
+    fake_client.start_connector.assert_called_once()


### PR DESCRIPTION
> **Stacked on #2582.** Base is `feat/sdk-connector-startup`, not `main`, because these agents call `start_connector()`, which that PR introduces. Retarget to `main` once #2582 merges.

## Purpose

None of the three agents in `agents/` ever appeared in the platform, so the Playground had nothing to invoke against any of them. `@endpoint` registers at import time and uvicorn imports the app module before it creates the event loop, so the connector deferred its connection and nothing picked it up. #2582 makes that failure loud and adds the call; this PR is the three agents adopting it.

## What Changed

- `start_connector()` from each lifespan: `visit-prep` (`app_factory.py`), `reg-advisor` and `travel-agent` (`app.py`). visit-prep resolves the client via `get_default_client()` because its factory deliberately discards it; the other two already keep a module-level `rhesis_client`.
- A test per agent driving the real lifespan and asserting the call happens.
- Credential isolation in the `reg-advisor` and `travel-agent` conftests — see below, this one matters.
- Corrected visit-prep's architecture note, which claimed the dev server opens the connector via uvicorn's event loop.

## Additional Context

The conftest change is not incidental tidying, it prevents a regression this PR would otherwise introduce. Both agents drive their app through `TestClient` as a context manager, which runs the lifespan. Their `.env` files hold real credentials and neither conftest isolated them, so once the lifespan starts the connector their **unit tests** would open a WebSocket to the platform and register endpoints on every run. Blanking the two variables makes `app.py` take its `DisabledClient` branch; empty strings survive `load_dotenv()`, which does not override values already in the environment. Confirmed it yields `DisabledClient` and a no-op call.

The connector deliberately does not start itself, which is why this adoption is needed per app rather than fixed once in the SDK: `connector/executor.py` awaits endpoint coroutines on whichever loop the connector runs on, and visit-prep caches per-conversation `asyncio.Lock` objects that raise if awaited from a different loop. The connector has to share the app's loop.

One thing I noticed and deliberately left alone: `reg-advisor` has no `logging.basicConfig` and relies on uvicorn's `log_level`, which only configures uvicorn's own loggers. Every `rhesis.sdk.*` INFO line is dropped, so its connector activity is invisible — my first verification run of that agent looked like a failure when it was working. Pre-existing and unrelated, but it makes that agent hard to debug and is worth a separate fix.

## Testing

All three suites, each up by exactly the new test: visit-prep 102 (from 101), reg-advisor 358 (from 357), travel-agent 235 (from 234).

```
cd agents/visit-prep  && uv run pytest -q
cd agents/reg-advisor && uv run pytest -q
cd agents/travel-agent && uv run pytest -q
```

Verified the new tests actually fail without the fix by removing the lifespan call again in visit-prep and travel-agent and watching them go red, then restoring.

Verified live against `api.rhesis.ai` too, which is the part the tests cannot prove. Each agent's log now shows the deferral warning at import, then `disconnected -> connecting`, `connected (websocket established)`, `Sent registration for 1 function(s)`; all three endpoints then appear in the project. Deliberately no invocations, `POST /chat`, or scenario runs — registration is observable without them, so the trace count in the project was unchanged at 21 before and after. Both borrowed `.env` files were restored to their own credentials afterwards.
