### PR TITLE
Extract experiment crud module

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/crud/__init__.py
@@ -103,29 +103,6 @@ def delete_endpoint(
     )
 
 
-# Experiment CRUD
-def get_experiments(
-    db: Session,
-    skip: int = 0,
-    limit: int = 10,
-    sort_by: str = "created_at",
-    sort_order: str = "desc",
-    filter: str | None = None,
-    organization_id: str = None,
-    user_id: str = None,
-) -> List[models.Experiment]:
-    return (
-        QueryBuilder(db, models.Experiment)
-        .with_related(include(models.Experiment.project))
-        .with_organization_filter(organization_id)
-        .with_visibility_filter(user_id)
-        .with_odata_filter(filter)
-        .with_sorting(sort_by, sort_order)
-        .with_pagination(skip, limit)
-        .all()
-    )
-
-
 # TestSet CRUD
 def get_test_set(
     db: Session, test_set_id: uuid.UUID, organization_id: str = None, user_id: str = None

--- a/apps/backend/src/rhesis/backend/app/crud/experiment.py
+++ b/apps/backend/src/rhesis/backend/app/crud/experiment.py
@@ -1,0 +1,35 @@
+"""CRUD operations for experiments.
+
+Part of the incremental split of the ``crud`` monolith: ``crud/__init__.py`` still holds
+the bulk of the functions, and per-entity modules like this one take over as the code
+around them is touched -- see ``apps/backend/AGENTS.md``'s crud-layout rule.
+"""
+
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.utils.query_utils import QueryBuilder, include
+
+
+def get_experiments(
+    db: Session,
+    skip: int = 0,
+    limit: int = 10,
+    sort_by: str = "created_at",
+    sort_order: str = "desc",
+    filter: str | None = None,
+    organization_id: str = None,
+    user_id: str = None,
+) -> List[models.Experiment]:
+    return (
+        QueryBuilder(db, models.Experiment)
+        .with_related(include(models.Experiment.project))
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .with_odata_filter(filter)
+        .with_sorting(sort_by, sort_order)
+        .with_pagination(skip, limit)
+        .all()
+    )

--- a/apps/backend/src/rhesis/backend/app/routers/experiments.py
+++ b/apps/backend/src/rhesis/backend/app/routers/experiments.py
@@ -24,6 +24,7 @@ from rhesis.backend.app.auth.capabilities import Permission
 from rhesis.backend.app.auth.principal import resolve_principal_from_request
 from rhesis.backend.app.auth.rbac import authorize_object, project_id_from_scope
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
+from rhesis.backend.app.crud import experiment as experiment_crud
 from rhesis.backend.app.crud.project import get_project
 from rhesis.backend.app.crud.test_run import get_test_runs
 from rhesis.backend.app.dependencies import (
@@ -81,7 +82,7 @@ def list_experiments(
     belonging to other users are excluded.
     """
     organization_id, user_id = tenant_context
-    rows = crud.get_experiments(
+    rows = experiment_crud.get_experiments(
         db,
         skip=skip,
         limit=limit,


### PR DESCRIPTION
## Purpose

`app/crud/__init__.py` is the crud monolith that `apps/backend/AGENTS.md` says should only shrink from here. This continues the incremental split (#2588, #2590, #2591, #2592, #2597, #2599, #2600), taking out the smallest remaining block.

## What Changed

- New `crud/experiment.py` with `get_experiments`, moved verbatim from `crud/__init__.py`, importing only what it needs.
- 23 lines removed from `crud/__init__.py`. No re-export left behind — the old name is gone from the monolith.
- `routers/experiments.py` switched to `from rhesis.backend.app.crud import experiment as experiment_crud`. It keeps its `from rhesis.backend.app import crud` import because line 231 still uses `crud.delete_item`.

This is a pure move: no logic, signature or behaviour changes.

## Additional Context

- Unlike the Endpoint and TestSet blocks, this one has no `_*_RELATED_FIELDS` constant — the `include(...)` calls are inline in the query, so nothing else moved with it.
- A repo-wide grep for `get_experiments` found exactly two hits: the definition and the single router call. No direct-name imports, no function-local imports, and no `mock.patch` string targets pointing at it.
- After this and the sibling endpoint PR, what remains in the monolith is TestSet and Test, which have to move together — `get_test_sets_for_test`, `get_test_set_tests`, `resolve_test_set` and `bulk_delete_tests` straddle both entities.

## Testing

Full backend suite from `apps/backend`: `uv run pytest ../../tests/backend/` → **7802 passed, 62 skipped, 1 xfailed** in 5m23s.

Targeted: `tests/backend/routes/test_experiments.py` → 63 passed; `tests/backend/services/test_experiment_service.py` → 7 passed.

Ruff check and format clean on all three touched files.
