### PR TITLE
Extract organization CRUD out of the crud/__init__.py monolith

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/crud/__init__.py
@@ -5,13 +5,11 @@ This code implements the CRUD operations for the models in the application.
 import logging
 import uuid
 from typing import Any, Dict, List, Optional, Union
-from uuid import UUID
 
-from sqlalchemy import and_, select, text
+from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models, schemas
-from rhesis.backend.app.database import reset_session_context
 from rhesis.backend.app.models.test import test_test_set_association
 from rhesis.backend.app.utils.crud_utils import (
     bulk_delete_by_ids,
@@ -26,26 +24,6 @@ from rhesis.backend.app.utils.crud_utils import (
 from rhesis.backend.app.utils.query_utils import QueryBuilder, include
 
 logger = logging.getLogger(__name__)
-
-
-# Helper function to print session variables
-def get_session_variables(db: Session):
-    """Get and return the current PostgreSQL session variables for debugging"""
-    results = {}
-    try:
-        # Check if variables exist before trying to show them
-        check_org = db.execute(
-            text("SELECT current_setting('app.current_organization', true)")
-        ).scalar()
-        check_user = db.execute(text("SELECT current_setting('app.current_user', true)")).scalar()
-
-        results["app.current_organization"] = check_org if check_org else "Not set"
-        results["app.current_user"] = check_user if check_user else "Not set"
-
-        return results
-    except Exception as e:
-        logger.debug(f"Error getting session variables: {e}")
-        return {"error": str(e)}
 
 
 # Endpoint CRUD
@@ -787,95 +765,6 @@ def delete_topic(
 ) -> Optional[models.Topic]:
     """Delete topic."""
     return delete_item(db, models.Topic, topic_id, organization_id, user_id)
-
-
-# Organization CRUD
-def get_organization(
-    db: Session, organization_id: uuid.UUID, tenant_organization_id: str = None, user_id: str = None
-) -> Optional[models.Organization]:
-    """Get organization."""
-    return get_item(db, models.Organization, organization_id, tenant_organization_id, user_id)
-
-
-def get_organizations(
-    db: Session,
-    skip: int = 0,
-    limit: int = 10,
-    sort_by: str = "created_at",
-    sort_order: str = "desc",
-    filter: str | None = None,
-    organization_id: str = None,
-    user_id: str = None,
-) -> List[models.Organization]:
-    return get_items(
-        db,
-        models.Organization,
-        skip,
-        limit,
-        sort_by,
-        sort_order,
-        filter,
-        organization_id=organization_id,
-        user_id=user_id,
-    )
-
-
-def create_organization(
-    db: Session,
-    organization: schemas.OrganizationCreate,
-    owner_user_id: Optional[UUID] = None,
-) -> models.Organization:
-    """Create a new organization without RLS checks, because we're creating a new organization.
-
-    When *owner_user_id* is supplied (always the case on the HTTP path) it overrides any
-    client-supplied ``owner_id``/``user_id`` values in the schema, making the backend
-    authoritative for org ownership (SP3 decision — server-set, cannot be forged).
-    Internal callers such as ``local_init.py`` that already supply the correct IDs in the
-    schema may pass ``owner_user_id=None`` to preserve the existing behaviour.
-    """
-    # Print session variables before reset
-    before_vars = get_session_variables(db)
-    logger.info(f"Session variables BEFORE reset: {before_vars}")
-
-    # Reset session context to ensure the new organization is created correctly
-    reset_session_context(db)
-
-    # Verify variables are cleared
-    after_vars = get_session_variables(db)
-    logger.info(f"Session variables AFTER reset: {after_vars}")
-
-    # Make sure session is clean to avoid RLS issues
-    db.expire_all()
-
-    # Convert Pydantic model to dict; project_id is not a column on Organization
-    org_data = organization.model_dump(exclude={"project_id"})
-
-    # Backend is authoritative for ownership when owner_user_id is provided.
-    if owner_user_id is not None:
-        org_data["owner_id"] = str(owner_user_id)
-        org_data["user_id"] = str(owner_user_id)
-
-    db_org = models.Organization(**org_data)
-
-    # Add to session - transaction management is handled by context manager
-    db.add(db_org)
-    db.flush()  # Flush to get the ID
-
-    # Simply return the object without refreshing
-    # The refresh operation is what often triggers RLS issues
-    logger.info(f"Organization created successfully: {db_org.id}")
-    return db_org
-
-
-def update_organization(
-    db: Session, organization_id: uuid.UUID, organization: schemas.OrganizationUpdate
-) -> Optional[models.Organization]:
-    return update_item(db, models.Organization, organization_id, organization)
-
-
-def delete_organization(db: Session, organization_id: uuid.UUID) -> Optional[models.Organization]:
-    """Delete organization - requires superuser permissions (handled in router)"""
-    return delete_item(db, models.Organization, organization_id)
 
 
 def get_test(

--- a/apps/backend/src/rhesis/backend/app/crud/organization.py
+++ b/apps/backend/src/rhesis/backend/app/crud/organization.py
@@ -1,0 +1,144 @@
+"""CRUD operations for organizations.
+
+Part of the incremental split of the ``crud`` monolith: ``crud/__init__.py`` still holds
+the bulk of the functions, and per-entity modules like this one take over as the code
+around them is touched.
+
+``create_organization`` is the one function here that steps outside the normal tenant
+machinery. Every other entity is created *inside* a tenant, so the org/user GUCs are
+already set and RLS applies; an organization *is* the tenant, so there is nothing to scope
+it to yet. It therefore calls ``reset_session_context`` to blank those GUCs, expires the
+session so no already-loaded row drags a stale tenant context along, and returns the
+flushed object without a refresh -- the refresh is what typically trips RLS here.
+
+``get_session_variables`` lives in this module because ``create_organization`` is its only
+caller: it reads back ``app.current_organization``/``app.current_user`` before and after
+that reset so the debug log shows the GUCs really were cleared.
+"""
+
+import logging
+import uuid
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models, schemas
+from rhesis.backend.app.database import reset_session_context
+from rhesis.backend.app.utils.crud_utils import (
+    delete_item,
+    get_item,
+    get_items,
+    update_item,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Helper function to print session variables
+def get_session_variables(db: Session):
+    """Get and return the current PostgreSQL session variables for debugging"""
+    results = {}
+    try:
+        # Check if variables exist before trying to show them
+        check_org = db.execute(
+            text("SELECT current_setting('app.current_organization', true)")
+        ).scalar()
+        check_user = db.execute(text("SELECT current_setting('app.current_user', true)")).scalar()
+
+        results["app.current_organization"] = check_org if check_org else "Not set"
+        results["app.current_user"] = check_user if check_user else "Not set"
+
+        return results
+    except Exception as e:
+        logger.debug(f"Error getting session variables: {e}")
+        return {"error": str(e)}
+
+
+def get_organization(
+    db: Session, organization_id: uuid.UUID, tenant_organization_id: str = None, user_id: str = None
+) -> Optional[models.Organization]:
+    """Get organization."""
+    return get_item(db, models.Organization, organization_id, tenant_organization_id, user_id)
+
+
+def get_organizations(
+    db: Session,
+    skip: int = 0,
+    limit: int = 10,
+    sort_by: str = "created_at",
+    sort_order: str = "desc",
+    filter: str | None = None,
+    organization_id: str = None,
+    user_id: str = None,
+) -> List[models.Organization]:
+    return get_items(
+        db,
+        models.Organization,
+        skip,
+        limit,
+        sort_by,
+        sort_order,
+        filter,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+
+
+def create_organization(
+    db: Session,
+    organization: schemas.OrganizationCreate,
+    owner_user_id: Optional[UUID] = None,
+) -> models.Organization:
+    """Create a new organization without RLS checks, because we're creating a new organization.
+
+    When *owner_user_id* is supplied (always the case on the HTTP path) it overrides any
+    client-supplied ``owner_id``/``user_id`` values in the schema, making the backend
+    authoritative for org ownership (SP3 decision — server-set, cannot be forged).
+    Internal callers such as ``local_init.py`` that already supply the correct IDs in the
+    schema may pass ``owner_user_id=None`` to preserve the existing behaviour.
+    """
+    # Print session variables before reset
+    before_vars = get_session_variables(db)
+    logger.info(f"Session variables BEFORE reset: {before_vars}")
+
+    # Reset session context to ensure the new organization is created correctly
+    reset_session_context(db)
+
+    # Verify variables are cleared
+    after_vars = get_session_variables(db)
+    logger.info(f"Session variables AFTER reset: {after_vars}")
+
+    # Make sure session is clean to avoid RLS issues
+    db.expire_all()
+
+    # Convert Pydantic model to dict; project_id is not a column on Organization
+    org_data = organization.model_dump(exclude={"project_id"})
+
+    # Backend is authoritative for ownership when owner_user_id is provided.
+    if owner_user_id is not None:
+        org_data["owner_id"] = str(owner_user_id)
+        org_data["user_id"] = str(owner_user_id)
+
+    db_org = models.Organization(**org_data)
+
+    # Add to session - transaction management is handled by context manager
+    db.add(db_org)
+    db.flush()  # Flush to get the ID
+
+    # Simply return the object without refreshing
+    # The refresh operation is what often triggers RLS issues
+    logger.info(f"Organization created successfully: {db_org.id}")
+    return db_org
+
+
+def update_organization(
+    db: Session, organization_id: uuid.UUID, organization: schemas.OrganizationUpdate
+) -> Optional[models.Organization]:
+    return update_item(db, models.Organization, organization_id, organization)
+
+
+def delete_organization(db: Session, organization_id: uuid.UUID) -> Optional[models.Organization]:
+    """Delete organization - requires superuser permissions (handled in router)"""
+    return delete_item(db, models.Organization, organization_id)

--- a/apps/backend/src/rhesis/backend/app/routers/organization.py
+++ b/apps/backend/src/rhesis/backend/app/routers/organization.py
@@ -6,11 +6,12 @@ from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.auth.capabilities import Permission, capability
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app import crud, models, schemas
+from rhesis.backend.app import models, schemas
 from rhesis.backend.app.auth.user_utils import (
     require_current_user_or_token,
     require_current_user_or_token_without_context,
 )
+from rhesis.backend.app.crud import organization as organization_crud
 from rhesis.backend.app.database import set_session_variables
 from rhesis.backend.app.dependencies import (
     get_db_session,
@@ -50,7 +51,9 @@ def create_organization(
 ):
     # owner_id and user_id are always set server-side from the authenticated caller —
     # the client-supplied values are ignored so the onboarding flow cannot forge ownership.
-    return crud.create_organization(db=db, organization=organization, owner_user_id=current_user.id)
+    return organization_crud.create_organization(
+        db=db, organization=organization, owner_user_id=current_user.id
+    )
 
 
 @router.get("/", response_model=list[schemas.Organization])
@@ -69,7 +72,7 @@ def read_organizations(
     """Get all organizations with their related objects"""
     try:
         organization_id, user_id = tenant_context
-        return crud.get_organizations(
+        return organization_crud.get_organizations(
             db=db,
             skip=skip,
             limit=limit,
@@ -92,7 +95,7 @@ def read_organization(
 ):
     try:
         tenant_organization_id, user_id = tenant_context
-        db_organization = crud.get_organization(
+        db_organization = organization_crud.get_organization(
             db,
             organization_id=organization_id,
             tenant_organization_id=tenant_organization_id,
@@ -115,7 +118,7 @@ def update_organization(
     db: Session = Depends(get_tenant_db_session),
     current_user: User = Depends(require_current_user_or_token),
 ):
-    db_organization = crud.update_organization(
+    db_organization = organization_crud.update_organization(
         db, organization_id=organization_id, organization=organization
     )
     if db_organization is None:
@@ -135,7 +138,7 @@ def initialize_organization_data(
 ):
     """Load initial data for an organization if onboarding is not complete."""
     try:
-        org = crud.get_organization(db, organization_id=organization_id)
+        org = organization_crud.get_organization(db, organization_id=organization_id)
         if not org:
             raise HTTPException(status_code=404, detail="Organization not found")
 
@@ -271,7 +274,7 @@ def rollback_organization_data(
     """Rollback initial data for an organization."""
     try:
         print(f"Rolling back initial data for organization {organization_id}")
-        org = crud.get_organization(db, organization_id=organization_id)
+        org = organization_crud.get_organization(db, organization_id=organization_id)
         if not org:
             raise HTTPException(status_code=404, detail="Organization not found")
 

--- a/apps/backend/src/rhesis/backend/app/services/platform_key.py
+++ b/apps/backend/src/rhesis/backend/app/services/platform_key.py
@@ -49,7 +49,7 @@ def _load_org(db: Session, organization_id) -> Organization | None:
     ``Organization`` is exempt from the ambient tenant auto-filter (it is
     queried before any tenant context exists), so a direct ``id`` lookup is
     the correct pattern here -- mirroring ``feature_gates._load_org`` and
-    ``crud.get_organization``. Callers pass the authenticated user's own
+    ``crud.organization.get_organization``. Callers pass the authenticated user's own
     ``organization_id``, which keeps access org-scoped.
 
     Soft-deleted orgs are still excluded despite the plain ``db.query(...)``:

--- a/tests/backend/crud/test_transaction_management.py
+++ b/tests/backend/crud/test_transaction_management.py
@@ -30,8 +30,9 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app import crud, models, schemas
+from rhesis.backend.app import models, schemas
 from rhesis.backend.app.constants import EntityType
+from rhesis.backend.app.crud import organization as organization_crud
 from rhesis.backend.app.crud import tag as tag_crud
 from rhesis.backend.app.crud import user as user_crud
 from rhesis.backend.app.crud.comment import add_emoji_reaction, remove_emoji_reaction
@@ -57,7 +58,7 @@ class TestCRUDTransactionManagement:
         org_create = schemas.OrganizationCreate(**org_data)
 
         # Create organization
-        result = crud.create_organization(test_db, org_create)
+        result = organization_crud.create_organization(test_db, org_create)
 
         # Verify organization was created and persisted
         assert result is not None
@@ -84,7 +85,7 @@ class TestCRUDTransactionManagement:
         # Mock db.add to raise an exception to test rollback
         with patch.object(test_db, "add", side_effect=IntegrityError("", "", "")):
             with pytest.raises(IntegrityError):
-                crud.create_organization(test_db, org_create)
+                organization_crud.create_organization(test_db, org_create)
 
         # Verify no organization was created (transaction rolled back)
         final_count = test_db.query(models.Organization).count()
@@ -328,7 +329,7 @@ class TestCRUDTransactionManagement:
         org_data1["user_id"] = str(authenticated_user.id)
         org_create1 = schemas.OrganizationCreate(**org_data1)
 
-        result1 = crud.create_organization(test_db, org_create1)
+        result1 = organization_crud.create_organization(test_db, org_create1)
         assert result1 is not None
 
         # Create second organization
@@ -338,7 +339,7 @@ class TestCRUDTransactionManagement:
         org_data2["user_id"] = str(authenticated_user.id)
         org_create2 = schemas.OrganizationCreate(**org_data2)
 
-        result2 = crud.create_organization(test_db, org_create2)
+        result2 = organization_crud.create_organization(test_db, org_create2)
         assert result2 is not None
 
         # Verify both organizations exist independently
@@ -366,7 +367,7 @@ class TestCRUDTransactionManagement:
         org_data1["user_id"] = str(authenticated_user.id)
         org_create1 = schemas.OrganizationCreate(**org_data1)
 
-        result1 = crud.create_organization(test_db, org_create1)
+        result1 = organization_crud.create_organization(test_db, org_create1)
         assert result1 is not None
 
         # Try to create second organization with exception
@@ -378,7 +379,7 @@ class TestCRUDTransactionManagement:
 
         with patch.object(test_db, "add", side_effect=IntegrityError("", "", "")):
             with pytest.raises(IntegrityError):
-                crud.create_organization(test_db, org_create2)
+                organization_crud.create_organization(test_db, org_create2)
 
         # Verify first organization still exists (not affected by second failure)
         db_org1 = (

--- a/tests/backend/fixtures/test_setup.py
+++ b/tests/backend/fixtures/test_setup.py
@@ -18,8 +18,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 # Import backend modules
-from rhesis.backend.app import crud, models
+from rhesis.backend.app import models
 from rhesis.backend.app.auth.token_utils import generate_api_token
+from rhesis.backend.app.crud import organization as organization_crud
 from rhesis.backend.app.crud import user as user_crud
 from rhesis.backend.app.crud.token import create_token
 from rhesis.backend.app.database import get_database_url
@@ -64,7 +65,7 @@ def create_test_organization(db: Session, name: str = "Test Organization") -> mo
         is_onboarding_complete=False,  # Will be set to True after initial data load
     )
 
-    organization = crud.create_organization(db, org_data)
+    organization = organization_crud.create_organization(db, org_data)
     print(f"✅ Created test organization: {organization.name} (ID: {organization.id})")
 
     return organization


### PR DESCRIPTION
## Purpose

Continues the incremental split of the `crud/__init__.py` monolith (#2410 through #2458, most recently #2588 for Test Result) by moving the Organization CRUD functions into their own per-entity module, per the "split, don't grow" rule in `apps/backend/AGENTS.md`.

## What Changed

New `app/crud/organization.py` holds `get_organization`, `get_organizations`, `create_organization`, `update_organization` and `delete_organization`, moved verbatim out of the `# Organization CRUD` section of `crud/__init__.py`, plus its own `logger`.

The `get_session_variables` debug helper moved with them. It sat at the top of the monolith but `create_organization` was its only caller — it reads back `app.current_organization` / `app.current_user` before and after the session-context reset so the log shows the GUCs really were cleared — so it belongs in this module.

`create_organization`'s behaviour is untouched: it still calls `reset_session_context(db)` and skips RLS (an organization *is* the tenant, so there is nothing to scope it to yet), still expires the session, still returns the flushed object without a refresh, and still honours `owner_user_id=None` for internal callers that already supply the correct IDs in the schema. The module docstring now explains why.

Callers moved to the house pattern (`from rhesis.backend.app.crud import organization as organization_crud`): `routers/organization.py`, `tests/backend/fixtures/test_setup.py` and `tests/backend/crud/test_transaction_management.py`. In all three the bare `crud` name was used only for organization functions, so `crud` was dropped from their `from rhesis.backend.app import crud, ...` lines. A stale `crud.get_organization` doc reference in `services/platform_key.py` was updated to `crud.organization.get_organization`.

**Note for the sibling extraction PRs open against the same file:** this is the PR that also drops the now-unused imports from the top of `crud/__init__.py` — `text` from the `sqlalchemy` import on line 10 (only `get_session_variables` used it), the whole `from rhesis.backend.app.database import reset_session_context` line (only `create_organization` used it), and `from uuid import UUID` (only `create_organization`'s signature used it). `and_` and `select` stay; they are still used by the TestSet and Test sections. No other line in the import block was touched, reordered or reformatted.

`crud/__init__.py` drops 111 lines, from 1336 to 1225.

## Additional Context

Pure refactor. Function bodies were moved byte-for-byte (verified by diffing the extracted blocks against the originals) — no signature, query or behaviour change, so the generated SQL is identical. The only pre-existing lint findings left in place are `typing.Union` unused in `crud/__init__.py` and the import-order plus unused `fastapi.APIRouter` findings in `routers/organization.py`, all of which are already present on `main`.

## Testing

`uv run pytest ../../tests/backend/security/ ../../tests/backend/crud/ ../../tests/backend/routes/test_organization.py ../../tests/backend/services/test_organization.py ../../tests/backend/auth/ -q` from `apps/backend` — 1931 passed, 6 skipped (all pre-existing skips). Ruff check and format clean on every touched file apart from the pre-existing findings noted above.
