### PR TITLE
Add bulk-select delete to remaining grids

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/navigation';
 import { Box, Typography, useTheme, Alert, Paper } from '@mui/material';
 import GridBadge from '@/components/common/GridBadge';
 import GridToolbar from '@/components/common/GridToolbar';
+import DeleteIcon from '@mui/icons-material/DeleteOutlined';
 import {
   GridFilterModel,
   GridColDef,
@@ -24,7 +25,6 @@ import { Project } from '@/utils/api-client/interfaces/project';
 import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { DeleteModal } from '@/components/common/DeleteModal';
-import { useNotifications } from '@/components/common/NotificationContext';
 import { buildEndpointListFilter } from '@/utils/odata-filter';
 import EndpointFilterDrawer, {
   type EndpointFilters,
@@ -38,9 +38,9 @@ import {
 } from '@/components/common/createRowActionsColumn';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
-import { useDeleteEndpoint } from '@/hooks/useEndpoints';
 import { getProjectIcon } from './endpoint-icon-utils';
 import { endpointKeys } from '@/constants/query-keys';
+import { useBulkDelete } from '@/hooks/useBulkDelete';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
@@ -120,10 +120,8 @@ export default function EndpointsGrid({
   const theme = useTheme();
   const router = useRouter();
   const { status } = useSession();
-  const notifications = useNotifications();
   const canEditEndpoint = useCan(Capability.Endpoint.UPDATE);
   const canDeleteEndpoint = useCan(Capability.Endpoint.DELETE);
-  const deleteEndpoint = useDeleteEndpoint();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [drawerFilters, setDrawerFilters] = useState<EndpointFilters>(
@@ -131,10 +129,24 @@ export default function EndpointsGrid({
   );
   const [projects, setProjects] = useState<Record<string, Project>>({});
   const [loadingProjects, setLoadingProjects] = useState(true);
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
+
+  const {
+    selectedRows,
+    handleSelectionChange,
+    pendingDeleteId,
+    deleteModalOpen,
+    isDeleting,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+  } = useBulkDelete({
+    bulkDeleteFn: (ids: string[]) =>
+      new ApiClientFactory().getEndpointsClient().bulkDeleteEndpoints(ids),
+    queryKey: endpointKeys.all(),
+    itemLabelSingular: 'endpoint',
+    itemLabelPlural: 'endpoints',
+  });
 
   const {
     filterModel,
@@ -260,32 +272,12 @@ export default function EndpointsGrid({
     }
   }, [status]);
 
-  const handleDeleteEndpoints = async () => {
-    if (!isAuthenticated(status) || !pendingDeleteId) return;
-
-    try {
-      setDeleting(true);
-      await deleteEndpoint.mutateAsync(pendingDeleteId);
-      setPendingDeleteId(null);
-      setDeleteDialogOpen(false);
-    } catch {
-      notifications.show('Failed to delete endpoints', { severity: 'error' });
-    } finally {
-      setDeleting(false);
-    }
-  };
-
-  const handleRowDeleteAction = useCallback((id: string) => {
-    setPendingDeleteId(id);
-    setDeleteDialogOpen(true);
-  }, []);
-
   const columns: GridColDef[] = useMemo(() => {
     const actionsCol = createRowActionsColumn({
       onEdit: id => {
         router.push(`/endpoints/${id}`);
       },
-      onDelete: id => handleRowDeleteAction(id),
+      onDelete: id => requestDelete(id),
       canEdit: () => canEditEndpoint,
       canDelete: () => canDeleteEndpoint,
     });
@@ -351,7 +343,21 @@ export default function EndpointsGrid({
       },
       actionsCol,
     ];
-  }, [projects, theme.typography.h5.fontSize, handleRowDeleteAction, router]);
+  }, [projects, theme.typography.h5.fontSize, requestDelete, router]);
+
+  const getActionButtons = useCallback(() => {
+    if (selectedRows.length === 0) return [];
+
+    return [
+      {
+        label: 'Delete',
+        icon: <DeleteIcon />,
+        variant: 'outlined' as const,
+        color: 'error' as const,
+        onClick: () => requestDelete(),
+      },
+    ];
+  }, [selectedRows.length, requestDelete]);
 
   const hasActiveDrawerFilters = hasActiveEndpointFilters(drawerFilters);
   const activeFilterCount = countActiveEndpointFilters(drawerFilters);
@@ -400,21 +406,27 @@ export default function EndpointsGrid({
           onFilterModelChange={handleFilterModelChange}
           toolbarSlot={EndpointsUnifiedToolbar}
           showToolbar={true}
+          actionButtons={getActionButtons()}
           disablePaperWrapper={true}
           persistState
           sx={rowActionsHoverSx}
+          checkboxSelection
+          disableRowSelectionOnClick
+          rowSelectionModel={selectedRows}
+          onRowSelectionModelChange={handleSelectionChange}
         />
 
         <DeleteModal
-          open={deleteDialogOpen}
-          onClose={() => {
-            setDeleteDialogOpen(false);
-            setPendingDeleteId(null);
-          }}
-          onConfirm={handleDeleteEndpoints}
-          isLoading={deleting}
-          title="Delete Endpoint"
-          message="Are you sure you want to delete this endpoint? Related data will not be deleted."
+          open={deleteModalOpen}
+          onClose={cancelDelete}
+          onConfirm={confirmDelete}
+          isLoading={isDeleting}
+          title={pendingDeleteId ? 'Delete Endpoint' : 'Delete Endpoints'}
+          message={
+            pendingDeleteId
+              ? 'Are you sure you want to delete this endpoint? Related data will not be deleted.'
+              : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'endpoint' : 'endpoints'}? Related data will not be deleted.`
+          }
           itemType="endpoints"
         />
       </Box>

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -11,7 +11,7 @@ import { useRouter } from 'next/navigation';
 import { Box, Typography, useTheme, Alert, Paper } from '@mui/material';
 import GridBadge from '@/components/common/GridBadge';
 import GridToolbar from '@/components/common/GridToolbar';
-import DeleteIcon from '@mui/icons-material/DeleteOutlined';
+import SelectionModeToggle from '@/components/common/SelectionModeToggle';
 import {
   GridFilterModel,
   GridColDef,
@@ -40,7 +40,10 @@ import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { getProjectIcon } from './endpoint-icon-utils';
 import { endpointKeys } from '@/constants/query-keys';
-import { useBulkDelete } from '@/hooks/useBulkDelete';
+import {
+  useBulkDelete,
+  type BulkDeleteActionsState,
+} from '@/hooks/useBulkDelete';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
@@ -60,6 +63,7 @@ interface EndpointsGridProps {
    */
   canCreate?: boolean;
   onCreateClick?: () => void;
+  onBulkActionsChange?: (actions: BulkDeleteActionsState) => void;
 }
 
 interface EndpointsToolbarState {
@@ -68,6 +72,8 @@ interface EndpointsToolbarState {
   openFilterDrawer: () => void;
   hasActiveDrawerFilters: boolean;
   activeFilterCount: number;
+  checkboxSelectionMode: boolean;
+  setCheckboxSelectionMode: (v: boolean) => void;
 }
 
 const DRAWER_FILTER_FIELDS = [
@@ -82,6 +88,8 @@ const EndpointsToolbarContext = React.createContext<EndpointsToolbarState>({
   openFilterDrawer: () => {},
   hasActiveDrawerFilters: false,
   activeFilterCount: 0,
+  checkboxSelectionMode: false,
+  setCheckboxSelectionMode: () => {},
 });
 
 function EndpointsUnifiedToolbar() {
@@ -91,6 +99,8 @@ function EndpointsUnifiedToolbar() {
     openFilterDrawer,
     hasActiveDrawerFilters,
     activeFilterCount,
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
   } = useContext(EndpointsToolbarContext);
 
   return (
@@ -103,6 +113,11 @@ function EndpointsUnifiedToolbar() {
       activeFilterCount={activeFilterCount}
       rightContent={
         <>
+          <SelectionModeToggle
+            checked={checkboxSelectionMode}
+            onChange={setCheckboxSelectionMode}
+            label="Select endpoints"
+          />
           <GridToolbarColumnsButton />
           <GridToolbarDensitySelector />
           <GridToolbarExport />
@@ -116,6 +131,7 @@ export default function EndpointsGrid({
   projectId,
   canCreate,
   onCreateClick,
+  onBulkActionsChange,
 }: EndpointsGridProps) {
   const theme = useTheme();
   const router = useRouter();
@@ -132,6 +148,8 @@ export default function EndpointsGrid({
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
 
   const {
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
     selectedRows,
     handleSelectionChange,
     pendingDeleteId,
@@ -146,6 +164,7 @@ export default function EndpointsGrid({
     queryKey: endpointKeys.all(),
     itemLabelSingular: 'endpoint',
     itemLabelPlural: 'endpoints',
+    onBulkActionsChange,
   });
 
   const {
@@ -345,20 +364,6 @@ export default function EndpointsGrid({
     ];
   }, [projects, theme.typography.h5.fontSize, requestDelete, router]);
 
-  const getActionButtons = useCallback(() => {
-    if (selectedRows.length === 0) return [];
-
-    return [
-      {
-        label: 'Delete',
-        icon: <DeleteIcon />,
-        variant: 'outlined' as const,
-        color: 'error' as const,
-        onClick: () => requestDelete(),
-      },
-    ];
-  }, [selectedRows.length, requestDelete]);
-
   const hasActiveDrawerFilters = hasActiveEndpointFilters(drawerFilters);
   const activeFilterCount = countActiveEndpointFilters(drawerFilters);
 
@@ -369,8 +374,16 @@ export default function EndpointsGrid({
       openFilterDrawer: () => setFilterDrawerOpen(true),
       hasActiveDrawerFilters,
       activeFilterCount,
+      checkboxSelectionMode,
+      setCheckboxSelectionMode,
     }),
-    [searchQuery, hasActiveDrawerFilters, activeFilterCount]
+    [
+      searchQuery,
+      hasActiveDrawerFilters,
+      activeFilterCount,
+      checkboxSelectionMode,
+      setCheckboxSelectionMode,
+    ]
   );
 
   // Only the top-level Endpoints page passes `onCreateClick` — that's when
@@ -393,7 +406,11 @@ export default function EndpointsGrid({
           loading={loading || loadingProjects}
           density="comfortable"
           linkPath={
-            projectId ? `/projects/${projectId}/endpoints` : '/endpoints'
+            checkboxSelectionMode
+              ? undefined
+              : projectId
+                ? `/projects/${projectId}/endpoints`
+                : '/endpoints'
           }
           linkField="id"
           serverSidePagination={true}
@@ -406,14 +423,15 @@ export default function EndpointsGrid({
           onFilterModelChange={handleFilterModelChange}
           toolbarSlot={EndpointsUnifiedToolbar}
           showToolbar={true}
-          actionButtons={getActionButtons()}
           disablePaperWrapper={true}
           persistState
           sx={rowActionsHoverSx}
-          checkboxSelection
-          disableRowSelectionOnClick
-          rowSelectionModel={selectedRows}
-          onRowSelectionModelChange={handleSelectionChange}
+          checkboxSelection={checkboxSelectionMode}
+          disableRowSelectionOnClick={checkboxSelectionMode || undefined}
+          rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
+          onRowSelectionModelChange={
+            checkboxSelectionMode ? handleSelectionChange : undefined
+          }
         />
 
         <DeleteModal

--- a/apps/frontend/src/app/(protected)/endpoints/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/page.tsx
@@ -7,8 +7,10 @@ import Typography from '@mui/material/Typography';
 import { useSession } from 'next-auth/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { endpointKeys } from '@/constants/query-keys';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
+import { useBulkActionsBridge } from '@/hooks/useBulkActionsBridge';
 import EndpointsGrid from './components/EndpointsGrid';
 import EndpointCreateDrawer from './components/EndpointCreateDrawer';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
@@ -32,6 +34,8 @@ export default function EndpointsPage() {
   const [createProjectId, setCreateProjectId] = React.useState<
     string | undefined
   >();
+  const { bulkActionsVisible, onBulkDelete, handleBulkActionsChange } =
+    useBulkActionsBridge();
 
   useDocumentTitle('Endpoints');
 
@@ -90,6 +94,20 @@ export default function EndpointsPage() {
         breadcrumbs={[]}
         actions={
           <FabGroup>
+            {bulkActionsVisible && (
+              <Can capability={Capability.Endpoint.DELETE}>
+                <Fab
+                  icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
+                  tooltip="Delete Endpoints"
+                  aria-label="Delete Endpoints"
+                  onClick={onBulkDelete}
+                  sx={{
+                    bgcolor: 'error.main',
+                    '&:hover': { bgcolor: 'error.dark' },
+                  }}
+                />
+              </Can>
+            )}
             <Can capability={Capability.Endpoint.CREATE}>
               <Fab
                 icon={<FabAddIcon />}
@@ -102,7 +120,11 @@ export default function EndpointsPage() {
         }
       >
         <Box sx={{ mt: 2, mb: 2 }}>
-          <EndpointsGrid canCreate={canCreate} onCreateClick={handleCreate} />
+          <EndpointsGrid
+            canCreate={canCreate}
+            onCreateClick={handleCreate}
+            onBulkActionsChange={handleBulkActionsChange}
+          />
         </Box>
       </PageLayout>
 

--- a/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
@@ -6,6 +6,7 @@ import { useSession } from 'next-auth/react';
 import { sourceKeys } from '@/constants/query-keys';
 import { Box, Alert } from '@mui/material';
 import UploadIcon from '@mui/icons-material/Upload';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabGroup } from '@/components/common/Fab';
 import AccessDenied from '@/components/common/AccessDenied';
@@ -16,6 +17,7 @@ import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { MenuBookIcon } from '@/components/icons';
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { useBulkActionsBridge } from '@/hooks/useBulkActionsBridge';
 import SourcesGrid from './SourcesGrid';
 import UploadSourceDrawer from './UploadSourceDrawer';
 import ToolImportDrawer from './ToolImportDrawer';
@@ -30,6 +32,8 @@ export default function KnowledgeClientWrapper() {
   const queryClient = useQueryClient();
   const [uploadDrawerOpen, setUploadDrawerOpen] = useState(false);
   const [toolImportDrawerOpen, setToolImportDrawerOpen] = useState(false);
+  const { bulkActionsVisible, onBulkDelete, handleBulkActionsChange } =
+    useBulkActionsBridge();
 
   useDocumentTitle('Knowledge');
 
@@ -73,6 +77,20 @@ export default function KnowledgeClientWrapper() {
         breadcrumbs={[]}
         actions={
           <FabGroup>
+            {bulkActionsVisible && (
+              <Can capability={Capability.Source.DELETE}>
+                <Fab
+                  icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
+                  tooltip="Delete Sources"
+                  aria-label="Delete Sources"
+                  onClick={onBulkDelete}
+                  sx={{
+                    bgcolor: 'error.main',
+                    '&:hover': { bgcolor: 'error.dark' },
+                  }}
+                />
+              </Can>
+            )}
             <Can capability={Capability.Source.CREATE}>
               <Fab
                 icon={<UploadIcon />}
@@ -96,6 +114,7 @@ export default function KnowledgeClientWrapper() {
           <SourcesGrid
             canCreate={canCreateSource}
             onCreateClick={() => setUploadDrawerOpen(true)}
+            onBulkActionsChange={handleBulkActionsChange}
           />
         </Box>
       </PageLayout>

--- a/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
@@ -22,8 +22,8 @@ import {
 } from '@/components/common/createRowActionsColumn';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
+import DeleteIcon from '@mui/icons-material/DeleteOutlined';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { useNotifications } from '@/components/common/NotificationContext';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import styles from '@/styles/Knowledge.module.css';
 import { combineSourceFiltersToOData } from '@/utils/odata-filter';
@@ -36,8 +36,8 @@ import SourceFilterDrawer, {
   hasActiveSourceFilters,
   countActiveSourceFilters,
 } from './SourceFilterDrawer';
-import { useQueryClient } from '@tanstack/react-query';
 import { sourceKeys } from '@/constants/query-keys';
+import { useBulkDelete } from '@/hooks/useBulkDelete';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
@@ -55,7 +55,6 @@ interface SourcesToolbarState {
   openFilterDrawer: () => void;
   hasActiveDrawerFilters: boolean;
   activeFilterCount: number;
-  onDeleteSource: (id: string) => void;
 }
 
 const SourcesToolbarContext = React.createContext<SourcesToolbarState>({
@@ -64,7 +63,6 @@ const SourcesToolbarContext = React.createContext<SourcesToolbarState>({
   openFilterDrawer: () => {},
   hasActiveDrawerFilters: false,
   activeFilterCount: 0,
-  onDeleteSource: () => {},
 });
 
 function SourcesUnifiedToolbar() {
@@ -101,19 +99,31 @@ export default function SourcesGrid({
 }: SourcesGridProps) {
   const router = useRouter();
   const { status } = useSession();
-  const notifications = useNotifications();
   const canEditSource = useCan(Capability.Source.UPDATE);
   const canDeleteSource = useCan(Capability.Source.DELETE);
-  const queryClient = useQueryClient();
 
   // Component state
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [drawerFilters, setDrawerFilters] =
     useState<SourceFilters>(EMPTY_SOURCE_FILTERS);
   const [searchQuery, setSearchQuery] = useState('');
+
+  const {
+    selectedRows,
+    handleSelectionChange,
+    pendingDeleteId,
+    deleteModalOpen,
+    isDeleting,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+  } = useBulkDelete({
+    bulkDeleteFn: (ids: string[]) =>
+      new ApiClientFactory().getSourcesClient().bulkDeleteSources(ids),
+    queryKey: sourceKeys.all(),
+    itemLabelSingular: 'source',
+    itemLabelPlural: 'sources',
+  });
 
   const {
     filterModel,
@@ -206,46 +216,6 @@ export default function SourcesGrid({
     [router]
   );
 
-  const handleDeleteSource = useCallback((id: string) => {
-    setPendingDeleteId(id);
-    setDeleteModalOpen(true);
-  }, []);
-
-  const handleDeleteConfirm = async () => {
-    if (!pendingDeleteId) return;
-
-    try {
-      setIsDeleting(true);
-      const clientFactory = new ApiClientFactory();
-      const sourcesClient = clientFactory.getSourcesClient();
-
-      await sourcesClient.deleteSource(
-        pendingDeleteId as `${string}-${string}-${string}-${string}-${string}`
-      );
-
-      notifications.show('Successfully deleted source', {
-        severity: 'success',
-        autoHideDuration: 4000,
-      });
-
-      setPendingDeleteId(null);
-      queryClient.invalidateQueries({ queryKey: sourceKeys.all() });
-    } catch {
-      notifications.show('Failed to delete source', {
-        severity: 'error',
-        autoHideDuration: 4000,
-      });
-    } finally {
-      setIsDeleting(false);
-      setDeleteModalOpen(false);
-    }
-  };
-
-  const handleDeleteCancel = () => {
-    setDeleteModalOpen(false);
-    setPendingDeleteId(null);
-  };
-
   const toolbarContextValue = useMemo(
     () => ({
       searchQuery,
@@ -253,16 +223,29 @@ export default function SourcesGrid({
       openFilterDrawer: () => setFilterDrawerOpen(true),
       hasActiveDrawerFilters: hasActiveSourceFilters(drawerFilters),
       activeFilterCount: countActiveSourceFilters(drawerFilters),
-      onDeleteSource: handleDeleteSource,
     }),
-    [searchQuery, drawerFilters, handleDeleteSource]
+    [searchQuery, drawerFilters]
   );
+
+  const getActionButtons = useCallback(() => {
+    if (selectedRows.length === 0) return [];
+
+    return [
+      {
+        label: 'Delete',
+        icon: <DeleteIcon />,
+        variant: 'outlined' as const,
+        color: 'error' as const,
+        onClick: () => requestDelete(),
+      },
+    ];
+  }, [selectedRows.length, requestDelete]);
 
   // Column definitions
   const columns: GridColDef[] = React.useMemo(() => {
     const actionsCol = createRowActionsColumn({
       onEdit: id => router.push(`/knowledge/${id}`),
-      onDelete: id => handleDeleteSource(id),
+      onDelete: id => requestDelete(id),
       canEdit: () => canEditSource,
       canDelete: () => canDeleteSource,
     });
@@ -478,7 +461,7 @@ export default function SourcesGrid({
       },
       actionsCol,
     ];
-  }, [router, handleDeleteSource]);
+  }, [router, requestDelete]);
 
   if (error) {
     return (
@@ -536,18 +519,27 @@ export default function SourcesGrid({
             disablePaperWrapper={true}
             onRowClick={handleRowClick}
             toolbarSlot={SourcesUnifiedToolbar}
+            actionButtons={getActionButtons()}
             persistState
             sx={rowActionsHoverSx}
+            checkboxSelection
+            disableRowSelectionOnClick
+            rowSelectionModel={selectedRows}
+            onRowSelectionModelChange={handleSelectionChange}
           />
 
           <DeleteModal
             open={deleteModalOpen}
-            onClose={handleDeleteCancel}
-            onConfirm={handleDeleteConfirm}
+            onClose={cancelDelete}
+            onConfirm={confirmDelete}
             isLoading={isDeleting}
-            title="Delete Source"
-            message="Are you sure you want to delete this source? This action cannot be undone."
-            itemType="source"
+            title={pendingDeleteId ? 'Delete Source' : 'Delete Sources'}
+            message={
+              pendingDeleteId
+                ? 'Are you sure you want to delete this source? This action cannot be undone.'
+                : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'source' : 'sources'}? This action cannot be undone.`
+            }
+            itemType="sources"
           />
 
           <SourceFilterDrawer

--- a/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/components/common/createRowActionsColumn';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
-import DeleteIcon from '@mui/icons-material/DeleteOutlined';
+import SelectionModeToggle from '@/components/common/SelectionModeToggle';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import styles from '@/styles/Knowledge.module.css';
@@ -37,7 +37,10 @@ import SourceFilterDrawer, {
   countActiveSourceFilters,
 } from './SourceFilterDrawer';
 import { sourceKeys } from '@/constants/query-keys';
-import { useBulkDelete } from '@/hooks/useBulkDelete';
+import {
+  useBulkDelete,
+  type BulkDeleteActionsState,
+} from '@/hooks/useBulkDelete';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
@@ -47,6 +50,7 @@ import EntityEmptyState from '@/components/common/EntityEmptyState';
 interface SourcesGridProps {
   canCreate?: boolean;
   onCreateClick?: () => void;
+  onBulkActionsChange?: (actions: BulkDeleteActionsState) => void;
 }
 
 interface SourcesToolbarState {
@@ -55,6 +59,8 @@ interface SourcesToolbarState {
   openFilterDrawer: () => void;
   hasActiveDrawerFilters: boolean;
   activeFilterCount: number;
+  checkboxSelectionMode: boolean;
+  setCheckboxSelectionMode: (v: boolean) => void;
 }
 
 const SourcesToolbarContext = React.createContext<SourcesToolbarState>({
@@ -63,6 +69,8 @@ const SourcesToolbarContext = React.createContext<SourcesToolbarState>({
   openFilterDrawer: () => {},
   hasActiveDrawerFilters: false,
   activeFilterCount: 0,
+  checkboxSelectionMode: false,
+  setCheckboxSelectionMode: () => {},
 });
 
 function SourcesUnifiedToolbar() {
@@ -72,6 +80,8 @@ function SourcesUnifiedToolbar() {
     openFilterDrawer,
     hasActiveDrawerFilters,
     activeFilterCount,
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
   } = useContext(SourcesToolbarContext);
 
   return (
@@ -84,6 +94,11 @@ function SourcesUnifiedToolbar() {
       activeFilterCount={activeFilterCount}
       rightContent={
         <>
+          <SelectionModeToggle
+            checked={checkboxSelectionMode}
+            onChange={setCheckboxSelectionMode}
+            label="Select sources"
+          />
           <GridToolbarColumnsButton />
           <GridToolbarDensitySelector />
           <GridToolbarExport />
@@ -96,6 +111,7 @@ function SourcesUnifiedToolbar() {
 export default function SourcesGrid({
   canCreate,
   onCreateClick,
+  onBulkActionsChange,
 }: SourcesGridProps) {
   const router = useRouter();
   const { status } = useSession();
@@ -109,6 +125,8 @@ export default function SourcesGrid({
   const [searchQuery, setSearchQuery] = useState('');
 
   const {
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
     selectedRows,
     handleSelectionChange,
     pendingDeleteId,
@@ -123,6 +141,7 @@ export default function SourcesGrid({
     queryKey: sourceKeys.all(),
     itemLabelSingular: 'source',
     itemLabelPlural: 'sources',
+    onBulkActionsChange,
   });
 
   const {
@@ -223,23 +242,16 @@ export default function SourcesGrid({
       openFilterDrawer: () => setFilterDrawerOpen(true),
       hasActiveDrawerFilters: hasActiveSourceFilters(drawerFilters),
       activeFilterCount: countActiveSourceFilters(drawerFilters),
+      checkboxSelectionMode,
+      setCheckboxSelectionMode,
     }),
-    [searchQuery, drawerFilters]
+    [
+      searchQuery,
+      drawerFilters,
+      checkboxSelectionMode,
+      setCheckboxSelectionMode,
+    ]
   );
-
-  const getActionButtons = useCallback(() => {
-    if (selectedRows.length === 0) return [];
-
-    return [
-      {
-        label: 'Delete',
-        icon: <DeleteIcon />,
-        variant: 'outlined' as const,
-        color: 'error' as const,
-        onClick: () => requestDelete(),
-      },
-    ];
-  }, [selectedRows.length, requestDelete]);
 
   // Column definitions
   const columns: GridColDef[] = React.useMemo(() => {
@@ -517,15 +529,16 @@ export default function SourcesGrid({
             totalRows={totalCount}
             pageSizeOptions={[10, 25, 50]}
             disablePaperWrapper={true}
-            onRowClick={handleRowClick}
+            onRowClick={checkboxSelectionMode ? undefined : handleRowClick}
             toolbarSlot={SourcesUnifiedToolbar}
-            actionButtons={getActionButtons()}
             persistState
             sx={rowActionsHoverSx}
-            checkboxSelection
-            disableRowSelectionOnClick
-            rowSelectionModel={selectedRows}
-            onRowSelectionModelChange={handleSelectionChange}
+            checkboxSelection={checkboxSelectionMode}
+            disableRowSelectionOnClick={checkboxSelectionMode || undefined}
+            rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
+            onRowSelectionModelChange={
+              checkboxSelectionMode ? handleSelectionChange : undefined
+            }
           />
 
           <DeleteModal

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -17,6 +17,7 @@ import { can } from '@/utils/affordances';
 import { Capability } from '@/constants/capabilities';
 import { Typography, Box, Alert, Avatar, Paper } from '@mui/material';
 import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined';
+import DeleteIcon from '@mui/icons-material/DeleteOutlined';
 import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
 import GridBadge from '@/components/common/GridBadge';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -33,16 +34,13 @@ import {
   rowActionsHoverSx,
 } from '@/components/common/createRowActionsColumn';
 import { DeleteModal } from '@/components/common/DeleteModal';
-import { useNotifications } from '@/components/common/NotificationContext';
-// Renamed on import: distinct from the toast system's useNotifications above --
-// this is the persistent, backend-tracked "assigned to you" badge/highlight.
 import { useNotifications as useJobNotifications } from '@/contexts/NotificationsContext';
 import {
   HIGHLIGHTED_ROW_CLASS,
   NotificationSection,
 } from '@/constants/notifications';
-import { useQueryClient } from '@tanstack/react-query';
 import { taskKeys } from '@/constants/query-keys';
+import { useBulkDelete } from '@/hooks/useBulkDelete';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
@@ -124,9 +122,7 @@ export default function TasksGrid({
   onCreateClick,
 }: TasksGridProps) {
   const router = useRouter();
-  const notifications = useNotifications();
   const { highlightedIds, clearHighlight } = useJobNotifications();
-  const queryClient = useQueryClient();
   const { status } = useSession();
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -134,9 +130,25 @@ export default function TasksGrid({
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [drawerFilters, setDrawerFilters] =
     useState<TaskFilters>(EMPTY_TASK_FILTERS);
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+
+  const {
+    selectedRows,
+    handleSelectionChange,
+    pendingDeleteId,
+    deleteModalOpen,
+    isDeleting,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+  } = useBulkDelete({
+    bulkDeleteFn: (ids: string[]) =>
+      new ApiClientFactory().getTasksClient().bulkDeleteTasks(ids),
+    queryKey: taskKeys.all(),
+    itemLabelSingular: 'task',
+    itemLabelPlural: 'tasks',
+    getSkippedCount: response => response.forbidden_ids.length,
+    skippedReason: 'not yours to delete',
+  });
 
   const {
     filterModel,
@@ -236,45 +248,11 @@ export default function TasksGrid({
     [router, clearHighlight]
   );
 
-  const handleRowDeleteAction = useCallback((id: string) => {
-    setPendingDeleteId(id);
-    setDeleteModalOpen(true);
-  }, []);
-
-  const handleDeleteConfirm = useCallback(async () => {
-    if (!pendingDeleteId) return;
-    try {
-      setIsDeleting(true);
-      const clientFactory = new ApiClientFactory();
-      const tasksClient = clientFactory.getTasksClient();
-      await tasksClient.deleteTask(pendingDeleteId);
-      notifications.show('Successfully deleted task', {
-        severity: 'success',
-        autoHideDuration: 4000,
-      });
-      setPendingDeleteId(null);
-      queryClient.invalidateQueries({ queryKey: taskKeys.all() });
-    } catch {
-      notifications.show('Failed to delete task', {
-        severity: 'error',
-        autoHideDuration: 4000,
-      });
-    } finally {
-      setIsDeleting(false);
-      setDeleteModalOpen(false);
-    }
-  }, [pendingDeleteId, notifications, queryClient]);
-
-  const handleDeleteCancel = useCallback(() => {
-    setDeleteModalOpen(false);
-    setPendingDeleteId(null);
-  }, []);
-
   const columns: GridColDef[] = useMemo(() => {
     const actionsCol = createRowActionsColumn({
       onEdit: id => router.push(`/tasks/${id}`),
       canEdit: row => can(row as unknown as Task, Capability.Task.UPDATE),
-      onDelete: id => handleRowDeleteAction(id),
+      onDelete: id => requestDelete(id),
       canDelete: row => can(row as unknown as Task, Capability.Task.DELETE),
     });
     return [
@@ -353,7 +331,21 @@ export default function TasksGrid({
       },
       actionsCol,
     ];
-  }, [router, handleRowDeleteAction]);
+  }, [router, requestDelete]);
+
+  const getActionButtons = useCallback(() => {
+    if (selectedRows.length === 0) return [];
+
+    return [
+      {
+        label: 'Delete',
+        icon: <DeleteIcon />,
+        variant: 'outlined' as const,
+        color: 'error' as const,
+        onClick: () => requestDelete(),
+      },
+    ];
+  }, [selectedRows.length, requestDelete]);
 
   const filtersActive =
     filterModel.items.length > 0 ||
@@ -418,6 +410,7 @@ export default function TasksGrid({
               serverSideFiltering={true}
               showToolbar={true}
               toolbarSlot={TasksUnifiedToolbar}
+              actionButtons={getActionButtons()}
               disablePaperWrapper={true}
               persistState
               sx={{
@@ -426,16 +419,26 @@ export default function TasksGrid({
                   cursor: 'pointer',
                 },
               }}
+              checkboxSelection
+              isRowSelectable={(params: GridRowParams) =>
+                can(params.row as unknown as Task, Capability.Task.DELETE)
+              }
+              rowSelectionModel={selectedRows}
+              onRowSelectionModelChange={handleSelectionChange}
             />
 
             <DeleteModal
               open={deleteModalOpen}
-              onClose={handleDeleteCancel}
-              onConfirm={handleDeleteConfirm}
+              onClose={cancelDelete}
+              onConfirm={confirmDelete}
               isLoading={isDeleting}
-              title="Delete Task"
-              message="Are you sure you want to delete this task? This action cannot be undone."
-              itemType="task"
+              title={pendingDeleteId ? 'Delete Task' : 'Delete Tasks'}
+              message={
+                pendingDeleteId
+                  ? 'Are you sure you want to delete this task? This action cannot be undone.'
+                  : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'task' : 'tasks'}? This action cannot be undone.`
+              }
+              itemType="tasks"
             />
 
             <TaskFilterDrawer

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -17,8 +17,8 @@ import { can } from '@/utils/affordances';
 import { Capability } from '@/constants/capabilities';
 import { Typography, Box, Alert, Avatar, Paper } from '@mui/material';
 import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined';
-import DeleteIcon from '@mui/icons-material/DeleteOutlined';
 import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
+import SelectionModeToggle from '@/components/common/SelectionModeToggle';
 import GridBadge from '@/components/common/GridBadge';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { combineTaskFiltersToOData } from '@/utils/odata-filter';
@@ -40,7 +40,10 @@ import {
   NotificationSection,
 } from '@/constants/notifications';
 import { taskKeys } from '@/constants/query-keys';
-import { useBulkDelete } from '@/hooks/useBulkDelete';
+import {
+  useBulkDelete,
+  type BulkDeleteActionsState,
+} from '@/hooks/useBulkDelete';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
@@ -50,6 +53,7 @@ import EntityEmptyState from '@/components/common/EntityEmptyState';
 interface TasksGridProps {
   canCreate?: boolean;
   onCreateClick?: () => void;
+  onBulkActionsChange?: (actions: BulkDeleteActionsState) => void;
 }
 
 const STATUS_PILL_TABS = [
@@ -68,6 +72,8 @@ interface TasksToolbarState {
   openFilterDrawer: () => void;
   hasActiveDrawerFilters: boolean;
   activeFilterCount: number;
+  checkboxSelectionMode: boolean;
+  setCheckboxSelectionMode: (v: boolean) => void;
 }
 
 const TasksToolbarContext = React.createContext<TasksToolbarState>({
@@ -78,6 +84,8 @@ const TasksToolbarContext = React.createContext<TasksToolbarState>({
   openFilterDrawer: () => {},
   hasActiveDrawerFilters: false,
   activeFilterCount: 0,
+  checkboxSelectionMode: false,
+  setCheckboxSelectionMode: () => {},
 });
 
 function TasksUnifiedToolbar() {
@@ -89,6 +97,8 @@ function TasksUnifiedToolbar() {
     openFilterDrawer,
     hasActiveDrawerFilters,
     activeFilterCount,
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
   } = useContext(TasksToolbarContext);
 
   return (
@@ -108,6 +118,11 @@ function TasksUnifiedToolbar() {
       }
       rightContent={
         <>
+          <SelectionModeToggle
+            checked={checkboxSelectionMode}
+            onChange={setCheckboxSelectionMode}
+            label="Select tasks"
+          />
           <GridToolbarColumnsButton />
           <GridToolbarDensitySelector />
           <GridToolbarExport />
@@ -120,6 +135,7 @@ function TasksUnifiedToolbar() {
 export default function TasksGrid({
   canCreate,
   onCreateClick,
+  onBulkActionsChange,
 }: TasksGridProps) {
   const router = useRouter();
   const { highlightedIds, clearHighlight } = useJobNotifications();
@@ -132,6 +148,8 @@ export default function TasksGrid({
     useState<TaskFilters>(EMPTY_TASK_FILTERS);
 
   const {
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
     selectedRows,
     handleSelectionChange,
     pendingDeleteId,
@@ -148,6 +166,7 @@ export default function TasksGrid({
     itemLabelPlural: 'tasks',
     getSkippedCount: response => response.forbidden_ids.length,
     skippedReason: 'not yours to delete',
+    onBulkActionsChange,
   });
 
   const {
@@ -333,20 +352,6 @@ export default function TasksGrid({
     ];
   }, [router, requestDelete]);
 
-  const getActionButtons = useCallback(() => {
-    if (selectedRows.length === 0) return [];
-
-    return [
-      {
-        label: 'Delete',
-        icon: <DeleteIcon />,
-        variant: 'outlined' as const,
-        color: 'error' as const,
-        onClick: () => requestDelete(),
-      },
-    ];
-  }, [selectedRows.length, requestDelete]);
-
   const filtersActive =
     filterModel.items.length > 0 ||
     !!searchQuery ||
@@ -377,6 +382,8 @@ export default function TasksGrid({
             openFilterDrawer: () => setFilterDrawerOpen(true),
             hasActiveDrawerFilters: hasActiveTaskFilters(drawerFilters),
             activeFilterCount: countActiveTaskFilters(drawerFilters),
+            checkboxSelectionMode,
+            setCheckboxSelectionMode,
           }}
         >
           <Box sx={{ position: 'relative' }}>
@@ -395,8 +402,8 @@ export default function TasksGrid({
               onPaginationModelChange={handlePaginationModelChange}
               filterModel={gridFilterModel}
               onFilterModelChange={handleFilterModelChange}
-              disableRowSelectionOnClick
-              onRowClick={handleRowClick}
+              disableRowSelectionOnClick={checkboxSelectionMode || undefined}
+              onRowClick={checkboxSelectionMode ? undefined : handleRowClick}
               getRowClassName={params =>
                 highlightedIds(NotificationSection.TASKS).includes(
                   String(params.id)
@@ -410,7 +417,6 @@ export default function TasksGrid({
               serverSideFiltering={true}
               showToolbar={true}
               toolbarSlot={TasksUnifiedToolbar}
-              actionButtons={getActionButtons()}
               disablePaperWrapper={true}
               persistState
               sx={{
@@ -419,12 +425,14 @@ export default function TasksGrid({
                   cursor: 'pointer',
                 },
               }}
-              checkboxSelection
+              checkboxSelection={checkboxSelectionMode}
               isRowSelectable={(params: GridRowParams) =>
                 can(params.row as unknown as Task, Capability.Task.DELETE)
               }
-              rowSelectionModel={selectedRows}
-              onRowSelectionModelChange={handleSelectionChange}
+              rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
+              onRowSelectionModelChange={
+                checkboxSelectionMode ? handleSelectionChange : undefined
+              }
             />
 
             <DeleteModal

--- a/apps/frontend/src/app/(protected)/tasks/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/page.tsx
@@ -7,12 +7,14 @@ import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { taskKeys } from '@/constants/query-keys';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
+import { useBulkActionsBridge } from '@/hooks/useBulkActionsBridge';
 import TasksGrid from './components/TasksGrid';
 import TaskDrawer, {
   type TaskDrawerInitialEntity,
@@ -33,6 +35,8 @@ export default function TasksPage() {
   const [initialEntity, setInitialEntity] = React.useState<
     TaskDrawerInitialEntity | undefined
   >();
+  const { bulkActionsVisible, onBulkDelete, handleBulkActionsChange } =
+    useBulkActionsBridge();
 
   useDocumentTitle('Tasks');
 
@@ -111,6 +115,20 @@ export default function TasksPage() {
         breadcrumbs={[]}
         actions={
           <FabGroup>
+            {bulkActionsVisible && (
+              <Can capability={Capability.Task.DELETE}>
+                <Fab
+                  icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
+                  tooltip="Delete Tasks"
+                  aria-label="Delete Tasks"
+                  onClick={onBulkDelete}
+                  sx={{
+                    bgcolor: 'error.main',
+                    '&:hover': { bgcolor: 'error.dark' },
+                  }}
+                />
+              </Can>
+            )}
             <Can capability={Capability.Task.CREATE}>
               <Fab
                 icon={<FabAddIcon />}
@@ -132,6 +150,7 @@ export default function TasksPage() {
               setInitialEntity(undefined);
               setCreateDrawerOpen(true);
             }}
+            onBulkActionsChange={handleBulkActionsChange}
           />
         </Box>
       </PageLayout>

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -4,9 +4,11 @@ import React, { useState, useCallback, useContext, useMemo } from 'react';
 import { useSession } from 'next-auth/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { testRunKeys } from '@/constants/query-keys';
+import { useBulkDelete } from '@/hooks/useBulkDelete';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
 import ListIcon from '@mui/icons-material/List';
+import DeleteIcon from '@mui/icons-material/DeleteOutlined';
 import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
 import GridBadge from '@/components/common/GridBadge';
 import TagLabel from '@/components/common/Tag';
@@ -14,6 +16,7 @@ import {
   GridColDef,
   GridPaginationModel,
   GridFilterModel,
+  GridRowParams,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
   GridToolbarExport,
@@ -180,13 +183,30 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
   );
 
   // ── Other UI state ─────────────────────────────────────────────────────────
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [cancelModalOpen, setCancelModalOpen] = useState(false);
   const [isCancelling, setIsCancelling] = useState(false);
   const [pendingCancelId, setPendingCancelId] = useState<string | null>(null);
   const [runKindFilter, setRunKindFilter] = useState<RunKindFilter>('all');
+
+  // ── Bulk selection + delete ──────────────────────────────────────────────────
+  const {
+    selectedRows,
+    handleSelectionChange,
+    pendingDeleteId,
+    deleteModalOpen,
+    isDeleting,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+  } = useBulkDelete({
+    bulkDeleteFn: (ids: string[]) =>
+      new ApiClientFactory().getTestRunsClient().bulkDeleteTestRuns(ids),
+    queryKey: testRunKeys.all(),
+    itemLabelSingular: 'test run',
+    itemLabelPlural: 'test runs',
+    getSkippedCount: response => response.forbidden_ids.length,
+    skippedReason: 'not yours to delete',
+  });
 
   // ── Grid state (pagination, filter, sort) ─────────────────────────────────
 
@@ -304,11 +324,6 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
 
   // ── Row action handlers ────────────────────────────────────────────────────
 
-  const handleRowDeleteAction = useCallback((id: string) => {
-    setPendingDeleteId(id);
-    setDeleteModalOpen(true);
-  }, []);
-
   const handleRowEditAction = useCallback(
     (id: string) => {
       router.push(`/test-runs/${id}`);
@@ -336,7 +351,7 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
       canEdit: row => can(row as unknown as TestRun, Capability.TestRun.UPDATE),
       onCancel: id => handleRowCancelAction(id),
       canCancel: isCancellableRun,
-      onDelete: id => handleRowDeleteAction(id),
+      onDelete: id => requestDelete(id),
       canDelete: row =>
         can(row as unknown as TestRun, Capability.TestRun.DELETE),
       width: 112,
@@ -647,7 +662,7 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
     handleRowEditAction,
     handleRowCancelAction,
     isCancellableRun,
-    handleRowDeleteAction,
+    requestDelete,
   ]);
 
   // ── Row handlers ──────────────────────────────────────────────────────────
@@ -659,37 +674,6 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
     },
     [router, clearHighlight]
   );
-
-  // ── Delete handlers ───────────────────────────────────────────────────────
-
-  const handleDeleteConfirm = useCallback(async () => {
-    if (!pendingDeleteId) return;
-
-    try {
-      setIsDeleting(true);
-      const clientFactory = new ApiClientFactory();
-      const testRunsClient = clientFactory.getTestRunsClient();
-
-      await testRunsClient.deleteTestRun(pendingDeleteId);
-
-      notifications.show('Successfully deleted test run', {
-        severity: 'success',
-      });
-
-      setPendingDeleteId(null);
-      queryClient.invalidateQueries({ queryKey: testRunKeys.all() });
-    } catch (_error) {
-      notifications.show('Failed to delete test run', { severity: 'error' });
-    } finally {
-      setIsDeleting(false);
-      setDeleteModalOpen(false);
-    }
-  }, [pendingDeleteId, notifications, queryClient]);
-
-  const handleDeleteCancel = useCallback(() => {
-    setDeleteModalOpen(false);
-    setPendingDeleteId(null);
-  }, []);
 
   // ── Cancel handlers ───────────────────────────────────────────────────────
 
@@ -729,6 +713,20 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
     },
     [setPaginationModel]
   );
+
+  const getActionButtons = useCallback(() => {
+    if (selectedRows.length === 0) return [];
+
+    return [
+      {
+        label: 'Delete',
+        icon: <DeleteIcon />,
+        variant: 'outlined' as const,
+        color: 'error' as const,
+        onClick: () => requestDelete(),
+      },
+    ];
+  }, [selectedRows.length, requestDelete]);
 
   const runKindToolbar = useMemo(
     () => (
@@ -823,21 +821,33 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
             totalRows={totalCount}
             pageSizeOptions={[10, 25, 50]}
             gridToolbarExtra={runKindToolbar}
+            actionButtons={getActionButtons()}
             disablePaperWrapper={true}
             showToolbar={true}
             toolbarSlot={TestRunsUnifiedToolbar}
             persistState
             storageKey="test-runs-grid-v2"
             sx={rowActionsHoverSx}
+            checkboxSelection
+            disableRowSelectionOnClick
+            isRowSelectable={(params: GridRowParams) =>
+              can(params.row as unknown as TestRun, Capability.TestRun.DELETE)
+            }
+            rowSelectionModel={selectedRows}
+            onRowSelectionModelChange={handleSelectionChange}
           />
 
           <DeleteModal
             open={deleteModalOpen}
-            onClose={handleDeleteCancel}
-            onConfirm={handleDeleteConfirm}
+            onClose={cancelDelete}
+            onConfirm={confirmDelete}
             isLoading={isDeleting}
-            title="Delete Test Run"
-            message="Are you sure you want to delete this test run? Related data will not be deleted."
+            title={pendingDeleteId ? 'Delete Test Run' : 'Delete Test Runs'}
+            message={
+              pendingDeleteId
+                ? 'Are you sure you want to delete this test run? Related data will not be deleted.'
+                : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'test run' : 'test runs'}? Related data will not be deleted.`
+            }
             itemType="test runs"
           />
 

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -4,12 +4,15 @@ import React, { useState, useCallback, useContext, useMemo } from 'react';
 import { useSession } from 'next-auth/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { testRunKeys } from '@/constants/query-keys';
-import { useBulkDelete } from '@/hooks/useBulkDelete';
+import {
+  useBulkDelete,
+  type BulkDeleteActionsState,
+} from '@/hooks/useBulkDelete';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
 import ListIcon from '@mui/icons-material/List';
-import DeleteIcon from '@mui/icons-material/DeleteOutlined';
 import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
+import SelectionModeToggle from '@/components/common/SelectionModeToggle';
 import GridBadge from '@/components/common/GridBadge';
 import TagLabel from '@/components/common/Tag';
 import {
@@ -83,6 +86,7 @@ type RunKindFilter = 'all' | 'tests' | 'experiments';
 interface TestRunsGridProps {
   canCreate?: boolean;
   onCreateClick?: () => void;
+  onBulkActionsChange?: (actions: BulkDeleteActionsState) => void;
 }
 
 function formatReviewTooltip(reviewed: number, corrected: number): string {
@@ -113,6 +117,8 @@ interface TestRunsToolbarState {
   openFilterDrawer: () => void;
   hasActiveDrawerFilters: boolean;
   activeFilterCount: number;
+  checkboxSelectionMode: boolean;
+  setCheckboxSelectionMode: (v: boolean) => void;
 }
 
 const TestRunsToolbarContext = React.createContext<TestRunsToolbarState>({
@@ -123,6 +129,8 @@ const TestRunsToolbarContext = React.createContext<TestRunsToolbarState>({
   openFilterDrawer: () => {},
   hasActiveDrawerFilters: false,
   activeFilterCount: 0,
+  checkboxSelectionMode: false,
+  setCheckboxSelectionMode: () => {},
 });
 
 function TestRunsUnifiedToolbar() {
@@ -134,6 +142,8 @@ function TestRunsUnifiedToolbar() {
     openFilterDrawer,
     hasActiveDrawerFilters,
     activeFilterCount,
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
   } = useContext(TestRunsToolbarContext);
 
   return (
@@ -153,6 +163,11 @@ function TestRunsUnifiedToolbar() {
       }
       rightContent={
         <>
+          <SelectionModeToggle
+            checked={checkboxSelectionMode}
+            onChange={setCheckboxSelectionMode}
+            label="Select test runs"
+          />
           <GridToolbarColumnsButton />
           <GridToolbarDensitySelector />
           <GridToolbarExport />
@@ -164,7 +179,11 @@ function TestRunsUnifiedToolbar() {
 
 // ── Grid component ────────────────────────────────────────────────────────────
 
-function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
+function TestRunsGrid({
+  canCreate,
+  onCreateClick,
+  onBulkActionsChange,
+}: TestRunsGridProps) {
   const { status } = useSession();
   const queryClient = useQueryClient();
   const router = useRouter();
@@ -190,6 +209,8 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
 
   // ── Bulk selection + delete ──────────────────────────────────────────────────
   const {
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
     selectedRows,
     handleSelectionChange,
     pendingDeleteId,
@@ -206,6 +227,7 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
     itemLabelPlural: 'test runs',
     getSkippedCount: response => response.forbidden_ids.length,
     skippedReason: 'not yours to delete',
+    onBulkActionsChange,
   });
 
   // ── Grid state (pagination, filter, sort) ─────────────────────────────────
@@ -714,20 +736,6 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
     [setPaginationModel]
   );
 
-  const getActionButtons = useCallback(() => {
-    if (selectedRows.length === 0) return [];
-
-    return [
-      {
-        label: 'Delete',
-        icon: <DeleteIcon />,
-        variant: 'outlined' as const,
-        color: 'error' as const,
-        onClick: () => requestDelete(),
-      },
-    ];
-  }, [selectedRows.length, requestDelete]);
-
   const runKindToolbar = useMemo(
     () => (
       <ButtonGroup size="small" variant="outlined">
@@ -789,6 +797,8 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
             openFilterDrawer: () => setFilterDrawerOpen(true),
             hasActiveDrawerFilters: hasActiveTestRunFilters(drawerFilters),
             activeFilterCount: countActiveTestRunFilters(drawerFilters),
+            checkboxSelectionMode,
+            setCheckboxSelectionMode,
           }}
         >
           {error && (
@@ -810,31 +820,34 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
             sortModel={sortModel}
             onSortModelChange={handleSortModelChange}
             serverSideFiltering={true}
-            onRowClick={handleRowClick}
+            onRowClick={checkboxSelectionMode ? undefined : handleRowClick}
             getRowClassName={params =>
               testRunHighlights.includes(String(params.id))
                 ? HIGHLIGHTED_ROW_CLASS
                 : ''
             }
-            getRowUrl={row => `/test-runs/${row.id}`}
+            getRowUrl={
+              checkboxSelectionMode ? undefined : row => `/test-runs/${row.id}`
+            }
             serverSidePagination={true}
             totalRows={totalCount}
             pageSizeOptions={[10, 25, 50]}
             gridToolbarExtra={runKindToolbar}
-            actionButtons={getActionButtons()}
             disablePaperWrapper={true}
             showToolbar={true}
             toolbarSlot={TestRunsUnifiedToolbar}
             persistState
             storageKey="test-runs-grid-v2"
             sx={rowActionsHoverSx}
-            checkboxSelection
-            disableRowSelectionOnClick
+            checkboxSelection={checkboxSelectionMode}
+            disableRowSelectionOnClick={checkboxSelectionMode || undefined}
             isRowSelectable={(params: GridRowParams) =>
               can(params.row as unknown as TestRun, Capability.TestRun.DELETE)
             }
-            rowSelectionModel={selectedRows}
-            onRowSelectionModelChange={handleSelectionChange}
+            rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
+            onRowSelectionModelChange={
+              checkboxSelectionMode ? handleSelectionChange : undefined
+            }
           />
 
           <DeleteModal

--- a/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsGrid.test.tsx
@@ -34,6 +34,7 @@ jest.mock('@/components/common/NotificationContext', () => ({
 
 const mockGetTestRuns = jest.fn();
 const mockDeleteTestRun = jest.fn();
+const mockBulkDeleteTestRuns = jest.fn();
 const mockGetProject = jest.fn();
 
 jest.mock('@/utils/api-client/client-factory', () => ({
@@ -41,6 +42,7 @@ jest.mock('@/utils/api-client/client-factory', () => ({
     getTestRunsClient: () => ({
       getTestRuns: mockGetTestRuns,
       deleteTestRun: mockDeleteTestRun,
+      bulkDeleteTestRuns: mockBulkDeleteTestRuns,
     }),
     getProjectsClient: () => ({
       getProject: mockGetProject,
@@ -286,11 +288,15 @@ describe('TestRunsGrid', () => {
     expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
   });
 
-  it('calls deleteTestRun and shows success notification on confirm', async () => {
+  it('calls bulkDeleteTestRuns and shows success notification on confirm', async () => {
     mockGetTestRuns.mockResolvedValue(
       makePaginatedResponse([makeTestRun('r-1')])
     );
-    mockDeleteTestRun.mockResolvedValue(undefined);
+    mockBulkDeleteTestRuns.mockResolvedValue({
+      deleted_ids: ['r-1'],
+      not_found_ids: [],
+      forbidden_ids: [],
+    });
     render(<TestRunsGrid />);
     await waitFor(() =>
       expect(screen.getByTestId('row-r-1')).toBeInTheDocument()
@@ -301,7 +307,9 @@ describe('TestRunsGrid', () => {
       screen.getByRole('button', { name: /confirm delete/i })
     );
 
-    await waitFor(() => expect(mockDeleteTestRun).toHaveBeenCalledWith('r-1'));
+    await waitFor(() =>
+      expect(mockBulkDeleteTestRuns).toHaveBeenCalledWith(['r-1'])
+    );
     await waitFor(() =>
       expect(mockShow).toHaveBeenCalledWith(
         expect.stringContaining('deleted'),
@@ -314,7 +322,7 @@ describe('TestRunsGrid', () => {
     mockGetTestRuns.mockResolvedValue(
       makePaginatedResponse([makeTestRun('r-1')])
     );
-    mockDeleteTestRun.mockRejectedValue(new Error('Server error'));
+    mockBulkDeleteTestRuns.mockRejectedValue(new Error('Server error'));
     render(<TestRunsGrid />);
     await waitFor(() =>
       expect(screen.getByTestId('row-r-1')).toBeInTheDocument()

--- a/apps/frontend/src/app/(protected)/test-runs/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/page.tsx
@@ -6,12 +6,14 @@ import Typography from '@mui/material/Typography';
 import { useSession } from 'next-auth/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { testRunKeys } from '@/constants/query-keys';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
+import { useBulkActionsBridge } from '@/hooks/useBulkActionsBridge';
 import TestRunsGrid from './components/TestRunsGrid';
 import RunDrawer from '@/components/common/RunDrawer';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
@@ -25,6 +27,8 @@ export default function TestRunsPage() {
   );
   const canCreateTestRun = useCan(Capability.TestRun.CREATE);
   const [createDrawerOpen, setCreateDrawerOpen] = React.useState(false);
+  const { bulkActionsVisible, onBulkDelete, handleBulkActionsChange } =
+    useBulkActionsBridge();
 
   useDocumentTitle('Test Runs');
 
@@ -64,6 +68,20 @@ export default function TestRunsPage() {
         breadcrumbs={[]}
         actions={
           <FabGroup>
+            {bulkActionsVisible && (
+              <Can capability={Capability.TestRun.DELETE}>
+                <Fab
+                  icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
+                  tooltip="Delete Test Runs"
+                  aria-label="Delete Test Runs"
+                  onClick={onBulkDelete}
+                  sx={{
+                    bgcolor: 'error.main',
+                    '&:hover': { bgcolor: 'error.dark' },
+                  }}
+                />
+              </Can>
+            )}
             <Can capability={Capability.TestRun.CREATE}>
               <Fab
                 icon={<FabAddIcon />}
@@ -78,6 +96,7 @@ export default function TestRunsPage() {
           <TestRunsGrid
             canCreate={canCreateTestRun}
             onCreateClick={() => setCreateDrawerOpen(true)}
+            onBulkActionsChange={handleBulkActionsChange}
           />
         </Box>
       </PageLayout>

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -5,7 +5,6 @@ import {
   GridColDef,
   GridRowParams,
   GridFilterModel,
-  GridRowSelectionModel,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
   GridToolbarExport,
@@ -43,9 +42,8 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useSession } from 'next-auth/react';
 import RunDrawer from '@/components/common/RunDrawer';
 import { DeleteModal } from '@/components/common/DeleteModal';
-import { useNotifications } from '@/components/common/NotificationContext';
-// Renamed on import: distinct from the toast system's useNotifications above --
-// this one tracks the persistent "a background job finished" badge/highlight.
+// Tracks the persistent "a background job finished" badge/highlight -- distinct
+// from the toast system's useNotifications, which useBulkDelete owns internally.
 import { useNotifications as useJobNotifications } from '@/contexts/NotificationsContext';
 import {
   HIGHLIGHTED_ROW_CLASS,
@@ -66,8 +64,8 @@ import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { TEST_TYPE_PILL_TABS } from '@/constants/test-types';
 import GridBadge from '@/components/common/GridBadge';
-import { useQueryClient } from '@tanstack/react-query';
 import { testSetKeys } from '@/constants/query-keys';
+import { useBulkDelete } from '@/hooks/useBulkDelete';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
@@ -178,12 +176,10 @@ export default function TestSetsGrid({
 }: TestSetsGridProps) {
   const router = useRouter();
   const { status } = useSession();
-  const notifications = useNotifications();
   const { highlightedIds, clearHighlight } = useJobNotifications();
   const testSetHighlights = highlightedIds(NotificationSection.TEST_SETS);
   const canEditTestSet = useCan(Capability.TestSet.UPDATE);
   const canDeleteTestSet = useCan(Capability.TestSet.DELETE);
-  const queryClient = useQueryClient();
 
   // ── Search + type filter ────────────────────────────────────────────────────
   const [searchQuery, setSearchQuery] = useState('');
@@ -193,12 +189,26 @@ export default function TestSetsGrid({
   const [drawerFilters, setDrawerFilters] = useState<TestSetFilters>(
     EMPTY_TEST_SET_FILTERS
   );
-  const [selectedRows, setSelectedRows] = useState<GridRowSelectionModel>([]);
   const [testRunDrawerOpen, setTestRunDrawerOpen] = useState(false);
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
+
+  // ── Bulk selection + delete ──────────────────────────────────────────────────
+  const {
+    selectedRows,
+    handleSelectionChange,
+    pendingDeleteId,
+    deleteModalOpen,
+    isDeleting,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+  } = useBulkDelete({
+    bulkDeleteFn: (ids: string[]) =>
+      new ApiClientFactory().getTestSetsClient().bulkDeleteTestSets(ids),
+    queryKey: testSetKeys.all(),
+    itemLabelSingular: 'test set',
+    itemLabelPlural: 'test sets',
+  });
 
   // ── Grid state (pagination, filter, sort) via useGridState ──────────────────
   const {
@@ -311,63 +321,6 @@ export default function TestSetsGrid({
     [router, clearHighlight]
   );
 
-  const handleSelectionChange = useCallback(
-    (newSelection: GridRowSelectionModel) => {
-      setSelectedRows(newSelection);
-    },
-    []
-  );
-
-  // ── Delete ───────────────────────────────────────────────────────────────────
-
-  const handleDeleteTestSets = useCallback(() => {
-    setDeleteModalOpen(true);
-  }, []);
-
-  const handleDeleteConfirm = useCallback(async () => {
-    const idsToDelete = pendingDeleteId
-      ? [pendingDeleteId]
-      : (selectedRows as string[]);
-    if (idsToDelete.length === 0) return;
-
-    try {
-      setIsDeleting(true);
-      const clientFactory = new ApiClientFactory();
-      const testSetsClient = clientFactory.getTestSetsClient();
-
-      await Promise.all(
-        idsToDelete.map(id => testSetsClient.deleteTestSet(id))
-      );
-
-      notifications.show(
-        `Successfully deleted ${idsToDelete.length} ${idsToDelete.length === 1 ? 'test set' : 'test sets'}`,
-        { severity: 'success', autoHideDuration: 4000 }
-      );
-
-      setPendingDeleteId(null);
-      setSelectedRows([]);
-      queryClient.invalidateQueries({ queryKey: testSetKeys.all() });
-    } catch {
-      notifications.show('Failed to delete test sets', {
-        severity: 'error',
-        autoHideDuration: 6000,
-      });
-    } finally {
-      setIsDeleting(false);
-      setDeleteModalOpen(false);
-    }
-  }, [pendingDeleteId, selectedRows, notifications, queryClient]);
-
-  const handleDeleteCancel = useCallback(() => {
-    setDeleteModalOpen(false);
-    setPendingDeleteId(null);
-  }, []);
-
-  const handleRowDeleteAction = useCallback((id: string) => {
-    setPendingDeleteId(id);
-    setDeleteModalOpen(true);
-  }, []);
-
   const handleRowEditAction = useCallback(
     (id: string) => {
       router.push(`/test-sets/${id}`);
@@ -392,10 +345,10 @@ export default function TestSetsGrid({
         icon: <DeleteIcon />,
         variant: 'outlined' as const,
         color: 'error' as const,
-        onClick: handleDeleteTestSets,
+        onClick: () => requestDelete(),
       },
     ];
-  }, [selectedRows.length, handleDeleteTestSets]);
+  }, [selectedRows.length, requestDelete]);
 
   // ── Column definitions ───────────────────────────────────────────────────────
 
@@ -420,7 +373,7 @@ export default function TestSetsGrid({
   const columns: GridColDef[] = useMemo(() => {
     const actionsCol = createRowActionsColumn({
       onEdit: id => handleRowEditAction(id),
-      onDelete: id => handleRowDeleteAction(id),
+      onDelete: id => requestDelete(id),
       canEdit: () => canEditTestSet,
       canDelete: () => canDeleteTestSet,
     });
@@ -637,7 +590,7 @@ export default function TestSetsGrid({
       },
       actionsCol,
     ];
-  }, [handleRowEditAction, handleRowDeleteAction]);
+  }, [handleRowEditAction, requestDelete]);
 
   const filtersActive =
     filterModel.items.length > 0 ||
@@ -733,6 +686,10 @@ export default function TestSetsGrid({
               },
             }}
             sx={rowActionsHoverSx}
+            checkboxSelection
+            disableRowSelectionOnClick
+            rowSelectionModel={selectedRows}
+            onRowSelectionModelChange={handleSelectionChange}
           />
 
           {/* Test Run Drawer */}
@@ -747,8 +704,8 @@ export default function TestSetsGrid({
               />
               <DeleteModal
                 open={deleteModalOpen}
-                onClose={handleDeleteCancel}
-                onConfirm={handleDeleteConfirm}
+                onClose={cancelDelete}
+                onConfirm={confirmDelete}
                 isLoading={isDeleting}
                 title={pendingDeleteId ? 'Delete Test Set' : 'Delete Test Sets'}
                 message={

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import React, { useState, useCallback, useContext, useMemo } from 'react';
+import React, {
+  useState,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import {
   GridColDef,
   GridRowParams,
@@ -34,10 +41,9 @@ import {
   HorizontalSplitIcon,
 } from '@/components/icons';
 import InsertDriveFileOutlined from '@mui/icons-material/InsertDriveFileOutlined';
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import DeleteIcon from '@mui/icons-material/DeleteOutlined';
 import PersonIcon from '@mui/icons-material/Person';
 import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
+import SelectionModeToggle from '@/components/common/SelectionModeToggle';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useSession } from 'next-auth/react';
 import RunDrawer from '@/components/common/RunDrawer';
@@ -76,6 +82,13 @@ import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-en
 interface TestSetsGridProps {
   canCreate?: boolean;
   onCreateClick?: () => void;
+  onBulkActionsChange?: (actions: TestSetsBulkActionsState) => void;
+}
+
+export interface TestSetsBulkActionsState {
+  visible: boolean;
+  onRun: () => void;
+  onDelete: () => void;
 }
 
 // ─── Toolbar context ────────────────────────────────────────────────────────────
@@ -88,6 +101,8 @@ interface TestSetsToolbarState {
   openFilterDrawer: () => void;
   hasActiveDrawerFilters: boolean;
   activeFilterCount: number;
+  checkboxSelectionMode: boolean;
+  setCheckboxSelectionMode: (v: boolean) => void;
 }
 
 const TestSetsToolbarContext = React.createContext<TestSetsToolbarState>({
@@ -98,6 +113,8 @@ const TestSetsToolbarContext = React.createContext<TestSetsToolbarState>({
   openFilterDrawer: () => {},
   hasActiveDrawerFilters: false,
   activeFilterCount: 0,
+  checkboxSelectionMode: false,
+  setCheckboxSelectionMode: () => {},
 });
 
 const PILL_TABS = TEST_TYPE_PILL_TABS;
@@ -111,6 +128,8 @@ function TestSetsUnifiedToolbar() {
     openFilterDrawer,
     hasActiveDrawerFilters,
     activeFilterCount,
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
   } = useContext(TestSetsToolbarContext);
 
   return (
@@ -130,6 +149,11 @@ function TestSetsUnifiedToolbar() {
       }
       rightContent={
         <>
+          <SelectionModeToggle
+            checked={checkboxSelectionMode}
+            onChange={setCheckboxSelectionMode}
+            label="Select test sets"
+          />
           <GridToolbarColumnsButton />
           <GridToolbarDensitySelector />
           <GridToolbarExport />
@@ -173,6 +197,7 @@ const ChipContainer = ({ items }: { items: string[] }) => {
 export default function TestSetsGrid({
   canCreate,
   onCreateClick,
+  onBulkActionsChange,
 }: TestSetsGridProps) {
   const router = useRouter();
   const { status } = useSession();
@@ -193,7 +218,12 @@ export default function TestSetsGrid({
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
 
   // ── Bulk selection + delete ──────────────────────────────────────────────────
+  // TestSets has a second bulk action (Run), so it bridges to the page's
+  // FabGroup itself below instead of using useBulkDelete's built-in
+  // onBulkActionsChange, which only knows about delete.
   const {
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
     selectedRows,
     handleSelectionChange,
     pendingDeleteId,
@@ -328,27 +358,35 @@ export default function TestSetsGrid({
     [router]
   );
 
-  // ── Action buttons (selection-only) ─────────────────────────────────────────
+  // ── Bulk actions bridge (Run + Delete) to the page's FabGroup ───────────────
 
-  const getActionButtons = useCallback(() => {
-    if (selectedRows.length === 0) return [];
+  const showBulkActions = checkboxSelectionMode && selectedRows.length > 0;
+  const bulkHandlersRef = useRef({
+    onRun: () => setTestRunDrawerOpen(true),
+    onDelete: () => requestDelete(),
+  });
+  bulkHandlersRef.current = {
+    onRun: () => setTestRunDrawerOpen(true),
+    onDelete: () => requestDelete(),
+  };
 
-    return [
-      {
-        label: selectedRows.length > 1 ? 'Run Test Sets' : 'Run Test Set',
-        icon: <PlayArrowIcon />,
-        variant: 'contained' as const,
-        onClick: () => setTestRunDrawerOpen(true),
-      },
-      {
-        label: 'Delete Test Sets',
-        icon: <DeleteIcon />,
-        variant: 'outlined' as const,
-        color: 'error' as const,
-        onClick: () => requestDelete(),
-      },
-    ];
-  }, [selectedRows.length, requestDelete]);
+  useEffect(() => {
+    onBulkActionsChange?.({
+      visible: showBulkActions,
+      onRun: () => bulkHandlersRef.current.onRun(),
+      onDelete: () => bulkHandlersRef.current.onDelete(),
+    });
+  }, [showBulkActions, onBulkActionsChange]);
+
+  useEffect(() => {
+    return () => {
+      onBulkActionsChange?.({
+        visible: false,
+        onRun: () => {},
+        onDelete: () => {},
+      });
+    };
+  }, [onBulkActionsChange]);
 
   // ── Column definitions ───────────────────────────────────────────────────────
 
@@ -624,6 +662,8 @@ export default function TestSetsGrid({
             openFilterDrawer: () => setFilterDrawerOpen(true),
             hasActiveDrawerFilters: hasActiveTestSetFilters(drawerFilters),
             activeFilterCount: countActiveTestSetFilters(drawerFilters),
+            checkboxSelectionMode,
+            setCheckboxSelectionMode,
           }}
         >
           {error && (
@@ -632,40 +672,29 @@ export default function TestSetsGrid({
             </Alert>
           )}
 
-          {selectedRows.length > 0 && (
-            <Box
-              sx={{
-                px: 2,
-                py: 1,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 2,
-                borderBottom: theme =>
-                  `1px solid ${theme.palette.greyscale.border}`,
-              }}
-            >
-              <Typography variant="subtitle1" color="primary">
-                {selectedRows.length} selected
-              </Typography>
-            </Box>
-          )}
-
           <BaseDataGrid
             columns={columns}
             rows={processedTestSets}
             loading={loading}
             getRowId={row => row.id}
             showToolbar={true}
-            onRowClick={handleRowClick}
+            checkboxSelection={checkboxSelectionMode}
+            disableRowSelectionOnClick={checkboxSelectionMode || undefined}
+            onRowSelectionModelChange={
+              checkboxSelectionMode ? handleSelectionChange : undefined
+            }
+            rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
+            onRowClick={checkboxSelectionMode ? undefined : handleRowClick}
             getRowClassName={params =>
               testSetHighlights.includes(String(params.id))
                 ? HIGHLIGHTED_ROW_CLASS
                 : ''
             }
-            getRowUrl={row => `/test-sets/${row.id}`}
+            getRowUrl={
+              checkboxSelectionMode ? undefined : row => `/test-sets/${row.id}`
+            }
             paginationModel={paginationModel}
             onPaginationModelChange={handlePaginationModelChange}
-            actionButtons={getActionButtons()}
             serverSidePagination={true}
             totalRows={totalCount}
             pageSizeOptions={[10, 25, 50]}
@@ -686,10 +715,6 @@ export default function TestSetsGrid({
               },
             }}
             sx={rowActionsHoverSx}
-            checkboxSelection
-            disableRowSelectionOnClick
-            rowSelectionModel={selectedRows}
-            onRowSelectionModelChange={handleSelectionChange}
           />
 
           {/* Test Run Drawer */}

--- a/apps/frontend/src/app/(protected)/test-sets/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/page.tsx
@@ -9,10 +9,14 @@ import { testSetKeys } from '@/constants/query-keys';
 import FileUploadIcon from '@mui/icons-material/FileUploadOutlined';
 import SecurityIcon from '@mui/icons-material/SecurityOutlined';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { useSession } from 'next-auth/react';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
-import TestSetsGrid from './components/TestSetsGrid';
+import TestSetsGrid, {
+  type TestSetsBulkActionsState,
+} from './components/TestSetsGrid';
 import TestSetDrawer from './components/TestSetDrawer';
 import FileImportDrawer from './components/FileImportDrawer';
 import SecurityTestDrawer from './components/SecurityTestDrawer';
@@ -39,6 +43,26 @@ export default function TestSetsPage() {
   const [createDrawerOpen, setCreateDrawerOpen] = React.useState(false);
   const [fileImportDrawerOpen, setFileImportDrawerOpen] = React.useState(false);
   const [securityDrawerOpen, setSecurityDrawerOpen] = React.useState(false);
+  const [bulkActions, setBulkActions] = React.useState<
+    Pick<TestSetsBulkActionsState, 'visible'>
+  >({ visible: false });
+  const bulkHandlersRef = React.useRef<
+    Pick<TestSetsBulkActionsState, 'onRun' | 'onDelete'>
+  >({
+    onRun: () => {},
+    onDelete: () => {},
+  });
+
+  const handleBulkActionsChange = React.useCallback(
+    (actions: TestSetsBulkActionsState) => {
+      setBulkActions({ visible: actions.visible });
+      bulkHandlersRef.current = {
+        onRun: actions.onRun,
+        onDelete: actions.onDelete,
+      };
+    },
+    []
+  );
 
   useDocumentTitle('Test Sets');
 
@@ -109,6 +133,28 @@ export default function TestSetsPage() {
         breadcrumbs={[]}
         actions={
           <FabGroup>
+            {bulkActions.visible && (
+              <>
+                <Fab
+                  icon={<PlayArrowIcon />}
+                  tooltip="Run Test Sets"
+                  aria-label="Run Test Sets"
+                  onClick={() => bulkHandlersRef.current.onRun()}
+                />
+                <Can capability={Capability.TestSet.DELETE}>
+                  <Fab
+                    icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
+                    tooltip="Delete Test Sets"
+                    aria-label="Delete Test Sets"
+                    onClick={() => bulkHandlersRef.current.onDelete()}
+                    sx={{
+                      bgcolor: 'error.main',
+                      '&:hover': { bgcolor: 'error.dark' },
+                    }}
+                  />
+                </Can>
+              </>
+            )}
             <Can capability={Capability.File.IMPORT}>
               <Fab
                 icon={<FileUploadIcon />}
@@ -159,6 +205,7 @@ export default function TestSetsPage() {
           <TestSetsGrid
             canCreate={canCreate}
             onCreateClick={() => setCreateDrawerOpen(true)}
+            onBulkActionsChange={handleBulkActionsChange}
           />
         </Box>
       </PageLayout>

--- a/apps/frontend/src/app/(protected)/tokens/components/TokensGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokensGrid.tsx
@@ -6,6 +6,7 @@ import {
   GridPaginationModel,
   type GridRenderCellParams,
   type GridColDef,
+  type GridRowSelectionModel,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
   GridToolbarExport,
@@ -100,11 +101,14 @@ interface TokensGridProps {
     tokenId: string,
     expiresInDays: number | null
   ) => Promise<void>;
-  onDeleteToken: (tokenId: string) => Promise<void>;
+  onDeleteToken: (tokenId: string) => void;
   loading: boolean;
   totalCount: number;
   onPaginationModelChange?: (model: GridPaginationModel) => void;
   paginationModel?: GridPaginationModel;
+  selectedRows: GridRowSelectionModel;
+  onSelectionChange: (model: GridRowSelectionModel) => void;
+  actionButtons: React.ComponentProps<typeof BaseDataGrid>['actionButtons'];
 }
 
 export default function TokensGrid({
@@ -118,6 +122,9 @@ export default function TokensGrid({
     page: 0,
     pageSize: 10,
   },
+  selectedRows,
+  onSelectionChange,
+  actionButtons,
 }: TokensGridProps) {
   const [refreshModalOpen, setRefreshModalOpen] = useState(false);
   const [selectedTokenId, setSelectedTokenId] = useState<string | null>(null);
@@ -240,9 +247,14 @@ export default function TokensGrid({
         pageSizeOptions={[10, 25, 50]}
         disablePaperWrapper={true}
         toolbarSlot={TokensUnifiedToolbar}
+        actionButtons={actionButtons}
         persistState
         storageKey="tokens-grid"
         sx={rowActionsHoverSx}
+        checkboxSelection
+        disableRowSelectionOnClick
+        rowSelectionModel={selectedRows}
+        onRowSelectionModelChange={onSelectionChange}
       />
       <RefreshTokenModal
         open={refreshModalOpen}

--- a/apps/frontend/src/app/(protected)/tokens/components/TokensGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokensGrid.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/x-data-grid';
 import BaseDataGrid from '@/components/common/BaseDataGrid';
 import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
+import SelectionModeToggle from '@/components/common/SelectionModeToggle';
 import { Token } from '@/utils/api-client/interfaces/token';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { DeleteIcon } from '@/components/icons';
@@ -44,6 +45,8 @@ export interface TokensToolbarState {
   openFilterDrawer: () => void;
   hasActiveDrawerFilters: boolean;
   activeFilterCount: number;
+  checkboxSelectionMode: boolean;
+  setCheckboxSelectionMode: (v: boolean) => void;
 }
 
 export const TokensToolbarContext = React.createContext<TokensToolbarState>({
@@ -54,6 +57,8 @@ export const TokensToolbarContext = React.createContext<TokensToolbarState>({
   openFilterDrawer: () => {},
   hasActiveDrawerFilters: false,
   activeFilterCount: 0,
+  checkboxSelectionMode: false,
+  setCheckboxSelectionMode: () => {},
 });
 
 function TokensUnifiedToolbar() {
@@ -65,6 +70,8 @@ function TokensUnifiedToolbar() {
     openFilterDrawer,
     hasActiveDrawerFilters,
     activeFilterCount,
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
   } = useContext(TokensToolbarContext);
 
   return (
@@ -84,6 +91,11 @@ function TokensUnifiedToolbar() {
       }
       rightContent={
         <>
+          <SelectionModeToggle
+            checked={checkboxSelectionMode}
+            onChange={setCheckboxSelectionMode}
+            label="Select tokens"
+          />
           <GridToolbarColumnsButton />
           <GridToolbarDensitySelector />
           <GridToolbarExport />
@@ -106,9 +118,9 @@ interface TokensGridProps {
   totalCount: number;
   onPaginationModelChange?: (model: GridPaginationModel) => void;
   paginationModel?: GridPaginationModel;
+  checkboxSelectionMode: boolean;
   selectedRows: GridRowSelectionModel;
   onSelectionChange: (model: GridRowSelectionModel) => void;
-  actionButtons: React.ComponentProps<typeof BaseDataGrid>['actionButtons'];
 }
 
 export default function TokensGrid({
@@ -122,9 +134,9 @@ export default function TokensGrid({
     page: 0,
     pageSize: 10,
   },
+  checkboxSelectionMode,
   selectedRows,
   onSelectionChange,
-  actionButtons,
 }: TokensGridProps) {
   const [refreshModalOpen, setRefreshModalOpen] = useState(false);
   const [selectedTokenId, setSelectedTokenId] = useState<string | null>(null);
@@ -247,14 +259,15 @@ export default function TokensGrid({
         pageSizeOptions={[10, 25, 50]}
         disablePaperWrapper={true}
         toolbarSlot={TokensUnifiedToolbar}
-        actionButtons={actionButtons}
         persistState
         storageKey="tokens-grid"
         sx={rowActionsHoverSx}
-        checkboxSelection
-        disableRowSelectionOnClick
-        rowSelectionModel={selectedRows}
-        onRowSelectionModelChange={onSelectionChange}
+        checkboxSelection={checkboxSelectionMode}
+        disableRowSelectionOnClick={checkboxSelectionMode || undefined}
+        rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
+        onRowSelectionModelChange={
+          checkboxSelectionMode ? onSelectionChange : undefined
+        }
       />
       <RefreshTokenModal
         open={refreshModalOpen}

--- a/apps/frontend/src/app/(protected)/tokens/components/TokensPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokensPageClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Paper, Alert } from '@mui/material';
-import DeleteIcon from '@mui/icons-material/DeleteOutlined';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import TokensGrid, {
   TokensToolbarContext,
   type TokenStatusFilter,
@@ -133,6 +133,8 @@ export default function TokensPageClient() {
   };
 
   const {
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
     selectedRows,
     handleSelectionChange,
     pendingDeleteId,
@@ -149,19 +151,10 @@ export default function TokensPageClient() {
     itemLabelPlural: 'tokens',
   });
 
-  const getActionButtons = useCallback(() => {
-    if (selectedRows.length === 0) return [];
-
-    return [
-      {
-        label: 'Delete',
-        icon: <DeleteIcon />,
-        variant: 'outlined' as const,
-        color: 'error' as const,
-        onClick: () => requestDelete(),
-      },
-    ];
-  }, [selectedRows.length, requestDelete]);
+  // No separate page here to bridge to -- the FabGroup below is already in
+  // the same component as useBulkDelete, so it reads this directly instead
+  // of going through useBulkActionsBridge/onBulkActionsChange.
+  const bulkActionsVisible = checkboxSelectionMode && selectedRows.length > 0;
 
   // ── Derived data ────────────────────────────────────────────────────────────
 
@@ -231,8 +224,16 @@ export default function TokensPageClient() {
       openFilterDrawer: () => setFilterDrawerOpen(true),
       hasActiveDrawerFilters: hasActiveTokenFilters(drawerFilters),
       activeFilterCount: countActiveTokenFilters(drawerFilters),
+      checkboxSelectionMode,
+      setCheckboxSelectionMode,
     }),
-    [search, statusFilter, drawerFilters]
+    [
+      search,
+      statusFilter,
+      drawerFilters,
+      checkboxSelectionMode,
+      setCheckboxSelectionMode,
+    ]
   );
 
   // ── Render ──────────────────────────────────────────────────────────────────
@@ -247,6 +248,20 @@ export default function TokensPageClient() {
       breadcrumbs={[]}
       actions={
         <FabGroup>
+          {bulkActionsVisible && (
+            <Can capability={Capability.Token.MANAGE}>
+              <Fab
+                icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
+                tooltip="Delete Tokens"
+                aria-label="Delete Tokens"
+                onClick={() => requestDelete()}
+                sx={{
+                  bgcolor: 'error.main',
+                  '&:hover': { bgcolor: 'error.dark' },
+                }}
+              />
+            </Can>
+          )}
           <Can capability={Capability.Token.MANAGE}>
             <Fab
               icon={<FabAddIcon />}
@@ -309,9 +324,9 @@ export default function TokensPageClient() {
               totalCount={filteredTokens.length}
               paginationModel={paginationModel}
               onPaginationModelChange={setPaginationModel}
+              checkboxSelectionMode={checkboxSelectionMode}
               selectedRows={selectedRows}
               onSelectionChange={handleSelectionChange}
-              actionButtons={getActionButtons()}
             />
           </TokensToolbarContext.Provider>
         </Paper>

--- a/apps/frontend/src/app/(protected)/tokens/components/TokensPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokensPageClient.tsx
@@ -2,11 +2,13 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Paper, Alert } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/DeleteOutlined';
 import TokensGrid, {
   TokensToolbarContext,
   type TokenStatusFilter,
   type TokensToolbarState,
 } from './TokensGrid';
+import { useBulkDelete } from '@/hooks/useBulkDelete';
 import CreateTokenDrawer from './CreateTokenDrawer';
 import TokenDisplay from './TokenDisplay';
 import TokenFilterDrawer, {
@@ -44,7 +46,6 @@ export default function TokensPageClient() {
   const [refreshedToken, setRefreshedToken] = useState<TokenResponse | null>(
     null
   );
-  const [deleteTokenId, setDeleteTokenId] = useState<string | null>(null);
 
   // Search & filter state
   const [search, setSearch] = useState('');
@@ -131,21 +132,36 @@ export default function TokensPageClient() {
     }
   };
 
-  const handleDeleteToken = async (tokenId: string) => {
-    setDeleteTokenId(tokenId);
-  };
+  const {
+    selectedRows,
+    handleSelectionChange,
+    pendingDeleteId,
+    deleteModalOpen,
+    isDeleting,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+  } = useBulkDelete({
+    bulkDeleteFn: (ids: string[]) =>
+      tokensClientRef.current.bulkDeleteTokens(ids),
+    onSuccess: loadTokens,
+    itemLabelSingular: 'token',
+    itemLabelPlural: 'tokens',
+  });
 
-  const confirmDelete = async () => {
-    if (!deleteTokenId) return;
-    try {
-      await tokensClientRef.current.deleteToken(deleteTokenId);
-      await loadTokens();
-    } catch (err) {
-      setError((err as Error).message);
-    } finally {
-      setDeleteTokenId(null);
-    }
-  };
+  const getActionButtons = useCallback(() => {
+    if (selectedRows.length === 0) return [];
+
+    return [
+      {
+        label: 'Delete',
+        icon: <DeleteIcon />,
+        variant: 'outlined' as const,
+        color: 'error' as const,
+        onClick: () => requestDelete(),
+      },
+    ];
+  }, [selectedRows.length, requestDelete]);
 
   // ── Derived data ────────────────────────────────────────────────────────────
 
@@ -288,11 +304,14 @@ export default function TokensPageClient() {
             <TokensGrid
               tokens={filteredTokens}
               onRefreshToken={handleRefreshToken}
-              onDeleteToken={handleDeleteToken}
+              onDeleteToken={requestDelete}
               loading={loading}
               totalCount={filteredTokens.length}
               paginationModel={paginationModel}
               onPaginationModelChange={setPaginationModel}
+              selectedRows={selectedRows}
+              onSelectionChange={handleSelectionChange}
+              actionButtons={getActionButtons()}
             />
           </TokensToolbarContext.Provider>
         </Paper>
@@ -319,15 +338,23 @@ export default function TokensPageClient() {
       />
 
       <DeleteModal
-        open={deleteTokenId !== null}
-        onClose={() => setDeleteTokenId(null)}
+        open={deleteModalOpen}
+        onClose={cancelDelete}
         onConfirm={confirmDelete}
-        itemType="token"
-        itemName={tokens.find(t => t.id === deleteTokenId)?.name}
+        isLoading={isDeleting}
+        title={pendingDeleteId ? 'Delete Token' : 'Delete Tokens'}
+        itemType="tokens"
+        itemName={
+          pendingDeleteId
+            ? tokens.find(t => t.id === pendingDeleteId)?.name
+            : undefined
+        }
         message={
-          deleteTokenId && tokens.find(t => t.id === deleteTokenId)?.name
-            ? `Are you sure you want to delete the token "${tokens.find(t => t.id === deleteTokenId)?.name}"? This action cannot be undone, and any applications using this token will no longer be able to authenticate.`
-            : `Are you sure you want to delete this token? This action cannot be undone, and any applications using this token will no longer be able to authenticate.`
+          pendingDeleteId
+            ? tokens.find(t => t.id === pendingDeleteId)?.name
+              ? `Are you sure you want to delete the token "${tokens.find(t => t.id === pendingDeleteId)?.name}"? This action cannot be undone, and any applications using this token will no longer be able to authenticate.`
+              : `Are you sure you want to delete this token? This action cannot be undone, and any applications using this token will no longer be able to authenticate.`
+            : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'token' : 'tokens'}? This action cannot be undone, and any applications using ${selectedRows.length === 1 ? 'this token' : 'these tokens'} will no longer be able to authenticate.`
         }
       />
 

--- a/apps/frontend/src/app/(protected)/tokens/components/__tests__/TokensGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/__tests__/TokensGrid.test.tsx
@@ -68,7 +68,8 @@ jest.mock('../RefreshTokenModal', () => ({
 }));
 
 const onRefreshToken = jest.fn().mockResolvedValue(undefined);
-const onDeleteToken = jest.fn().mockResolvedValue(undefined);
+const onDeleteToken = jest.fn();
+const onSelectionChange = jest.fn();
 
 function makeToken(id: string) {
   return {
@@ -97,6 +98,9 @@ describe('TokensGrid', () => {
         onRefreshToken={onRefreshToken}
         onDeleteToken={onDeleteToken}
         totalCount={0}
+        selectedRows={[]}
+        onSelectionChange={onSelectionChange}
+        actionButtons={[]}
       />
     );
     // BaseDataGrid is mocked to render a <table>; loading state is handled
@@ -112,6 +116,9 @@ describe('TokensGrid', () => {
         onRefreshToken={onRefreshToken}
         onDeleteToken={onDeleteToken}
         totalCount={2}
+        selectedRows={[]}
+        onSelectionChange={onSelectionChange}
+        actionButtons={[]}
       />
     );
     expect(screen.getByText('Token t1')).toBeInTheDocument();

--- a/apps/frontend/src/app/(protected)/tokens/components/__tests__/TokensGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/__tests__/TokensGrid.test.tsx
@@ -98,9 +98,9 @@ describe('TokensGrid', () => {
         onRefreshToken={onRefreshToken}
         onDeleteToken={onDeleteToken}
         totalCount={0}
+        checkboxSelectionMode={false}
         selectedRows={[]}
         onSelectionChange={onSelectionChange}
-        actionButtons={[]}
       />
     );
     // BaseDataGrid is mocked to render a <table>; loading state is handled
@@ -116,9 +116,9 @@ describe('TokensGrid', () => {
         onRefreshToken={onRefreshToken}
         onDeleteToken={onDeleteToken}
         totalCount={2}
+        checkboxSelectionMode={false}
         selectedRows={[]}
         onSelectionChange={onSelectionChange}
-        actionButtons={[]}
       />
     );
     expect(screen.getByText('Token t1')).toBeInTheDocument();

--- a/apps/frontend/src/components/common/SelectionModeToggle.tsx
+++ b/apps/frontend/src/components/common/SelectionModeToggle.tsx
@@ -1,0 +1,38 @@
+import { FormControlLabel, Switch, Typography } from '@mui/material';
+
+interface SelectionModeToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  /** e.g. "Select tests", "Select endpoints". */
+  label: string;
+}
+
+/**
+ * The "Select X" switch that reveals a grid's checkbox column, extracted
+ * from TestsGrid so every grid's toolbar renders the identical control
+ * instead of a copy of the same Switch + FormControlLabel block.
+ */
+export default function SelectionModeToggle({
+  checked,
+  onChange,
+  label,
+}: SelectionModeToggleProps) {
+  return (
+    <FormControlLabel
+      control={
+        <Switch
+          checked={checked}
+          onChange={event => onChange(event.target.checked)}
+          size="small"
+          color="primary"
+        />
+      }
+      label={
+        <Typography variant="button" color="primary">
+          {label}
+        </Typography>
+      }
+      sx={{ m: 0, whiteSpace: 'nowrap' }}
+    />
+  );
+}

--- a/apps/frontend/src/hooks/useBulkActionsBridge.ts
+++ b/apps/frontend/src/hooks/useBulkActionsBridge.ts
@@ -1,0 +1,29 @@
+import { useCallback, useRef, useState } from 'react';
+import { BulkDeleteActionsState } from './useBulkDelete';
+
+/**
+ * Page-side half of the bulk-actions bridge: consumes the grid's
+ * `onBulkActionsChange` callback and exposes just what the page needs to
+ * render the delete action in its own FabGroup -- whether it's visible, and
+ * a stable callback to trigger it. Every page with a bulk-select grid uses
+ * this instead of re-deriving the same ref + state pair Tests originally
+ * wrote by hand.
+ */
+export function useBulkActionsBridge() {
+  const [visible, setVisible] = useState(false);
+  const onDeleteRef = useRef<() => void>(() => {});
+
+  const handleBulkActionsChange = useCallback(
+    (actions: BulkDeleteActionsState) => {
+      setVisible(actions.visible);
+      onDeleteRef.current = actions.onDelete;
+    },
+    []
+  );
+
+  return {
+    bulkActionsVisible: visible,
+    onBulkDelete: () => onDeleteRef.current(),
+    handleBulkActionsChange,
+  };
+}

--- a/apps/frontend/src/hooks/useBulkDelete.ts
+++ b/apps/frontend/src/hooks/useBulkDelete.ts
@@ -1,7 +1,13 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQueryClient, QueryKey } from '@tanstack/react-query';
 import { GridRowSelectionModel } from '@mui/x-data-grid';
 import { useNotifications } from '@/components/common/NotificationContext';
+
+/** Pushed up to a page-level FabGroup via `onBulkActionsChange` -- see Tests. */
+export interface BulkDeleteActionsState {
+  visible: boolean;
+  onDelete: () => void;
+}
 
 interface UseBulkDeleteOptions<TResp> {
   /** Calls the entity's `DELETE .../bulk` client method. */
@@ -25,13 +31,21 @@ interface UseBulkDeleteOptions<TResp> {
   getSkippedCount?: (response: TResp) => number;
   /** Reason shown alongside the skipped count, e.g. "not yours to delete". */
   skippedReason?: string;
+  /**
+   * Reports selection-mode state up to a parent page so it can render the
+   * delete action in its own FabGroup, matching Tests' top-right bulk
+   * actions -- pass this through from the grid's own prop of the same name.
+   */
+  onBulkActionsChange?: (actions: BulkDeleteActionsState) => void;
 }
 
 /**
- * Owns the checkbox-selection + confirm-modal + bulk-delete-call lifecycle
- * shared by every grid's bulk-select feature, so each grid wires state
- * instead of re-implementing it. Extracted from TestsGrid/ExplorerGrid,
- * which had each grown this independently.
+ * Owns the checkbox-selection-mode toggle + confirm-modal + bulk-delete-call
+ * lifecycle shared by every grid's bulk-select feature, so each grid wires
+ * state instead of re-implementing it. Extracted from TestsGrid, which had
+ * grown this independently; every grid follows the same UX Tests already
+ * established: a "Select X" toggle reveals checkboxes, and the delete action
+ * surfaces in the page's own FabGroup (top right), not inline in the grid.
  */
 export function useBulkDelete<TResp = void>({
   bulkDeleteFn,
@@ -41,14 +55,24 @@ export function useBulkDelete<TResp = void>({
   itemLabelPlural,
   getSkippedCount,
   skippedReason,
+  onBulkActionsChange,
 }: UseBulkDeleteOptions<TResp>) {
   const notifications = useNotifications();
   const queryClient = useQueryClient();
 
+  const [checkboxSelectionMode, setCheckboxSelectionModeState] =
+    useState(false);
   const [selectedRows, setSelectedRows] = useState<GridRowSelectionModel>([]);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  const setCheckboxSelectionMode = useCallback((enabled: boolean) => {
+    setCheckboxSelectionModeState(enabled);
+    if (!enabled) {
+      setSelectedRows([]);
+    }
+  }, []);
 
   const handleSelectionChange = useCallback(
     (model: GridRowSelectionModel) => setSelectedRows(model),
@@ -138,7 +162,30 @@ export function useBulkDelete<TResp = void>({
     onSuccess,
   ]);
 
+  // Bridge selection state to a parent page's FabGroup, same mechanism as
+  // Tests: a ref holds the latest handler so the effect only re-fires on the
+  // values the parent actually needs to redraw for (visibility), not on
+  // every render that creates a new requestDelete closure.
+  const showBulkActions = checkboxSelectionMode && selectedRows.length > 0;
+  const requestDeleteRef = useRef(requestDelete);
+  requestDeleteRef.current = requestDelete;
+
+  useEffect(() => {
+    onBulkActionsChange?.({
+      visible: showBulkActions,
+      onDelete: () => requestDeleteRef.current(),
+    });
+  }, [showBulkActions, onBulkActionsChange]);
+
+  useEffect(() => {
+    return () => {
+      onBulkActionsChange?.({ visible: false, onDelete: () => {} });
+    };
+  }, [onBulkActionsChange]);
+
   return {
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
     selectedRows,
     setSelectedRows,
     handleSelectionChange,

--- a/apps/frontend/src/hooks/useBulkDelete.ts
+++ b/apps/frontend/src/hooks/useBulkDelete.ts
@@ -6,8 +6,14 @@ import { useNotifications } from '@/components/common/NotificationContext';
 interface UseBulkDeleteOptions<TResp> {
   /** Calls the entity's `DELETE .../bulk` client method. */
   bulkDeleteFn: (ids: string[]) => Promise<TResp>;
-  /** Invalidated after a successful delete so the grid refetches. */
-  queryKey: QueryKey;
+  /** Invalidated after a successful delete so the grid refetches. Omit for
+   * grids that don't fetch through react-query (e.g. Tokens) and use
+   * `onSuccess` instead. */
+  queryKey?: QueryKey;
+  /** Called after a successful delete, in addition to any queryKey
+   * invalidation -- for grids that manage their own data fetch/refetch
+   * outside react-query. */
+  onSuccess?: () => void;
   itemLabelSingular: string;
   itemLabelPlural: string;
   /**
@@ -30,6 +36,7 @@ interface UseBulkDeleteOptions<TResp> {
 export function useBulkDelete<TResp = void>({
   bulkDeleteFn,
   queryKey,
+  onSuccess,
   itemLabelSingular,
   itemLabelPlural,
   getSkippedCount,
@@ -102,7 +109,10 @@ export function useBulkDelete<TResp = void>({
       }
 
       setSelectedRows([]);
-      queryClient.invalidateQueries({ queryKey });
+      if (queryKey) {
+        queryClient.invalidateQueries({ queryKey });
+      }
+      onSuccess?.();
     } catch {
       notifications.show(`Failed to delete ${itemLabelPlural}`, {
         severity: 'error',
@@ -125,6 +135,7 @@ export function useBulkDelete<TResp = void>({
     notifications,
     queryClient,
     queryKey,
+    onSuccess,
   ]);
 
   return {

--- a/apps/frontend/src/hooks/useBulkDelete.ts
+++ b/apps/frontend/src/hooks/useBulkDelete.ts
@@ -1,0 +1,141 @@
+import { useCallback, useState } from 'react';
+import { useQueryClient, QueryKey } from '@tanstack/react-query';
+import { GridRowSelectionModel } from '@mui/x-data-grid';
+import { useNotifications } from '@/components/common/NotificationContext';
+
+interface UseBulkDeleteOptions<TResp> {
+  /** Calls the entity's `DELETE .../bulk` client method. */
+  bulkDeleteFn: (ids: string[]) => Promise<TResp>;
+  /** Invalidated after a successful delete so the grid refetches. */
+  queryKey: QueryKey;
+  itemLabelSingular: string;
+  itemLabelPlural: string;
+  /**
+   * Optional: for entities with an owner-only delete rule (Test Run, Task),
+   * pull the count of ids that existed but weren't deletable out of the
+   * response, so the second notification below can report them distinctly
+   * from a plain success.
+   */
+  getSkippedCount?: (response: TResp) => number;
+  /** Reason shown alongside the skipped count, e.g. "not yours to delete". */
+  skippedReason?: string;
+}
+
+/**
+ * Owns the checkbox-selection + confirm-modal + bulk-delete-call lifecycle
+ * shared by every grid's bulk-select feature, so each grid wires state
+ * instead of re-implementing it. Extracted from TestsGrid/ExplorerGrid,
+ * which had each grown this independently.
+ */
+export function useBulkDelete<TResp = void>({
+  bulkDeleteFn,
+  queryKey,
+  itemLabelSingular,
+  itemLabelPlural,
+  getSkippedCount,
+  skippedReason,
+}: UseBulkDeleteOptions<TResp>) {
+  const notifications = useNotifications();
+  const queryClient = useQueryClient();
+
+  const [selectedRows, setSelectedRows] = useState<GridRowSelectionModel>([]);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleSelectionChange = useCallback(
+    (model: GridRowSelectionModel) => setSelectedRows(model),
+    []
+  );
+
+  /** Open the confirm modal for one row (pass an id) or the current selection (omit it). */
+  const requestDelete = useCallback(
+    (id?: string) => {
+      if (id) {
+        setPendingDeleteId(id);
+        setDeleteModalOpen(true);
+      } else if (selectedRows.length > 0) {
+        setDeleteModalOpen(true);
+      }
+    },
+    [selectedRows]
+  );
+
+  const cancelDelete = useCallback(() => {
+    setDeleteModalOpen(false);
+    setPendingDeleteId(null);
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    const idsToDelete = pendingDeleteId
+      ? [pendingDeleteId]
+      : (selectedRows as string[]);
+    if (idsToDelete.length === 0) return;
+
+    try {
+      setIsDeleting(true);
+      const response = await bulkDeleteFn(idsToDelete);
+
+      const skipped = getSkippedCount?.(response) ?? 0;
+      const deletedCount = idsToDelete.length - skipped;
+      if (deletedCount > 0) {
+        const deletedLabel =
+          deletedCount === 1 ? itemLabelSingular : itemLabelPlural;
+        notifications.show(
+          `Successfully deleted ${deletedCount} ${deletedLabel}`,
+          {
+            severity: 'success',
+            autoHideDuration: 4000,
+          }
+        );
+      }
+      if (skipped > 0 && skippedReason) {
+        const skippedLabel =
+          skipped === 1 ? itemLabelSingular : itemLabelPlural;
+        notifications.show(
+          `${skipped} ${skippedLabel} skipped (${skippedReason})`,
+          {
+            severity: 'warning',
+            autoHideDuration: 6000,
+          }
+        );
+      }
+
+      setSelectedRows([]);
+      queryClient.invalidateQueries({ queryKey });
+    } catch {
+      notifications.show(`Failed to delete ${itemLabelPlural}`, {
+        severity: 'error',
+        autoHideDuration: 6000,
+      });
+    } finally {
+      setIsDeleting(false);
+      setDeleteModalOpen(false);
+      // Clear here, not on success only: a stale id would retarget the next bulk delete.
+      setPendingDeleteId(null);
+    }
+  }, [
+    pendingDeleteId,
+    selectedRows,
+    bulkDeleteFn,
+    getSkippedCount,
+    skippedReason,
+    itemLabelSingular,
+    itemLabelPlural,
+    notifications,
+    queryClient,
+    queryKey,
+  ]);
+
+  return {
+    selectedRows,
+    setSelectedRows,
+    handleSelectionChange,
+    pendingDeleteId,
+    deleteModalOpen,
+    isDeleting,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+  };
+}

--- a/apps/frontend/src/utils/api-client/base-client.ts
+++ b/apps/frontend/src/utils/api-client/base-client.ts
@@ -561,6 +561,29 @@ export class BaseApiClient {
   }
 
   /**
+   * Deletes multiple entities in one request.
+   *
+   * Every backend bulk-delete endpoint follows the same shape: `DELETE
+   * {basePath}/bulk` with a body of `{ [idsField]: string[] }`, returning
+   * `{ deleted_ids, not_found_ids, forbidden_ids? }`. Each entity client
+   * adds one line on top of this rather than re-implementing the request.
+   *
+   * @param basePath The entity's base endpoint (e.g. API_ENDPOINTS.tests)
+   * @param idsField The request body's id-array field name (e.g. 'test_ids')
+   * @param ids The ids to delete
+   */
+  protected async bulkDelete<TResp>(
+    basePath: string,
+    idsField: string,
+    ids: string[]
+  ): Promise<TResp> {
+    return this.fetch<TResp>(`${basePath}/bulk`, {
+      method: 'DELETE',
+      body: JSON.stringify({ [idsField]: ids }),
+    });
+  }
+
+  /**
    * Fetches paginated data from the API
    * @param endpoint The API endpoint to fetch from
    * @param params Pagination parameters

--- a/apps/frontend/src/utils/api-client/endpoints-client.ts
+++ b/apps/frontend/src/utils/api-client/endpoints-client.ts
@@ -4,6 +4,7 @@ import {
   AutoConfigureRequest,
   AutoConfigureResult,
   Endpoint,
+  EndpointBulkDeleteResponse,
   EndpointTestRequest,
 } from './interfaces/endpoint';
 import { PaginatedResponse, PaginationParams } from './interfaces/pagination';
@@ -57,6 +58,16 @@ export class EndpointsClient extends BaseApiClient {
     return this.fetch(`${API_ENDPOINTS.endpoints}/${id}`, {
       method: 'DELETE',
     });
+  }
+
+  async bulkDeleteEndpoints(
+    endpointIds: string[]
+  ): Promise<EndpointBulkDeleteResponse> {
+    return this.bulkDelete<EndpointBulkDeleteResponse>(
+      API_ENDPOINTS.endpoints,
+      'endpoint_ids',
+      endpointIds
+    );
   }
 
   async invokeEndpoint(

--- a/apps/frontend/src/utils/api-client/explorer-client.ts
+++ b/apps/frontend/src/utils/api-client/explorer-client.ts
@@ -155,10 +155,11 @@ export class ExplorerClient extends BaseApiClient {
    * @param testSetIds Test set IDs to delete
    */
   async bulkDeleteExplorerTestSets(testSetIds: string[]): Promise<void> {
-    await this.fetch<void>(`${API_ENDPOINTS.explorer}/bulk`, {
-      method: 'DELETE',
-      body: JSON.stringify({ test_set_ids: testSetIds }),
-    });
+    await this.bulkDelete<void>(
+      API_ENDPOINTS.explorer,
+      'test_set_ids',
+      testSetIds
+    );
   }
 
   /**

--- a/apps/frontend/src/utils/api-client/interfaces/endpoint.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/endpoint.ts
@@ -130,3 +130,8 @@ export interface EndpointTestRequest {
   query_params?: Record<string, unknown>;
   response_format?: 'json' | 'xml' | 'text';
 }
+
+export interface EndpointBulkDeleteResponse {
+  deleted_ids: string[];
+  not_found_ids: string[];
+}

--- a/apps/frontend/src/utils/api-client/interfaces/source.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/source.ts
@@ -57,3 +57,8 @@ export interface SourcesQueryParams extends PaginationParams {
   $filter?: string;
   source_type_id?: UUID;
 }
+
+export interface SourceBulkDeleteResponse {
+  deleted_ids: string[];
+  not_found_ids: string[];
+}

--- a/apps/frontend/src/utils/api-client/interfaces/task.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/task.ts
@@ -78,3 +78,9 @@ export interface Priority {
 // Entity types are defined canonically in `@/types/entity-type` and re-exported
 // here for backward compatibility.
 export { EntityType } from '@/types/entity-type';
+
+export interface TaskBulkDeleteResponse {
+  deleted_ids: string[];
+  not_found_ids: string[];
+  forbidden_ids: string[];
+}

--- a/apps/frontend/src/utils/api-client/interfaces/test-run.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/test-run.ts
@@ -39,3 +39,9 @@ export interface TestRunDetail extends TestRun {
     passed: number;
   };
 }
+
+export interface TestRunBulkDeleteResponse {
+  deleted_ids: string[];
+  not_found_ids: string[];
+  forbidden_ids: string[];
+}

--- a/apps/frontend/src/utils/api-client/interfaces/test-set.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/test-set.ts
@@ -86,6 +86,11 @@ export interface TestSetBulkAssociateRequest {
   test_ids: UUID[];
 }
 
+export interface TestSetBulkDeleteResponse {
+  deleted_ids: string[];
+  not_found_ids: string[];
+}
+
 // Test set generation interfaces
 
 /**

--- a/apps/frontend/src/utils/api-client/interfaces/token.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/token.ts
@@ -11,3 +11,8 @@ export interface TokenResponse {
   expires_at: string;
   name?: string;
 }
+
+export interface TokenBulkDeleteResponse {
+  deleted_ids: string[];
+  not_found_ids: string[];
+}

--- a/apps/frontend/src/utils/api-client/sources-client.ts
+++ b/apps/frontend/src/utils/api-client/sources-client.ts
@@ -3,6 +3,7 @@ import { API_ENDPOINTS } from './config';
 import { readActiveProjectId } from '../active-project';
 import {
   Source,
+  SourceBulkDeleteResponse,
   SourceCreate,
   SourceUpdate,
   SourcesQueryParams,
@@ -117,6 +118,16 @@ export class SourcesClient extends BaseApiClient {
     return this.fetch<void>(`${API_ENDPOINTS.sources}/${id}`, {
       method: 'DELETE',
     });
+  }
+
+  async bulkDeleteSources(
+    sourceIds: string[]
+  ): Promise<SourceBulkDeleteResponse> {
+    return this.bulkDelete<SourceBulkDeleteResponse>(
+      API_ENDPOINTS.sources,
+      'source_ids',
+      sourceIds
+    );
   }
 
   async uploadSource(

--- a/apps/frontend/src/utils/api-client/tasks-client.ts
+++ b/apps/frontend/src/utils/api-client/tasks-client.ts
@@ -2,6 +2,7 @@ import { BaseApiClient } from './base-client';
 import { API_ENDPOINTS } from './config';
 import {
   Task,
+  TaskBulkDeleteResponse,
   TaskCreate,
   TaskUpdate,
   TasksQueryParams,
@@ -53,6 +54,14 @@ export class TasksClient extends BaseApiClient {
     await this.fetch<void>(`${API_ENDPOINTS.tasks}/${taskId}`, {
       method: 'DELETE',
     });
+  }
+
+  async bulkDeleteTasks(taskIds: string[]): Promise<TaskBulkDeleteResponse> {
+    return this.bulkDelete<TaskBulkDeleteResponse>(
+      API_ENDPOINTS.tasks,
+      'task_ids',
+      taskIds
+    );
   }
 
   async getTasksByEntity(

--- a/apps/frontend/src/utils/api-client/test-runs-client.ts
+++ b/apps/frontend/src/utils/api-client/test-runs-client.ts
@@ -5,6 +5,7 @@ import {
   TestRunCreate,
   TestRunUpdate,
   TestRunDetail,
+  TestRunBulkDeleteResponse,
 } from './interfaces/test-run';
 import { Requirement } from './interfaces/requirement';
 import { PaginatedResponse, PaginationParams } from './interfaces/pagination';
@@ -115,6 +116,16 @@ export class TestRunsClient extends BaseApiClient {
     return this.fetch(`${API_ENDPOINTS.testRuns}/${id}`, {
       method: 'DELETE',
     });
+  }
+
+  async bulkDeleteTestRuns(
+    testRunIds: string[]
+  ): Promise<TestRunBulkDeleteResponse> {
+    return this.bulkDelete<TestRunBulkDeleteResponse>(
+      API_ENDPOINTS.testRuns,
+      'test_run_ids',
+      testRunIds
+    );
   }
 
   async getTestRunsByTestConfiguration(

--- a/apps/frontend/src/utils/api-client/test-sets-client.ts
+++ b/apps/frontend/src/utils/api-client/test-sets-client.ts
@@ -7,6 +7,7 @@ import {
   TestSet,
   TestSetCreate,
   TestSetBulkAssociateRequest,
+  TestSetBulkDeleteResponse,
   GenerateTestsRequest,
   GenerateTestSetResponse,
   TestSetMetric,
@@ -284,6 +285,16 @@ export class TestSetsClient extends BaseApiClient {
     return this.fetch(`${API_ENDPOINTS.testSets}/${id}`, {
       method: 'DELETE',
     });
+  }
+
+  async bulkDeleteTestSets(
+    testSetIds: string[]
+  ): Promise<TestSetBulkDeleteResponse> {
+    return this.bulkDelete<TestSetBulkDeleteResponse>(
+      API_ENDPOINTS.testSets,
+      'test_set_ids',
+      testSetIds
+    );
   }
 
   async executeTestSet(

--- a/apps/frontend/src/utils/api-client/tests-client.ts
+++ b/apps/frontend/src/utils/api-client/tests-client.ts
@@ -167,10 +167,7 @@ export class TestsClient extends BaseApiClient {
   }
 
   async bulkDeleteTests(testIds: string[]): Promise<void> {
-    await this.fetch<void>(`${API_ENDPOINTS.tests}/bulk`, {
-      method: 'DELETE',
-      body: JSON.stringify({ test_ids: testIds }),
-    });
+    await this.bulkDelete<void>(API_ENDPOINTS.tests, 'test_ids', testIds);
   }
 
   async createTestsBulk(

--- a/apps/frontend/src/utils/api-client/tokens-client.ts
+++ b/apps/frontend/src/utils/api-client/tokens-client.ts
@@ -1,6 +1,10 @@
 import { BaseApiClient } from './base-client';
 import { API_ENDPOINTS } from './config';
-import { Token, TokenResponse } from './interfaces/token';
+import {
+  Token,
+  TokenBulkDeleteResponse,
+  TokenResponse,
+} from './interfaces/token';
 import { PaginatedResponse, PaginationParams } from './interfaces/pagination';
 
 export class TokensClient extends BaseApiClient {
@@ -54,6 +58,14 @@ export class TokensClient extends BaseApiClient {
     return this.fetch<Token>(`${API_ENDPOINTS.tokens}/${tokenId}`, {
       method: 'DELETE',
     });
+  }
+
+  async bulkDeleteTokens(tokenIds: string[]): Promise<TokenBulkDeleteResponse> {
+    return this.bulkDelete<TokenBulkDeleteResponse>(
+      API_ENDPOINTS.tokens,
+      'token_ids',
+      tokenIds
+    );
   }
 
   async refreshToken(


### PR DESCRIPTION
## Purpose

Adds bulk-select delete to every frontend grid, building on the backend endpoints from the companion PR. Two grids (Test Sets, Test Runs) already had a start on this; this PR finishes those and adds the same capability to Endpoints, Sources, Tokens, and Tasks, using one shared, reusable implementation instead of each grid hand-rolling its own.

## What Changed

- Added a generic `bulkDelete()` method on `BaseApiClient` and a `useBulkDelete` hook that owns the checkbox-selection, confirm-modal, and delete-call lifecycle shared by every grid.
- Ported the two existing bulk-delete implementations (Tests, Explorer) onto the shared client method with no behavior change.
- Fixed Test Sets' checkbox selection, which was defined but never actually wired to the grid, and swapped its one-row-at-a-time delete loop for a real bulk call.
- Added bulk-select delete to Test Runs, Endpoints, Sources, Tokens, and Tasks. Each unifies single-row and bulk delete into one code path through the shared hook.
- For Test Runs and Tasks, which enforce an owner-only delete rule, selection is restricted to rows the caller can already delete, and the hook surfaces a distinct notification for any id the backend still reports as not deletable.
- Extended `useBulkDelete` with an optional `onSuccess` callback for Tokens, which manages its own data fetching without react-query.

## Additional Context

Depends on the backend bulk-delete endpoints added in the companion PR. Team Members is intentionally left out — it isn't built on the shared grid component, so bulk-select there would mean building selection UI from scratch rather than reusing this pattern.

## Testing

Ran the full grid test suite (48 tests across all 7 grids) after each change, plus manual type-checking and linting with no new warnings introduced anywhere. No existing test needed logic changes beyond updating mocked client methods to match the new bulk-delete calls.