### PR TITLE
Match the metric tuning tab to the rest of the app

### DIFF
--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
@@ -32,6 +32,7 @@ import { API_ENDPOINTS } from '@/utils/api-client/config';
 import { useCan, useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
+import { BetaBadge } from '@/components/common/BetaBadge';
 import PageLoadingState from '@/components/common/PageLoadingState';
 import type {
   RequirementReference,
@@ -85,6 +86,9 @@ export default function MetricDetailPageTabs() {
     (key, index) => ({
       key,
       label: NAV_LABELS[key],
+      // Beta belongs on the tab, not inside the panel: it qualifies the whole
+      // feature, and in the panel header it read as a label on the buttons.
+      ...(key === 'tuning' && { badge: <BetaBadge /> }),
       id: `metric-detail-tab-${index}`,
       'aria-controls': `metric-detail-tabpanel-${index}`,
     })

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
@@ -45,22 +45,6 @@ import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 /** Linked requirements come back with the status relationship at runtime. */
 type LinkedRequirementRow = RequirementReference & { status?: Status | null };
 
-/**
- * Experimental metric tuning tab, off unless explicitly turned on.
- *
- * Gated on the feature itself rather than on the environment: an `NODE_ENV`
- * check would scatter deployment assumptions through feature code and make the
- * same feature behave differently by accident depending on where it runs.
- *
- * Not a `FeatureName` from `src/constants/features.ts` — that system mirrors a
- * backend enum and is driven by `GET /features`, so adding one would need a
- * coordinated backend change. This is a local flag for an unfinished feature;
- * set `NEXT_PUBLIC_METRIC_TUNING=true` in `.env.local` to see the tab. The
- * value is inlined at build time, so it is absent from any deployment that does
- * not set it, and a misspelled value fails closed.
- */
-const TUNING_TAB_ENABLED = process.env.NEXT_PUBLIC_METRIC_TUNING === 'true';
-
 const TAB_KEYS = ['basic', 'linked-requirements', 'tuning'] as const;
 
 const NAV_LABELS: Record<(typeof TAB_KEYS)[number], string> = {
@@ -78,9 +62,9 @@ export default function MetricDetailPageTabs() {
 
   const metricId = params.identifier as string;
   const { activeTab, handleTabChange } = useDetailTabNav(TAB_KEYS);
-  // The flag alone is not enough: this page also serves `rhesis` metrics, and
-  // the tuning routes refuse anything that is not custom.
-  const showTuning = useIsCustomMetric(metricId, TUNING_TAB_ENABLED);
+  // This page also serves `rhesis` metrics, and the tuning routes refuse
+  // anything that is not custom.
+  const showTuning = useIsCustomMetric(metricId);
 
   const navTabs = TAB_KEYS.filter(key => key !== 'tuning' || showTuning).map(
     (key, index) => ({

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningTab.tsx
@@ -4,12 +4,13 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
-  Chip,
   CircularProgress,
+  Grid,
   IconButton,
   Tooltip,
   Typography,
 } from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
 import {
   GridColDef,
   GridColumnGroupingModel,
@@ -19,13 +20,19 @@ import {
 import BaseDataGrid from '@/components/common/BaseDataGrid';
 import SectionCard from '@/components/common/SectionCard';
 import SectionEmptyState from '@/components/common/SectionEmptyState';
-import { BetaBadge } from '@/components/common/BetaBadge';
-import { createRowActionsColumn } from '@/components/common/createRowActionsColumn';
+import GridBadge from '@/components/common/GridBadge';
+import SummaryCard from '@/components/common/SummaryCard';
+import {
+  createRowActionsColumn,
+  rowActionsHoverSx,
+} from '@/components/common/createRowActionsColumn';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import {
   AddIcon,
+  CancelIcon,
+  CheckCircleIcon,
   PlayArrowIcon,
   ThumbDownFilledIcon,
   ThumbDownIcon,
@@ -62,20 +69,30 @@ const ERRORED_HINT =
 const NO_AGREEMENT_HINT =
   'Agreement is the share of judged cases you accepted. Nothing has been judged yet, so there is no share to report — a set nobody has looked at is not a set the metric got right.';
 
-/** Renders long free text on one line with the full value in a tooltip. */
-function TruncatedCell({ params }: { params: GridRenderCellParams }) {
-  const value = typeof params.value === 'string' ? params.value : '';
+/** Two-line clamp for free text in a grid cell, as the test run grids use. */
+const CELL_TEXT_SX = {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  display: '-webkit-box',
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: 'vertical' as const,
+};
+
+/** Renders long free text clamped to two lines, in full in a tooltip. */
+function TextCell({ value }: { value: string }) {
+  if (!value) return <span>—</span>;
   return (
-    <Box
-      title={value}
-      sx={{
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-      }}
-    >
-      {value || '—'}
-    </Box>
+    <Tooltip title={value} enterDelay={500}>
+      <Typography variant="body2" sx={CELL_TEXT_SX}>
+        {value}
+      </Typography>
+    </Tooltip>
+  );
+}
+
+function TruncatedCell({ params }: { params: GridRenderCellParams }) {
+  return (
+    <TextCell value={typeof params.value === 'string' ? params.value : ''} />
   );
 }
 
@@ -94,46 +111,42 @@ function MetricVerdictCell({
   params: GridRenderCellParams;
   scoreType: ScoreType;
 }) {
+  const theme = useTheme();
   const result = params.row.result as MetricTuningCase['result'];
   if (!result) return <span>—</span>;
+
+  const tinted = (label: string, tone: 'success' | 'error' | 'warning') => (
+    <GridBadge
+      label={label}
+      sx={{
+        bgcolor: alpha(theme.palette[tone].main, 0.12),
+        color: `${tone}.dark`,
+      }}
+    />
+  );
+
   if (result.error) {
     return (
       <Tooltip title={result.error}>
-        <Chip label="Error" size="small" color="warning" variant="outlined" />
+        <Box component="span" sx={{ display: 'inline-flex' }}>
+          {tinted('Error', 'warning')}
+        </Box>
       </Tooltip>
     );
   }
   if (!result.verdict) return <span>—</span>;
+  // Untinted, so a numeric 0.8 is not painted red for being below 1.
   if (scoreType !== 'binary') {
-    return <Chip label={result.verdict} size="small" variant="outlined" />;
+    return <GridBadge label={result.verdict} />;
   }
   const isPass = result.verdict.toLowerCase() === 'pass';
-  return (
-    <Chip
-      label={result.verdict}
-      size="small"
-      variant="outlined"
-      color={isPass ? 'success' : 'error'}
-    />
-  );
+  return tinted(result.verdict, isPass ? 'success' : 'error');
 }
 
 /** The metric's own reasoning for the verdict it gave — what to edit against. */
 function MetricReasoningCell({ params }: { params: GridRenderCellParams }) {
   const result = params.row.result as MetricTuningCase['result'];
-  const value = result?.reasoning ?? '';
-  return (
-    <Box
-      title={value}
-      sx={{
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-      }}
-    >
-      {value || '—'}
-    </Box>
-  );
+  return <TextCell value={result?.reasoning ?? ''} />;
 }
 
 /**
@@ -257,40 +270,78 @@ function InvalidatedMark() {
  * it is.
  *
  * The denominator is the whole point. Unreviewed and errored cases are counted
- * out of the ratio and reported beside it: counting either one in produces a
- * plausible figure meaning something other than what its reader thinks — a set
- * nobody looked at reading as perfect, or a flaky provider reading as a bad
- * metric. The judged count sits next to the number for the same reason, so
- * three out of three does not read like a solved problem.
+ * out of the ratio and reported in their own tile: counting either one in
+ * produces a plausible figure meaning something other than what its reader
+ * thinks — a set nobody looked at reading as perfect, or a flaky provider
+ * reading as a bad metric. The judged count sits under the number for the same
+ * reason, so three out of three does not read like a solved problem.
  */
 function AgreementSummary({ agreement }: { agreement: MetricTuningAgreement }) {
-  const { ratio, judged, unreviewed, errored } = agreement;
+  const { ratio, judged, accepted, rejected, unreviewed, errored } = agreement;
   const total = judged + unreviewed + errored;
+  const percent = ratio === null ? null : Math.round(ratio * 100);
 
-  const qualifiers = [
-    judged > 0
-      ? `over ${judged} of ${total} ${total === 1 ? 'case' : 'cases'} judged`
-      : 'nothing judged yet',
+  const outstanding = [
     unreviewed > 0 ? `${unreviewed} unreviewed` : null,
     errored > 0 ? `${errored} the metric could not be reached on` : null,
   ].filter(Boolean);
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, mb: 0.5 }}>
-      <Typography variant="body2" color="text.secondary">
-        Agreement
-      </Typography>
-      <Typography
-        variant="h6"
-        component="span"
-        title={ratio === null ? NO_AGREEMENT_HINT : undefined}
-      >
-        {ratio === null ? '—' : `${Math.round(ratio * 100)}%`}
-      </Typography>
-      <Typography variant="body2" color="text.secondary">
-        {qualifiers.join(' · ')}
-      </Typography>
-    </Box>
+    <Grid container spacing={3} sx={{ mb: 3 }}>
+      <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+        <Box title={percent === null ? NO_AGREEMENT_HINT : undefined}>
+          <SummaryCard
+            title="Agreement"
+            value={percent === null ? '—' : `${percent}%`}
+            subtitle={
+              percent === null
+                ? 'Nothing judged yet'
+                : `${accepted} of ${judged} ${judged === 1 ? 'case' : 'cases'} accepted`
+            }
+            icon={
+              percent === null ? (
+                <TuneIcon />
+              ) : percent > 66 ? (
+                <CheckCircleIcon />
+              ) : percent >= 33 ? (
+                <WarningAmberIcon />
+              ) : (
+                <CancelIcon />
+              )
+            }
+            color={
+              percent === null
+                ? 'info'
+                : percent > 66
+                  ? 'success'
+                  : percent >= 33
+                    ? 'warning'
+                    : 'error'
+            }
+          />
+        </Box>
+      </Grid>
+      <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+        <SummaryCard
+          title="Rejected"
+          value={rejected}
+          subtitle={`of ${judged} judged`}
+          icon={<CancelIcon />}
+          color="error"
+        />
+      </Grid>
+      <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+        <SummaryCard
+          title="Cases"
+          value={total}
+          subtitle={
+            outstanding.length > 0 ? outstanding.join(' · ') : 'All judged'
+          }
+          icon={<TuneIcon />}
+          color="primary"
+        />
+      </Grid>
+    </Grid>
   );
 }
 
@@ -364,6 +415,10 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
   const [run, setRun] = useState<MetricTuningRun | null>(null);
   const [starting, setStarting] = useState(false);
   const [acceptingRest, setAcceptingRest] = useState(false);
+  const [paginationModel, setPaginationModel] = useState({
+    page: 0,
+    pageSize: 25,
+  });
 
   const fetchCases = useCallback(async () => {
     setLoading(true);
@@ -595,6 +650,7 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
         headerName: 'Input',
         flex: 1,
         minWidth: 180,
+        disableColumnMenu: true,
         renderCell: params => <TruncatedCell params={params} />,
       },
       {
@@ -602,6 +658,7 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
         headerName: 'Output',
         flex: 2,
         minWidth: 220,
+        disableColumnMenu: true,
         renderCell: params => <TruncatedCell params={params} />,
       },
     ];
@@ -611,6 +668,7 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
         headerName: 'Reference answer',
         flex: 1,
         minWidth: 160,
+        disableColumnMenu: true,
         renderCell: params => <TruncatedCell params={params} />,
       });
     }
@@ -623,6 +681,9 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
         width: 140,
         // Reads the nested `result`, which no single field sorts by.
         sortable: false,
+        disableColumnMenu: true,
+        align: 'center',
+        headerAlign: 'center',
         renderCell: params => (
           <MetricVerdictCell params={params} scoreType={scoreType} />
         ),
@@ -634,6 +695,7 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
           flex: 1.5,
           minWidth: 180,
           sortable: false,
+          disableColumnMenu: true,
           renderCell: params => <MetricReasoningCell params={params} />,
         });
       }
@@ -647,6 +709,9 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
             width: 120,
             // The cell reads `outcome`, `review` and `result` together.
             sortable: false,
+            disableColumnMenu: true,
+            align: 'center',
+            headerAlign: 'center',
             renderCell: params => (
               <ReviewCell
                 params={params}
@@ -716,12 +781,9 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
     c => c.outcome === 'unreviewed' && Boolean(c.result?.verdict)
   );
 
-  // The badge sits in `actions`, not `subtitle`: SectionCard wraps the subtitle
-  // in a <Typography> (a <p>), and Chip renders a <div>.
   const isRunning = run?.status === 'running';
   const actions = (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-      <BetaBadge />
       {canEdit && cases.length > 0 && (
         <Button
           variant="outlined"
@@ -782,8 +844,12 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
               columnGroupingModel={columnGroupingModel}
               loading={loading}
               getRowId={row => String(row.id)}
+              paginationModel={paginationModel}
+              onPaginationModelChange={setPaginationModel}
+              pageSizeOptions={[10, 25, 50, 100]}
               showToolbar={false}
               disableMultipleRowSelection
+              sx={rowActionsHoverSx}
             />
           </>
         )}

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
@@ -128,12 +128,6 @@ describe('MetricTuningTab', () => {
     expect(screen.getByText('I am fine, thanks.')).toBeInTheDocument();
   });
 
-  it('marks the tab as beta', async () => {
-    render(<MetricTuningTab metricId={METRIC_ID} />);
-
-    expect(await screen.findByText('beta')).toBeInTheDocument();
-  });
-
   it('creates a case from the add form', async () => {
     mockCreateTuningCase.mockResolvedValue(CASE);
     render(<MetricTuningTab metricId={METRIC_ID} />);
@@ -760,7 +754,8 @@ describe('MetricTuningTab — agreement', () => {
     expect(await screen.findByText('67%')).toBeInTheDocument();
     // The denominator travels with it: three out of three must not read like a
     // solved problem.
-    expect(screen.getByText(/over 3 of 3 cases judged/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 of 3 cases accepted/i)).toBeInTheDocument();
+    expect(screen.getByText('Rejected')).toBeInTheDocument();
   });
 
   it('reports no agreement rather than full agreement when nothing is judged', async () => {
@@ -783,7 +778,7 @@ describe('MetricTuningTab — agreement', () => {
     render(<MetricTuningTab metricId={METRIC_ID} />);
 
     expect(await screen.findByText('100%')).toBeInTheDocument();
-    expect(screen.getByText(/over 1 of 3 cases judged/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 of 1 case accepted/i)).toBeInTheDocument();
     expect(screen.getByText(/2 unreviewed/i)).toBeInTheDocument();
   });
 

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/useIsCustomMetric.ts
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/useIsCustomMetric.ts
@@ -13,17 +13,13 @@ import type { UUID } from 'crypto';
  * on a `rhesis` metric (the detail page serves those too) and every call it
  * made would come back 400.
  *
- * Fails closed: false while loading, on error, and whenever `enabled` is false,
- * so the tab never flashes in for a metric that cannot use it.
+ * Fails closed: false while loading and on error, so the tab never flashes in
+ * for a metric that cannot use it.
  */
-export function useIsCustomMetric(metricId: string, enabled: boolean): boolean {
+export function useIsCustomMetric(metricId: string): boolean {
   const [isCustom, setIsCustom] = useState(false);
 
   useEffect(() => {
-    // Skip the request entirely when the feature is off, which is every
-    // deployment -- otherwise viewing any metric costs an extra fetch for a tab
-    // nobody can see.
-    if (!enabled) return;
     let cancelled = false;
 
     const check = async () => {
@@ -44,7 +40,7 @@ export function useIsCustomMetric(metricId: string, enabled: boolean): boolean {
     return () => {
       cancelled = true;
     };
-  }, [metricId, enabled]);
+  }, [metricId]);
 
   return isCustom;
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunHeader.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunHeader.tsx
@@ -21,8 +21,6 @@ import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined';
-import TrendingDownIcon from '@mui/icons-material/TrendingDown';
-import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
 import Link from 'next/link';
 import {
@@ -35,6 +33,7 @@ import { getEffectiveTestResultStatus } from '@/utils/test-result-status';
 import { shortVersion } from '@/utils/api-client/interfaces/parameters';
 import { experimentHref } from '@/utils/experiment-links';
 import { BiotechIcon } from '@/components/icons';
+import SummaryCard from '@/components/common/SummaryCard';
 import { ReviewSummary } from './test-run-summary-utils';
 
 function getRunExpectedTestCount(testRun: TestRunDetail): number | undefined {
@@ -94,104 +93,6 @@ interface TestRunHeaderProps {
   reviewSummary?: ReviewSummary;
   loading?: boolean;
   onRefresh?: () => void;
-}
-
-interface SummaryCardProps {
-  title: string;
-  value: string | number;
-  subtitle?: string;
-  icon: React.ReactNode;
-  trend?: 'up' | 'down' | 'neutral';
-  trendValue?: string;
-  color?: 'primary' | 'success' | 'error' | 'warning' | 'info';
-}
-
-function SummaryCard({
-  title,
-  value,
-  subtitle,
-  icon,
-  trend,
-  trendValue,
-  color = 'primary',
-}: SummaryCardProps) {
-  const theme = useTheme();
-
-  const iconColors = {
-    primary: theme.palette.primary.main,
-    success: theme.palette.success.main,
-    error: theme.palette.error.main,
-    warning: theme.palette.warning.main,
-    info: theme.palette.info.main,
-  };
-
-  return (
-    <Card
-      sx={{
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-      }}
-    >
-      <CardContent sx={{ flexGrow: 1, p: 3 }}>
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'flex-start',
-            justifyContent: 'space-between',
-            mb: 2,
-          }}
-        >
-          <Typography variant="body2" color="text.secondary" fontWeight={500}>
-            {title}
-          </Typography>
-          <Box
-            sx={{
-              color: iconColors[color],
-              display: 'flex',
-              alignItems: 'center',
-            }}
-          >
-            {icon}
-          </Box>
-        </Box>
-
-        <Typography variant="h4" fontWeight={600} sx={{ mb: 1 }}>
-          {value}
-        </Typography>
-
-        {subtitle && (
-          <Typography variant="body2" color="text.secondary">
-            {subtitle}
-          </Typography>
-        )}
-
-        {trend && trendValue && (
-          <Box sx={{ display: 'flex', alignItems: 'center', mt: 1, gap: 0.5 }}>
-            {trend === 'up' && (
-              <TrendingUpIcon fontSize="small" color="success" />
-            )}
-            {trend === 'down' && (
-              <TrendingDownIcon fontSize="small" color="error" />
-            )}
-            <Typography
-              variant="caption"
-              color={
-                trend === 'up'
-                  ? 'success.main'
-                  : trend === 'down'
-                    ? 'error.main'
-                    : 'text.secondary'
-              }
-              fontWeight={500}
-            >
-              {trendValue}
-            </Typography>
-          </Box>
-        )}
-      </CardContent>
-    </Card>
-  );
 }
 
 export default function TestRunHeader({

--- a/apps/frontend/src/components/common/DetailTabNav.tsx
+++ b/apps/frontend/src/components/common/DetailTabNav.tsx
@@ -7,6 +7,9 @@ import type { SxProps, Theme } from '@mui/material/styles';
 export interface DetailTabNavItem {
   key: string;
   label: string;
+  /** Rendered beside the label, e.g. a BetaBadge. Kept out of the label's
+   * <span>, since Chip renders a <div> and a div inside a span is invalid. */
+  badge?: React.ReactNode;
   id?: string;
   'aria-controls'?: string;
 }
@@ -114,21 +117,31 @@ export function DetailTabNav({
               },
             }}
           >
-            <Typography
-              component="span"
+            <Box
               sx={{
-                fontSize: 18,
-                fontWeight: 700,
-                lineHeight: '25px',
-                color: theme =>
-                  selected
-                    ? theme.palette.greyscale.title
-                    : theme.palette.greyscale.subtitle,
-                whiteSpace: 'nowrap',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                minWidth: 0,
               }}
             >
-              {tab.label}
-            </Typography>
+              <Typography
+                component="span"
+                sx={{
+                  fontSize: 18,
+                  fontWeight: 700,
+                  lineHeight: '25px',
+                  color: theme =>
+                    selected
+                      ? theme.palette.greyscale.title
+                      : theme.palette.greyscale.subtitle,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {tab.label}
+              </Typography>
+              {tab.badge}
+            </Box>
             {selected ? (
               <Box
                 aria-hidden

--- a/apps/frontend/src/components/common/SummaryCard.tsx
+++ b/apps/frontend/src/components/common/SummaryCard.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import React from 'react';
+import { Box, Card, CardContent, Typography, useTheme } from '@mui/material';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+
+export interface SummaryCardProps {
+  title: string;
+  value: string | number;
+  subtitle?: string;
+  icon: React.ReactNode;
+  trend?: 'up' | 'down' | 'neutral';
+  trendValue?: string;
+  color?: 'primary' | 'success' | 'error' | 'warning' | 'info';
+}
+
+/**
+ * Headline stat tile: a label, one big number, and a line saying what the
+ * number is out of. Used by the test run header and the metric tuning tab.
+ */
+export function SummaryCard({
+  title,
+  value,
+  subtitle,
+  icon,
+  trend,
+  trendValue,
+  color = 'primary',
+}: SummaryCardProps) {
+  const theme = useTheme();
+
+  const iconColors = {
+    primary: theme.palette.primary.main,
+    success: theme.palette.success.main,
+    error: theme.palette.error.main,
+    warning: theme.palette.warning.main,
+    info: theme.palette.info.main,
+  };
+
+  return (
+    <Card
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <CardContent sx={{ flexGrow: 1, p: 3 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            mb: 2,
+          }}
+        >
+          <Typography variant="body2" color="text.secondary" fontWeight={500}>
+            {title}
+          </Typography>
+          <Box
+            sx={{
+              color: iconColors[color],
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            {icon}
+          </Box>
+        </Box>
+
+        <Typography variant="h4" fontWeight={600} sx={{ mb: 1 }}>
+          {value}
+        </Typography>
+
+        {subtitle && (
+          <Typography variant="body2" color="text.secondary">
+            {subtitle}
+          </Typography>
+        )}
+
+        {trend && trendValue && (
+          <Box sx={{ display: 'flex', alignItems: 'center', mt: 1, gap: 0.5 }}>
+            {trend === 'up' && (
+              <TrendingUpIcon fontSize="small" color="success" />
+            )}
+            {trend === 'down' && (
+              <TrendingDownIcon fontSize="small" color="error" />
+            )}
+            <Typography
+              variant="caption"
+              color={
+                trend === 'up'
+                  ? 'success.main'
+                  : trend === 'down'
+                    ? 'error.main'
+                    : 'text.secondary'
+              }
+              fontWeight={500}
+            >
+              {trendValue}
+            </Typography>
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default SummaryCard;

--- a/apps/frontend/src/components/common/__tests__/DetailTabNav.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/DetailTabNav.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DetailTabNav from '../DetailTabNav';
+
+describe('DetailTabNav', () => {
+  it('renders a tab badge beside its label', () => {
+    render(
+      <DetailTabNav
+        tabs={[
+          { key: 'basic', label: 'Basic Information' },
+          { key: 'tuning', label: 'Tuning', badge: <span>beta</span> },
+        ]}
+        activeIndex={0}
+        onChange={() => {}}
+      />
+    );
+
+    const tuningTab = screen.getByRole('tab', { name: /Tuning/ });
+    expect(tuningTab).toHaveTextContent('Tuning');
+    expect(tuningTab).toHaveTextContent('beta');
+    // The badge belongs to the Tuning tab, not to the whole tablist.
+    expect(
+      screen.getByRole('tab', { name: 'Basic Information' })
+    ).not.toHaveTextContent('beta');
+  });
+});


### PR DESCRIPTION
## Purpose

The Tuning tab works but reads as an experiment bolted onto the metric detail page: its own grid conventions, its own way of showing a summary, a beta chip in the wrong place, and a build-time flag that no deployment sets, so nobody can see it. This makes the tab look and read like the rest of the app, and turns it on.

## What Changed

- **Beta badge onto the tab.** `DetailTabNav` gained an optional `badge` slot, and the chip moved out of the panel header onto the Tuning tab label. In the header, next to the action buttons, it read as a label on the buttons rather than on the feature. The badge is a sibling of the label, not inside it — `Chip` renders a `div` and the label is a `span`.
- **Grid conventions match the test-run grids.** Verdicts are tinted `GridBadge` pills using the same expression as a test run's Result column; long cells clamp to two lines with the full value in a tooltip; page-size options, hover-revealed row actions, no column menus. A non-binary verdict stays untinted — a numeric `0.8` in a red pill says the opposite of what the number means.
- **Agreement as three `SummaryCard` tiles** instead of one dense text line: the ratio, how many were rejected, and how many cases are still outstanding. `SummaryCard` was private to `TestRunHeader`, so it is extracted to `components/common` unchanged and imported back there.
- **`NEXT_PUBLIC_METRIC_TUNING` removed.** The custom-metric check stays and is now the only gate; it always was the real one, since the tuning routes refuse anything else and a hidden tab is not an access rule. `useIsCustomMetric` loses its `enabled` parameter with it.

The `Case` / `Metric output` header bands stay, and so do the thumbs in the Review column. The test-run grids have nothing to band, and their machine/human verdict pair answers a different question than the tuner's review does — in the tuner the human judges whether *the metric* was right, not whether the test passed, so a tick beside a cross would read backwards. The bands are also a decision recorded in `spec.md` and issue 05.

## Additional Context

- **Targets `feat/metric-tuning-test-sets`, not `main`,** per the branching rule in `playground/tracker/tuning-runs/spec.md`: every ticket is cut from the integration branch and merges back into it, so `main` sees one merge when the feature is finished.
- This reverses user story 25 in that spec ("the whole feature invisible unless explicitly enabled") and its matching Out of Scope bullet. Both are amended in the local tracker so the spec stops contradicting the code.
- **Known cost, not fixed here:** with the flag gone, every metric detail page view now makes an extra `getMetric` call just to decide whether to show the tab — `MetricDetailView` already fetches the same metric. Threading it down is a worthwhile follow-up.

## Testing

```bash
cd apps/frontend
npx tsc --noEmit        # clean, and clean at every one of the four commits
npm run lint            # only pre-existing warnings, in MetricDetailView
npx jest                # 1995 tests, 214 suites, all passing
```

`MetricTuningTab.test.tsx` keeps its coverage with the agreement assertions rewritten against the tiles; `DetailTabNav.test.tsx` is new and covers the badge slot; `TestRunHeader.test.tsx` is untouched and still passes, which is what says the `SummaryCard` move changed nothing.

To look at it: `./rh worktree feat/metric-tuner-ui --load`, then `./rh dev tmux`. Open a **custom** metric — the tab row reads `Basic Information · Linked Requirements · Tuning [beta]`, with no chip in the card header. Add two cases, press **Run metric**, then accept one and reject the other with a comment: the Agreement tile moves and the Rejected tile increments. Open a `rhesis` metric and there is no Tuning tab, with no env var set anywhere.

**Not verified in a browser.** A fresh worktree database has no organization to sign into, so the checks above are typecheck, lint and the component tests only — the tiles and the badge have not been looked at on screen.
