### PR TITLE
Narrow the agreement read to the metadata it folds over

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/metric_tuning.py
+++ b/apps/backend/src/rhesis/backend/app/crud/metric_tuning.py
@@ -128,6 +128,33 @@ def get_tuning_cases(
     )
 
 
+def get_tuning_case_metadata(
+    db: Session, test_set_id: uuid.UUID, organization_id: str
+) -> List[Optional[dict]]:
+    """The ``test_metadata`` of every case in a tuning set, and nothing else.
+
+    The agreement fold reads only this. Going through ``get_tuning_cases`` would
+    eager-load the prompt beside it -- the whole case payload, one blob per case
+    -- to count four outcomes, on an endpoint the tuning tab polls on a timer.
+
+    Unordered on purpose: the caller tallies these, so the sort ``get_tuning_cases``
+    needs to keep the grid from reshuffling would be work for nothing here.
+    """
+    return [
+        row[0]
+        for row in db.query(models.Test.test_metadata)
+        .join(
+            test_test_set_association,
+            models.Test.id == test_test_set_association.c.test_id,
+        )
+        .filter(
+            test_test_set_association.c.test_set_id == test_set_id,
+            models.Test.organization_id == organization_id,
+        )
+        .all()
+    ]
+
+
 def get_tuning_case(
     db: Session, test_set_id: uuid.UUID, test_id: uuid.UUID, organization_id: str
 ) -> Optional[models.Test]:

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/agreement.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/agreement.py
@@ -67,8 +67,8 @@ def get_agreement(db: Session, metric: models.Metric, organization_id: str) -> T
     if not test_set:
         return TuningAgreement()
 
-    cases = crud_metric_tuning.get_tuning_cases(db, test_set.id, organization_id)
+    # Metadata only. The fold reads nothing else, and this endpoint is polled.
+    stored = crud_metric_tuning.get_tuning_case_metadata(db, test_set.id, organization_id)
     return agreement_over(
-        case_outcome(metric, parse_metric_tuning_case_metadata(db_test.test_metadata))[0]
-        for db_test in cases
+        case_outcome(metric, parse_metric_tuning_case_metadata(raw))[0] for raw in stored
     )

--- a/tests/backend/routes/test_metric_tuning_runs.py
+++ b/tests/backend/routes/test_metric_tuning_runs.py
@@ -36,6 +36,7 @@ from rhesis.backend.app import models
 from rhesis.backend.app.crud import metric_tuning as crud_metric_tuning
 from rhesis.backend.app.schemas.metric import MetricScope
 from rhesis.backend.app.schemas.metric_tuning_metadata import (
+    MetricTuningCaseResult,
     MetricTuningRunSummary,
     TuningRunStatus,
 )
@@ -1180,6 +1181,47 @@ class TestAgreement:
         assert agreement["ratio"] is None
         assert agreement["judged"] == 0
         assert agreement["unreviewed"] == 1
+
+    def test_a_run_that_died_before_reaching_a_case_leaves_it_out_of_the_ratio(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """A failed run is not two runs' numbers averaged together.
+
+        A run clears every case up front and refills them one at a time, so a
+        worker that died halfway leaves the cases it never reached carrying no
+        verdict at all. Those read as unreviewed and the denominator says so --
+        the ratio is only ever over the cases this run actually scored.
+        """
+        reached = _create_case(authenticated_client, tuning_metric.id)
+        missed = _create_case(authenticated_client, tuning_metric.id, input="The second one")
+        _run(test_db, tuning_metric, test_org_id, *[{"score": 1.0, "reason": "fine"}] * 2)
+        authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/reviews/accept-rest")
+        assert self._agreement(authenticated_client, tuning_metric.id)["judged"] == 2
+
+        # What a worker that died after the first case leaves behind.
+        test_db.expire_all()
+        db_test = (
+            test_db.query(models.Test).filter(models.Test.id == uuid.UUID(missed["id"])).first()
+        )
+        crud_metric_tuning.set_case_result(test_db, db_test, MetricTuningCaseResult())
+        service.fail_tuning_run(test_db, tuning_metric, test_org_id, "the worker went away.")
+
+        agreement = self._agreement(authenticated_client, tuning_metric.id)
+        assert agreement["ratio"] == 1.0
+        assert agreement["judged"] == 1
+        assert agreement["accepted"] == 1
+        assert agreement["unreviewed"] == 1
+        # The case it did reach is untouched, and the review on the one it missed
+        # is still in storage waiting for a verdict to be about again.
+        assert (
+            _cases_by_id(authenticated_client, tuning_metric.id)[reached["id"]]["outcome"]
+            == "accepted"
+        )
+        assert len(_stored_reviews(test_db, missed["id"])) == 1
 
     def test_a_review_that_survived_a_re_run_keeps_counting(
         self,


### PR DESCRIPTION
## Purpose

The tuning tab polls the agreement endpoint on a timer, and the fold behind it reads nothing but each case's outcome. It was going through `get_tuning_cases`, which eager-loads the prompt beside every case — the whole case payload, one blob per case — to count four outcomes. This narrows the read to the column the fold actually uses.

Follow-up to #2587, on the same base branch.

## What Changed

- `crud/metric_tuning.py`: new `get_tuning_case_metadata`, selecting the `test_metadata` column alone. It skips the ordering `get_tuning_cases` needs to keep the grid from reshuffling between polls, since a tally has no order to preserve.
- `services/metric_tuning/agreement.py`: `get_agreement` folds over that instead of over full `Test` rows.
- Regression test for a run that dies mid-set: a run clears every case up front and refills them one at a time, so a worker that dies halfway leaves the cases it never reached carrying no verdict at all. The test pins that those cases read as unreviewed and stay in the denominator — the ratio is only ever over the cases this run actually scored, never two runs' numbers averaged together — and that a review sitting on a case the run missed is kept, waiting for a verdict to be about again.

## Additional Context

- Behaviour is unchanged; this is a read-shape change plus a test.
- Base is `feat/metric-tuning-test-sets`, matching where #2587 landed. It is not on `main` yet.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/routes/test_metric_tuning_runs.py::TestAgreement -v
uv run pytest ../../tests/backend/services/metric_tuning/ -v
```

Both run locally: 9 passed in `TestAgreement` (including the new case), 98 passed in the service tests. Ruff check and format clean on all three files.
