### PR TITLE
Unify list grids on a single useList hook

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -25,8 +25,7 @@ import { Project } from '@/utils/api-client/interfaces/project';
 import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { DeleteModal } from '@/components/common/DeleteModal';
-import { usePaginatedList } from '@/hooks/usePaginatedList';
-import { listParams } from '@/utils/list';
+import { useList } from '@/hooks/useList';
 import { escapeODataValue } from '@/utils/odata-filter';
 import { endpointsList } from './list';
 import EndpointFilterDrawer, {
@@ -170,31 +169,14 @@ export default function EndpointsGrid({
     totalCount,
     isLoading: loading,
     error: rawError,
-    page,
-    rowsPerPage: pageSize,
-    onPageChange,
-    onRowsPerPageChange,
     refresh,
-  } = usePaginatedList<Endpoint>({
-    fetchPage: ({ skip, limit }) =>
-      endpointsList.list(
-        new ApiClientFactory(),
-        listParams(
-          endpointsList,
-          {
-            page: skip / limit + 1,
-            pageSize: limit,
-            sort: endpointsList.defaultSort,
-            filters,
-          },
-          extraODataClauses
-        )
-      ),
-    filterFingerprint: JSON.stringify(filters),
-    defaultPageSize: endpointsList.defaultPageSize,
+    paginationModel,
+    onPaginationModelChange: handlePaginationModelChange,
+  } = useList(endpointsList, {
+    filters,
+    extraFilters: extraODataClauses,
     initialData,
     initialTotalCount,
-    enabled: isAuthenticated(status),
     onError: () => setErrorDismissed(false),
   });
 
@@ -204,18 +186,6 @@ export default function EndpointsGrid({
 
   const error = rawError && !errorDismissed ? rawError : null;
   const dismissError = useCallback(() => setErrorDismissed(true), []);
-
-  const paginationModel = useMemo(() => ({ page, pageSize }), [page, pageSize]);
-  const handlePaginationModelChange = useCallback(
-    (model: { page: number; pageSize: number }) => {
-      if (model.pageSize !== pageSize) {
-        onRowsPerPageChange(model.pageSize);
-      } else {
-        onPageChange(model.page);
-      }
-    },
-    [pageSize, onPageChange, onRowsPerPageChange]
-  );
 
   const {
     checkboxSelectionMode,

--- a/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useContext, useMemo, useState } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import { Box, Chip, Typography } from '@mui/material';
 import {
   GridColDef,
@@ -40,8 +40,7 @@ import GridStateGate from '@/components/common/GridStateGate';
 import { BiotechIcon } from '@/components/icons';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { useNotifications } from '@/components/common/NotificationContext';
-import { usePaginatedList } from '@/hooks/usePaginatedList';
-import { listParams } from '@/utils/list';
+import { useList } from '@/hooks/useList';
 import { experimentsList } from './list';
 import CreateExperimentDialog from './CreateExperimentDialog';
 import { formatDate } from '@/utils/date';
@@ -176,41 +175,16 @@ export default function ExperimentsClientWrapper({
     data: experiments,
     totalCount,
     isLoading: loading,
-    page,
-    rowsPerPage: pageSize,
-    onPageChange,
-    onRowsPerPageChange,
     refresh,
-  } = usePaginatedList<ExperimentRead>({
-    fetchPage: ({ skip, limit }) =>
-      experimentsList.list(
-        new ApiClientFactory(),
-        listParams(experimentsList, {
-          page: skip / limit + 1,
-          pageSize: limit,
-          sort: experimentsList.defaultSort,
-          filters,
-        })
-      ),
-    filterFingerprint: JSON.stringify(filters),
-    defaultPageSize: experimentsList.defaultPageSize,
+    paginationModel,
+    onPaginationModelChange: handlePaginationModelChange,
+  } = useList(experimentsList, {
+    filters,
     initialData,
     initialTotalCount,
     onError: () =>
       notifications.show('Failed to load experiments', { severity: 'error' }),
   });
-
-  const paginationModel = useMemo(() => ({ page, pageSize }), [page, pageSize]);
-  const handlePaginationModelChange = useCallback(
-    (model: { page: number; pageSize: number }) => {
-      if (model.pageSize !== pageSize) {
-        onRowsPerPageChange(model.pageSize);
-      } else {
-        onPageChange(model.page);
-      }
-    },
-    [pageSize, onPageChange, onRowsPerPageChange]
-  );
 
   const handleDeleteExperiment = async () => {
     if (!deleteTargetId) return;

--- a/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
@@ -11,14 +11,12 @@ import React, {
 import {
   GridColDef,
   GridRowParams,
-  GridSortModel,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
   GridToolbarExport,
 } from '@mui/x-data-grid';
 import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
 import { useRouter } from 'next/navigation';
-import { useSession } from 'next-auth/react';
 import { Source } from '@/utils/api-client/interfaces/source';
 import { Box, Chip, Typography, Paper } from '@mui/material';
 import GridToolbar from '@/components/common/GridToolbar';
@@ -33,9 +31,7 @@ import SelectionModeToggle from '@/components/common/SelectionModeToggle';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import styles from '@/styles/Knowledge.module.css';
-import { usePaginatedList } from '@/hooks/usePaginatedList';
-import { listParams } from '@/utils/list';
-import { DEFAULT_GRID_SORT } from '@/utils/grid-sort';
+import { useList } from '@/hooks/useList';
 import { sourcesList } from './list';
 import { ChatIcon, MenuBookIcon } from '@/components/icons';
 import { formatFileSize, getFileExtension } from '@/constants/knowledge';
@@ -50,7 +46,6 @@ import {
   useBulkDelete,
   type BulkDeleteActionsState,
 } from '@/hooks/useBulkDelete';
-import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 import GridStateGate from '@/components/common/GridStateGate';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 
@@ -129,7 +124,6 @@ export default function SourcesGrid({
   refreshTrigger,
 }: SourcesGridProps) {
   const router = useRouter();
-  const { status } = useSession();
   const canEditSource = useCan(Capability.Source.UPDATE);
   const canDeleteSource = useCan(Capability.Source.DELETE);
 
@@ -138,7 +132,6 @@ export default function SourcesGrid({
   const [drawerFilters, setDrawerFilters] =
     useState<SourceFilters>(EMPTY_SOURCE_FILTERS);
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortModel, setSortModel] = useState<GridSortModel>(DEFAULT_GRID_SORT);
 
   const filters = useMemo(
     () => ({
@@ -150,40 +143,20 @@ export default function SourcesGrid({
     [searchQuery, drawerFilters]
   );
 
-  const sort = useMemo(
-    () => ({
-      by: sortModel[0]?.field || 'created_at',
-      order: (sortModel[0]?.sort || 'desc') as 'asc' | 'desc',
-    }),
-    [sortModel]
-  );
-
   const {
     data: sources,
     totalCount,
     isLoading: loading,
     error,
-    page,
-    rowsPerPage: pageSize,
-    onPageChange,
-    onRowsPerPageChange,
     refresh,
-  } = usePaginatedList<Source>({
-    fetchPage: ({ skip, limit }) =>
-      sourcesList.list(
-        new ApiClientFactory(),
-        listParams(sourcesList, {
-          page: skip / limit + 1,
-          pageSize: limit,
-          sort,
-          filters,
-        })
-      ),
-    filterFingerprint: JSON.stringify({ filters, sort }),
-    defaultPageSize: sourcesList.defaultPageSize,
+    paginationModel,
+    onPaginationModelChange: handlePaginationModelChange,
+    sortModel,
+    onSortModelChange: handleSortModelChange,
+  } = useList(sourcesList, {
+    filters,
     initialData,
     initialTotalCount,
-    enabled: isAuthenticated(status),
   });
 
   const {
@@ -205,21 +178,6 @@ export default function SourcesGrid({
     itemLabelPlural: 'sources',
     onBulkActionsChange,
   });
-
-  const paginationModel = useMemo(() => ({ page, pageSize }), [page, pageSize]);
-  const handlePaginationModelChange = useCallback(
-    (model: { page: number; pageSize: number }) => {
-      if (model.pageSize !== pageSize) {
-        onRowsPerPageChange(model.pageSize);
-      } else {
-        onPageChange(model.page);
-      }
-    },
-    [pageSize, onPageChange, onRowsPerPageChange]
-  );
-  const handleSortModelChange = useCallback((model: GridSortModel) => {
-    setSortModel(model);
-  }, []);
 
   const isFirstRefreshTrigger = useRef(true);
   useEffect(() => {

--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
@@ -34,12 +34,10 @@ import {
 } from '@/components/common/SectionOverviewTable';
 import { DeleteIcon } from '@/components/icons';
 import { useSession } from 'next-auth/react';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { User } from '@/utils/api-client/interfaces/user';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { DeleteModal } from '@/components/common/DeleteModal';
-import { usePaginatedList } from '@/hooks/usePaginatedList';
-import { listParams } from '@/utils/list';
+import { useList } from '@/hooks/useList';
 import {
   EMPTY_TEAM_FILTERS,
   hasActiveTeamFilters,
@@ -113,20 +111,8 @@ export default function TeamMembersGrid({
     onPageChange: setPage,
     onRowsPerPageChange,
     refresh,
-  } = usePaginatedList<User>({
-    fetchPage: ({ skip, limit }) =>
-      teamList.list(
-        new ApiClientFactory(),
-        listParams(teamList, {
-          page: skip / limit + 1,
-          pageSize: limit,
-          sort: teamList.defaultSort,
-          filters,
-        })
-      ),
-    filterFingerprint: JSON.stringify(filters),
-    defaultPageSize: teamList.defaultPageSize,
-    enabled: isAuthenticated(status),
+  } = useList(teamList, {
+    filters,
     onError: () => setError('Failed to load team members. Please try again.'),
   });
 

--- a/apps/frontend/src/app/(protected)/organizations/team/components/list.ts
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/list.ts
@@ -90,16 +90,15 @@ const TEAM_FILTERS = {
 };
 
 /**
- * Not wired through `useList`/`useListAuthGate`: today's team grid has no
- * independent read gate of its own (only Organization.READ, checked one level up by
- * `organizations/settings/page.tsx`), and adding one here would be a new restriction, not a
- * port. `capability` is still declared for documentation/typing; only `list`/`listParams`
- * are actually used, via `usePaginatedList` directly in `TeamMembersGrid`.
+ * Gated on Organization.READ, not Member.READ: the team grid has never had an
+ * independent read gate of its own -- `organizations/settings/page.tsx` checks
+ * Organization.READ one level up, and every Viewer holds it. Using Member.READ
+ * here would be a new restriction, not a port.
  */
 export const teamList = defineList({
   title: 'Team',
   resource: 'team members',
-  capability: Capability.Member.READ,
+  capability: Capability.Organization.READ,
   defaultPageSize: 25,
   filters: TEAM_FILTERS,
   list: (factory: ApiClientFactory, params) =>

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -17,7 +17,6 @@ import {
 } from '@mui/x-data-grid';
 import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
 import { useRouter } from 'next/navigation';
-import { useSession } from 'next-auth/react';
 import { Task } from '@/utils/api-client/interfaces/task';
 import { can } from '@/utils/affordances';
 import { Capability } from '@/constants/capabilities';
@@ -27,8 +26,7 @@ import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
 import SelectionModeToggle from '@/components/common/SelectionModeToggle';
 import GridBadge from '@/components/common/GridBadge';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { usePaginatedList } from '@/hooks/usePaginatedList';
-import { listParams } from '@/utils/list';
+import { useList } from '@/hooks/useList';
 import { tasksList } from './list';
 import { AVATAR_SIZES } from '@/constants/avatar-sizes';
 import TaskFilterDrawer, {
@@ -51,7 +49,6 @@ import {
   useBulkDelete,
   type BulkDeleteActionsState,
 } from '@/hooks/useBulkDelete';
-import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 import GridStateGate from '@/components/common/GridStateGate';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 
@@ -147,7 +144,6 @@ export default function TasksGrid({
 }: TasksGridProps) {
   const router = useRouter();
   const { highlightedIds, clearHighlight } = useJobNotifications();
-  const { status } = useSession();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
@@ -181,25 +177,11 @@ export default function TasksGrid({
     totalCount,
     isLoading: loading,
     error: rawError,
-    page,
-    rowsPerPage: pageSize,
-    onPageChange,
-    onRowsPerPageChange,
     refresh,
-  } = usePaginatedList<Task>({
-    fetchPage: ({ skip, limit }) =>
-      tasksList.list(
-        new ApiClientFactory(),
-        listParams(tasksList, {
-          page: skip / limit + 1,
-          pageSize: limit,
-          sort: tasksList.defaultSort,
-          filters,
-        })
-      ),
-    filterFingerprint: JSON.stringify(filters),
-    defaultPageSize: tasksList.defaultPageSize,
-    enabled: isAuthenticated(status),
+    paginationModel,
+    onPaginationModelChange: handlePaginationModelChange,
+  } = useList(tasksList, {
+    filters,
     onError: () => setErrorDismissed(false),
   });
 
@@ -209,18 +191,6 @@ export default function TasksGrid({
 
   const error = rawError && !errorDismissed ? rawError : null;
   const dismissError = useCallback(() => setErrorDismissed(true), []);
-
-  const paginationModel = useMemo(() => ({ page, pageSize }), [page, pageSize]);
-  const handlePaginationModelChange = useCallback(
-    (model: { page: number; pageSize: number }) => {
-      if (model.pageSize !== pageSize) {
-        onRowsPerPageChange(model.pageSize);
-      } else {
-        onPageChange(model.page);
-      }
-    },
-    [pageSize, onPageChange, onRowsPerPageChange]
-  );
 
   const {
     checkboxSelectionMode,

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -8,7 +8,6 @@ import React, {
   useContext,
   useMemo,
 } from 'react';
-import { useSession } from 'next-auth/react';
 import {
   useBulkDelete,
   type BulkDeleteActionsState,
@@ -21,7 +20,6 @@ import TagLabel from '@/components/common/Tag';
 import {
   GridColDef,
   GridRowParams,
-  GridSortModel,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
   GridToolbarExport,
@@ -62,9 +60,7 @@ import { can } from '@/utils/affordances';
 import { Capability } from '@/constants/capabilities';
 import { Tag } from '@/utils/api-client/interfaces/tag';
 import { DeleteModal } from '@/components/common/DeleteModal';
-import { usePaginatedList } from '@/hooks/usePaginatedList';
-import { listParams } from '@/utils/list';
-import { DEFAULT_GRID_SORT } from '@/utils/grid-sort';
+import { useList } from '@/hooks/useList';
 import { testRunsList } from './list';
 import TestRunFilterDrawer, {
   type TestRunFilters,
@@ -76,7 +72,6 @@ import {
   createRowActionsColumn,
   rowActionsHoverSx,
 } from '@/components/common/createRowActionsColumn';
-import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 import GridStateGate from '@/components/common/GridStateGate';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
@@ -187,7 +182,6 @@ function TestRunsGrid({
   onBulkActionsChange,
   refreshTrigger,
 }: TestRunsGridProps) {
-  const { status } = useSession();
   const router = useRouter();
   const notifications = useNotifications();
   const { highlightedIds, clearHighlight } = useNotificationBadges();
@@ -208,7 +202,6 @@ function TestRunsGrid({
   const [isCancelling, setIsCancelling] = useState(false);
   const [pendingCancelId, setPendingCancelId] = useState<string | null>(null);
   const [runKindFilter, setRunKindFilter] = useState<RunKindFilter>('all');
-  const [sortModel, setSortModel] = useState<GridSortModel>(DEFAULT_GRID_SORT);
   const [errorDismissed, setErrorDismissed] = useState(false);
 
   // ── Grid state (pagination, filter, sort) ─────────────────────────────────
@@ -229,19 +222,11 @@ function TestRunsGrid({
     [searchQuery, statusFilter, drawerFilters, runKindFilter]
   );
 
-  const sort = useMemo(
-    () => ({
-      by: sortModel[0]?.field || 'created_at',
-      order: (sortModel[0]?.sort || 'desc') as 'asc' | 'desc',
-    }),
-    [sortModel]
-  );
-
   // ── Data fetching ─────────────────────────────────────────────────────────
 
   // No `initialData`/SSR prefetch here on purpose: a run appears here as soon
   // as it's started, so server-rendered (and thus already-stale-by-the-time-
-  // it-renders) data would hide it. `usePaginatedList` always fetches once on
+  // it-renders) data would hide it. `useList` always fetches once on
   // mount when `initialData` is absent, which is exactly the guarantee this
   // page needs -- see the same note in TestSetsGrid.
   const {
@@ -249,25 +234,13 @@ function TestRunsGrid({
     totalCount,
     isLoading: loading,
     error: rawError,
-    page,
-    rowsPerPage: pageSize,
-    onPageChange,
-    onRowsPerPageChange,
     refresh,
-  } = usePaginatedList<TestRunDetail>({
-    fetchPage: ({ skip, limit }) =>
-      testRunsList.list(
-        new ApiClientFactory(),
-        listParams(testRunsList, {
-          page: skip / limit + 1,
-          pageSize: limit,
-          sort,
-          filters,
-        })
-      ),
-    filterFingerprint: JSON.stringify({ filters, sort }),
-    defaultPageSize: testRunsList.defaultPageSize,
-    enabled: isAuthenticated(status),
+    paginationModel,
+    onPaginationModelChange: handlePaginationModelChange,
+    sortModel,
+    onSortModelChange: handleSortModelChange,
+  } = useList(testRunsList, {
+    filters,
     onError: () => setErrorDismissed(false),
   });
 
@@ -277,21 +250,6 @@ function TestRunsGrid({
 
   const error = rawError && !errorDismissed ? rawError : null;
   const dismissError = useCallback(() => setErrorDismissed(true), []);
-
-  const paginationModel = useMemo(() => ({ page, pageSize }), [page, pageSize]);
-  const handlePaginationModelChange = useCallback(
-    (model: { page: number; pageSize: number }) => {
-      if (model.pageSize !== pageSize) {
-        onRowsPerPageChange(model.pageSize);
-      } else {
-        onPageChange(model.page);
-      }
-    },
-    [pageSize, onPageChange, onRowsPerPageChange]
-  );
-  const handleSortModelChange = useCallback((model: GridSortModel) => {
-    setSortModel(model);
-  }, []);
 
   // ── Bulk selection + delete ──────────────────────────────────────────────────
   const {

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -11,18 +11,14 @@ import React, {
 import {
   GridColDef,
   GridRowParams,
-  GridSortModel,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
   GridToolbarExport,
 } from '@mui/x-data-grid';
 import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
 import { useRouter } from 'next/navigation';
-import { usePaginatedList } from '@/hooks/usePaginatedList';
-import { listParams } from '@/utils/list';
-import { DEFAULT_GRID_SORT } from '@/utils/grid-sort';
+import { useList } from '@/hooks/useList';
 import { testSetsList } from './list';
-import { TestSet } from '@/utils/api-client/interfaces/test-set';
 import { Tag } from '@/utils/api-client/interfaces/tag';
 import {
   Box,
@@ -212,7 +208,6 @@ export default function TestSetsGrid({
   );
   const [testRunDrawerOpen, setTestRunDrawerOpen] = useState(false);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [sortModel, setSortModel] = useState<GridSortModel>(DEFAULT_GRID_SORT);
   const [errorDismissed, setErrorDismissed] = useState(false);
 
   // A pill click wins over the drawer's own testSetType value, matching the
@@ -236,43 +231,23 @@ export default function TestSetsGrid({
     [searchQuery, effectiveTestSetType, drawerFilters]
   );
 
-  const sort = useMemo(
-    () => ({
-      by: sortModel[0]?.field || 'created_at',
-      order: (sortModel[0]?.sort || 'desc') as 'asc' | 'desc',
-    }),
-    [sortModel]
-  );
-
   // No `initialData`/SSR prefetch here on purpose: a test set row exists from
   // the moment generation is *submitted* (the flow then redirects to its
   // detail page), so server-rendered data could predate a just-submitted row.
-  // `usePaginatedList` always fetches once on mount when `initialData` is
+  // `useList` always fetches once on mount when `initialData` is
   // absent, which is exactly the guarantee this page needs.
   const {
     data: testSets,
     totalCount,
     isLoading: loading,
     error: rawError,
-    page,
-    rowsPerPage: pageSize,
-    onPageChange,
-    onRowsPerPageChange,
     refresh,
-  } = usePaginatedList<TestSet>({
-    fetchPage: ({ skip, limit }) =>
-      testSetsList.list(
-        new ApiClientFactory(),
-        listParams(testSetsList, {
-          page: skip / limit + 1,
-          pageSize: limit,
-          sort,
-          filters,
-        })
-      ),
-    filterFingerprint: JSON.stringify({ filters, sort }),
-    defaultPageSize: testSetsList.defaultPageSize,
-    enabled: isAuthenticated(status),
+    paginationModel,
+    onPaginationModelChange: handlePaginationModelChange,
+    sortModel,
+    onSortModelChange: handleSortModelChange,
+  } = useList(testSetsList, {
+    filters,
     onError: () => setErrorDismissed(false),
   });
 
@@ -282,21 +257,6 @@ export default function TestSetsGrid({
 
   const error = rawError && !errorDismissed ? rawError : null;
   const dismissError = useCallback(() => setErrorDismissed(true), []);
-
-  const paginationModel = useMemo(() => ({ page, pageSize }), [page, pageSize]);
-  const handlePaginationModelChange = useCallback(
-    (model: { page: number; pageSize: number }) => {
-      if (model.pageSize !== pageSize) {
-        onRowsPerPageChange(model.pageSize);
-      } else {
-        onPageChange(model.page);
-      }
-    },
-    [pageSize, onPageChange, onRowsPerPageChange]
-  );
-  const handleSortModelChange = useCallback((model: GridSortModel) => {
-    setSortModel(model);
-  }, []);
 
   const isFirstRefreshTrigger = useRef(true);
   useEffect(() => {

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -14,7 +14,6 @@ import {
   GridRowParams,
   GridRowSelectionModel,
   GridRenderCellParams,
-  GridSortModel,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
   GridToolbarExport,
@@ -48,9 +47,7 @@ import { TestSet } from '@/utils/api-client/interfaces/test-set';
 import { TestSetsClient } from '@/utils/api-client/test-sets-client';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { DeleteModal } from '@/components/common/DeleteModal';
-import { usePaginatedList } from '@/hooks/usePaginatedList';
-import { listParams } from '@/utils/list';
-import { DEFAULT_GRID_SORT } from '@/utils/grid-sort';
+import { useList } from '@/hooks/useList';
 import { testsList } from './list';
 import TestFilterDrawer, {
   type TestFilters,
@@ -193,7 +190,6 @@ export default function TestsTable({
 }: TestsTableProps) {
   const router = useRouter();
   const notifications = useNotifications();
-  const isMounted = useRef(true);
   const canEditTest = useCan(Capability.Test.UPDATE);
   const canDeleteTest = useCan(Capability.Test.DELETE);
   const { status } = useSession();
@@ -203,7 +199,6 @@ export default function TestsTable({
   const [typeFilter, setTypeFilter] = useState('all');
   const [drawerFilters, setDrawerFilters] =
     useState<TestFilters>(EMPTY_TEST_FILTERS);
-  const [sortModel, setSortModel] = useState<GridSortModel>(DEFAULT_GRID_SORT);
   const [errorDismissed, setErrorDismissed] = useState(false);
 
   // Component state
@@ -263,42 +258,22 @@ export default function TestsTable({
     [searchQuery, effectiveTestType, drawerFilters]
   );
 
-  const sort = useMemo(
-    () => ({
-      by: sortModel[0]?.field || 'created_at',
-      order: (sortModel[0]?.sort || 'desc') as 'asc' | 'desc',
-    }),
-    [sortModel]
-  );
-
   const {
     data: tests,
     totalCount,
     isLoading: loading,
     error: rawError,
     page,
-    rowsPerPage: pageSize,
     onPageChange,
-    onRowsPerPageChange,
     refresh,
-  } = usePaginatedList<TestDetail>({
-    fetchPage: ({ skip, limit }) =>
-      testsList.list(
-        new ApiClientFactory(),
-        listParams(
-          testsList,
-          {
-            page: skip / limit + 1,
-            pageSize: limit,
-            sort,
-            filters,
-          },
-          insightsIdFilter ? [insightsIdFilter] : []
-        )
-      ),
-    filterFingerprint: JSON.stringify({ filters, sort, insightsIdFilter }),
-    defaultPageSize: testsList.defaultPageSize,
-    enabled: isAuthenticated(status) && insightsFilterReady,
+    paginationModel,
+    onPaginationModelChange: handlePaginationModelChange,
+    sortModel,
+    onSortModelChange: handleSortModelChange,
+  } = useList(testsList, {
+    filters,
+    extraFilters: insightsIdFilter ? [insightsIdFilter] : undefined,
+    enabled: insightsFilterReady,
     onError: () => setErrorDismissed(false),
   });
 
@@ -308,21 +283,6 @@ export default function TestsTable({
 
   const error = rawError && !errorDismissed ? rawError : null;
   const dismissError = useCallback(() => setErrorDismissed(true), []);
-
-  const paginationModel = useMemo(() => ({ page, pageSize }), [page, pageSize]);
-  const handlePaginationModelChange = useCallback(
-    (model: { page: number; pageSize: number }) => {
-      if (model.pageSize !== pageSize) {
-        onRowsPerPageChange(model.pageSize);
-      } else {
-        onPageChange(model.page);
-      }
-    },
-    [pageSize, onPageChange, onRowsPerPageChange]
-  );
-  const handleSortModelChange = useCallback((model: GridSortModel) => {
-    setSortModel(model);
-  }, []);
 
   // Compute whether selected tests have mixed types
   const selectedTestTypes = useMemo(() => {

--- a/apps/frontend/src/hooks/useList.ts
+++ b/apps/frontend/src/hooks/useList.ts
@@ -1,10 +1,12 @@
 'use client';
 
-import type { GridPaginationModel } from '@mui/x-data-grid';
+import * as React from 'react';
+import type { GridPaginationModel, GridSortModel } from '@mui/x-data-grid';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import {
   listParams,
   type ListDescriptor,
+  type ListSort,
   type FilterSpecMap,
   type FiltersOf,
 } from '@/utils/list';
@@ -13,6 +15,17 @@ import { usePaginatedList } from './usePaginatedList';
 
 interface UseListOptions<T, S extends FilterSpecMap> {
   filters: FiltersOf<S>;
+  /**
+   * OData clauses the caller doesn't own, passed through to `listParams` --
+   * e.g. scoping an embedded grid to one project, or Tests' resolved
+   * Insights id filter.
+   */
+  extraFilters?: (string | undefined)[];
+  /**
+   * Extra fetch gate AND'd with the auth gate -- e.g. Tests waiting for its
+   * Insights deep-link filter to resolve. Defaults to `true`.
+   */
+  enabled?: boolean;
   initialData?: T[];
   initialTotalCount?: number;
   onData?: (data: T[]) => void;
@@ -20,14 +33,18 @@ interface UseListOptions<T, S extends FilterSpecMap> {
 }
 
 /**
- * The client-side half of a list page: permission gate + paginated fetch,
- * both driven off one descriptor. Page/rowsPerPage state lives in
- * `usePaginatedList`; filters are owned by the caller and passed in.
+ * The client-side half of a list page: permission gate + paginated fetch +
+ * sort state, all driven off one descriptor. Page/rowsPerPage state lives in
+ * `usePaginatedList`; sort starts from `descriptor.defaultSort` (so it always
+ * matches what an SSR prefetch used); filters are owned by the caller and
+ * passed in.
  */
 export function useList<T, S extends FilterSpecMap>(
   descriptor: ListDescriptor<T, S>,
   {
     filters,
+    extraFilters,
+    enabled = true,
     initialData,
     initialTotalCount,
     onData,
@@ -36,24 +53,37 @@ export function useList<T, S extends FilterSpecMap>(
 ) {
   const gate = useListAuthGate(descriptor);
 
+  const [sortModel, setSortModel] = React.useState<GridSortModel>([
+    { field: descriptor.defaultSort.by, sort: descriptor.defaultSort.order },
+  ]);
+  // An un-sorted grid (user cleared the column sort) falls back to the default.
+  const sort: ListSort = {
+    by: sortModel[0]?.field ?? descriptor.defaultSort.by,
+    order: sortModel[0]?.sort ?? descriptor.defaultSort.order,
+  };
+
   const list = usePaginatedList<T>({
     fetchPage: ({ skip, limit }) =>
       descriptor.list(
         new ApiClientFactory(),
-        listParams(descriptor, {
-          page: skip / limit + 1,
-          pageSize: limit,
-          sort: descriptor.defaultSort,
-          filters,
-        })
+        listParams(
+          descriptor,
+          {
+            page: skip / limit + 1,
+            pageSize: limit,
+            sort,
+            filters,
+          },
+          extraFilters ?? []
+        )
       ),
-    filterFingerprint: JSON.stringify(filters),
+    filterFingerprint: JSON.stringify({ filters, sort, extraFilters }),
     defaultPageSize: descriptor.defaultPageSize,
     initialData,
     initialTotalCount,
     onData,
     onError,
-    enabled: gate.ready,
+    enabled: gate.ready && enabled,
   });
 
   return {
@@ -69,5 +99,8 @@ export function useList<T, S extends FilterSpecMap>(
         list.onPageChange(model.page);
       }
     },
+    /** Spread onto a sortable `<BaseDataGrid>`; omit for grids with fixed sort. */
+    sortModel,
+    onSortModelChange: setSortModel,
   };
 }

--- a/apps/frontend/src/hooks/useList.ts
+++ b/apps/frontend/src/hooks/useList.ts
@@ -56,7 +56,6 @@ export function useList<T, S extends FilterSpecMap>(
   const [sortModel, setSortModel] = React.useState<GridSortModel>([
     { field: descriptor.defaultSort.by, sort: descriptor.defaultSort.order },
   ]);
-  // An un-sorted grid (user cleared the column sort) falls back to the default.
   const sort: ListSort = {
     by: sortModel[0]?.field ?? descriptor.defaultSort.by,
     order: sortModel[0]?.sort ?? descriptor.defaultSort.order,
@@ -101,6 +100,16 @@ export function useList<T, S extends FilterSpecMap>(
     },
     /** Spread onto a sortable `<BaseDataGrid>`; omit for grids with fixed sort. */
     sortModel,
-    onSortModelChange: setSortModel,
+    onSortModelChange: (model: GridSortModel) =>
+      setSortModel(
+        model.length > 0
+          ? model
+          : [
+              {
+                field: descriptor.defaultSort.by,
+                sort: descriptor.defaultSort.order,
+              },
+            ]
+      ),
   };
 }


### PR DESCRIPTION
## Purpose

Eight list grids bypassed `useList` and hand-rolled `usePaginatedList` because the hook hardcoded the descriptor's default sort and dropped `listParams`' extra-clause argument. This closes those gaps so every list page goes through the one hook, which is also the prerequisite for moving the remaining pages to SSR prefetch.

## What Changed

- `useList` now owns the MUI sort model (seeded from `descriptor.defaultSort`), and accepts `extraFilters` (threaded into `listParams`) and `enabled` (AND'd with the auth gate). Sort and extra clauses are part of the refetch fingerprint.
- Migrated all eight direct `usePaginatedList` callers to `useList`: Tasks, Experiments, Endpoints, Test Runs, Test Sets, Sources, Tests, and Team Members. Each migration deletes local sort state, pagination plumbing, and `DEFAULT_GRID_SORT` copies.
- `teamList`'s capability becomes `Organization.READ`: the team grid's only real gate was the settings page's `Organization.READ` check, so the hook's built-in gate now matches it instead of adding a new `Member.READ` restriction.

## Additional Context

- Net -232 lines. `usePaginatedList` now has a single caller: `useList`.
- First step of the plan that continues in #2607 (SSR prefetch for the remaining list pages).

## Testing

- `npx tsc --noEmit`, ESLint, and Prettier are clean (no new warnings).
- Full jest suite passes (228 suites, 2115 tests).
- Manual: each migrated grid paginates, sorts, filters, and refreshes as before.
