### PR TITLE
Add live verdict matrix for test run summary

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/crud/test_run.py
@@ -21,9 +21,10 @@ the cascade to test results is driven by ``config/cascade_config.py`` inside
 
 import logging
 import uuid
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy import func
+from sqlalchemy.engine import Row
 from sqlalchemy.orm import Session, joinedload
 
 from rhesis.backend.app import models, schemas
@@ -390,4 +391,102 @@ def get_test_run_task_ids(
     return {
         row.id: (row.status.name if row.status else None, (row.attributes or {}).get("task_id"))
         for row in rows
+    }
+
+
+def get_ordered_tests_for_test_set(
+    db: Session, test_set_id: uuid.UUID, organization_id: str = None
+) -> List[Tuple[str, Optional[str], bool]]:
+    """Return ``[(test_id, requirement_id, is_multi_turn)]`` for a test set, ordered by test id.
+
+    Lean projection query (no ORM model hydration) used to snapshot the metric
+    plan's ``test_order`` at dispatch time, as the fallback column list for a
+    legacy test run with no stored plan, and (via ``is_multi_turn``) to apply
+    the same single-turn/multi-turn scope filtering the execution path uses.
+    """
+    from rhesis.backend.app.constants import TestType
+    from rhesis.backend.app.models.test import Test, test_test_set_association
+    from rhesis.backend.app.models.type_lookup import TypeLookup
+
+    query = (
+        db.query(Test.id, Test.requirement_id, TypeLookup.type_value)
+        .join(test_test_set_association, test_test_set_association.c.test_id == Test.id)
+        .outerjoin(TypeLookup, Test.test_type_id == TypeLookup.id)
+        .filter(
+            test_test_set_association.c.test_set_id == test_set_id,
+            Test.deleted_at.is_(None),
+        )
+    )
+    if organization_id:
+        query = query.filter(Test.organization_id == uuid.UUID(str(organization_id)))
+
+    rows = query.order_by(Test.id).all()
+    return [
+        (
+            str(test_id),
+            str(requirement_id) if requirement_id else None,
+            type_value == TestType.MULTI_TURN.value,
+        )
+        for test_id, requirement_id, type_value in rows
+    ]
+
+
+def get_metric_verdicts_for_run(
+    db: Session, test_run_id: uuid.UUID, organization_id: str = None
+) -> List[Row]:
+    """Return one row per (test, metric) evaluated in this run, from ``v_metric_stats``.
+
+    Projects the five columns the verdict grid reads rather than hydrating
+    ``MetricStatsView`` instances: the verdict-matrix endpoint is refetched
+    on every coalesced progress tick, per connected client, and a large run
+    is tens of thousands of rows -- ORM hydration there is pure overhead for
+    values that are read once and encoded into a string.
+    """
+    query = db.query(
+        models.MetricStatsView.test_id,
+        models.MetricStatsView.requirement_id,
+        models.MetricStatsView.metric_name,
+        models.MetricStatsView.effective_success,
+        models.MetricStatsView.has_override,
+        models.MetricStatsView.created_at,
+    ).filter(models.MetricStatsView.test_run_id == test_run_id)
+    if organization_id:
+        query = query.filter(
+            models.MetricStatsView.organization_id == uuid.UUID(str(organization_id))
+        )
+    return query.all()
+
+
+def get_test_outcomes_for_run(
+    db: Session, test_run_id: uuid.UUID, organization_id: str = None
+) -> Dict[str, str]:
+    """Map ``test_id`` to its most recent result's status for this run.
+
+    Reads ``status_name`` directly rather than ``v_test_result_stats.result``:
+    that computed column only distinguishes passed/failed/pending and folds
+    an "Error" status into pending (its CASE expression has no branch for
+    it), which would make an execution error indistinguishable from a test
+    that hasn't run yet.
+    """
+    query = db.query(
+        models.TestResultStatsView.test_id,
+        models.TestResultStatsView.status_name,
+        models.TestResultStatsView.created_at,
+    ).filter(models.TestResultStatsView.test_run_id == test_run_id)
+    if organization_id:
+        query = query.filter(
+            models.TestResultStatsView.organization_id == uuid.UUID(str(organization_id))
+        )
+    rows = query.all()
+
+    latest: Dict[str, Tuple[Any, str]] = {}
+    for test_id, status_name, created_at in rows:
+        key = str(test_id)
+        if key not in latest or created_at > latest[key][0]:
+            latest[key] = (created_at, status_name)
+
+    outcome_by_status = {"pass": "passed", "fail": "failed", "error": "error"}
+    return {
+        test_id: outcome_by_status.get((status_name or "").lower(), "pending")
+        for test_id, (_, status_name) in latest.items()
     }

--- a/apps/backend/src/rhesis/backend/app/models/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/models/__init__.py
@@ -28,7 +28,7 @@ from .requirement import Requirement
 from .source import Source
 
 # Import stats view models
-from .stats_views import TestResultStatsView, TestRunStatsView
+from .stats_views import MetricStatsView, TestResultStatsView, TestRunStatsView
 
 # Import models without dependencies first
 from .status import Status
@@ -104,6 +104,7 @@ __all__ = [
     "test_set_metric_association",
     "TestRunStatsView",
     "TestResultStatsView",
+    "MetricStatsView",
     "Usage",
 ]
 

--- a/apps/backend/src/rhesis/backend/app/routers/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_run.py
@@ -7,13 +7,13 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models, schemas
-from rhesis.backend.app.crud import test_run as test_run_crud
-from rhesis.backend.app.crud.telemetry import query_traces
 from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.principal import resolve_principal_from_request
 from rhesis.backend.app.auth.rbac import authorize_object, project_id_from_scope
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.constants import EnrichedDataKeys
+from rhesis.backend.app.crud import test_run as test_run_crud
+from rhesis.backend.app.crud.telemetry import query_traces
 from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
@@ -21,6 +21,7 @@ from rhesis.backend.app.dependencies import (
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.telemetry import TraceListResponse, TraceSource, TraceSummary
+from rhesis.backend.app.services import test_run as services_test_run
 from rhesis.backend.app.services.test_run import (
     get_test_results_for_test_run,
     rescore_test_run,
@@ -30,7 +31,6 @@ from rhesis.backend.app.utils.database_exceptions import handle_database_excepti
 from rhesis.backend.app.utils.decorators import with_count_header
 from rhesis.backend.app.utils.odata import apply_select
 from rhesis.backend.jobs.enums import RunStatus
-
 
 router = RhesisRouter(
     prefix="/test_runs",
@@ -181,6 +181,29 @@ def get_test_run_metrics(
     return test_run_crud.get_test_run_metrics(
         db, test_run_id=test_run_id, organization_id=organization_id
     )
+
+
+@router.get("/{test_run_id}/verdict-matrix", response_model=schemas.VerdictMatrix)
+def get_verdict_matrix(
+    test_run_id: UUID,
+    columns: Optional[str] = Query(None),
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Get the encoded verdict grid (metric rows x test columns) for this test run.
+
+    Pass ``?columns=none`` to omit the test id column list -- the live
+    summary view only needs it on first load, not on every WebSocket-
+    triggered refetch.
+    """
+    organization_id, user_id = tenant_context
+    db_test_run = test_run_crud.get_test_run(
+        db, test_run_id=test_run_id, organization_id=organization_id, user_id=user_id
+    )
+    if db_test_run is None:
+        raise HTTPException(status_code=404, detail="Test run not found")
+    return services_test_run.get_verdict_matrix(db, db_test_run, columns=columns)
 
 
 @router.put("/{test_run_id}", response_model=schemas.TestRun)

--- a/apps/backend/src/rhesis/backend/app/schemas/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/__init__.py
@@ -173,6 +173,12 @@ from .test_run import (
     TestRunDetail,
     TestRunUpdate,
 )
+from .test_run_verdicts import (
+    VerdictKpis,
+    VerdictMatrix,
+    VerdictRequirement,
+    VerdictRow,
+)
 from .test_set import (
     ExplorerTestSetCreate,
     TestData,
@@ -302,6 +308,10 @@ __all__ = [
     "TestRunUpdate",
     "TestRunBulkDeleteRequest",
     "TestRunBulkDeleteResponse",
+    "VerdictKpis",
+    "VerdictMatrix",
+    "VerdictRequirement",
+    "VerdictRow",
     "Status",
     "StatusBase",
     "StatusCreate",

--- a/apps/backend/src/rhesis/backend/app/schemas/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_run.py
@@ -96,6 +96,7 @@ class TestConfigurationReference(Base, ServerIdentity):
 
 class TestRunDetail(TestRun):
     id: UUID4
+    project_id: Optional[UUID4] = None
     counts: Optional[Dict[str, Any]] = None
     tags: Optional[List[TagRead]] = None
     status: Optional[StatusReference] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/test_run_verdicts.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_run_verdicts.py
@@ -1,0 +1,54 @@
+"""The verdict matrix: metric rows grouped by requirement, one encoded string
+of per-test verdicts per row. See ``services/test_run.py:get_verdict_matrix``.
+
+Cell alphabet, one character per test per metric row:
+    ``.`` pending   ``P`` passed   ``F`` failed
+    ``S`` scored (no pass/fail threshold)   ``E`` error   ``X`` not applicable
+"""
+
+from typing import List, Optional
+
+from pydantic import UUID4, BaseModel
+
+from rhesis.backend.app.schemas.base import Base
+
+
+class VerdictKpis(BaseModel):
+    pass_rate: Optional[float] = None
+    tests_executed: int = 0
+    tests_total: int = 0
+    verdicts_resolved: int = 0
+    verdicts_planned: int = 0
+    failures: int = 0
+
+
+class VerdictRequirement(BaseModel):
+    id: Optional[UUID4] = None
+    name: str
+    metric_keys: List[str]
+
+
+class VerdictRow(BaseModel):
+    requirement_id: Optional[UUID4] = None
+    metric_key: str
+    metric_name: str
+    metric_id: Optional[UUID4] = None
+    ambiguous: bool = False
+    verdicts: str
+    overrides: str
+    passed: int = 0
+    failed: int = 0
+    pending: int = 0
+
+
+class VerdictMatrix(Base):
+    test_run_id: UUID4
+    project_id: Optional[UUID4] = None
+    status: str
+    is_terminal: bool
+    version: int = 0
+    test_ids: Optional[List[UUID4]] = None
+    test_status: str = ""
+    requirements: List[VerdictRequirement] = []
+    rows: List[VerdictRow] = []
+    kpis: VerdictKpis = VerdictKpis()

--- a/apps/backend/src/rhesis/backend/app/schemas/websocket.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/websocket.py
@@ -79,6 +79,11 @@ class EventType(str, Enum):
     JOB_STATUS_CHANGED = "job.status_changed"  # job.status transitioned
     JOB_ACTIVITY_APPENDED = "job.activity_appended"  # a new activity_log row
 
+    # Test run live progress. Published by TestRunSink onto a
+    # "test_run:{test_run_id}" channel -- a coalesced tick telling the client
+    # to refetch the verdict-matrix endpoint, not a payload to patch state from.
+    TEST_RUN_PROGRESSED = "test_run.progressed"
+
 
 class WebSocketMessage(BaseModel):
     """WebSocket message schema.

--- a/apps/backend/src/rhesis/backend/app/services/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_run.py
@@ -2,7 +2,7 @@ import csv
 import logging
 import uuid
 from io import StringIO
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy.orm import Session
 
@@ -10,10 +10,14 @@ from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.crud import prompt as prompt_crud
 from rhesis.backend.app.crud import test_configuration as test_configuration_crud
 from rhesis.backend.app.crud import test_result as test_result_crud
+from rhesis.backend.app.crud import test_run as test_run_crud
 from rhesis.backend.app.crud.metric import get_requirement_metrics
 from rhesis.backend.app.crud.test_run import get_test_run, get_test_run_requirements
 
 logger = logging.getLogger(__name__)
+
+# Statuses a test run never leaves -- the grid stops refetching once here.
+_TERMINAL_RUN_STATUSES = {"Completed", "Partial", "Failed", "Cancelled"}
 
 
 def get_test_results_for_test_run(
@@ -274,3 +278,269 @@ def rescore_test_run(
         "reference_test_run_id": reference_test_run_id,
         "task_id": result.id,
     }
+
+
+def _is_newer(candidate: Any, incumbent: Any) -> bool:
+    """Whether ``candidate`` should displace ``incumbent`` as a cell's verdict.
+
+    An undated row never displaces a dated one (the view's ``created_at`` is
+    non-null in practice; this only decides the degenerate case rather than
+    letting it silently reorder results).
+    """
+    if candidate is None:
+        return False
+    if incumbent is None:
+        return True
+    return candidate >= incumbent
+
+
+def _fallback_plan_from_results(
+    db: Session, test_run: models.TestRun, organization_id: Optional[str]
+) -> Dict[str, Any]:
+    """Best-effort plan for a run dispatched before the metric-plan snapshot shipped.
+
+    Derives rows from metrics that were actually recorded rather than what
+    would be planned prospectively -- this module must not import ``jobs/``
+    (see ``apps/backend/AGENTS.md``'s layering rule), and the prospective
+    planner lives in ``jobs/execution/metric_plan.py``, run at dispatch time.
+    Not-applicable (scope-filtered) cells are not reconstructed: a legacy
+    run just never shows an ``X``, which is a fine degradation for runs old
+    enough to predate this feature.
+    """
+    test_config = test_run.test_configuration
+    test_set_id = test_config.test_set_id if test_config else None
+    ordered = (
+        test_run_crud.get_ordered_tests_for_test_set(db, test_set_id, organization_id)
+        if test_set_id
+        else []
+    )
+    test_order = [test_id for test_id, _, _ in ordered]
+    requirement_by_test = {test_id: req_id for test_id, req_id, _ in ordered}
+
+    tests_by_group: Dict[Optional[str], List[str]] = {}
+    for test_id, req_id, _ in ordered:
+        tests_by_group.setdefault(req_id, []).append(test_id)
+
+    verdict_rows = test_run_crud.get_metric_verdicts_for_run(
+        db, test_run.id, organization_id=organization_id
+    )
+
+    metrics_by_group: Dict[Optional[str], List[str]] = {}
+    cell_keys: Dict[str, Dict[str, str]] = {}
+    for row in verdict_rows:
+        test_id = str(row.test_id)
+        req_id = str(row.requirement_id) if row.requirement_id else requirement_by_test.get(test_id)
+        names = metrics_by_group.setdefault(req_id, [])
+        if row.metric_name not in names:
+            names.append(row.metric_name)
+        # A recorded row is its own evidence that the metric applied to this
+        # test, and the key it applied under is the name itself -- the
+        # runtime already resolved any suffix before writing the JSONB.
+        cell_keys.setdefault(test_id, {})[row.metric_name] = row.metric_name
+
+    requirement_ids = [req_id for req_id in metrics_by_group if req_id is not None]
+    requirement_names = _requirement_names_for_fallback(db, requirement_ids, organization_id)
+
+    # A test that produced no verdict row yet still needs its own group's
+    # metrics marked applicable, or every unexecuted column would read as
+    # not-applicable instead of pending.
+    for req_id, metric_names in metrics_by_group.items():
+        for test_id in tests_by_group.get(req_id, []):
+            per_test = cell_keys.setdefault(test_id, {})
+            for name in metric_names:
+                per_test.setdefault(name, name)
+
+    requirements_payload = [
+        {
+            "id": req_id,
+            "name": requirement_names.get(req_id, "Unassigned") if req_id else "Unassigned",
+            "metrics": [
+                {"key": name, "name": name, "id": None, "ambiguous": False}
+                for name in sorted(metric_names)
+            ],
+            "test_ids": tests_by_group.get(req_id, []),
+        }
+        for req_id, metric_names in metrics_by_group.items()
+    ]
+
+    return {
+        "source": "legacy",
+        "requirements": requirements_payload,
+        "test_order": test_order,
+        "cell_keys": cell_keys,
+    }
+
+
+def _requirement_names_for_fallback(
+    db: Session, requirement_ids: List[str], organization_id: Optional[str]
+) -> Dict[str, str]:
+    if not requirement_ids:
+        return {}
+    query = db.query(models.Requirement.id, models.Requirement.name).filter(
+        models.Requirement.id.in_([uuid.UUID(r) for r in requirement_ids])
+    )
+    if organization_id:
+        query = query.filter(models.Requirement.organization_id == uuid.UUID(str(organization_id)))
+    return {str(rid): name for rid, name in query.all()}
+
+
+def get_verdict_matrix(
+    db: Session,
+    test_run: models.TestRun,
+    columns: Optional[str] = None,
+) -> schemas.VerdictMatrix:
+    """Build the encoded verdict grid for a test run.
+
+    One row per (requirement, metric); each row's ``verdicts`` string has one
+    character per test in ``test_ids``' order: ``.`` pending, ``P`` passed,
+    ``F`` failed, ``S`` scored with no pass/fail threshold, ``E`` execution
+    error, ``X`` not applicable to that test.
+    """
+    org_id = str(test_run.organization_id) if test_run.organization_id else None
+    attributes = test_run.attributes or {}
+    plan = attributes.get("metric_plan")
+    if not plan:
+        plan = _fallback_plan_from_results(db, test_run, org_id)
+
+    test_order: List[str] = plan.get("test_order", [])
+    cell_keys: Dict[str, Dict[str, str]] = plan.get("cell_keys", {})
+
+    verdict_rows = test_run_crud.get_metric_verdicts_for_run(
+        db, test_run.id, organization_id=org_id
+    )
+    # Keep the newest row per (test, metric). A test can hold more than one
+    # test_result in a run (a rescore, or a duplicate persist), and
+    # get_test_outcomes_for_run already resolves to the latest -- letting an
+    # arbitrary row win here would show a stale verdict beside a current
+    # status for the same test.
+    verdict_index: Dict[Tuple[str, str], Tuple[Optional[bool], bool]] = {}
+    verdict_seen_at: Dict[Tuple[str, str], Any] = {}
+    for row in verdict_rows:
+        cell = (str(row.test_id), row.metric_name)
+        if cell in verdict_seen_at and not _is_newer(row.created_at, verdict_seen_at[cell]):
+            continue
+        verdict_seen_at[cell] = row.created_at
+        verdict_index[cell] = (row.effective_success, bool(row.has_override))
+
+    outcomes = test_run_crud.get_test_outcomes_for_run(db, test_run.id, organization_id=org_id)
+
+    requirements_payload: List[schemas.VerdictRequirement] = []
+    rows_payload: List[schemas.VerdictRow] = []
+
+    verdicts_resolved = 0
+    verdicts_planned = 0
+
+    for group in plan.get("requirements", []):
+        req_id = group.get("id")
+        metrics = group.get("metrics", [])
+        requirements_payload.append(
+            schemas.VerdictRequirement(
+                id=req_id,
+                name=group.get("name", "Unassigned"),
+                metric_keys=[m["key"] for m in metrics],
+            )
+        )
+
+        # A row belongs to one requirement, so every column outside that
+        # requirement's own tests is structurally not-applicable. Without
+        # this the row would claim the whole run's width and -- when another
+        # requirement carries a same-named metric -- read that requirement's
+        # verdicts as its own, since verdict_index is keyed on
+        # (test_id, jsonb_key) with no requirement dimension.
+        group_test_ids = set(group.get("test_ids", test_order))
+
+        for metric in metrics:
+            key = metric["key"]
+            name = metric["name"]
+            metric_ref = metric.get("id") or key
+            chars: List[str] = []
+            override_chars: List[str] = []
+            passed = failed = pending = 0
+
+            for test_id in test_order:
+                if test_id not in group_test_ids:
+                    chars.append("X")
+                    override_chars.append("0")
+                    continue
+
+                # Absent from cell_keys = scope-filtered out for this test.
+                actual_key = cell_keys.get(test_id, {}).get(metric_ref)
+                if actual_key is None:
+                    chars.append("X")
+                    override_chars.append("0")
+                    continue
+
+                verdicts_planned += 1
+                entry = verdict_index.get((test_id, actual_key))
+                if entry is not None:
+                    effective_success, has_override = entry
+                    verdicts_resolved += 1
+                    override_chars.append("1" if has_override else "0")
+                    if effective_success is True:
+                        chars.append("P")
+                        passed += 1
+                    elif effective_success is False:
+                        chars.append("F")
+                        failed += 1
+                    else:
+                        chars.append("S")
+                elif outcomes.get(test_id) == "error":
+                    chars.append("E")
+                    override_chars.append("0")
+                    verdicts_resolved += 1
+                else:
+                    chars.append(".")
+                    override_chars.append("0")
+                    pending += 1
+
+            rows_payload.append(
+                schemas.VerdictRow(
+                    requirement_id=req_id,
+                    metric_key=key,
+                    metric_name=name,
+                    metric_id=metric.get("id"),
+                    ambiguous=metric.get("ambiguous", False),
+                    verdicts="".join(chars),
+                    overrides="".join(override_chars),
+                    passed=passed,
+                    failed=failed,
+                    pending=pending,
+                )
+            )
+
+    tests_executed = sum(1 for test_id in test_order if test_id in outcomes)
+    passing_tests = sum(1 for test_id in test_order if outcomes.get(test_id) == "passed")
+    failing_tests = sum(1 for test_id in test_order if outcomes.get(test_id) in ("failed", "error"))
+    # Pass rate is over tests, not over metric verdicts, to agree with the
+    # number the runs list and the run header already show
+    # (result_processor.get_test_statistics_for_runs). A test with four of
+    # five metrics passing is a failed test, but an 80% verdict rate -- the
+    # Summary tab reporting the latter would contradict every other view of
+    # the same run. Per-metric pass counts stay on each row.
+    pass_rate = (
+        passing_tests / (passing_tests + failing_tests) if (passing_tests + failing_tests) else None
+    )
+
+    status_name = test_run.status.name if test_run.status else ""
+
+    return schemas.VerdictMatrix(
+        test_run_id=test_run.id,
+        project_id=test_run.project_id,
+        status=status_name,
+        is_terminal=status_name in _TERMINAL_RUN_STATUSES,
+        test_ids=None if columns == "none" else [uuid.UUID(tid) for tid in test_order],
+        test_status="".join(
+            {"passed": "P", "failed": "F", "error": "E"}.get(outcomes.get(tid, ""), ".")
+            for tid in test_order
+        ),
+        requirements=requirements_payload,
+        rows=rows_payload,
+        kpis=schemas.VerdictKpis(
+            pass_rate=pass_rate,
+            tests_executed=tests_executed,
+            tests_total=len(test_order),
+            verdicts_resolved=verdicts_resolved,
+            verdicts_planned=verdicts_planned,
+            failures=failing_tests,
+        ),
+    )

--- a/apps/backend/src/rhesis/backend/events/__init__.py
+++ b/apps/backend/src/rhesis/backend/events/__init__.py
@@ -9,6 +9,7 @@ and are imported directly by callers that construct them.
 
 from rhesis.backend.events.dispatcher import emit, register_sink
 from rhesis.backend.events.sinks.activity_log import ActivityLogSink
+from rhesis.backend.events.sinks.test_run import TestRunSink
 from rhesis.backend.events.sinks.websocket import WebSocketSink
 
 __all__ = ["emit", "register_sink"]
@@ -18,3 +19,4 @@ __all__ = ["emit", "register_sink"]
 # FeatureName, exactly as SSO/API_CLIENTS/RBAC do today.
 register_sink(ActivityLogSink())
 register_sink(WebSocketSink())
+register_sink(TestRunSink())

--- a/apps/backend/src/rhesis/backend/events/sinks/test_run.py
+++ b/apps/backend/src/rhesis/backend/events/sinks/test_run.py
@@ -1,0 +1,79 @@
+"""Publishes coalesced ``test_run.progressed`` ticks to ``test_run:{id}``.
+
+Opens NO database session, unlike ``WebSocketSink``. The channel comes
+straight from the event's own ``entity_id`` -- ``entity_type="test_run"`` is
+set at the call site, no ``celery_task_id`` -> job lookup needed. That is the
+whole point of this sink: a run emits far too many of these ticks (one per
+test phase transition) for a DB round-trip per event to be affordable, so
+ticks are coalesced in-process and flushed at most once per window.
+"""
+
+import logging
+import threading
+from typing import Dict, Optional
+
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.schemas.websocket import (
+    ChannelTarget,
+    EventType,
+    WebSocketMessage,
+)
+from rhesis.backend.app.services.websocket.publisher import publish_event
+from rhesis.backend.events.types import PlatformEvent, TestRunProgressed
+
+logger = logging.getLogger(__name__)
+
+COALESCE_WINDOW_S = 0.5
+
+
+class TestRunSink:
+    name = "test_run"
+    critical = False
+
+    def __init__(self) -> None:
+        self._pending: Dict[str, TestRunProgressed] = {}
+        self._lock = threading.Lock()
+        self._timers: Dict[str, threading.Timer] = {}
+
+    def handles(self, event: PlatformEvent) -> bool:
+        return isinstance(event, TestRunProgressed)
+
+    def deliver(self, event: PlatformEvent, db: Optional[Session]) -> None:
+        if not isinstance(event, TestRunProgressed):
+            return
+        entity_id = str(event.entity_id) if event.entity_id else None
+        if not entity_id:
+            return
+
+        with self._lock:
+            self._pending[entity_id] = event
+            if entity_id not in self._timers:
+                timer = threading.Timer(COALESCE_WINDOW_S, self._flush, args=[entity_id])
+                timer.daemon = True
+                timer.start()
+                self._timers[entity_id] = timer
+
+    def _flush(self, entity_id: str) -> None:
+        with self._lock:
+            event = self._pending.pop(entity_id, None)
+            self._timers.pop(entity_id, None)
+        if event is None:
+            return
+        try:
+            channel = ChannelTarget(channel=f"test_run:{entity_id}")
+            publish_event(
+                WebSocketMessage(
+                    type=EventType.TEST_RUN_PROGRESSED,
+                    channel=channel.channel,
+                    payload={
+                        "completed": event.completed,
+                        "total": event.total,
+                        "generating_test_ids": [str(tid) for tid in event.generating_test_ids],
+                        "evaluating_test_ids": [str(tid) for tid in event.evaluating_test_ids],
+                    },
+                ),
+                channel,
+            )
+        except Exception:
+            logger.debug("TestRunSink: publish failed for %s", entity_id, exc_info=True)

--- a/apps/backend/src/rhesis/backend/events/types.py
+++ b/apps/backend/src/rhesis/backend/events/types.py
@@ -20,7 +20,7 @@ test that can prove it works.
 """
 
 from datetime import datetime
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -102,3 +102,17 @@ class ActivityLogged(PlatformEvent):
     event_type: Literal["activity.logged"] = "activity.logged"
     level: Literal["info", "warning", "error"]
     message: str
+
+
+class TestRunProgressed(PlatformEvent):
+    """Coalesced grid tick -- counters and bounded in-flight ids only.
+
+    No per-verdict detail: the client refetches the verdict-matrix endpoint
+    on receipt instead of patching state from the payload. See TestRunSink.
+    """
+
+    event_type: Literal["test_run.progressed"] = "test_run.progressed"
+    completed: int
+    total: int
+    generating_test_ids: List[UUID] = Field(default_factory=list)
+    evaluating_test_ids: List[UUID] = Field(default_factory=list)

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/__init__.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/__init__.py
@@ -152,6 +152,7 @@ def execute_tests_as_batch(
     trace_id: Optional[str] = None,
     on_progress=None,
     on_emit=None,
+    on_test_phase=None,
 ) -> Dict[str, Any]:
     """Three-phase batch execution: pre-fetch, asyncio.gather, trigger results."""
     from rhesis.backend.jobs.execution.shared import (
@@ -200,7 +201,15 @@ def execute_tests_as_batch(
 
     # Phase 2: Async execution (DB-free, uses deferred tracing).
     test_ids = [str(t.id) for t in tests if str(t.id) in ctx.test_data]
-    results = _run_async(run_batch(ctx, test_ids, on_progress=on_progress, on_emit=on_emit))
+    results = _run_async(
+        run_batch(
+            ctx,
+            test_ids,
+            on_progress=on_progress,
+            on_emit=on_emit,
+            on_test_phase=on_test_phase,
+        )
+    )
 
     # Write error TestResult rows for tests that failed without being persisted
     # (e.g. invocation exceptions, timeouts).  Must run before trigger_results_collection

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/evaluation.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/evaluation.py
@@ -38,19 +38,10 @@ async def evaluate_metrics(
         )
         return {}
 
-    on_metric_complete = None
-    if on_emit:
-
-        def on_metric_complete(metric_key: str, result: Dict[str, Any]) -> None:
-            error = result.get("error")
-            if error:
-                on_emit(f"  {metric_key}: error ({error})")
-                return
-            passed = result.get("is_successful")
-            score = result.get("score", "?")
-            label = "passed" if passed else ("failed" if passed is False else "scored")
-            on_emit(f"  {metric_key}: {label} ({score})")
-
+    # No per-metric on_emit narration here: at 4-7 metrics/test this was
+    # producing ~28,000 ActivityLogged events (each opening its own DB
+    # session) for a single 4,000-test run. The batch-level progress line in
+    # runner.py's _tracked already narrates per-test completion.
     metrics_results = dict(penelope_metrics)
     test_metric_configs = ctx.get_metric_configs_for_test(test_id)
     try:
@@ -62,7 +53,6 @@ async def evaluate_metrics(
                     test,
                     output,
                     test_metric_configs,
-                    on_metric_complete=on_metric_complete,
                 )
             )
         else:
@@ -75,7 +65,6 @@ async def evaluate_metrics(
                     prompt_content,
                     expected_response,
                     test_metric_configs,
-                    on_metric_complete=on_metric_complete,
                 )
             )
     except Exception as e:

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/runner.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/runner.py
@@ -80,12 +80,19 @@ async def _run_gather(
     progress_base: int = 0,
     progress_total: int = 0,
     on_emit: Any = None,
+    on_test_phase: Any = None,
 ) -> List[Dict[str, Any]]:
     """Fan out test_ids as asyncio Tasks and gather results."""
     completed_count = 0
+    last_emit_time = time.monotonic()
+    # At most ~20 progress lines per batch, or one every 2s, whichever comes
+    # first, plus always the last one. Emitting every single test completion
+    # was producing ~4,000 ActivityLogged events (each opening a DB session)
+    # for a single 4,000-test run.
+    emit_interval = max(1, progress_total // 20) if progress_total else 1
 
     async def _tracked(test_id: str) -> Dict[str, Any]:
-        nonlocal completed_count
+        nonlocal completed_count, last_emit_time
         td = ctx.test_data.get(test_id)
         test_obj = td.get("test") if td else None
         cat_obj = getattr(test_obj, "category", None)
@@ -100,6 +107,7 @@ async def _run_gather(
                 penelope_agent,
                 evaluator,
                 on_emit=on_emit,
+                on_test_phase=on_test_phase,
             )
             status = result.get("status", "completed")
             return result
@@ -112,13 +120,24 @@ async def _run_gather(
                 except Exception:
                     pass
             if on_emit and progress_total:
-                try:
-                    label = f" — {category}" if category else ""
-                    error = result.get("error", "") if isinstance(result, dict) else ""
-                    suffix = f": {error}" if error and status == "failed" else ""
-                    on_emit(f"Test {current}/{progress_total} {status}{label}{suffix}")
-                except Exception:
-                    pass
+                now = time.monotonic()
+                # Failures are never throttled -- they carry the error text,
+                # which is the whole reason to read the activity log, and
+                # they are rare enough not to reintroduce the volume problem.
+                if (
+                    status == "failed"
+                    or current % emit_interval == 0
+                    or current == progress_total
+                    or now - last_emit_time > 2.0
+                ):
+                    try:
+                        label = f" — {category}" if category else ""
+                        error = result.get("error", "") if isinstance(result, dict) else ""
+                        suffix = f": {error}" if error and status == "failed" else ""
+                        on_emit(f"Test {current}/{progress_total} {status}{label}{suffix}")
+                        last_emit_time = now
+                    except Exception:
+                        pass
 
     tasks = [asyncio.create_task(_tracked(test_id)) for test_id in test_ids]
     watchdog = asyncio.create_task(_cancellation_watchdog(ctx.celery_task_id, tasks))
@@ -159,6 +178,7 @@ async def run_batch(
     test_ids: List[str],
     on_progress: Any = None,
     on_emit: Any = None,
+    on_test_phase: Any = None,
 ) -> List[Dict[str, Any]]:
     """Async entry point: run all tests with semaphore-gated concurrency.
 
@@ -232,6 +252,7 @@ async def run_batch(
         progress_base=0,
         progress_total=total,
         on_emit=on_emit,
+        on_test_phase=on_test_phase,
     )
 
     # --- Recovery pass passes ---
@@ -256,8 +277,17 @@ async def run_batch(
                     logger.warning(f"[BATCH] Recovery pass: no snapshot data for {tid}, skipping")
                     retry_ids = [t for t in retry_ids if t != tid]
 
+            # on_test_phase is threaded through here (unlike on_progress /
+            # on_emit, which would double-count against progress_total) so
+            # the live grid keeps ticking through recovery instead of
+            # freezing on the last main-pass state.
             recovery_results = await _run_gather(
-                ctx, retry_ids, semaphore, penelope_agent, evaluator
+                ctx,
+                retry_ids,
+                semaphore,
+                penelope_agent,
+                evaluator,
+                on_test_phase=on_test_phase,
             )
 
             recovered = 0
@@ -297,15 +327,28 @@ async def _execute_single_test(
     penelope_agent: Any = None,
     evaluator: Any = None,
     on_emit: Any = None,
+    on_test_phase: Any = None,
 ) -> Dict[str, Any]:
     """Unified coroutine for both single-turn and multi-turn tests."""
     async with semaphore:
+        # Both short-circuits below still report "done": they are terminal
+        # for this test, and without it the grid's completed count would
+        # never reach total on a run with skipped or unprefetched tests.
+        def _report_done() -> None:
+            if on_test_phase:
+                try:
+                    on_test_phase(test_id, "done")
+                except Exception:
+                    logger.debug("on_test_phase(done) failed", exc_info=True)
+
         if test_id in ctx.existing_result_ids:
             logger.info(f"[BATCH] Skipping test {test_id}: result already exists")
+            _report_done()
             return {"test_id": test_id, "status": "skipped", "execution_time": 0}
 
         td = ctx.test_data.get(test_id)
         if not td:
+            _report_done()
             return {
                 "test_id": test_id,
                 "status": "failed",
@@ -318,6 +361,12 @@ async def _execute_single_test(
         expected_response = td["expected_response"]
 
         is_multi_turn = is_multi_turn_test(test)
+
+        if on_test_phase:
+            try:
+                on_test_phase(test_id, "generating")
+            except Exception:
+                logger.debug("on_test_phase(generating) failed", exc_info=True)
 
         test_execution_context = {
             "test_run_id": str(ctx.test_run.id),
@@ -350,6 +399,11 @@ async def _execute_single_test(
                 deferred_traces = result.get("deferred_traces", deferred_traces)
                 # Absent for single-turn tests, which have no evaluation contract concept.
                 contract_usable = result.get("contract_usable", True)
+                if on_test_phase:
+                    try:
+                        on_test_phase(test_id, "evaluating")
+                    except Exception:
+                        logger.debug("on_test_phase(evaluating) failed", exc_info=True)
             except asyncio.TimeoutError:
                 logger.error(f"[BATCH] Test {test_id} timed out after {ctx.per_test_timeout}s")
                 return {
@@ -438,6 +492,11 @@ async def _execute_single_test(
         finally:
             ctx.test_data.pop(test_id, None)
             ctx.input_files.pop(test_id, None)
+            if on_test_phase:
+                try:
+                    on_test_phase(test_id, "done")
+                except Exception:
+                    logger.debug("on_test_phase(done) failed", exc_info=True)
             deferred_traces.clear()
             output.clear()
             penelope_metrics.clear()

--- a/apps/backend/src/rhesis/backend/jobs/execution/metric_plan.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/metric_plan.py
@@ -1,0 +1,229 @@
+"""Snapshot which metrics apply to which tests, frozen at dispatch time.
+
+Stored on ``test_run.attributes["metric_plan"]`` so the verdict grid's frame
+(requirements, metric rows, column count) is known before any test runs --
+before this, the grid could only be built retroactively from recorded
+``test_result`` rows, which is what ``app/services/test_run.py`` falls back
+to for a run dispatched before this shipped.
+
+Lives under ``jobs/`` rather than ``app/services/`` because it needs
+``get_test_metrics`` and ``filter_configs_by_scope``, both jobs-internal --
+see ``apps/backend/AGENTS.md``'s "jobs/ depends on services/utils, never the
+reverse" rule.
+
+Plan shape::
+
+    {
+      "source": "requirement" | "test_set" | "execution_time" | "none" | "mixed",
+      "requirements": [
+        {"id", "name", "metrics": [{"key", "name", "id", "ambiguous"}], "test_ids": [...]}
+      ],
+      "test_order": [test_id, ...],          # every column, in grid order
+      "cell_keys": {test_id: {metric_ref: jsonb_key}},
+    }
+
+``test_ids`` is what scopes a metric row to its own requirement's columns: a
+row spans every column in ``test_order``, so without it a row would claim
+cells for tests belonging to some other requirement, and (when two
+requirements carry a same-named metric) read that other requirement's
+verdicts as its own.
+
+``cell_keys`` maps a metric row to the ``test_metrics`` JSONB key the runtime
+will actually store that metric's result under, per test. It is not always
+the row's own ``key``: the runtime assigns duplicate-name suffixes *after*
+scope filtering (``batch/evaluation.py`` filters, then
+``LocalStrategy._generate_unique_metric_keys`` numbers the survivors), so for
+two same-named metrics of differing scope the survivor takes the bare name
+whichever one it is. A missing entry means the metric does not apply to that
+test at all.
+"""
+
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.crud.test_run import get_ordered_tests_for_test_set
+from rhesis.backend.app.models.test_configuration import TestConfiguration
+from rhesis.backend.app.models.test_set import TestSet
+from rhesis.backend.app.schemas.metric import MetricScope
+from rhesis.backend.jobs.execution.evaluation import filter_configs_by_scope
+from rhesis.backend.jobs.execution.executors.data import get_test_metrics
+
+_EMPTY_PLAN: Dict[str, Any] = {
+    "source": "none",
+    "requirements": [],
+    "test_order": [],
+    "cell_keys": {},
+}
+
+
+def _assign_metric_keys(metrics: List[models.Metric]) -> List[Tuple[str, models.Metric, bool]]:
+    """Mirror ``_generate_unique_metric_keys`` in metrics/strategies/local.py.
+
+    Same stable sort (name, class_name, id) and ``_N`` suffixing, so a
+    metric's key here matches the key its result actually lands under.
+    ``ambiguous`` is True whenever more than one metric in this group shares
+    a base key, including the one that keeps the bare key.
+    """
+    base_keys = [m.name if m.name and m.name.strip() else m.class_name for m in metrics]
+    counts: Dict[str, int] = {}
+    for key in base_keys:
+        counts[key] = counts.get(key, 0) + 1
+
+    order = sorted(
+        range(len(metrics)),
+        key=lambda i: (base_keys[i], metrics[i].class_name or "", str(metrics[i].id or "")),
+    )
+    used: set = set()
+    assigned: Dict[int, str] = {}
+    for i in order:
+        base_key = base_keys[i]
+        unique_key = base_key
+        counter = 1
+        while unique_key in used:
+            unique_key = f"{base_key}_{counter}"
+            counter += 1
+        used.add(unique_key)
+        assigned[i] = unique_key
+
+    return [(assigned[i], metrics[i], counts[base_keys[i]] > 1) for i in range(len(metrics))]
+
+
+def _metric_ref(metric: models.Metric, key: str) -> str:
+    """Stable per-row identity for cell_keys, independent of the display key."""
+    return str(metric.id) if metric.id else key
+
+
+def _requirement_names(
+    db: Session, requirement_ids: List[str], organization_id: Optional[str]
+) -> Dict[str, str]:
+    if not requirement_ids:
+        return {}
+    query = db.query(models.Requirement.id, models.Requirement.name).filter(
+        models.Requirement.id.in_([uuid.UUID(r) for r in requirement_ids])
+    )
+    if organization_id:
+        query = query.filter(models.Requirement.organization_id == uuid.UUID(str(organization_id)))
+    return {str(rid): name for rid, name in query.all()}
+
+
+def build_metric_plan(
+    db: Session,
+    test_config: TestConfiguration,
+    test_set: TestSet,
+    organization_id: str = None,
+    user_id: str = None,
+) -> Dict[str, Any]:
+    """Snapshot which metrics apply to which tests, frozen at dispatch.
+
+    Metric resolution is delegated to ``get_test_metrics`` per requirement
+    group rather than once for the whole run: its three-level priority
+    (execution-time config > test set > requirement) is evaluated against a
+    specific test, so asking one arbitrary "sample" test would let a single
+    requirement-less test collapse the entire plan to zero rows.
+
+    Restores ``db.info['_scope']`` on the way out. ``get_test_metrics`` calls
+    ``bind_scope_to_session``, and this runs inside the FastAPI request that
+    dispatches the run -- leaving that bound would apply a stale project
+    filter to every later query on the request's session (see
+    ``apps/backend/AGENTS.md``, "Side-channel and in-request scope binding").
+    """
+    scope_before = db.info.get("_scope")
+    try:
+        return _build_metric_plan(db, test_config, test_set, organization_id, user_id)
+    finally:
+        if scope_before is None:
+            db.info.pop("_scope", None)
+        else:
+            db.info["_scope"] = scope_before
+
+
+def _build_metric_plan(
+    db: Session,
+    test_config: TestConfiguration,
+    test_set: TestSet,
+    organization_id: Optional[str],
+    user_id: Optional[str],
+) -> Dict[str, Any]:
+    ordered = get_ordered_tests_for_test_set(db, test_set.id, organization_id)
+    test_order = [test_id for test_id, _, _ in ordered]
+    if not ordered:
+        return {**_EMPTY_PLAN, "test_order": test_order}
+
+    tests_by_group: Dict[Optional[str], List[str]] = {}
+    is_multi_turn_by_test: Dict[str, bool] = {}
+    for test_id, req_id, is_multi_turn in ordered:
+        tests_by_group.setdefault(req_id, []).append(test_id)
+        is_multi_turn_by_test[test_id] = is_multi_turn
+
+    requirement_ids = sorted(g for g in tests_by_group if g is not None)
+    groups: List[Optional[str]] = requirement_ids + ([None] if None in tests_by_group else [])
+    requirement_names = _requirement_names(db, requirement_ids, organization_id)
+
+    requirements_payload: List[Dict[str, Any]] = []
+    cell_keys: Dict[str, Dict[str, str]] = {}
+    sources: set = set()
+
+    for group in groups:
+        group_test_ids = tests_by_group.get(group, [])
+        representative = (
+            db.query(models.Test).filter(models.Test.id == uuid.UUID(group_test_ids[0])).first()
+        )
+        if representative is None:
+            metrics, source = [], "none"
+        else:
+            metrics, source = get_test_metrics(
+                representative,
+                db,
+                organization_id=organization_id,
+                user_id=user_id,
+                test_set=test_set,
+                test_configuration=test_config,
+                return_source=True,
+            )
+        sources.add(source)
+
+        keyed = _assign_metric_keys(metrics)
+        requirements_payload.append(
+            {
+                "id": group,
+                "name": requirement_names.get(group, "Unassigned") if group else "Unassigned",
+                "metrics": [
+                    {
+                        "key": key,
+                        "name": metric.name or metric.class_name,
+                        "id": str(metric.id) if metric.id else None,
+                        "ambiguous": ambiguous,
+                    }
+                    for key, metric, ambiguous in keyed
+                ],
+                "test_ids": group_test_ids,
+            }
+        )
+
+        for test_id in group_test_ids:
+            scope = (
+                MetricScope.MULTI_TURN
+                if is_multi_turn_by_test.get(test_id)
+                else MetricScope.SINGLE_TURN
+            )
+            kept = filter_configs_by_scope([metric for _, metric, _ in keyed], scope, test_id)
+            # Re-key the survivors the way the runtime will, so a suffix that
+            # only exists because of a filtered-out sibling doesn't end up in
+            # the lookup. Identical to the row key whenever no name collides.
+            runtime_key_by_metric = {id(m): key for key, m, _ in _assign_metric_keys(kept)}
+            row_key_by_metric = {id(m): key for key, m, _ in keyed}
+            per_test = {
+                _metric_ref(m, row_key_by_metric[id(m)]): runtime_key_by_metric[id(m)] for m in kept
+            }
+            if per_test:
+                cell_keys[test_id] = per_test
+
+    return {
+        "source": sources.pop() if len(sources) == 1 else "mixed",
+        "requirements": requirements_payload,
+        "test_order": test_order,
+        "cell_keys": cell_keys,
+    }

--- a/apps/backend/src/rhesis/backend/jobs/execution/orchestration.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/orchestration.py
@@ -30,6 +30,7 @@ def execute_test_cases(
     trace_id: str = None,
     on_progress=None,
     on_emit=None,
+    on_test_phase=None,
 ) -> Dict[str, Any]:
     """Execute test cases based on the configured execution mode.
 
@@ -41,6 +42,9 @@ def execute_test_cases(
         trace_id: Optional trace ID for trace-based evaluation
         on_progress: Optional callback(current, total) to update job progress
         on_emit: Optional callback(message) to write activity log entries
+        on_test_phase: Optional callback(test_id, phase) for "generating" /
+            "evaluating" transitions, batch mode only (see sequential.py for
+            why the sequential path only ever reports "generating")
     """
 
     test_set = get_test_set(session, str(test_config.test_set_id), str(test_config.organization_id))
@@ -68,6 +72,7 @@ def execute_test_cases(
             trace_id=trace_id,
             on_progress=on_progress,
             on_emit=on_emit,
+            on_test_phase=on_test_phase,
         )
     else:
         return execute_tests_as_batch(
@@ -79,4 +84,5 @@ def execute_test_cases(
             trace_id=trace_id,
             on_progress=on_progress,
             on_emit=on_emit,
+            on_test_phase=on_test_phase,
         )

--- a/apps/backend/src/rhesis/backend/jobs/execution/results.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/results.py
@@ -2,6 +2,7 @@
 Task for collecting and processing test execution results.
 """
 
+import logging
 from datetime import datetime, timezone
 from typing import Any, Dict
 from uuid import UUID
@@ -13,6 +14,42 @@ from rhesis.backend.celery.core import app
 from rhesis.backend.jobs.base import EmailEnabledJob, email_notification, in_app_notification
 from rhesis.backend.jobs.execution.result_processor import TestRunProcessor
 from rhesis.backend.notifications.email.template_service import EmailTemplate
+
+logger = logging.getLogger(__name__)
+
+
+def _emit_terminal_tick(task, test_run, org_id, user_id, project_id, total: int) -> None:
+    """Publish one last grid tick after the run's terminal status is written.
+
+    Every other tick comes from an in-flight phase transition, and the last
+    of those fires before this task runs -- so without this the final
+    coalesced publish still reports the run as in Progress, and a client
+    that stops refetching on ``is_terminal`` never learns the run finished.
+    """
+    try:
+        from rhesis.backend.events import emit
+        from rhesis.backend.events.correlation import resolve_ids
+        from rhesis.backend.events.types import TestRunProgressed
+
+        trace_id, span_id = resolve_ids()
+        emit(
+            TestRunProgressed(
+                occurred_at=datetime.now(timezone.utc),
+                organization_id=UUID(org_id),
+                project_id=UUID(project_id) if project_id else None,
+                user_id=UUID(user_id) if user_id else None,
+                trace_id=trace_id,
+                span_id=span_id,
+                celery_task_id=getattr(task.request, "id", None),
+                entity_type="test_run",
+                entity_id=test_run.id,
+                source="collect_results",
+                completed=total,
+                total=total,
+            )
+        )
+    except Exception:
+        logger.debug("Terminal TestRunProgressed emit failed", exc_info=True)
 
 
 @in_app_notification(NotificationEventType.TestRun.EXECUTION_COMPLETED)
@@ -94,6 +131,7 @@ def collect_results(self, *args, **kwargs) -> Dict[str, Any]:
             if exec_time:
                 summary_line += f" in {exec_time}"
             self.emit(summary_line)
+            _emit_terminal_tick(self, test_run, org_id, user_id, project_id, total)
             self.log_with_context("info", f"Test run update completed for: {test_run_id}")
 
             return summary_data

--- a/apps/backend/src/rhesis/backend/jobs/execution/run.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/run.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 from typing import Dict
 
@@ -9,6 +10,8 @@ from rhesis.backend.app.models.test_configuration import TestConfiguration
 from rhesis.backend.app.models.test_run import TestRun
 from rhesis.backend.app.utils.crud_utils import get_or_create_status
 from rhesis.backend.jobs.enums import RunStatus
+
+logger = logging.getLogger(__name__)
 
 
 class TestExecutionError(Exception):
@@ -85,6 +88,36 @@ def create_test_run(
         organization_id=str(test_config.organization_id),
         user_id=str(executor_user_id) if executor_user_id else str(test_config.user_id or ""),
     )
+
+    # Freeze the verdict grid's frame (requirements, metric rows, column
+    # count) before any test runs -- see jobs/execution/metric_plan.py.
+    # Best-effort: a run whose plan could not be built still dispatches, and
+    # get_verdict_matrix rebuilds a grid from recorded results instead.
+    if test_config.test_set_id and test_config.test_set is not None:
+        from rhesis.backend.jobs.execution.metric_plan import build_metric_plan
+
+        # SAVEPOINT, not a bare try: the plan runs several queries, and a DB
+        # error in any of them (statement timeout, serialization failure)
+        # aborts the surrounding transaction. Swallowing that without
+        # rolling back would turn a skippable snapshot into an
+        # InFailedSqlTransaction on the create_test_run below.
+        nested = session.begin_nested()
+        try:
+            snapshot.attributes["metric_plan"] = build_metric_plan(
+                session,
+                test_config,
+                test_config.test_set,
+                organization_id=str(test_config.organization_id),
+                user_id=str(executor_user_id) if executor_user_id else None,
+            )
+            nested.commit()
+        except Exception:
+            nested.rollback()
+            snapshot.attributes.pop("metric_plan", None)
+            logger.warning(
+                f"Failed to build metric plan for test configuration {test_config.id}",
+                exc_info=True,
+            )
 
     test_run_data = {
         "test_configuration_id": test_config.id,

--- a/apps/backend/src/rhesis/backend/jobs/execution/sequential.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/sequential.py
@@ -34,6 +34,7 @@ def execute_tests_sequentially(
     trace_id: str = None,
     on_progress=None,
     on_emit=None,
+    on_test_phase=None,
 ) -> Dict[str, Any]:
     """Execute test cases sequentially, one after another.
 
@@ -46,6 +47,10 @@ def execute_tests_sequentially(
         trace_id: Optional trace ID for trace-based evaluation
         on_progress: Optional callback(current, total) to update job progress
         on_emit: Optional callback(message) to write activity log entries
+        on_test_phase: Optional callback(test_id, phase). Only ever reports
+            "generating", right before the test runs -- unlike the batch
+            path, there is no seam between invocation and evaluation here to
+            report "evaluating" from (execute_test does both in one call).
     """
     logger.info(f"Starting sequential execution for test run {test_run.id} with {len(tests)} tests")
 
@@ -144,6 +149,12 @@ def execute_tests_sequentially(
 
         logger.info(f"Executing test {i}/{len(tests)}: {test.id}")
 
+        if on_test_phase:
+            try:
+                on_test_phase(str(test.id), "generating")
+            except Exception:
+                logger.debug("on_test_phase(generating) failed", exc_info=True)
+
         try:
             import asyncio
 
@@ -181,6 +192,12 @@ def execute_tests_sequentially(
                 on_progress(i, len(tests))
             if on_emit:
                 on_emit(f"Test {i}/{len(tests)} failed")
+        finally:
+            if on_test_phase:
+                try:
+                    on_test_phase(str(test.id), "done")
+                except Exception:
+                    logger.debug("on_test_phase(done) failed", exc_info=True)
 
     end_time = datetime.now(timezone.utc)
     execution_time = (end_time - start_time).total_seconds()

--- a/apps/backend/src/rhesis/backend/jobs/test_configuration.py
+++ b/apps/backend/src/rhesis/backend/jobs/test_configuration.py
@@ -3,6 +3,7 @@ This module contains the main entry point for test configuration execution,
 with detailed implementation in the execution/ directory modules.
 """
 
+import logging
 from uuid import UUID
 
 from rhesis.backend.app.crud.test_run import get_test_run
@@ -25,6 +26,68 @@ from rhesis.backend.jobs.utils import (
     update_test_run_with_error,
     validate_task_parameters,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _make_on_test_phase(self, test_run, org_id, user_id, project_id, total_tests):
+    """Build the in-flight phase callback for the verdict grid's live columns.
+
+    Tracks generating/evaluating test ids locally (there is no shared
+    ExecutionContext between the batch and sequential paths) and emits a
+    TestRunProgressed tick on every transition -- cheap to call at this
+    frequency because TestRunSink coalesces publishes per test run at 500ms;
+    this call site is not where the volume reduction happens.
+    """
+    from datetime import datetime, timezone
+
+    generating_ids: set = set()
+    evaluating_ids: set = set()
+    # A set, not a counter: a recovery pass re-runs a test through the whole
+    # generating -> evaluating -> done cycle, and counting each "done" would
+    # push completed past total.
+    completed_ids: set = set()
+
+    def _on_test_phase(test_id: str, phase: str) -> None:
+        if phase == "generating":
+            generating_ids.add(test_id)
+            evaluating_ids.discard(test_id)
+        elif phase == "evaluating":
+            generating_ids.discard(test_id)
+            evaluating_ids.add(test_id)
+        elif phase == "done":
+            completed_ids.add(test_id)
+            generating_ids.discard(test_id)
+            evaluating_ids.discard(test_id)
+
+        try:
+            from rhesis.backend.events import emit
+            from rhesis.backend.events.correlation import resolve_ids
+            from rhesis.backend.events.types import TestRunProgressed
+
+            trace_id, span_id = resolve_ids()
+            emit(
+                TestRunProgressed(
+                    occurred_at=datetime.now(timezone.utc),
+                    organization_id=UUID(org_id),
+                    project_id=UUID(project_id) if project_id else None,
+                    user_id=UUID(user_id) if user_id else None,
+                    trace_id=trace_id,
+                    span_id=span_id,
+                    celery_task_id=getattr(self.request, "id", None),
+                    entity_type="test_run",
+                    entity_id=test_run.id,
+                    source="execute_test_configuration",
+                    completed=len(completed_ids),
+                    total=total_tests,
+                    generating_test_ids=[UUID(tid) for tid in generating_ids],
+                    evaluating_test_ids=[UUID(tid) for tid in evaluating_ids],
+                )
+            )
+        except Exception:
+            logger.debug("TestRunProgressed emit failed", exc_info=True)
+
+    return _on_test_phase
 
 
 @app.task(
@@ -166,6 +229,9 @@ def execute_test_configuration(self, test_configuration_id: str, test_run_id: st
             self.emit(f"Executing {' '.join(context_parts)}")
 
             # Execute test cases (parallel or sequential)
+            on_test_phase = _make_on_test_phase(
+                self, test_run, org_id, user_id, project_id, total_tests
+            )
             result = execute_test_cases(
                 db,
                 test_config,
@@ -173,6 +239,7 @@ def execute_test_configuration(self, test_configuration_id: str, test_run_id: st
                 reference_test_run_id=reference_test_run_id,
                 on_progress=self.set_progress,
                 on_emit=self.emit,
+                on_test_phase=on_test_phase,
             )
             self.emit(f"Execution complete")
 

--- a/apps/backend/src/rhesis/backend/metrics/metric_config.py
+++ b/apps/backend/src/rhesis/backend/metrics/metric_config.py
@@ -157,6 +157,9 @@ def metric_model_to_config(metric: MetricModel) -> MetricConfig:
     field_names = {f.name for f in dataclasses.fields(MetricConfig)}
     filtered = {k: v for k, v in config.items() if k in field_names}
     cfg = MetricConfig(**filtered)
+    # Needed so _generate_unique_metric_keys can break a (name, class_name)
+    # tie deterministically when two distinct metrics happen to share both.
+    cfg.id = str(metric.id) if metric.id else None
     if model_id := (str(metric.model_id) if metric.model_id else None):
         cfg.parameters = dict(cfg.parameters or {})
         cfg.parameters["model_id"] = model_id

--- a/apps/backend/src/rhesis/backend/metrics/strategies/local.py
+++ b/apps/backend/src/rhesis/backend/metrics/strategies/local.py
@@ -345,11 +345,26 @@ class LocalStrategy:
     def _generate_unique_metric_keys(
         self, metric_tasks: List[Tuple[str, BaseMetric, MetricConfig, str]]
     ) -> Tuple[List[str], Dict[str, Any]]:
-        metric_keys = []
-        used_keys: set = set()
-        results: Dict[str, Any] = {}
+        # Suffixes are assigned in a stable order (name, class_name, id) rather
+        # than the caller's iteration order, which is not guaranteed stable
+        # across runs. Otherwise two duplicate-named metrics could swap which
+        # one gets the bare key and which gets "_1" from one run to the next,
+        # breaking the verdict matrix's assumption that a metric key identifies
+        # the same metric across the run's lifetime.
+        def _stable_sort_key(index: int) -> Tuple[str, str, str]:
+            _, _, metric_config, _ = metric_tasks[index]
+            return (
+                metric_config.name or "",
+                metric_config.class_name or "",
+                str(metric_config.id or ""),
+            )
 
-        for class_name, metric, metric_config, backend in metric_tasks:
+        order = sorted(range(len(metric_tasks)), key=_stable_sort_key)
+
+        used_keys: set = set()
+        assigned: Dict[int, str] = {}
+        for index in order:
+            class_name, metric, metric_config, backend = metric_tasks[index]
             metric_name = metric_config.name
             base_key = metric_name if metric_name and metric_name.strip() else class_name
 
@@ -360,8 +375,10 @@ class LocalStrategy:
                 counter += 1
 
             used_keys.add(unique_key)
-            metric_keys.append(unique_key)
-            results[unique_key] = None  # pre-populate to track incomplete metrics
+            assigned[index] = unique_key
+
+        metric_keys = [assigned[index] for index in range(len(metric_tasks))]
+        results: Dict[str, Any] = {key: None for key in metric_keys}
 
         return metric_keys, results
 

--- a/apps/frontend/src/utils/websocket/types.ts
+++ b/apps/frontend/src/utils/websocket/types.ts
@@ -65,6 +65,11 @@ export enum EventType {
   // replace polling with a live subscription.
   JOB_STATUS_CHANGED = 'job.status_changed',
   JOB_ACTIVITY_APPENDED = 'job.activity_appended',
+
+  // Test run live progress, published on a "test_run:{test_run_id}" channel.
+  // A coalesced tick telling the client to refetch the verdict-matrix
+  // endpoint, not a payload to patch state from.
+  TEST_RUN_PROGRESSED = 'test_run.progressed',
 }
 
 /**

--- a/tests/backend/events/test_test_run_sink.py
+++ b/tests/backend/events/test_test_run_sink.py
@@ -1,0 +1,149 @@
+"""TestRunSink: coalesces test_run.progressed ticks and publishes to
+test_run:{entity_id} with no database session. Timers are not awaited in
+real time -- ``_flush`` is called directly, since the sink's own coalescing
+window is an implementation detail these tests don't need to wait out.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+from uuid import uuid4
+
+from rhesis.backend.app.schemas.websocket import ChannelTarget, EventType
+from rhesis.backend.events.sinks.test_run import TestRunSink
+from rhesis.backend.events.types import ActivityLogged, TestRunProgressed
+
+_PATCH_TARGET = "rhesis.backend.events.sinks.test_run.publish_event"
+
+
+def _progressed(**overrides) -> TestRunProgressed:
+    fields = dict(
+        occurred_at=datetime.now(timezone.utc),
+        organization_id=uuid4(),
+        trace_id="a" * 32,
+        span_id="b" * 16,
+        source="test",
+        entity_type="test_run",
+        entity_id=uuid4(),
+        completed=1,
+        total=10,
+    )
+    fields.update(overrides)
+    return TestRunProgressed(**fields)
+
+
+class TestTestRunSinkHandles:
+    def test_handles_only_test_run_progressed(self):
+        sink = TestRunSink()
+        assert sink.handles(_progressed())
+        assert not sink.handles(
+            ActivityLogged(
+                occurred_at=datetime.now(timezone.utc),
+                organization_id=uuid4(),
+                trace_id="a" * 32,
+                span_id="b" * 16,
+                source="test",
+                level="info",
+                message="hi",
+            )
+        )
+
+
+class TestTestRunSinkDeliver:
+    def test_no_db_session_opened(self):
+        """The whole point of this sink over WebSocketSink: no DB lookup."""
+        sink = TestRunSink()
+        event = _progressed()
+
+        with (
+            patch(_PATCH_TARGET) as mock_publish,
+            patch("rhesis.backend.events.sinks.test_run.threading.Timer") as mock_timer_cls,
+        ):
+            sink.deliver(event, db=None)
+            sink._flush(str(event.entity_id))
+
+        mock_publish.assert_called_once()
+        # Confirms nothing under this sink ever touches a Session -- deliver()
+        # takes db=None and never dereferences it.
+        assert mock_timer_cls.called
+
+    def test_publishes_to_test_run_channel(self):
+        sink = TestRunSink()
+        event = _progressed(completed=3, total=10)
+
+        with patch(_PATCH_TARGET) as mock_publish:
+            sink.deliver(event, db=None)
+            sink._flush(str(event.entity_id))
+
+        message, target = mock_publish.call_args.args
+        assert isinstance(target, ChannelTarget)
+        assert target.channel == f"test_run:{event.entity_id}"
+        assert message.type == EventType.TEST_RUN_PROGRESSED
+        assert message.payload["completed"] == 3
+        assert message.payload["total"] == 10
+        assert message.payload["generating_test_ids"] == []
+        assert message.payload["evaluating_test_ids"] == []
+
+    def test_no_entity_id_publishes_nothing(self):
+        sink = TestRunSink()
+        event = _progressed(entity_id=None)
+
+        with patch(_PATCH_TARGET) as mock_publish:
+            sink.deliver(event, db=None)
+
+        mock_publish.assert_not_called()
+
+    def test_coalesces_rapid_events_for_same_run(self):
+        """Two rapid deliver() calls for one entity_id produce one publish,
+        of the latest event -- deliver() overwrites _pending, it doesn't queue.
+        """
+        sink = TestRunSink()
+        entity_id = uuid4()
+        first = _progressed(entity_id=entity_id, completed=1, total=10)
+        second = _progressed(entity_id=entity_id, completed=2, total=10)
+
+        with (
+            patch(_PATCH_TARGET) as mock_publish,
+            patch("rhesis.backend.events.sinks.test_run.threading.Timer"),
+        ):
+            sink.deliver(first, db=None)
+            sink.deliver(second, db=None)
+            sink._flush(str(entity_id))
+
+        mock_publish.assert_called_once()
+        message, _ = mock_publish.call_args.args
+        assert message.payload["completed"] == 2
+
+    def test_separate_runs_not_coalesced(self):
+        sink = TestRunSink()
+        event_a = _progressed()
+        event_b = _progressed()
+
+        with (
+            patch(_PATCH_TARGET) as mock_publish,
+            patch("rhesis.backend.events.sinks.test_run.threading.Timer"),
+        ):
+            sink.deliver(event_a, db=None)
+            sink.deliver(event_b, db=None)
+            sink._flush(str(event_a.entity_id))
+            sink._flush(str(event_b.entity_id))
+
+        assert mock_publish.call_count == 2
+        channels = {call.args[1].channel for call in mock_publish.call_args_list}
+        assert channels == {f"test_run:{event_a.entity_id}", f"test_run:{event_b.entity_id}"}
+
+    def test_flush_with_nothing_pending_publishes_nothing(self):
+        sink = TestRunSink()
+        with patch(_PATCH_TARGET) as mock_publish:
+            sink._flush(str(uuid4()))
+        mock_publish.assert_not_called()
+
+    def test_publish_failure_is_swallowed(self):
+        sink = TestRunSink()
+        event = _progressed()
+
+        with (
+            patch(_PATCH_TARGET, side_effect=RuntimeError("redis down")),
+            patch("rhesis.backend.events.sinks.test_run.threading.Timer"),
+        ):
+            sink.deliver(event, db=None)
+            sink._flush(str(event.entity_id))  # must not raise

--- a/tests/backend/jobs/test_metric_plan_dispatch.py
+++ b/tests/backend/jobs/test_metric_plan_dispatch.py
@@ -1,0 +1,105 @@
+"""create_test_run's metric-plan snapshot is best-effort and must not be
+able to take the dispatch down with it.
+
+The snapshot runs several queries on the caller's session. A DB error in any
+of them aborts the surrounding transaction, so swallowing the exception
+without rolling back would leave create_test_run's own INSERT to fail with
+InFailedSqlTransaction -- turning a skippable nicety into a 500 on every
+run dispatch.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.jobs.execution.run import create_test_run
+
+
+@pytest.fixture
+def dispatch_setup(test_db: Session, test_organization, db_user, db_endpoint, db_status):
+    test_config = models.TestConfiguration(
+        endpoint_id=db_endpoint.id,
+        organization_id=test_organization.id,
+        user_id=db_user.id,
+    )
+    test_db.add(test_config)
+    test_db.flush()
+
+    test_set = models.TestSet(
+        name="Dispatch Test Set",
+        user_id=db_user.id,
+        organization_id=test_organization.id,
+        status_id=db_status.id,
+    )
+    test_db.add(test_set)
+    test_db.flush()
+    test_config.test_set_id = test_set.id
+
+    test = models.Test(
+        user_id=db_user.id, organization_id=test_organization.id, requirement_id=None
+    )
+    test_db.add(test)
+    test_db.flush()
+    test_db.execute(
+        models.test_test_set_association.insert().values(
+            test_id=test.id,
+            test_set_id=test_set.id,
+            organization_id=test_organization.id,
+            user_id=db_user.id,
+        )
+    )
+    test_db.commit()
+    return test_config
+
+
+class TestMetricPlanSnapshotIsBestEffort:
+    def test_plan_is_stored_on_the_run(self, test_db: Session, dispatch_setup):
+        test_run = create_test_run(test_db, dispatch_setup)
+        test_db.commit()
+
+        assert "metric_plan" in (test_run.attributes or {})
+        assert test_run.attributes["metric_plan"]["test_order"]
+
+    def test_database_error_in_the_plan_does_not_fail_dispatch(
+        self, test_db: Session, dispatch_setup
+    ):
+        """A DB error inside the snapshot must leave the session usable, so
+        the run row still gets created and committed.
+
+        The failure has to be real SQL, not a mocked Python exception:
+        Postgres marks the whole transaction aborted, and it is that state
+        -- not the exception -- that the SAVEPOINT exists to contain. A
+        raise-only mock leaves the transaction healthy and the test passes
+        with or without the fix.
+        """
+
+        def _boom(db, *args, **kwargs):
+            db.execute(text("SELECT * FROM a_table_that_does_not_exist"))
+
+        with patch(
+            "rhesis.backend.jobs.execution.metric_plan._build_metric_plan",
+            side_effect=_boom,
+        ):
+            test_run = create_test_run(test_db, dispatch_setup)
+            # The commit is the assertion: an aborted transaction raises here.
+            test_db.commit()
+
+        assert test_run.id is not None
+        assert "metric_plan" not in (test_run.attributes or {})
+
+    def test_plan_failure_leaves_the_run_readable(self, test_db: Session, dispatch_setup):
+        """And the run is a real row afterwards, not a half-flushed object."""
+
+        with patch(
+            "rhesis.backend.jobs.execution.metric_plan._build_metric_plan",
+            side_effect=ValueError("planner bug"),
+        ):
+            test_run = create_test_run(test_db, dispatch_setup)
+            test_db.commit()
+
+        reloaded = test_db.query(models.TestRun).filter(models.TestRun.id == test_run.id).first()
+        assert reloaded is not None
+        assert "metric_plan" not in (reloaded.attributes or {})

--- a/tests/backend/jobs/test_progress_narration.py
+++ b/tests/backend/jobs/test_progress_narration.py
@@ -349,99 +349,13 @@ class TestSequentialExecutionNarration:
 
 @pytest.mark.unit
 class TestMetricLevelNarration:
-    """evaluate_metrics wraps on_emit into per-metric feedback."""
+    """evaluate_metrics no longer wires on_emit into per-metric feedback.
 
-    def test_emits_per_metric_result(self):
-        from rhesis.backend.jobs.execution.batch.evaluation import evaluate_metrics
-
-        ctx = MagicMock()
-        ctx.get_metric_configs_for_test.return_value = ["cfg"]
-
-        evaluator = MagicMock()
-
-        async def _fake_a_evaluate(**kwargs):
-            cb = kwargs.get("on_metric_complete")
-            if cb:
-                cb("Toxicity", {"is_successful": True, "score": 0.95})
-                cb("Relevance", {"is_successful": False, "score": 0.3})
-                cb("Coherence", {"is_successful": None, "score": 0.7})
-            return {"Toxicity": {}, "Relevance": {}, "Coherence": {}}
-
-        evaluator.a_evaluate = _fake_a_evaluate
-
-        test = MagicMock()
-        test.test_configuration = {}
-        test.test_metadata = {}
-
-        emit_calls = []
-
-        async def _fake_single_turn(_ctx, ev, _test, _output, _prompt, _expected, _configs, on_metric_complete=None):
-            return await ev.a_evaluate(
-                input_text=_prompt, output_text="resp", expected_output=_expected,
-                context=[], metrics=_configs, on_metric_complete=on_metric_complete,
-            )
-
-        with patch(
-            "rhesis.backend.jobs.execution.batch.evaluation._evaluate_single_turn_metrics",
-            side_effect=_fake_single_turn,
-        ):
-            result = asyncio.run(
-                evaluate_metrics(
-                    ctx, evaluator, test, "t1",
-                    {"response": "hello"}, "prompt", "expected",
-                    False, {},
-                    on_emit=lambda m: emit_calls.append(m),
-                )
-            )
-
-        assert len(emit_calls) == 3
-        assert "Toxicity: passed (0.95)" in emit_calls[0]
-        assert "Relevance: failed (0.3)" in emit_calls[1]
-        assert "Coherence: scored (0.7)" in emit_calls[2]
-
-    def test_emits_error_detail_for_crashed_metric(self):
-        from rhesis.backend.jobs.execution.batch.evaluation import evaluate_metrics
-
-        ctx = MagicMock()
-        ctx.get_metric_configs_for_test.return_value = ["cfg"]
-
-        evaluator = MagicMock()
-
-        async def _fake_a_evaluate(**kwargs):
-            cb = kwargs.get("on_metric_complete")
-            if cb:
-                cb("Toxicity", {"is_successful": False, "score": 0.0, "error": "Timeout"})
-            return {"Toxicity": {}}
-
-        evaluator.a_evaluate = _fake_a_evaluate
-
-        test = MagicMock()
-        test.test_configuration = {}
-        test.test_metadata = {}
-
-        emit_calls = []
-
-        async def _fake_single_turn(_ctx, ev, _test, _output, _prompt, _expected, _configs, on_metric_complete=None):
-            return await ev.a_evaluate(
-                input_text=_prompt, output_text="resp", expected_output=_expected,
-                context=[], metrics=_configs, on_metric_complete=on_metric_complete,
-            )
-
-        with patch(
-            "rhesis.backend.jobs.execution.batch.evaluation._evaluate_single_turn_metrics",
-            side_effect=_fake_single_turn,
-        ):
-            asyncio.run(
-                evaluate_metrics(
-                    ctx, evaluator, test, "t1",
-                    {"response": "hello"}, "prompt", "expected",
-                    False, {},
-                    on_emit=lambda m: emit_calls.append(m),
-                )
-            )
-
-        assert len(emit_calls) == 1
-        assert "Toxicity: error (Timeout)" in emit_calls[0]
+    Per-metric narration was producing ~28,000 ActivityLogged events (each
+    opening its own DB session) for a single large run -- see
+    jobs/execution/batch/evaluation.py's evaluate_metrics docstring comment.
+    The batch-level "Test N/M" line in runner.py is the only narration left.
+    """
 
     def test_no_emit_without_callback(self):
         from rhesis.backend.jobs.execution.batch.evaluation import evaluate_metrics
@@ -480,6 +394,49 @@ class TestMetricLevelNarration:
             )
         assert result == {}
 
+    def test_on_emit_present_still_gets_no_per_metric_callback(self):
+        """Passing on_emit no longer wires it into a per-metric callback."""
+        from rhesis.backend.jobs.execution.batch.evaluation import evaluate_metrics
+
+        ctx = MagicMock()
+        ctx.get_metric_configs_for_test.return_value = ["cfg"]
+
+        evaluator = MagicMock()
+
+        async def _fake_a_evaluate(**kwargs):
+            assert kwargs.get("on_metric_complete") is None
+            return {"Toxicity": {}}
+
+        evaluator.a_evaluate = _fake_a_evaluate
+
+        test = MagicMock()
+        test.test_configuration = {}
+        test.test_metadata = {}
+
+        emit_calls = []
+
+        async def _fake_single_turn(_ctx, ev, _test, _output, _prompt, _expected, _configs, on_metric_complete=None):
+            return await ev.a_evaluate(
+                input_text=_prompt, output_text="resp", expected_output=_expected,
+                context=[], metrics=_configs, on_metric_complete=on_metric_complete,
+            )
+
+        with patch(
+            "rhesis.backend.jobs.execution.batch.evaluation._evaluate_single_turn_metrics",
+            side_effect=_fake_single_turn,
+        ):
+            result = asyncio.run(
+                evaluate_metrics(
+                    ctx, evaluator, test, "t1",
+                    {"response": "hello"}, "prompt", "expected",
+                    False, {},
+                    on_emit=lambda m: emit_calls.append(m),
+                )
+            )
+
+        assert result == {"Toxicity": {}}
+        assert emit_calls == []
+
 
 @pytest.mark.unit
 class TestBatchExecutionNarration:
@@ -510,7 +467,7 @@ class TestBatchExecutionNarration:
         emit_calls = []
         progress_calls = []
 
-        async def _fake_single(ctx, test_id, semaphore, agent, evaluator, on_emit=None):
+        async def _fake_single(ctx, test_id, semaphore, agent, evaluator, on_emit=None, on_test_phase=None):
             return {"test_id": test_id, "status": "succeeded", "execution_time": 10}
 
         with patch(
@@ -547,7 +504,7 @@ class TestBatchExecutionNarration:
 
         emit_calls = []
 
-        async def _fake_single(ctx, test_id, semaphore, agent, evaluator, on_emit=None):
+        async def _fake_single(ctx, test_id, semaphore, agent, evaluator, on_emit=None, on_test_phase=None):
             return {
                 "test_id": test_id,
                 "status": "failed",

--- a/tests/backend/jobs/test_terminal_tick.py
+++ b/tests/backend/jobs/test_terminal_tick.py
@@ -1,0 +1,66 @@
+"""collect_results publishes one last grid tick after the terminal status.
+
+Every other TestRunProgressed comes from an in-flight phase transition, and
+the last of those fires while the run is still in Progress. Without a tick
+from here the final coalesced publish reports the run as running, and a
+client that stops refetching on ``is_terminal`` never learns it finished.
+"""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from rhesis.backend.events.types import TestRunProgressed
+from rhesis.backend.jobs.execution.results import _emit_terminal_tick
+
+
+@pytest.mark.unit
+class TestTerminalTick:
+    def _task(self):
+        task = MagicMock()
+        task.request.id = "celery-task-1"
+        return task
+
+    def test_emits_a_completed_tick_for_the_run(self):
+        test_run = MagicMock()
+        test_run.id = uuid4()
+        org_id = str(uuid4())
+
+        with patch("rhesis.backend.events.emit") as mock_emit:
+            _emit_terminal_tick(self._task(), test_run, org_id, None, None, total=7)
+
+        mock_emit.assert_called_once()
+        event = mock_emit.call_args.args[0]
+        assert isinstance(event, TestRunProgressed)
+        assert event.entity_type == "test_run"
+        assert event.entity_id == test_run.id
+        assert event.source == "collect_results"
+        # completed == total is what flips the grid's progress readout to done.
+        assert event.completed == 7
+        assert event.total == 7
+        assert event.generating_test_ids == []
+        assert event.evaluating_test_ids == []
+
+    def test_carries_project_and_user_when_present(self):
+        test_run = MagicMock()
+        test_run.id = uuid4()
+        org_id, user_id, project_id = str(uuid4()), str(uuid4()), str(uuid4())
+
+        with patch("rhesis.backend.events.emit") as mock_emit:
+            _emit_terminal_tick(self._task(), test_run, org_id, user_id, project_id, total=1)
+
+        event = mock_emit.call_args.args[0]
+        assert str(event.organization_id) == org_id
+        assert str(event.user_id) == user_id
+        assert str(event.project_id) == project_id
+
+    def test_emit_failure_does_not_propagate(self):
+        """A dropped live-update push must never fail the results task that
+        already wrote the run's terminal status.
+        """
+        test_run = MagicMock()
+        test_run.id = uuid4()
+
+        with patch("rhesis.backend.events.emit", side_effect=RuntimeError("redis down")):
+            _emit_terminal_tick(self._task(), test_run, str(uuid4()), None, None, total=1)

--- a/tests/backend/jobs/test_test_phase_callbacks.py
+++ b/tests/backend/jobs/test_test_phase_callbacks.py
@@ -1,0 +1,135 @@
+"""The on_test_phase callback chain that drives the verdict grid's live columns.
+
+Every test that enters the batch must eventually report "done", or the
+grid's completed count never reaches total and the progress readout stalls
+short of 100% forever.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rhesis.backend.jobs.execution.batch.runner import run_batch
+
+
+def _ctx(test_ids, *, recovery_rounds=0):
+    ctx = MagicMock()
+    ctx.batch_concurrency = 4
+    ctx.per_test_timeout = 60
+    ctx.recovery_rounds = recovery_rounds
+    ctx.celery_task_id = None
+    ctx.existing_result_ids = set()
+    ctx.test_data = {tid: {"test": MagicMock(category=None)} for tid in test_ids}
+    ctx.input_files = {}
+    return ctx
+
+
+@pytest.mark.unit
+class TestPhaseReporting:
+    def test_skipped_test_still_reports_done(self):
+        """An idempotency skip returns before any phase fires, so without an
+        explicit report the test would sit in-flight forever.
+        """
+        ctx = _ctx(["t1"])
+        ctx.existing_result_ids = {"t1"}
+        phases = []
+
+        asyncio.run(run_batch(ctx, ["t1"], on_test_phase=lambda tid, p: phases.append((tid, p))))
+
+        assert phases == [("t1", "done")]
+
+    def test_missing_prefetch_data_still_reports_done(self):
+        ctx = _ctx([])
+        ctx.test_data = {}
+        phases = []
+
+        asyncio.run(run_batch(ctx, ["t1"], on_test_phase=lambda tid, p: phases.append((tid, p))))
+
+        assert phases == [("t1", "done")]
+
+    def test_recovery_pass_keeps_reporting_phases(self):
+        """Without on_test_phase threaded into the recovery round the live
+        grid freezes on the main pass's last state for the whole retry.
+        """
+        ctx = _ctx(["t1"], recovery_rounds=1)
+        phases = []
+        attempts = {"n": 0}
+
+        async def _fake_single(ctx, test_id, semaphore, agent, evaluator, **kwargs):
+            attempts["n"] += 1
+            cb = kwargs.get("on_test_phase")
+            if cb:
+                cb(test_id, "generating")
+                cb(test_id, "done")
+            # Fail the first attempt so a recovery round is triggered.
+            if attempts["n"] == 1:
+                return {"test_id": test_id, "status": "failed", "error": "boom"}
+            return {"test_id": test_id, "status": "succeeded", "execution_time": 1}
+
+        with patch(
+            "rhesis.backend.jobs.execution.batch.runner._execute_single_test",
+            side_effect=_fake_single,
+        ):
+            asyncio.run(
+                run_batch(
+                    ctx,
+                    ["t1"],
+                    on_test_phase=lambda tid, p: phases.append((tid, p)),
+                )
+            )
+
+        assert attempts["n"] == 2, "recovery round did not run"
+        # Two full cycles: one per attempt.
+        assert phases == [
+            ("t1", "generating"),
+            ("t1", "done"),
+            ("t1", "generating"),
+            ("t1", "done"),
+        ]
+
+
+@pytest.mark.unit
+class TestFailureNarrationIsNotThrottled:
+    def test_every_failure_emits_its_error(self):
+        """The throttle keeps activity-log volume down, but a failure line
+        carries the error text -- the reason to read the log at all.
+
+        Concurrency is pinned to 1 so completion order is submission order
+        and ``current`` is the test's index: the failures below sit at odd
+        positions, which ``current % emit_interval`` (interval 2) skips. With
+        a nondeterministic order they would land on an emitting slot roughly
+        half the time and the test would pass without the fix.
+        """
+        test_ids = [f"t{i}" for i in range(40)]
+        ctx = _ctx(test_ids)
+        ctx.batch_concurrency = 1
+        emits = []
+
+        # 0-indexed t2/t4/t6 complete as current=3/5/7 -- all odd.
+        failing = {"t2", "t4", "t6"}
+
+        async def _fake_single(ctx, test_id, semaphore, agent, evaluator, **kwargs):
+            async with semaphore:
+                if test_id in failing:
+                    return {
+                        "test_id": test_id,
+                        "status": "failed",
+                        "error": f"boom-{test_id}",
+                        "execution_time": 1,
+                    }
+                return {"test_id": test_id, "status": "succeeded", "execution_time": 1}
+
+        with patch(
+            "rhesis.backend.jobs.execution.batch.runner._execute_single_test",
+            side_effect=_fake_single,
+        ):
+            asyncio.run(run_batch(ctx, test_ids, on_emit=lambda m: emits.append(m)))
+
+        failure_lines = [m for m in emits if "failed" in m]
+        assert len(failure_lines) == 3
+        for tid in failing:
+            assert any(f"boom-{tid}" in m for m in failure_lines)
+
+        # The successes are still throttled -- 40 tests must not produce 40 lines.
+        assert len(emits) < 40

--- a/tests/backend/metrics/test_local_strategy_metric_keys.py
+++ b/tests/backend/metrics/test_local_strategy_metric_keys.py
@@ -1,0 +1,55 @@
+"""_generate_unique_metric_keys assigns suffixes in a stable order (name,
+class_name, id) rather than the caller's iteration order, so the same
+metric gets the same key across runs -- see the verdict matrix's cell
+alignment in app/services/test_run.py, which depends on this.
+"""
+
+from rhesis.backend.metrics.strategies.local import LocalStrategy
+from rhesis.sdk.metrics import MetricConfig
+
+
+def _config(name: str, class_name: str, metric_id: str) -> MetricConfig:
+    return MetricConfig(name=name, class_name=class_name, id=metric_id)
+
+
+def _tasks(configs):
+    # (class_name, metric, metric_config, backend) -- only metric_config is
+    # read by _generate_unique_metric_keys.
+    return [(c.class_name, None, c, "rhesis") for c in configs]
+
+
+class TestUniqueMetricKeyDeterminism:
+    def test_duplicate_names_get_the_same_suffix_regardless_of_input_order(self):
+        strategy = LocalStrategy()
+        a = _config("Accuracy", "AccuracyMetric", "11111111-1111-1111-1111-111111111111")
+        b = _config("Accuracy", "AccuracyMetric", "22222222-2222-2222-2222-222222222222")
+
+        keys_forward, _ = strategy._generate_unique_metric_keys(_tasks([a, b]))
+        keys_reversed, _ = strategy._generate_unique_metric_keys(_tasks([b, a]))
+
+        # The lower id ("111...") always gets the bare key, the higher id
+        # always gets the suffix -- independent of which came first in the
+        # input list.
+        assert dict(zip([a.id, b.id], keys_forward)) == {a.id: "Accuracy", b.id: "Accuracy_1"}
+        assert dict(zip([b.id, a.id], keys_reversed)) == {a.id: "Accuracy", b.id: "Accuracy_1"}
+
+    def test_keys_align_positionally_with_input_tasks(self):
+        strategy = LocalStrategy()
+        a = _config("Accuracy", "AccuracyMetric", "1")
+        b = _config("Toxicity", "ToxicityMetric", "2")
+        c = _config("Accuracy", "AccuracyMetric", "3")
+
+        keys, results = strategy._generate_unique_metric_keys(_tasks([a, b, c]))
+
+        assert len(keys) == 3
+        assert keys[1] == "Toxicity"
+        assert {keys[0], keys[2]} == {"Accuracy", "Accuracy_1"}
+        assert set(results.keys()) == set(keys)
+
+    def test_falls_back_to_class_name_when_no_metric_name(self):
+        strategy = LocalStrategy()
+        a = MetricConfig(name=None, class_name="CustomMetric", id="1")
+
+        keys, _ = strategy._generate_unique_metric_keys(_tasks([a]))
+
+        assert keys == ["CustomMetric"]

--- a/tests/backend/routes/test_verdict_matrix_api.py
+++ b/tests/backend/routes/test_verdict_matrix_api.py
@@ -1,0 +1,118 @@
+"""GET /test_runs/{id}/verdict-matrix -- tenant boundary and shape.
+
+Encoding correctness (cell alphabet, KPIs, plan/fallback paths) is covered
+at the service layer in tests/backend/services/test_verdict_matrix.py; this
+file only checks the route wires auth, 404s, and the columns=none param.
+"""
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from tests.backend.fixtures.test_setup import create_test_organization_and_user
+
+
+def _auth(token) -> dict:
+    return {"Authorization": f"Bearer {token.token}"}
+
+
+def _make_run(db: Session, org, user) -> models.TestRun:
+    project = models.Project(
+        name="Verdict Matrix Project",
+        organization_id=org.id,
+        user_id=user.id,
+    )
+    db.add(project)
+    db.flush()
+
+    endpoint = models.Endpoint(
+        name="Verdict Matrix Endpoint",
+        connection_type="REST",
+        url="https://api.example.com/test",
+        method="POST",
+        organization_id=org.id,
+        user_id=user.id,
+        project_id=project.id,
+    )
+    db.add(endpoint)
+    db.flush()
+
+    test_config = models.TestConfiguration(
+        endpoint_id=endpoint.id,
+        organization_id=org.id,
+        user_id=user.id,
+    )
+    db.add(test_config)
+    db.flush()
+
+    status = models.Status(name="Progress", organization_id=org.id, user_id=user.id)
+    db.add(status)
+    db.flush()
+
+    test_run = models.TestRun(
+        name="Verdict Matrix Route Run",
+        user_id=user.id,
+        organization_id=org.id,
+        status_id=status.id,
+        test_configuration_id=test_config.id,
+    )
+    db.add(test_run)
+    db.commit()
+    db.refresh(test_run)
+    return test_run
+
+
+class TestVerdictMatrixEndpoint:
+    def test_returns_matrix_shape_for_own_run(self, client: TestClient, test_db: Session):
+        org, user, token = create_test_organization_and_user(
+            test_db, "Verdict Matrix Org", "owner@verdict-matrix.com", "Owner"
+        )
+        test_run = _make_run(test_db, org, user)
+
+        response = client.get(f"/test_runs/{test_run.id}/verdict-matrix", headers=_auth(token))
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["test_run_id"] == str(test_run.id)
+        assert body["rows"] == []
+        assert body["requirements"] == []
+        assert body["kpis"]["tests_total"] == 0
+
+    def test_columns_none_omits_test_ids(self, client: TestClient, test_db: Session):
+        org, user, token = create_test_organization_and_user(
+            test_db, "Verdict Matrix Org 2", "owner2@verdict-matrix.com", "Owner"
+        )
+        test_run = _make_run(test_db, org, user)
+
+        response = client.get(
+            f"/test_runs/{test_run.id}/verdict-matrix?columns=none", headers=_auth(token)
+        )
+
+        assert response.status_code == 200
+        assert response.json()["test_ids"] is None
+
+    def test_other_organization_gets_404(self, client: TestClient, test_db: Session):
+        owner_org, owner_user, _ = create_test_organization_and_user(
+            test_db, "Verdict Matrix Owner Org", "owner3@verdict-matrix.com", "Owner"
+        )
+        test_run = _make_run(test_db, owner_org, owner_user)
+
+        _, _, other_token = create_test_organization_and_user(
+            test_db, "Verdict Matrix Other Org", "other@verdict-matrix.com", "Other"
+        )
+
+        response = client.get(
+            f"/test_runs/{test_run.id}/verdict-matrix", headers=_auth(other_token)
+        )
+
+        assert response.status_code == 404
+
+    def test_unknown_run_is_404(self, client: TestClient, test_db: Session):
+        _, _, token = create_test_organization_and_user(
+            test_db, "Verdict Matrix Org 4", "owner4@verdict-matrix.com", "Owner"
+        )
+        response = client.get(
+            "/test_runs/00000000-0000-0000-0000-000000000000/verdict-matrix",
+            headers=_auth(token),
+        )
+        assert response.status_code == 404

--- a/tests/backend/services/test_verdict_matrix.py
+++ b/tests/backend/services/test_verdict_matrix.py
@@ -1,0 +1,829 @@
+"""Integration coverage for the verdict matrix: build_metric_plan's
+dispatch-time snapshot feeding get_verdict_matrix's encoded grid, against a
+real Postgres so v_metric_stats/v_test_result_stats are exercised for real.
+
+The riskiest part of this feature is that a metric plan's row key must match
+the JSONB key v_metric_stats reports for that metric's result -- both derive
+the key the same way (name/class_name/id, suffixed on collision), but they
+run in different modules (jobs/execution/metric_plan.py vs
+metrics/strategies/local.py) at different times, so a drift between them
+would silently blank every cell instead of raising.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.constants import TestResultStatus
+from rhesis.backend.app.services.test_run import get_verdict_matrix
+from rhesis.backend.app.utils.crud_utils import get_or_create_status, get_or_create_type_lookup
+from rhesis.backend.jobs.execution.metric_plan import build_metric_plan
+
+
+def _metric(db, org_id, user_id, *, name, scope, class_name="AccuracyMetric"):
+    backend_type = get_or_create_type_lookup(db, "BackendType", "rhesis", str(org_id), str(user_id))
+    metric_type = get_or_create_type_lookup(
+        db, "MetricType", "custom-prompt", str(org_id), str(user_id)
+    )
+    metric = models.Metric(
+        metric_scope=scope,
+        name=name,
+        class_name=class_name,
+        score_type="numeric",
+        evaluation_prompt="Evaluate",
+        backend_type_id=backend_type.id,
+        metric_type_id=metric_type.id,
+        organization_id=org_id,
+        user_id=user_id,
+    )
+    db.add(metric)
+    db.flush()
+    return metric
+
+
+def _link_metric(db, requirement, metric, org_id, user_id):
+    db.execute(
+        models.requirement_metric_association.insert().values(
+            requirement_id=requirement.id,
+            metric_id=metric.id,
+            organization_id=org_id,
+            user_id=user_id,
+        )
+    )
+
+
+def _add_to_set(db, test, test_set, org_id, user_id):
+    db.execute(
+        models.test_test_set_association.insert().values(
+            test_id=test.id,
+            test_set_id=test_set.id,
+            organization_id=org_id,
+            user_id=user_id,
+        )
+    )
+
+
+@pytest.fixture
+def verdict_matrix_setup(test_db: Session, test_organization, db_user, db_endpoint, db_status):
+    org_id = test_organization.id
+    user_id = db_user.id
+
+    test_config = models.TestConfiguration(
+        endpoint_id=db_endpoint.id,
+        organization_id=org_id,
+        user_id=user_id,
+    )
+    test_db.add(test_config)
+    test_db.flush()
+
+    test_set = models.TestSet(
+        name="Verdict Matrix Test Set",
+        user_id=user_id,
+        organization_id=org_id,
+        status_id=db_status.id,
+    )
+    test_db.add(test_set)
+    test_db.flush()
+    test_config.test_set_id = test_set.id
+    test_db.flush()
+
+    requirement = models.Requirement(
+        name="Req A",
+        organization_id=org_id,
+        user_id=user_id,
+    )
+    test_db.add(requirement)
+    test_db.flush()
+
+    backend_type = get_or_create_type_lookup(
+        test_db, "BackendType", "rhesis", str(org_id), str(user_id)
+    )
+    metric_type = get_or_create_type_lookup(
+        test_db, "MetricType", "custom-prompt", str(org_id), str(user_id)
+    )
+
+    metric = models.Metric(
+        metric_scope=["Single-Turn"],
+        name="Accuracy",
+        class_name="AccuracyMetric",
+        score_type="numeric",
+        evaluation_prompt="Evaluate accuracy",
+        backend_type_id=backend_type.id,
+        metric_type_id=metric_type.id,
+        organization_id=org_id,
+        user_id=user_id,
+    )
+    test_db.add(metric)
+    test_db.flush()
+
+    test_db.execute(
+        models.requirement_metric_association.insert().values(
+            requirement_id=requirement.id,
+            metric_id=metric.id,
+            organization_id=org_id,
+            user_id=user_id,
+        )
+    )
+
+    test_a = models.Test(user_id=user_id, organization_id=org_id, requirement_id=requirement.id)
+    test_b = models.Test(user_id=user_id, organization_id=org_id, requirement_id=requirement.id)
+    test_db.add_all([test_a, test_b])
+    test_db.flush()
+
+    for test in (test_a, test_b):
+        test_db.execute(
+            models.test_test_set_association.insert().values(
+                test_id=test.id,
+                test_set_id=test_set.id,
+                organization_id=org_id,
+                user_id=user_id,
+            )
+        )
+
+    test_run = models.TestRun(
+        name="Verdict Matrix Run",
+        user_id=user_id,
+        organization_id=org_id,
+        status_id=db_status.id,
+        test_configuration_id=test_config.id,
+        project_id=None,
+    )
+    test_db.add(test_run)
+    test_db.flush()
+
+    pass_status = get_or_create_status(
+        test_db, TestResultStatus.PASS.value, "TestResult", organization_id=str(org_id)
+    )
+
+    passed_result = models.TestResult(
+        test_run_id=test_run.id,
+        test_configuration_id=test_config.id,
+        test_id=test_a.id,
+        organization_id=org_id,
+        user_id=user_id,
+        status_id=pass_status.id,
+        test_metrics={"metrics": {"Accuracy": {"is_successful": True, "score": 0.95}}},
+    )
+    test_db.add(passed_result)
+    test_db.commit()
+
+    return {
+        "test_config": test_config,
+        "test_set": test_set,
+        "test_run": test_run,
+        "requirement": requirement,
+        "metric": metric,
+        "test_a": test_a,
+        "test_b": test_b,
+        "org_id": str(org_id),
+    }
+
+
+@pytest.fixture
+def two_requirement_setup(test_db: Session, test_organization, db_user, db_endpoint, db_status):
+    """Two requirements, one test each, both metrics named "Accuracy".
+
+    The shared name is deliberate: it is what makes a missing group boundary
+    visible, since a (test_id, metric_key) lookup with no requirement
+    dimension would pull one requirement's verdict onto the other's row.
+    """
+    org_id = test_organization.id
+    user_id = db_user.id
+
+    test_config = models.TestConfiguration(
+        endpoint_id=db_endpoint.id, organization_id=org_id, user_id=user_id
+    )
+    test_db.add(test_config)
+    test_db.flush()
+
+    test_set = models.TestSet(
+        name="Two Requirement Test Set",
+        user_id=user_id,
+        organization_id=org_id,
+        status_id=db_status.id,
+    )
+    test_db.add(test_set)
+    test_db.flush()
+    test_config.test_set_id = test_set.id
+    test_db.flush()
+
+    backend_type = get_or_create_type_lookup(
+        test_db, "BackendType", "rhesis", str(org_id), str(user_id)
+    )
+    metric_type = get_or_create_type_lookup(
+        test_db, "MetricType", "custom-prompt", str(org_id), str(user_id)
+    )
+
+    groups = {}
+    for label in ("a", "b"):
+        requirement = models.Requirement(
+            name=f"Req {label.upper()}", organization_id=org_id, user_id=user_id
+        )
+        test_db.add(requirement)
+        test_db.flush()
+
+        metric = models.Metric(
+            metric_scope=["Single-Turn"],
+            name="Accuracy",
+            class_name="AccuracyMetric",
+            score_type="numeric",
+            evaluation_prompt="Evaluate accuracy",
+            backend_type_id=backend_type.id,
+            metric_type_id=metric_type.id,
+            organization_id=org_id,
+            user_id=user_id,
+        )
+        test_db.add(metric)
+        test_db.flush()
+        test_db.execute(
+            models.requirement_metric_association.insert().values(
+                requirement_id=requirement.id,
+                metric_id=metric.id,
+                organization_id=org_id,
+                user_id=user_id,
+            )
+        )
+
+        test = models.Test(user_id=user_id, organization_id=org_id, requirement_id=requirement.id)
+        test_db.add(test)
+        test_db.flush()
+        test_db.execute(
+            models.test_test_set_association.insert().values(
+                test_id=test.id,
+                test_set_id=test_set.id,
+                organization_id=org_id,
+                user_id=user_id,
+            )
+        )
+        groups[label] = {"requirement": requirement, "metric": metric, "test": test}
+
+    test_run = models.TestRun(
+        name="Two Requirement Run",
+        user_id=user_id,
+        organization_id=org_id,
+        status_id=db_status.id,
+        test_configuration_id=test_config.id,
+    )
+    test_db.add(test_run)
+    test_db.flush()
+
+    # Test A passes its metric, test B fails its own -- distinct verdicts so a
+    # row picking up the wrong test's cell is unambiguous in the assertion.
+    for label, status_name, is_successful in (
+        ("a", TestResultStatus.PASS.value, True),
+        ("b", TestResultStatus.FAIL.value, False),
+    ):
+        status = get_or_create_status(
+            test_db, status_name, "TestResult", organization_id=str(org_id)
+        )
+        test_db.add(
+            models.TestResult(
+                test_run_id=test_run.id,
+                test_configuration_id=test_config.id,
+                test_id=groups[label]["test"].id,
+                organization_id=org_id,
+                user_id=user_id,
+                status_id=status.id,
+                test_metrics={"metrics": {"Accuracy": {"is_successful": is_successful}}},
+            )
+        )
+    test_db.commit()
+
+    return {
+        "test_config": test_config,
+        "test_set": test_set,
+        "test_run": test_run,
+        "requirement_a": groups["a"]["requirement"],
+        "requirement_b": groups["b"]["requirement"],
+        "test_a": groups["a"]["test"],
+        "test_b": groups["b"]["test"],
+        "org_id": str(org_id),
+    }
+
+
+class TestBuildMetricPlan:
+    def test_requirement_sourced_plan_has_one_row_per_metric(
+        self, test_db: Session, verdict_matrix_setup
+    ):
+        setup = verdict_matrix_setup
+        plan = build_metric_plan(
+            test_db,
+            setup["test_config"],
+            setup["test_set"],
+            organization_id=setup["org_id"],
+        )
+
+        assert plan["source"] == "requirement"
+        assert len(plan["requirements"]) == 1
+        group = plan["requirements"][0]
+        assert group["id"] == str(setup["requirement"].id)
+        assert group["name"] == "Req A"
+        assert [m["key"] for m in group["metrics"]] == ["Accuracy"]
+        assert group["metrics"][0]["ambiguous"] is False
+
+        test_order = plan["test_order"]
+        assert set(test_order) == {str(setup["test_a"].id), str(setup["test_b"].id)}
+
+        # Both tests are single-turn and the metric is Single-Turn scoped, so
+        # nothing is filtered: every test maps the row to the bare key.
+        metric_ref = str(setup["metric"].id)
+        assert plan["cell_keys"] == {
+            str(setup["test_a"].id): {metric_ref: "Accuracy"},
+            str(setup["test_b"].id): {metric_ref: "Accuracy"},
+        }
+        assert group["test_ids"] == test_order
+
+    def test_restores_request_scope(self, test_db: Session, verdict_matrix_setup):
+        """get_test_metrics calls bind_scope_to_session, and this runs inside
+        the FastAPI request that dispatches the run -- a leaked _scope would
+        apply a stale project filter to every later query on that session.
+        """
+        setup = verdict_matrix_setup
+        before = test_db.info.get("_scope")
+
+        build_metric_plan(
+            test_db,
+            setup["test_config"],
+            setup["test_set"],
+            organization_id=setup["org_id"],
+        )
+
+        assert test_db.info.get("_scope") == before
+
+
+class TestGetVerdictMatrix:
+    def test_encodes_passed_and_pending_cells(self, test_db: Session, verdict_matrix_setup):
+        setup = verdict_matrix_setup
+        plan = build_metric_plan(
+            test_db,
+            setup["test_config"],
+            setup["test_set"],
+            organization_id=setup["org_id"],
+        )
+        test_run = setup["test_run"]
+        test_run.attributes = {"metric_plan": plan}
+        test_db.commit()
+        test_db.refresh(test_run)
+
+        matrix = get_verdict_matrix(test_db, test_run)
+
+        assert len(matrix.rows) == 1
+        row = matrix.rows[0]
+        assert row.metric_key == "Accuracy"
+
+        test_order = plan["test_order"]
+        index_a = test_order.index(str(setup["test_a"].id))
+        index_b = test_order.index(str(setup["test_b"].id))
+        assert row.verdicts[index_a] == "P"
+        assert row.verdicts[index_b] == "."
+        assert row.passed == 1
+        assert row.pending == 1
+        assert row.failed == 0
+
+        assert matrix.kpis.tests_total == 2
+        assert matrix.kpis.tests_executed == 1
+        assert matrix.kpis.verdicts_planned == 2
+        assert matrix.kpis.verdicts_resolved == 1
+        assert matrix.kpis.failures == 0
+        # Over tests (1 of 1 executed passed), not over verdicts -- see the
+        # pass_rate comment in get_verdict_matrix.
+        assert matrix.kpis.pass_rate == 1.0
+
+    def test_columns_none_omits_test_ids(self, test_db: Session, verdict_matrix_setup):
+        setup = verdict_matrix_setup
+        plan = build_metric_plan(
+            test_db,
+            setup["test_config"],
+            setup["test_set"],
+            organization_id=setup["org_id"],
+        )
+        test_run = setup["test_run"]
+        test_run.attributes = {"metric_plan": plan}
+        test_db.commit()
+        test_db.refresh(test_run)
+
+        full = get_verdict_matrix(test_db, test_run)
+        assert full.test_ids is not None
+        assert len(full.test_ids) == 2
+
+        thin = get_verdict_matrix(test_db, test_run, columns="none")
+        assert thin.test_ids is None
+        assert len(thin.rows) == len(full.rows)
+
+    def test_missing_plan_falls_back_to_recorded_results(
+        self, test_db: Session, verdict_matrix_setup
+    ):
+        """No stored metric_plan (a legacy run) -- the grid is derived from
+        v_metric_stats instead of a prospective plan, and still shows the
+        one metric that has a recorded verdict.
+        """
+        setup = verdict_matrix_setup
+        test_run = setup["test_run"]
+        assert not (test_run.attributes or {}).get("metric_plan")
+
+        matrix = get_verdict_matrix(test_db, test_run)
+
+        assert len(matrix.rows) == 1
+        assert matrix.rows[0].metric_key == "Accuracy"
+        assert matrix.rows[0].passed == 1
+
+
+class TestTwoRequirements:
+    """A metric row belongs to one requirement, so it must only span that
+    requirement's own tests. Everything else in the run is a column the row
+    can never have a verdict for and has to read as not-applicable.
+    """
+
+    def test_row_marks_other_requirements_tests_not_applicable(
+        self, test_db: Session, two_requirement_setup
+    ):
+        setup = two_requirement_setup
+        plan = build_metric_plan(
+            test_db,
+            setup["test_config"],
+            setup["test_set"],
+            organization_id=setup["org_id"],
+        )
+        test_run = setup["test_run"]
+        test_run.attributes = {"metric_plan": plan}
+        test_db.commit()
+        test_db.refresh(test_run)
+
+        matrix = get_verdict_matrix(test_db, test_run)
+
+        test_order = plan["test_order"]
+        index_a = test_order.index(str(setup["test_a"].id))
+        index_b = test_order.index(str(setup["test_b"].id))
+
+        rows_by_req = {str(row.requirement_id): row for row in matrix.rows}
+        row_a = rows_by_req[str(setup["requirement_a"].id)]
+        row_b = rows_by_req[str(setup["requirement_b"].id)]
+
+        # Requirement A's row owns test A and disowns test B, and vice versa.
+        assert row_a.verdicts[index_b] == "X"
+        assert row_b.verdicts[index_a] == "X"
+
+        # Test A passed, test B failed -- each must land on its own row only,
+        # even though both metrics share the base key "Accuracy".
+        assert row_a.verdicts[index_a] == "P"
+        assert row_b.verdicts[index_b] == "F"
+        assert (row_a.passed, row_a.failed) == (1, 0)
+        assert (row_b.passed, row_b.failed) == (0, 1)
+
+    def test_planned_verdicts_exclude_foreign_columns(
+        self, test_db: Session, two_requirement_setup
+    ):
+        """Two requirements x one metric x one own test each = 2 planned
+        cells, not 4 -- the other two are structurally not-applicable.
+        """
+        setup = two_requirement_setup
+        plan = build_metric_plan(
+            test_db,
+            setup["test_config"],
+            setup["test_set"],
+            organization_id=setup["org_id"],
+        )
+        test_run = setup["test_run"]
+        test_run.attributes = {"metric_plan": plan}
+        test_db.commit()
+        test_db.refresh(test_run)
+
+        matrix = get_verdict_matrix(test_db, test_run)
+
+        assert matrix.kpis.verdicts_planned == 2
+        assert matrix.kpis.verdicts_resolved == 2
+
+
+class TestSourceResolutionPerGroup:
+    """Metric source is resolved per requirement group, not once from an
+    arbitrary "sample" test. Asking a single test made the whole plan hostage
+    to whichever test happened to sort first.
+    """
+
+    def test_requirement_less_first_test_does_not_blank_the_plan(
+        self, test_db: Session, test_organization, db_user, db_endpoint, db_status
+    ):
+        org_id = test_organization.id
+        user_id = db_user.id
+
+        test_config = models.TestConfiguration(
+            endpoint_id=db_endpoint.id, organization_id=org_id, user_id=user_id
+        )
+        test_db.add(test_config)
+        test_db.flush()
+
+        test_set = models.TestSet(
+            name="Mixed Assignment Test Set",
+            user_id=user_id,
+            organization_id=org_id,
+            status_id=db_status.id,
+        )
+        test_db.add(test_set)
+        test_db.flush()
+        test_config.test_set_id = test_set.id
+        test_db.flush()
+
+        requirement = models.Requirement(
+            name="Req With Metrics", organization_id=org_id, user_id=user_id
+        )
+        test_db.add(requirement)
+        test_db.flush()
+        metric = _metric(test_db, org_id, user_id, name="Accuracy", scope=["Single-Turn"])
+        _link_metric(test_db, requirement, metric, org_id, user_id)
+
+        # Explicit ids: get_ordered_tests_for_test_set orders by Test.id, so
+        # the all-zeroes id guarantees the requirement-less test is the one a
+        # single-sample implementation would have asked.
+        unassigned = models.Test(
+            id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            user_id=user_id,
+            organization_id=org_id,
+            requirement_id=None,
+        )
+        assigned = models.Test(
+            id=uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff"),
+            user_id=user_id,
+            organization_id=org_id,
+            requirement_id=requirement.id,
+        )
+        test_db.add_all([unassigned, assigned])
+        test_db.flush()
+        for test in (unassigned, assigned):
+            _add_to_set(test_db, test, test_set, org_id, user_id)
+        test_db.commit()
+
+        plan = build_metric_plan(test_db, test_config, test_set, organization_id=str(org_id))
+
+        assert plan["test_order"][0] == str(unassigned.id)
+
+        by_id = {g["id"]: g for g in plan["requirements"]}
+        assert [m["key"] for m in by_id[str(requirement.id)]["metrics"]] == ["Accuracy"]
+        assert by_id[str(requirement.id)]["test_ids"] == [str(assigned.id)]
+
+        # The unassigned group is still present as its own (empty) bucket.
+        assert by_id[None]["metrics"] == []
+        assert by_id[None]["test_ids"] == [str(unassigned.id)]
+
+
+class TestScopeFilteredKeys:
+    """cell_keys must carry the key the runtime will really write, not the
+    plan's own row key. The runtime numbers duplicate names *after* scope
+    filtering, so a survivor takes the bare name even when the plan gave that
+    metric a suffix.
+    """
+
+    def test_survivor_of_scope_filter_maps_to_the_bare_key(
+        self, test_db: Session, test_organization, db_user, db_endpoint, db_status
+    ):
+        org_id = test_organization.id
+        user_id = db_user.id
+
+        test_config = models.TestConfiguration(
+            endpoint_id=db_endpoint.id, organization_id=org_id, user_id=user_id
+        )
+        test_db.add(test_config)
+        test_db.flush()
+
+        test_set = models.TestSet(
+            name="Scope Filter Test Set",
+            user_id=user_id,
+            organization_id=org_id,
+            status_id=db_status.id,
+        )
+        test_db.add(test_set)
+        test_db.flush()
+        test_config.test_set_id = test_set.id
+        test_db.flush()
+
+        requirement = models.Requirement(
+            name="Req Mixed Scope", organization_id=org_id, user_id=user_id
+        )
+        test_db.add(requirement)
+        test_db.flush()
+
+        # Same name, different scopes. Sorted by (name, class_name, id) the
+        # multi-turn one wins the bare key in the plan, so a single-turn test
+        # must still resolve its own metric to "Accuracy" -- the runtime,
+        # having filtered first, has only one metric left to name.
+        multi = _metric(
+            test_db,
+            org_id,
+            user_id,
+            name="Accuracy",
+            scope=["Multi-Turn"],
+            class_name="AAAMetric",
+        )
+        single = _metric(
+            test_db,
+            org_id,
+            user_id,
+            name="Accuracy",
+            scope=["Single-Turn"],
+            class_name="ZZZMetric",
+        )
+        _link_metric(test_db, requirement, multi, org_id, user_id)
+        _link_metric(test_db, requirement, single, org_id, user_id)
+
+        single_turn_test = models.Test(
+            user_id=user_id, organization_id=org_id, requirement_id=requirement.id
+        )
+        test_db.add(single_turn_test)
+        test_db.flush()
+        _add_to_set(test_db, single_turn_test, test_set, org_id, user_id)
+        test_db.commit()
+
+        plan = build_metric_plan(test_db, test_config, test_set, organization_id=str(org_id))
+
+        keys = {m["id"]: m["key"] for m in plan["requirements"][0]["metrics"]}
+        assert keys[str(multi.id)] == "Accuracy"
+        assert keys[str(single.id)] == "Accuracy_1"
+
+        # The single-turn test keeps only its own metric, and reads it under
+        # the bare key the runtime will have used.
+        per_test = plan["cell_keys"][str(single_turn_test.id)]
+        assert per_test == {str(single.id): "Accuracy"}
+
+        # And the multi-turn-only metric reads as not-applicable, not pending.
+        test_run = models.TestRun(
+            name="Scope Filter Run",
+            user_id=user_id,
+            organization_id=org_id,
+            status_id=db_status.id,
+            test_configuration_id=test_config.id,
+            attributes={"metric_plan": plan},
+        )
+        test_db.add(test_run)
+        test_db.commit()
+
+        matrix = get_verdict_matrix(test_db, test_run)
+        rows = {str(r.metric_id): r for r in matrix.rows}
+        assert rows[str(multi.id)].verdicts == "X"
+        assert rows[str(single.id)].verdicts == "."
+
+
+class TestDuplicateResults:
+    def test_newest_result_wins_per_cell(self, test_db: Session, verdict_matrix_setup):
+        """A rescore (or a duplicate persist) leaves two test_result rows for
+        one test. get_test_outcomes_for_run already takes the latest, so the
+        verdict has to agree or the grid shows a stale cell beside a current
+        status.
+        """
+        setup = verdict_matrix_setup
+        plan = build_metric_plan(
+            test_db,
+            setup["test_config"],
+            setup["test_set"],
+            organization_id=setup["org_id"],
+        )
+        test_run = setup["test_run"]
+        test_run.attributes = {"metric_plan": plan}
+
+        # The fixture already recorded a passing result for test_a. Add a
+        # newer failing one for the same (test, metric).
+        fail_status = get_or_create_status(
+            test_db,
+            TestResultStatus.FAIL.value,
+            "TestResult",
+            organization_id=setup["org_id"],
+        )
+        newer = models.TestResult(
+            test_run_id=test_run.id,
+            test_configuration_id=setup["test_config"].id,
+            test_id=setup["test_a"].id,
+            organization_id=uuid.UUID(setup["org_id"]),
+            user_id=setup["test_a"].user_id,
+            status_id=fail_status.id,
+            test_metrics={"metrics": {"Accuracy": {"is_successful": False}}},
+            created_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        test_db.add(newer)
+        test_db.commit()
+        test_db.refresh(test_run)
+
+        matrix = get_verdict_matrix(test_db, test_run)
+
+        index_a = plan["test_order"].index(str(setup["test_a"].id))
+        assert matrix.rows[0].verdicts[index_a] == "F"
+
+
+class TestPassRateIsOverTests:
+    def test_partially_passing_test_counts_as_one_failed_test(
+        self, test_db: Session, test_organization, db_user, db_endpoint, db_status
+    ):
+        """One test, two metrics, one passing one failing. Over verdicts that
+        is 50%; over tests it is 0%, because the test as a whole failed. The
+        runs list and run header both report the latter, so the grid must too.
+        """
+        org_id = test_organization.id
+        user_id = db_user.id
+
+        test_config = models.TestConfiguration(
+            endpoint_id=db_endpoint.id, organization_id=org_id, user_id=user_id
+        )
+        test_db.add(test_config)
+        test_db.flush()
+
+        test_set = models.TestSet(
+            name="Pass Rate Test Set",
+            user_id=user_id,
+            organization_id=org_id,
+            status_id=db_status.id,
+        )
+        test_db.add(test_set)
+        test_db.flush()
+        test_config.test_set_id = test_set.id
+        test_db.flush()
+
+        requirement = models.Requirement(name="Req Mixed", organization_id=org_id, user_id=user_id)
+        test_db.add(requirement)
+        test_db.flush()
+        good = _metric(
+            test_db, org_id, user_id, name="Good", scope=["Single-Turn"], class_name="GoodMetric"
+        )
+        bad = _metric(
+            test_db, org_id, user_id, name="Bad", scope=["Single-Turn"], class_name="BadMetric"
+        )
+        _link_metric(test_db, requirement, good, org_id, user_id)
+        _link_metric(test_db, requirement, bad, org_id, user_id)
+
+        test = models.Test(user_id=user_id, organization_id=org_id, requirement_id=requirement.id)
+        test_db.add(test)
+        test_db.flush()
+        _add_to_set(test_db, test, test_set, org_id, user_id)
+        test_db.commit()
+
+        plan = build_metric_plan(test_db, test_config, test_set, organization_id=str(org_id))
+
+        fail_status = get_or_create_status(
+            test_db, TestResultStatus.FAIL.value, "TestResult", organization_id=str(org_id)
+        )
+        test_run = models.TestRun(
+            name="Pass Rate Run",
+            user_id=user_id,
+            organization_id=org_id,
+            status_id=db_status.id,
+            test_configuration_id=test_config.id,
+            attributes={"metric_plan": plan},
+        )
+        test_db.add(test_run)
+        test_db.flush()
+        test_db.add(
+            models.TestResult(
+                test_run_id=test_run.id,
+                test_configuration_id=test_config.id,
+                test_id=test.id,
+                organization_id=org_id,
+                user_id=user_id,
+                status_id=fail_status.id,
+                test_metrics={
+                    "metrics": {
+                        "Good": {"is_successful": True},
+                        "Bad": {"is_successful": False},
+                    }
+                },
+            )
+        )
+        test_db.commit()
+        test_db.refresh(test_run)
+
+        matrix = get_verdict_matrix(test_db, test_run)
+
+        rows = {r.metric_key: r for r in matrix.rows}
+        assert rows["Good"].verdicts == "P"
+        assert rows["Bad"].verdicts == "F"
+
+        assert matrix.kpis.pass_rate == 0.0, "pass rate must be over tests, not verdicts"
+        assert matrix.kpis.failures == 1
+        assert matrix.kpis.verdicts_resolved == 2
+
+
+class TestIsNewer:
+    """The rule behind "newest result wins per cell". Covered directly
+    because the integration test cannot control the order Postgres returns
+    rows in, so it would pass by luck against a last-row-wins implementation.
+    """
+
+    def test_later_timestamp_wins(self):
+        from rhesis.backend.app.services.test_run import _is_newer
+
+        earlier = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        later = earlier + timedelta(hours=1)
+        assert _is_newer(later, earlier) is True
+        assert _is_newer(earlier, later) is False
+
+    def test_equal_timestamps_take_the_later_row(self):
+        from rhesis.backend.app.services.test_run import _is_newer
+
+        same = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        assert _is_newer(same, same) is True
+
+    def test_undated_never_displaces_a_dated_row(self):
+        from rhesis.backend.app.services.test_run import _is_newer
+
+        dated = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        assert _is_newer(None, dated) is False
+        assert _is_newer(dated, None) is True
+        assert _is_newer(None, None) is False


### PR DESCRIPTION
## Purpose

The Test Run Summary tab is static and aggregate-only. It fetches once on mount, never updates, and shows nothing about individual tests, so there is no way to watch a run progress or see which specific test failed which specific metric without leaving the page.

This is the backend half of rebuilding that tab as a **verdict grid**: metric rows grouped under requirements, one column per test, one cell per (test, metric) verdict, filling in live as the run executes. It ships on its own because the endpoint and event type have to exist before the frontend can consume them. The frontend PR follows.

Along the way this fixes a real scaling problem in the execution path that is independent of the grid: a 4,000-test run was writing roughly 32,000 `ActivityLogged` events, each opening two DB sessions on the same asyncio event loop the tests were sharing.

## What Changed

**Live transport.** A new `TestRunProgressed` event carries counters and bounded in-flight id lists, published to a `test_run:{id}` channel by a new `TestRunSink` and coalesced at 500ms. The sink deliberately opens no database session: the channel comes straight from the event's own `entity_id`, so a run can emit one of these per test-phase transition without paying a DB round-trip apiece. The payload is a tick, not state — clients refetch rather than patch, because out-of-order deltas from ten concurrent coroutines would corrupt a patched grid.

**Metric plan snapshot at dispatch.** `jobs/execution/metric_plan.py` freezes the grid's frame (requirements, metric rows, column count) onto `test_run.attributes` before any test runs, so the tab can render full width in grey on load instead of growing as results arrive. This cannot be derived from `requirement_metric` alone — metric resolution is a three-level priority (execution-time config > test set > requirement) plus per-test scope filtering.

**Verdict matrix endpoint.** `GET /test_runs/{id}/verdict-matrix` returns the grid as one encoded string per metric row (`.` pending, `P` passed, `F` failed, `S` scored, `E` error, `X` not applicable), which keeps a 4,000-test run's matrix around 60KB with `?columns=none`. A run dispatched before the snapshot shipped has no plan, so the grid is rebuilt from recorded results instead.

**In-flight phase callbacks.** `on_test_phase` reports generating/evaluating/done per test, threaded through both the batch and sequential execution paths, so the grid's live columns come from real execution state rather than synthetic animation.

**Emit volume reduction.** Per-metric activity log narration is removed (~28,000 events on a large run) and the per-test line is throttled to roughly 20 per batch (~4,000 down to ~50). Failures are exempt from the throttle — they carry the error text, which is the reason to read the log.

**Two pre-existing bugs fixed as prerequisites.** `_generate_unique_metric_keys` assigned duplicate-name suffixes in the caller's iteration order, which is not stable across runs, so two same-named metrics could swap which one held the bare key between runs. `metric_model_to_config` was dropping the metric's `id`, leaving that tie-break with nothing to break the tie on.

## Additional Context

Builds on the job tracking, events and WebSocket layer from #2593. The `test_run:` channel rule already existed in `services/websocket/authorization.py` but nothing published to it until now.

`TestRunDetail` now exposes `project_id` directly. The fail-closed `project_isolation` policy needs it on SUBSCRIBE, and it was previously only reachable through `test_configuration.endpoint.project.id`.

Two decisions worth a second opinion:

- `kpis.pass_rate` is computed over **tests**, not over metric verdicts, to agree with the number the runs list and run header already show. A test with four of five metrics passing is a failed test but an 80% verdict rate, and having the Summary tab disagree with every other view of the same run seemed worse than the alternative. Easy to flip if the intent was verdict-level, since it sits next to a separate "Verdicts resolved/planned" KPI.
- The matrix aggregation and string encoding still happen in Python. Column projection landed here; moving the aggregation into SQL is a larger change deferred to its own PR, written up in `playground/jobs-system/future-verdict-matrix-sql.md`. Worth doing before large runs hit this endpoint — no measurements have been taken yet, so that PR should start by profiling.

A code review pass on this branch surfaced 12 findings, all addressed. The most serious was a cross-contamination bug: a metric row spanned every column in the run rather than only its own requirement's tests, so with two requirements carrying a same-named metric, one requirement's row displayed the other's verdicts. Each fix was verified by reverting it and confirming the corresponding test fails — which is how I found that two of my own tests had been passing vacuously.

Size note: 1,068 lines of source across 23 files, plus 1,476 lines of tests. Larger than the usual target, but the commits are individually reviewable and ordered so each builds on the one before.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/services/test_verdict_matrix.py \
  ../../tests/backend/routes/test_verdict_matrix_api.py \
  ../../tests/backend/jobs/test_test_phase_callbacks.py \
  ../../tests/backend/jobs/test_metric_plan_dispatch.py \
  ../../tests/backend/jobs/test_terminal_tick.py \
  ../../tests/backend/events/test_test_run_sink.py \
  ../../tests/backend/metrics/test_local_strategy_metric_keys.py -v
```

93 tests pass across the touched areas; the full backend suite (`jobs/`, `metrics/`, `events/`, `services/`, `crud/`, `routes/`, `security/`, `schemas/`) is green at 6,081 passed with no failures.

Manual verification against a real run:

1. Hit `GET /test_runs/{id}/verdict-matrix` on a **queued** run — every cell should be `.`, and `len(row.verdicts)` should equal `len(test_ids)` on every row.
2. Same endpoint on a **completed** run — cells resolve, and `kpis.tests_total` matches the run's test count.
3. `?columns=none` should return `test_ids: null` with the rows unchanged.
4. A run belonging to another organization should 404.
5. Count `activity_log` rows for one execution before and after this branch — expect roughly two orders of magnitude fewer.
