### PR TITLE
Move Tasks, Test Runs, Test Sets and Tests pages to SSR prefetch

### DIFF
--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -58,6 +58,9 @@ interface TasksGridProps {
   onBulkActionsChange?: (actions: BulkDeleteActionsState) => void;
   /** Bumped by the page after a create succeeds, to trigger a re-fetch. */
   refreshTrigger?: number;
+  /** Server-fetched first page — when present, skips the initial client fetch. */
+  initialData?: Task[];
+  initialTotalCount?: number;
 }
 
 const STATUS_PILL_TABS = [
@@ -141,6 +144,8 @@ export default function TasksGrid({
   onCreateClick,
   onBulkActionsChange,
   refreshTrigger,
+  initialData,
+  initialTotalCount,
 }: TasksGridProps) {
   const router = useRouter();
   const { highlightedIds, clearHighlight } = useJobNotifications();
@@ -182,6 +187,8 @@ export default function TasksGrid({
     onPaginationModelChange: handlePaginationModelChange,
   } = useList(tasksList, {
     filters,
+    initialData,
+    initialTotalCount,
     onError: () => setErrorDismissed(false),
   });
 

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksPageClient.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import { useSearchParams } from 'next/navigation';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
+import { Can, useCan } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
+import { useBulkActionsBridge } from '@/hooks/useBulkActionsBridge';
+import { useListAuthGate } from '@/hooks/useListAuthGate';
+import TasksGrid from './TasksGrid';
+import TaskDrawer, { type TaskDrawerInitialEntity } from './TaskDrawer';
+import { tasksList } from './list';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { EntityType } from '@/types/tasks';
+import type { Task } from '@/utils/api-client/interfaces/task';
+
+interface TasksPageClientProps {
+  /** Server-fetched first page — when present, skips the initial client fetch. */
+  initialData?: Task[];
+  initialTotalCount?: number;
+}
+
+export default function TasksPageClient({
+  initialData,
+  initialTotalCount = 0,
+}: TasksPageClientProps) {
+  const gate = useListAuthGate(tasksList);
+  const canCreateTask = useCan(Capability.Task.CREATE);
+  const searchParams = useSearchParams();
+  const [createDrawerOpen, setCreateDrawerOpen] = React.useState(false);
+  const [initialEntity, setInitialEntity] = React.useState<
+    TaskDrawerInitialEntity | undefined
+  >();
+  const [refreshTrigger, setRefreshTrigger] = React.useState(0);
+  const { bulkActionsVisible, onBulkDelete, handleBulkActionsChange } =
+    useBulkActionsBridge();
+
+  useDocumentTitle('Tasks');
+
+  React.useEffect(() => {
+    const shouldOpen = searchParams.get('create') === 'true';
+    if (!shouldOpen) return;
+
+    const entityType = searchParams.get('entityType') as EntityType | null;
+    const entityId = searchParams.get('entityId');
+    const commentId = searchParams.get('commentId');
+
+    const task_metadata: Record<string, unknown> = {};
+    if (commentId) task_metadata.comment_id = commentId;
+    const testResultId = searchParams.get('test_result_id');
+    const testRunId = searchParams.get('test_run_id');
+    if (testResultId) task_metadata.test_result_id = testResultId;
+    if (testRunId) task_metadata.test_run_id = testRunId;
+
+    if (entityType && entityId) {
+      setInitialEntity({
+        entityType,
+        entityId,
+        task_metadata:
+          Object.keys(task_metadata).length > 0 ? task_metadata : undefined,
+      });
+    } else {
+      setInitialEntity(undefined);
+    }
+
+    setCreateDrawerOpen(true);
+
+    const newUrl = new URL(window.location.href);
+    newUrl.searchParams.delete('create');
+    window.history.replaceState({}, '', newUrl.toString());
+  }, [searchParams]);
+
+  const handleCreateSuccess = React.useCallback(() => {
+    setCreateDrawerOpen(false);
+    setInitialEntity(undefined);
+    setRefreshTrigger(prev => prev + 1);
+  }, []);
+
+  const handleCloseDrawer = React.useCallback(() => {
+    setCreateDrawerOpen(false);
+    setInitialEntity(undefined);
+  }, []);
+
+  if (!gate.ready) return gate.node;
+
+  return (
+    <>
+      <PageLayout
+        title="Tasks"
+        description="Track and manage work items linked to tests, endpoints, and comments across your organization."
+        breadcrumbs={[]}
+        actions={
+          <FabGroup>
+            {bulkActionsVisible && (
+              <Can capability={Capability.Task.DELETE}>
+                <Fab
+                  icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
+                  tooltip="Delete Tasks"
+                  aria-label="Delete Tasks"
+                  onClick={onBulkDelete}
+                  sx={{
+                    bgcolor: 'error.main',
+                    '&:hover': { bgcolor: 'error.dark' },
+                  }}
+                />
+              </Can>
+            )}
+            <Can capability={Capability.Task.CREATE}>
+              <Fab
+                icon={<FabAddIcon />}
+                tooltip="New Task"
+                aria-label="New Task"
+                onClick={() => {
+                  setInitialEntity(undefined);
+                  setCreateDrawerOpen(true);
+                }}
+              />
+            </Can>
+          </FabGroup>
+        }
+      >
+        <Box sx={{ mt: 2, mb: 2 }}>
+          <TasksGrid
+            canCreate={canCreateTask}
+            onCreateClick={() => {
+              setInitialEntity(undefined);
+              setCreateDrawerOpen(true);
+            }}
+            onBulkActionsChange={handleBulkActionsChange}
+            refreshTrigger={refreshTrigger}
+            initialData={initialData}
+            initialTotalCount={initialTotalCount}
+          />
+        </Box>
+      </PageLayout>
+
+      <TaskDrawer
+        open={createDrawerOpen}
+        onClose={handleCloseDrawer}
+        initialEntity={initialEntity}
+        onSuccess={handleCreateSuccess}
+      />
+    </>
+  );
+}

--- a/apps/frontend/src/app/(protected)/tasks/components/__tests__/TasksPageClient.test.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/__tests__/TasksPageClient.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import TasksPage from '../page';
+import TasksPageClient from '../TasksPageClient';
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -30,7 +30,7 @@ jest.mock('@/components/common/Can', () => ({
 
 // TasksGrid owns the query and the loading/empty/populated decision itself —
 // the page's only job is to wire `canCreate`/`onCreateClick` through to it.
-jest.mock('../components/TasksGrid', () => {
+jest.mock('../TasksGrid', () => {
   return function MockTasksGrid({
     canCreate,
     onCreateClick,
@@ -46,20 +46,20 @@ jest.mock('../components/TasksGrid', () => {
   };
 });
 
-jest.mock('../components/TaskDrawer', () => {
+jest.mock('../TaskDrawer', () => {
   return function MockTaskDrawer({ open }: { open: boolean }) {
     return open ? <div data-testid="task-drawer" /> : null;
   };
 });
 
-describe('TasksPage', () => {
+describe('TasksPageClient', () => {
   it('passes canCreate through to the grid', () => {
-    render(<TasksPage />);
+    render(<TasksPageClient />);
     expect(screen.getByText('mock-create-task')).toBeEnabled();
   });
 
   it('opens the create drawer when the grid invokes onCreateClick', async () => {
-    render(<TasksPage />);
+    render(<TasksPageClient />);
     await userEvent.click(screen.getByText('mock-create-task'));
     expect(screen.getByTestId('task-drawer')).toBeInTheDocument();
   });

--- a/apps/frontend/src/app/(protected)/tasks/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/page.tsx
@@ -1,165 +1,36 @@
-'use client';
-
-import * as React from 'react';
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
-import { useSession } from 'next-auth/react';
-import { useSearchParams } from 'next/navigation';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
-import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
+import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { prefetchList } from '@/utils/server-prefetch';
+import { emptyFilters, listParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
-import AccessDenied from '@/components/common/AccessDenied';
-import PageLoadingState from '@/components/common/PageLoadingState';
-import { useBulkActionsBridge } from '@/hooks/useBulkActionsBridge';
-import TasksGrid from './components/TasksGrid';
-import TaskDrawer, {
-  type TaskDrawerInitialEntity,
-} from './components/TaskDrawer';
-import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { EntityType } from '@/types/tasks';
-import { isAuthenticated, isSessionLoading } from '@/hooks/useIsAuthenticated';
+import TasksPageClient from './components/TasksPageClient';
+import { tasksList } from './components/list';
 
-export default function TasksPage() {
-  const { status } = useSession();
-  const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
-    Capability.Task.READ
+/**
+ * Server component: fetches the first page of tasks before rendering so the
+ * page arrives with content already in place -- no client-side spinner on
+ * first load. See `prefetchList` for the permission-gating rationale.
+ */
+export default async function TasksPage() {
+  const factory = await createServerApiFactory();
+
+  const { initialData, initialTotalCount } = await prefetchList(
+    Capability.Task.READ,
+    () =>
+      tasksList.list(
+        factory,
+        listParams(tasksList, {
+          page: 1,
+          pageSize: tasksList.defaultPageSize,
+          sort: tasksList.defaultSort,
+          filters: emptyFilters(tasksList),
+        })
+      )
   );
-  const canCreateTask = useCan(Capability.Task.CREATE);
-  const searchParams = useSearchParams();
-  const [createDrawerOpen, setCreateDrawerOpen] = React.useState(false);
-  const [initialEntity, setInitialEntity] = React.useState<
-    TaskDrawerInitialEntity | undefined
-  >();
-  const [refreshTrigger, setRefreshTrigger] = React.useState(0);
-  const { bulkActionsVisible, onBulkDelete, handleBulkActionsChange } =
-    useBulkActionsBridge();
-
-  useDocumentTitle('Tasks');
-
-  React.useEffect(() => {
-    const shouldOpen = searchParams.get('create') === 'true';
-    if (!shouldOpen) return;
-
-    const entityType = searchParams.get('entityType') as EntityType | null;
-    const entityId = searchParams.get('entityId');
-    const commentId = searchParams.get('commentId');
-
-    const task_metadata: Record<string, unknown> = {};
-    if (commentId) task_metadata.comment_id = commentId;
-    const testResultId = searchParams.get('test_result_id');
-    const testRunId = searchParams.get('test_run_id');
-    if (testResultId) task_metadata.test_result_id = testResultId;
-    if (testRunId) task_metadata.test_run_id = testRunId;
-
-    if (entityType && entityId) {
-      setInitialEntity({
-        entityType,
-        entityId,
-        task_metadata:
-          Object.keys(task_metadata).length > 0 ? task_metadata : undefined,
-      });
-    } else {
-      setInitialEntity(undefined);
-    }
-
-    setCreateDrawerOpen(true);
-
-    const newUrl = new URL(window.location.href);
-    newUrl.searchParams.delete('create');
-    window.history.replaceState({}, '', newUrl.toString());
-  }, [searchParams]);
-
-  const handleCreateSuccess = React.useCallback(() => {
-    setCreateDrawerOpen(false);
-    setInitialEntity(undefined);
-    setRefreshTrigger(prev => prev + 1);
-  }, []);
-
-  const handleCloseDrawer = React.useCallback(() => {
-    setCreateDrawerOpen(false);
-    setInitialEntity(undefined);
-  }, []);
-
-  if (isSessionLoading(status)) {
-    return (
-      <PageLayout title="Tasks" breadcrumbs={[]}>
-        <Box sx={{ p: 3 }}>
-          <Typography>Loading...</Typography>
-        </Box>
-      </PageLayout>
-    );
-  }
-
-  if (permsLoading) return <PageLoadingState />;
-  if (!canRead) return <AccessDenied resource="tasks" />;
-
-  if (!isAuthenticated(status)) {
-    return (
-      <PageLayout title="Tasks" breadcrumbs={[]}>
-        <Box sx={{ p: 3 }}>
-          <Typography color="error">No session token available</Typography>
-        </Box>
-      </PageLayout>
-    );
-  }
 
   return (
-    <>
-      <PageLayout
-        title="Tasks"
-        description="Track and manage work items linked to tests, endpoints, and comments across your organization."
-        breadcrumbs={[]}
-        actions={
-          <FabGroup>
-            {bulkActionsVisible && (
-              <Can capability={Capability.Task.DELETE}>
-                <Fab
-                  icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
-                  tooltip="Delete Tasks"
-                  aria-label="Delete Tasks"
-                  onClick={onBulkDelete}
-                  sx={{
-                    bgcolor: 'error.main',
-                    '&:hover': { bgcolor: 'error.dark' },
-                  }}
-                />
-              </Can>
-            )}
-            <Can capability={Capability.Task.CREATE}>
-              <Fab
-                icon={<FabAddIcon />}
-                tooltip="New Task"
-                aria-label="New Task"
-                onClick={() => {
-                  setInitialEntity(undefined);
-                  setCreateDrawerOpen(true);
-                }}
-              />
-            </Can>
-          </FabGroup>
-        }
-      >
-        <Box sx={{ mt: 2, mb: 2 }}>
-          <TasksGrid
-            canCreate={canCreateTask}
-            onCreateClick={() => {
-              setInitialEntity(undefined);
-              setCreateDrawerOpen(true);
-            }}
-            onBulkActionsChange={handleBulkActionsChange}
-            refreshTrigger={refreshTrigger}
-          />
-        </Box>
-      </PageLayout>
-
-      <TaskDrawer
-        open={createDrawerOpen}
-        onClose={handleCloseDrawer}
-        initialEntity={initialEntity}
-        onSuccess={handleCreateSuccess}
-      />
-    </>
+    <TasksPageClient
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -84,6 +84,9 @@ interface TestRunsGridProps {
   onBulkActionsChange?: (actions: BulkDeleteActionsState) => void;
   /** Bumped by the page after a cancel succeeds, to trigger a re-fetch. */
   refreshTrigger?: number;
+  /** Server-fetched first page — when present, skips the initial client fetch. */
+  initialData?: TestRunDetail[];
+  initialTotalCount?: number;
 }
 
 function formatReviewTooltip(reviewed: number, corrected: number): string {
@@ -181,6 +184,8 @@ function TestRunsGrid({
   onCreateClick,
   onBulkActionsChange,
   refreshTrigger,
+  initialData,
+  initialTotalCount,
 }: TestRunsGridProps) {
   const router = useRouter();
   const notifications = useNotifications();
@@ -224,11 +229,6 @@ function TestRunsGrid({
 
   // ── Data fetching ─────────────────────────────────────────────────────────
 
-  // No `initialData`/SSR prefetch here on purpose: a run appears here as soon
-  // as it's started, so server-rendered (and thus already-stale-by-the-time-
-  // it-renders) data would hide it. `useList` always fetches once on
-  // mount when `initialData` is absent, which is exactly the guarantee this
-  // page needs -- see the same note in TestSetsGrid.
   const {
     data: testRuns,
     totalCount,
@@ -241,6 +241,8 @@ function TestRunsGrid({
     onSortModelChange: handleSortModelChange,
   } = useList(testRunsList, {
     filters,
+    initialData,
+    initialTotalCount,
     onError: () => setErrorDismissed(false),
   });
 

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsPageClient.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
+import { Can, useCan } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
+import { useBulkActionsBridge } from '@/hooks/useBulkActionsBridge';
+import { useListAuthGate } from '@/hooks/useListAuthGate';
+import TestRunsGrid from './TestRunsGrid';
+import RunDrawer from '@/components/common/RunDrawer';
+import { testRunsList } from './list';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import type { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
+
+interface TestRunsPageClientProps {
+  /** Server-fetched first page — when present, skips the initial client fetch. */
+  initialData?: TestRunDetail[];
+  initialTotalCount?: number;
+}
+
+export default function TestRunsPageClient({
+  initialData,
+  initialTotalCount = 0,
+}: TestRunsPageClientProps) {
+  const gate = useListAuthGate(testRunsList);
+  const canCreateTestRun = useCan(Capability.TestRun.CREATE);
+  const [createDrawerOpen, setCreateDrawerOpen] = React.useState(false);
+  const [refreshTrigger, setRefreshTrigger] = React.useState(0);
+  const { bulkActionsVisible, onBulkDelete, handleBulkActionsChange } =
+    useBulkActionsBridge();
+
+  useDocumentTitle('Test Runs');
+
+  const handleCreateSuccess = React.useCallback(() => {
+    setCreateDrawerOpen(false);
+    setRefreshTrigger(prev => prev + 1);
+  }, []);
+
+  if (!gate.ready) return gate.node;
+
+  return (
+    <>
+      <PageLayout
+        title="Test Runs"
+        description="Executions of your test sets against AI endpoints. Track status, results, and history of each run."
+        breadcrumbs={[]}
+        actions={
+          <FabGroup>
+            {bulkActionsVisible && (
+              <Can capability={Capability.TestRun.DELETE}>
+                <Fab
+                  icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
+                  tooltip="Delete Test Runs"
+                  aria-label="Delete Test Runs"
+                  onClick={onBulkDelete}
+                  sx={{
+                    bgcolor: 'error.main',
+                    '&:hover': { bgcolor: 'error.dark' },
+                  }}
+                />
+              </Can>
+            )}
+            <Can capability={Capability.TestRun.CREATE}>
+              <Fab
+                icon={<FabAddIcon />}
+                tooltip="New Test Run"
+                onClick={() => setCreateDrawerOpen(true)}
+              />
+            </Can>
+          </FabGroup>
+        }
+      >
+        <Box sx={{ mt: 2, mb: 2 }}>
+          <TestRunsGrid
+            canCreate={canCreateTestRun}
+            onCreateClick={() => setCreateDrawerOpen(true)}
+            onBulkActionsChange={handleBulkActionsChange}
+            refreshTrigger={refreshTrigger}
+            initialData={initialData}
+            initialTotalCount={initialTotalCount}
+          />
+        </Box>
+      </PageLayout>
+
+      <RunDrawer
+        mode="newTestRun"
+        open={createDrawerOpen}
+        onClose={() => setCreateDrawerOpen(false)}
+        onSuccess={handleCreateSuccess}
+      />
+    </>
+  );
+}

--- a/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsPageClient.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsPageClient.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import TestRunsPage from '../page';
+import TestRunsPageClient from '../TestRunsPageClient';
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -31,7 +31,7 @@ jest.mock('@/components/common/Can', () => ({
 // TestRunsGrid owns the query and the loading/empty/populated decision
 // itself — the page's only job is to wire `canCreate`/`onCreateClick`
 // through to it correctly.
-jest.mock('../components/TestRunsGrid', () => {
+jest.mock('../TestRunsGrid', () => {
   return function MockTestRunsGrid({
     canCreate,
     onCreateClick,
@@ -53,14 +53,14 @@ jest.mock('@/components/common/RunDrawer', () => {
   };
 });
 
-describe('TestRunsPage', () => {
+describe('TestRunsPageClient', () => {
   it('passes canCreate through to the grid', () => {
-    render(<TestRunsPage />);
+    render(<TestRunsPageClient />);
     expect(screen.getByText('mock-create-test-run')).toBeEnabled();
   });
 
   it('opens the create drawer when the grid invokes onCreateClick', async () => {
-    render(<TestRunsPage />);
+    render(<TestRunsPageClient />);
     await userEvent.click(screen.getByText('mock-create-test-run'));
     expect(screen.getByTestId('run-drawer')).toBeInTheDocument();
   });

--- a/apps/frontend/src/app/(protected)/test-runs/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/page.tsx
@@ -1,111 +1,36 @@
-'use client';
-
-import * as React from 'react';
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
-import { useSession } from 'next-auth/react';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
-import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
+import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { prefetchList } from '@/utils/server-prefetch';
+import { emptyFilters, listParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
-import AccessDenied from '@/components/common/AccessDenied';
-import PageLoadingState from '@/components/common/PageLoadingState';
-import { useBulkActionsBridge } from '@/hooks/useBulkActionsBridge';
-import TestRunsGrid from './components/TestRunsGrid';
-import RunDrawer from '@/components/common/RunDrawer';
-import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { isAuthenticated, isSessionLoading } from '@/hooks/useIsAuthenticated';
+import TestRunsPageClient from './components/TestRunsPageClient';
+import { testRunsList } from './components/list';
 
-export default function TestRunsPage() {
-  const { status } = useSession();
-  const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
-    Capability.TestRun.READ
+/**
+ * Server component: fetches the first page of test runs before rendering so
+ * the page arrives with content already in place -- no client-side spinner
+ * on first load. See `prefetchList` for the permission-gating rationale.
+ */
+export default async function TestRunsPage() {
+  const factory = await createServerApiFactory();
+
+  const { initialData, initialTotalCount } = await prefetchList(
+    Capability.TestRun.READ,
+    () =>
+      testRunsList.list(
+        factory,
+        listParams(testRunsList, {
+          page: 1,
+          pageSize: testRunsList.defaultPageSize,
+          sort: testRunsList.defaultSort,
+          filters: emptyFilters(testRunsList),
+        })
+      )
   );
-  const canCreateTestRun = useCan(Capability.TestRun.CREATE);
-  const [createDrawerOpen, setCreateDrawerOpen] = React.useState(false);
-  const [refreshTrigger, setRefreshTrigger] = React.useState(0);
-  const { bulkActionsVisible, onBulkDelete, handleBulkActionsChange } =
-    useBulkActionsBridge();
-
-  useDocumentTitle('Test Runs');
-
-  const handleCreateSuccess = React.useCallback(() => {
-    setCreateDrawerOpen(false);
-    setRefreshTrigger(prev => prev + 1);
-  }, []);
-
-  if (isSessionLoading(status)) {
-    return (
-      <PageLayout title="Test Runs" breadcrumbs={[]}>
-        <Box sx={{ p: 3 }}>
-          <Typography>Loading...</Typography>
-        </Box>
-      </PageLayout>
-    );
-  }
-
-  if (permsLoading) return <PageLoadingState />;
-  if (!canRead) return <AccessDenied resource="test runs" />;
-
-  if (!isAuthenticated(status)) {
-    return (
-      <PageLayout title="Test Runs" breadcrumbs={[]}>
-        <Box sx={{ p: 3 }}>
-          <Typography color="error">No session token available</Typography>
-        </Box>
-      </PageLayout>
-    );
-  }
 
   return (
-    <>
-      <PageLayout
-        title="Test Runs"
-        description="Executions of your test sets against AI endpoints. Track status, results, and history of each run."
-        breadcrumbs={[]}
-        actions={
-          <FabGroup>
-            {bulkActionsVisible && (
-              <Can capability={Capability.TestRun.DELETE}>
-                <Fab
-                  icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
-                  tooltip="Delete Test Runs"
-                  aria-label="Delete Test Runs"
-                  onClick={onBulkDelete}
-                  sx={{
-                    bgcolor: 'error.main',
-                    '&:hover': { bgcolor: 'error.dark' },
-                  }}
-                />
-              </Can>
-            )}
-            <Can capability={Capability.TestRun.CREATE}>
-              <Fab
-                icon={<FabAddIcon />}
-                tooltip="New Test Run"
-                onClick={() => setCreateDrawerOpen(true)}
-              />
-            </Can>
-          </FabGroup>
-        }
-      >
-        <Box sx={{ mt: 2, mb: 2 }}>
-          <TestRunsGrid
-            canCreate={canCreateTestRun}
-            onCreateClick={() => setCreateDrawerOpen(true)}
-            onBulkActionsChange={handleBulkActionsChange}
-            refreshTrigger={refreshTrigger}
-          />
-        </Box>
-      </PageLayout>
-
-      <RunDrawer
-        mode="newTestRun"
-        open={createDrawerOpen}
-        onClose={() => setCreateDrawerOpen(false)}
-        onSuccess={handleCreateSuccess}
-      />
-    </>
+    <TestRunsPageClient
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -19,6 +19,7 @@ import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
 import { useRouter } from 'next/navigation';
 import { useList } from '@/hooks/useList';
 import { testSetsList } from './list';
+import type { TestSet } from '@/utils/api-client/interfaces/test-set';
 import { Tag } from '@/utils/api-client/interfaces/tag';
 import {
   Box,
@@ -74,6 +75,9 @@ interface TestSetsGridProps {
   onBulkActionsChange?: (actions: TestSetsBulkActionsState) => void;
   /** Bumped by the page after a create/import/generate succeeds, to trigger a re-fetch. */
   refreshTrigger?: number;
+  /** Server-fetched first page — when present, skips the initial client fetch. */
+  initialData?: TestSet[];
+  initialTotalCount?: number;
 }
 
 export interface TestSetsBulkActionsState {
@@ -190,6 +194,8 @@ export default function TestSetsGrid({
   onCreateClick,
   onBulkActionsChange,
   refreshTrigger,
+  initialData,
+  initialTotalCount,
 }: TestSetsGridProps) {
   const router = useRouter();
   const { status } = useSession();
@@ -231,11 +237,6 @@ export default function TestSetsGrid({
     [searchQuery, effectiveTestSetType, drawerFilters]
   );
 
-  // No `initialData`/SSR prefetch here on purpose: a test set row exists from
-  // the moment generation is *submitted* (the flow then redirects to its
-  // detail page), so server-rendered data could predate a just-submitted row.
-  // `useList` always fetches once on mount when `initialData` is
-  // absent, which is exactly the guarantee this page needs.
   const {
     data: testSets,
     totalCount,
@@ -248,6 +249,8 @@ export default function TestSetsGrid({
     onSortModelChange: handleSortModelChange,
   } = useList(testSetsList, {
     filters,
+    initialData,
+    initialTotalCount,
     onError: () => setErrorDismissed(false),
   });
 

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsPageClient.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+import Box from '@mui/material/Box';
+import FileUploadIcon from '@mui/icons-material/FileUploadOutlined';
+import SecurityIcon from '@mui/icons-material/SecurityOutlined';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
+import TestSetsGrid, { type TestSetsBulkActionsState } from './TestSetsGrid';
+import TestSetDrawer from './TestSetDrawer';
+import FileImportDrawer from './FileImportDrawer';
+import SecurityTestDrawer from './SecurityTestDrawer';
+import { testSetsList } from './list';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { useNotifications } from '@/components/common/NotificationContext';
+import { Can, useCan } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
+import { useListAuthGate } from '@/hooks/useListAuthGate';
+import type { TestSet } from '@/utils/api-client/interfaces/test-set';
+
+interface TestSetsPageClientProps {
+  /** Server-fetched first page — when present, skips the initial client fetch. */
+  initialData?: TestSet[];
+  initialTotalCount?: number;
+}
+
+export default function TestSetsPageClient({
+  initialData,
+  initialTotalCount = 0,
+}: TestSetsPageClientProps) {
+  const router = useRouter();
+  const notifications = useNotifications();
+  const gate = useListAuthGate(testSetsList);
+  const canCreate = useCan(Capability.TestSet.CREATE);
+  const canGarak = useCan(Capability.Garak.CREATE);
+  const canOwasp = useCan(Capability.Owasp.CREATE);
+
+  const [createDrawerOpen, setCreateDrawerOpen] = React.useState(false);
+  const [fileImportDrawerOpen, setFileImportDrawerOpen] = React.useState(false);
+  const [securityDrawerOpen, setSecurityDrawerOpen] = React.useState(false);
+  const [bulkActions, setBulkActions] = React.useState<
+    Pick<TestSetsBulkActionsState, 'visible'>
+  >({ visible: false });
+  const bulkHandlersRef = React.useRef<
+    Pick<TestSetsBulkActionsState, 'onRun' | 'onDelete'>
+  >({
+    onRun: () => {},
+    onDelete: () => {},
+  });
+  const [refreshTrigger, setRefreshTrigger] = React.useState(0);
+  const bumpRefreshTrigger = React.useCallback(
+    () => setRefreshTrigger(prev => prev + 1),
+    []
+  );
+
+  const handleBulkActionsChange = React.useCallback(
+    (actions: TestSetsBulkActionsState) => {
+      setBulkActions({ visible: actions.visible });
+      bulkHandlersRef.current = {
+        onRun: actions.onRun,
+        onDelete: actions.onDelete,
+      };
+    },
+    []
+  );
+
+  useDocumentTitle('Test Sets');
+
+  const handleCreateSuccess = React.useCallback(() => {
+    setCreateDrawerOpen(false);
+    bumpRefreshTrigger();
+  }, [bumpRefreshTrigger]);
+
+  const handleFileImportSuccess = React.useCallback(
+    (_testSetId: string) => {
+      bumpRefreshTrigger();
+      notifications.show('Test set imported successfully from file', {
+        severity: 'success',
+      });
+    },
+    [bumpRefreshTrigger, notifications]
+  );
+
+  const handleGarakImportStarted = React.useCallback(() => {
+    // Import/generation run as background tasks — this fires once they're
+    // queued, not once they're done. Refresh now so the list picks up
+    // completed test sets whenever the user next revisits it.
+    bumpRefreshTrigger();
+    notifications.show(
+      'Garak import started — the test set(s) will appear in your list shortly',
+      { severity: 'success', autoHideDuration: 6000 }
+    );
+  }, [bumpRefreshTrigger, notifications]);
+
+  const handleOwaspGenerateSuccess = React.useCallback(() => {
+    // Generation runs as a background task — this fires once it's queued,
+    // not once it's done. Refresh now so the list picks up the completed
+    // test set whenever the user next revisits it, mirroring Garak import.
+    bumpRefreshTrigger();
+    notifications.show('OWASP test set generation started', {
+      severity: 'success',
+    });
+  }, [bumpRefreshTrigger, notifications]);
+
+  if (!gate.ready) return gate.node;
+
+  return (
+    <>
+      <PageLayout
+        title="Test Sets"
+        description="Curated collections of tests you can version, share, and execute against your AI endpoints."
+        breadcrumbs={[]}
+        actions={
+          <FabGroup>
+            {bulkActions.visible && (
+              <>
+                <Fab
+                  icon={<PlayArrowIcon />}
+                  tooltip="Run Test Sets"
+                  aria-label="Run Test Sets"
+                  onClick={() => bulkHandlersRef.current.onRun()}
+                />
+                <Can capability={Capability.TestSet.DELETE}>
+                  <Fab
+                    icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
+                    tooltip="Delete Test Sets"
+                    aria-label="Delete Test Sets"
+                    onClick={() => bulkHandlersRef.current.onDelete()}
+                    sx={{
+                      bgcolor: 'error.main',
+                      '&:hover': { bgcolor: 'error.dark' },
+                    }}
+                  />
+                </Can>
+              </>
+            )}
+            <Can capability={Capability.File.IMPORT}>
+              <Fab
+                icon={<FileUploadIcon />}
+                tooltip="Import from File"
+                onClick={() => setFileImportDrawerOpen(true)}
+              />
+            </Can>
+            {(canGarak || canOwasp) && (
+              <Fab
+                icon={<SecurityIcon />}
+                tooltip={
+                  canGarak && canOwasp
+                    ? 'Import from Garak or OWASP'
+                    : canOwasp
+                      ? 'Generate from OWASP'
+                      : 'Import from Garak'
+                }
+                aria-label={
+                  canGarak && canOwasp
+                    ? 'Import from Garak or OWASP'
+                    : canOwasp
+                      ? 'Generate from OWASP'
+                      : 'Import from Garak'
+                }
+                onClick={() => setSecurityDrawerOpen(true)}
+              />
+            )}
+            <Can capability={Capability.TestSet.GENERATE}>
+              <Fab
+                icon={<AutoFixHighIcon />}
+                tooltip="AI generated Test Set"
+                aria-label="AI generated Test Set"
+                onClick={() => router.push('/test-sets/new-generated')}
+              />
+            </Can>
+            <Can capability={Capability.TestSet.CREATE}>
+              <Fab
+                icon={<FabAddIcon />}
+                tooltip="New Test Set"
+                aria-label="New Test Set"
+                onClick={() => setCreateDrawerOpen(true)}
+              />
+            </Can>
+          </FabGroup>
+        }
+      >
+        <Box sx={{ mt: 2, mb: 2 }}>
+          <TestSetsGrid
+            canCreate={canCreate}
+            onCreateClick={() => setCreateDrawerOpen(true)}
+            onBulkActionsChange={handleBulkActionsChange}
+            refreshTrigger={refreshTrigger}
+            initialData={initialData}
+            initialTotalCount={initialTotalCount}
+          />
+        </Box>
+      </PageLayout>
+
+      <TestSetDrawer
+        open={createDrawerOpen}
+        onClose={() => setCreateDrawerOpen(false)}
+        onSuccess={handleCreateSuccess}
+      />
+
+      <FileImportDrawer
+        open={fileImportDrawerOpen}
+        onClose={() => setFileImportDrawerOpen(false)}
+        onSuccess={handleFileImportSuccess}
+      />
+
+      <SecurityTestDrawer
+        open={securityDrawerOpen}
+        onClose={() => setSecurityDrawerOpen(false)}
+        onImportStarted={handleGarakImportStarted}
+        onOwaspSuccess={handleOwaspGenerateSuccess}
+        canUseGarak={canGarak}
+        canUseOwasp={canOwasp}
+      />
+    </>
+  );
+}

--- a/apps/frontend/src/app/(protected)/test-sets/components/__tests__/TestSetsPageClient.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/__tests__/TestSetsPageClient.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import TestSetsPage from '../page';
+import TestSetsPageClient from '../TestSetsPageClient';
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -38,7 +38,7 @@ jest.mock('@/components/common/NotificationContext', () => ({
 // TestSetsGrid owns the query and the loading/empty/populated decision
 // itself (see TestSetsGrid.test.tsx for that behavior) — the page's only
 // job is to wire `canCreate` and `onCreateClick` through to it correctly.
-jest.mock('../components/TestSetsGrid', () => {
+jest.mock('../TestSetsGrid', () => {
   return function MockTestSetsGrid({
     canCreate,
     onCreateClick,
@@ -54,32 +54,32 @@ jest.mock('../components/TestSetsGrid', () => {
   };
 });
 
-jest.mock('../components/TestSetDrawer', () => {
+jest.mock('../TestSetDrawer', () => {
   return function MockTestSetDrawer({ open }: { open: boolean }) {
     return open ? <div data-testid="test-set-drawer" /> : null;
   };
 });
 
-jest.mock('../components/FileImportDrawer', () => {
+jest.mock('../FileImportDrawer', () => {
   return function MockFileImportDrawer() {
     return null;
   };
 });
 
-jest.mock('../components/SecurityTestDrawer', () => {
+jest.mock('../SecurityTestDrawer', () => {
   return function MockSecurityTestDrawer() {
     return null;
   };
 });
 
-describe('TestSetsPage', () => {
+describe('TestSetsPageClient', () => {
   it('passes canCreate through to the grid', () => {
-    render(<TestSetsPage />);
+    render(<TestSetsPageClient />);
     expect(screen.getByText('mock-create-test-set')).toBeEnabled();
   });
 
   it('opens the create drawer when the grid invokes onCreateClick', async () => {
-    render(<TestSetsPage />);
+    render(<TestSetsPageClient />);
     await userEvent.click(screen.getByText('mock-create-test-set'));
     expect(screen.getByTestId('test-set-drawer')).toBeInTheDocument();
   });

--- a/apps/frontend/src/app/(protected)/test-sets/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/page.tsx
@@ -1,238 +1,36 @@
-'use client';
-
-import * as React from 'react';
-import { useRouter } from 'next/navigation';
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
-import FileUploadIcon from '@mui/icons-material/FileUploadOutlined';
-import SecurityIcon from '@mui/icons-material/SecurityOutlined';
-import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import { useSession } from 'next-auth/react';
-import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
-import TestSetsGrid, {
-  type TestSetsBulkActionsState,
-} from './components/TestSetsGrid';
-import TestSetDrawer from './components/TestSetDrawer';
-import FileImportDrawer from './components/FileImportDrawer';
-import SecurityTestDrawer from './components/SecurityTestDrawer';
-import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { useNotifications } from '@/components/common/NotificationContext';
-import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
+import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { prefetchList } from '@/utils/server-prefetch';
+import { emptyFilters, listParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
-import AccessDenied from '@/components/common/AccessDenied';
-import PageLoadingState from '@/components/common/PageLoadingState';
-import { isAuthenticated, isSessionLoading } from '@/hooks/useIsAuthenticated';
+import TestSetsPageClient from './components/TestSetsPageClient';
+import { testSetsList } from './components/list';
 
-export default function TestSetsPage() {
-  const { status } = useSession();
-  const router = useRouter();
-  const notifications = useNotifications();
-  const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
-    Capability.TestSet.READ
+/**
+ * Server component: fetches the first page of test sets before rendering so
+ * the page arrives with content already in place -- no client-side spinner
+ * on first load. See `prefetchList` for the permission-gating rationale.
+ */
+export default async function TestSetsPage() {
+  const factory = await createServerApiFactory();
+
+  const { initialData, initialTotalCount } = await prefetchList(
+    Capability.TestSet.READ,
+    () =>
+      testSetsList.list(
+        factory,
+        listParams(testSetsList, {
+          page: 1,
+          pageSize: testSetsList.defaultPageSize,
+          sort: testSetsList.defaultSort,
+          filters: emptyFilters(testSetsList),
+        })
+      )
   );
-  const canCreate = useCan(Capability.TestSet.CREATE);
-  const canGarak = useCan(Capability.Garak.CREATE);
-  const canOwasp = useCan(Capability.Owasp.CREATE);
-
-  const [createDrawerOpen, setCreateDrawerOpen] = React.useState(false);
-  const [fileImportDrawerOpen, setFileImportDrawerOpen] = React.useState(false);
-  const [securityDrawerOpen, setSecurityDrawerOpen] = React.useState(false);
-  const [bulkActions, setBulkActions] = React.useState<
-    Pick<TestSetsBulkActionsState, 'visible'>
-  >({ visible: false });
-  const bulkHandlersRef = React.useRef<
-    Pick<TestSetsBulkActionsState, 'onRun' | 'onDelete'>
-  >({
-    onRun: () => {},
-    onDelete: () => {},
-  });
-  const [refreshTrigger, setRefreshTrigger] = React.useState(0);
-  const bumpRefreshTrigger = React.useCallback(
-    () => setRefreshTrigger(prev => prev + 1),
-    []
-  );
-
-  const handleBulkActionsChange = React.useCallback(
-    (actions: TestSetsBulkActionsState) => {
-      setBulkActions({ visible: actions.visible });
-      bulkHandlersRef.current = {
-        onRun: actions.onRun,
-        onDelete: actions.onDelete,
-      };
-    },
-    []
-  );
-
-  useDocumentTitle('Test Sets');
-
-  const handleCreateSuccess = React.useCallback(() => {
-    setCreateDrawerOpen(false);
-    bumpRefreshTrigger();
-  }, [bumpRefreshTrigger]);
-
-  const handleFileImportSuccess = React.useCallback(
-    (_testSetId: string) => {
-      bumpRefreshTrigger();
-      notifications.show('Test set imported successfully from file', {
-        severity: 'success',
-      });
-    },
-    [bumpRefreshTrigger, notifications]
-  );
-
-  const handleGarakImportStarted = React.useCallback(() => {
-    // Import/generation run as background tasks — this fires once they're
-    // queued, not once they're done. Refresh now so the list picks up
-    // completed test sets whenever the user next revisits it.
-    bumpRefreshTrigger();
-    notifications.show(
-      'Garak import started — the test set(s) will appear in your list shortly',
-      { severity: 'success', autoHideDuration: 6000 }
-    );
-  }, [bumpRefreshTrigger, notifications]);
-
-  const handleOwaspGenerateSuccess = React.useCallback(() => {
-    // Generation runs as a background task — this fires once it's queued,
-    // not once it's done. Refresh now so the list picks up the completed
-    // test set whenever the user next revisits it, mirroring Garak import.
-    bumpRefreshTrigger();
-    notifications.show('OWASP test set generation started', {
-      severity: 'success',
-    });
-  }, [bumpRefreshTrigger, notifications]);
-
-  if (isSessionLoading(status)) {
-    return (
-      <PageLayout title="Test Sets" breadcrumbs={[]}>
-        <Box sx={{ p: 3 }}>
-          <Typography>Loading...</Typography>
-        </Box>
-      </PageLayout>
-    );
-  }
-
-  if (permsLoading) return <PageLoadingState />;
-  if (!canRead) return <AccessDenied resource="test sets" />;
-
-  if (!isAuthenticated(status)) {
-    return (
-      <PageLayout title="Test Sets" breadcrumbs={[]}>
-        <Box sx={{ p: 3 }}>
-          <Typography color="error">No session token available</Typography>
-        </Box>
-      </PageLayout>
-    );
-  }
 
   return (
-    <>
-      <PageLayout
-        title="Test Sets"
-        description="Curated collections of tests you can version, share, and execute against your AI endpoints."
-        breadcrumbs={[]}
-        actions={
-          <FabGroup>
-            {bulkActions.visible && (
-              <>
-                <Fab
-                  icon={<PlayArrowIcon />}
-                  tooltip="Run Test Sets"
-                  aria-label="Run Test Sets"
-                  onClick={() => bulkHandlersRef.current.onRun()}
-                />
-                <Can capability={Capability.TestSet.DELETE}>
-                  <Fab
-                    icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
-                    tooltip="Delete Test Sets"
-                    aria-label="Delete Test Sets"
-                    onClick={() => bulkHandlersRef.current.onDelete()}
-                    sx={{
-                      bgcolor: 'error.main',
-                      '&:hover': { bgcolor: 'error.dark' },
-                    }}
-                  />
-                </Can>
-              </>
-            )}
-            <Can capability={Capability.File.IMPORT}>
-              <Fab
-                icon={<FileUploadIcon />}
-                tooltip="Import from File"
-                onClick={() => setFileImportDrawerOpen(true)}
-              />
-            </Can>
-            {(canGarak || canOwasp) && (
-              <Fab
-                icon={<SecurityIcon />}
-                tooltip={
-                  canGarak && canOwasp
-                    ? 'Import from Garak or OWASP'
-                    : canOwasp
-                      ? 'Generate from OWASP'
-                      : 'Import from Garak'
-                }
-                aria-label={
-                  canGarak && canOwasp
-                    ? 'Import from Garak or OWASP'
-                    : canOwasp
-                      ? 'Generate from OWASP'
-                      : 'Import from Garak'
-                }
-                onClick={() => setSecurityDrawerOpen(true)}
-              />
-            )}
-            <Can capability={Capability.TestSet.GENERATE}>
-              <Fab
-                icon={<AutoFixHighIcon />}
-                tooltip="AI generated Test Set"
-                aria-label="AI generated Test Set"
-                onClick={() => router.push('/test-sets/new-generated')}
-              />
-            </Can>
-            <Can capability={Capability.TestSet.CREATE}>
-              <Fab
-                icon={<FabAddIcon />}
-                tooltip="New Test Set"
-                aria-label="New Test Set"
-                onClick={() => setCreateDrawerOpen(true)}
-              />
-            </Can>
-          </FabGroup>
-        }
-      >
-        <Box sx={{ mt: 2, mb: 2 }}>
-          <TestSetsGrid
-            canCreate={canCreate}
-            onCreateClick={() => setCreateDrawerOpen(true)}
-            onBulkActionsChange={handleBulkActionsChange}
-            refreshTrigger={refreshTrigger}
-          />
-        </Box>
-      </PageLayout>
-
-      <TestSetDrawer
-        open={createDrawerOpen}
-        onClose={() => setCreateDrawerOpen(false)}
-        onSuccess={handleCreateSuccess}
-      />
-
-      <FileImportDrawer
-        open={fileImportDrawerOpen}
-        onClose={() => setFileImportDrawerOpen(false)}
-        onSuccess={handleFileImportSuccess}
-      />
-
-      <SecurityTestDrawer
-        open={securityDrawerOpen}
-        onClose={() => setSecurityDrawerOpen(false)}
-        onImportStarted={handleGarakImportStarted}
-        onOwaspSuccess={handleOwaspGenerateSuccess}
-        canUseGarak={canGarak}
-        canUseOwasp={canOwasp}
-      />
-    </>
+    <TestSetsPageClient
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -85,6 +85,9 @@ interface TestsTableProps {
   insightsFailedFilter?: InsightsFailedTestsFilter | null;
   insightsEndpointName?: string;
   onBulkActionsChange?: (actions: TestsBulkActionsState) => void;
+  /** Server-fetched first page — when present, skips the initial client fetch. */
+  initialData?: TestDetail[];
+  initialTotalCount?: number;
 }
 
 export interface TestsBulkActionsState {
@@ -187,6 +190,8 @@ export default function TestsTable({
   insightsFailedFilter = null,
   insightsEndpointName,
   onBulkActionsChange,
+  initialData,
+  initialTotalCount,
 }: TestsTableProps) {
   const router = useRouter();
   const notifications = useNotifications();
@@ -274,6 +279,8 @@ export default function TestsTable({
     filters,
     extraFilters: insightsIdFilter ? [insightsIdFilter] : undefined,
     enabled: insightsFilterReady,
+    initialData,
+    initialTotalCount,
     onError: () => setErrorDismissed(false),
   });
 

--- a/apps/frontend/src/app/(protected)/tests/components/TestsPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsPageClient.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import * as React from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Box from '@mui/material/Box';
+import { useQueryClient } from '@tanstack/react-query';
+import EditNoteIcon from '@mui/icons-material/EditNote';
+import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { Fab, FabGroup } from '@/components/common/Fab';
+import { CategoryIcon } from '@/components/icons';
+import TestsGrid, { type TestsBulkActionsState } from './TestsGrid';
+import FileImportDrawer from '@/app/(protected)/test-sets/components/FileImportDrawer';
+import { testsList } from './list';
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { useOnboarding } from '@/contexts/OnboardingContext';
+import { parseInsightsFailedTestsSearchParams } from '@/app/(protected)/insights/utils/insights-failed-tests';
+import { useEndpoint } from '@/hooks/useEndpoints';
+import { Can, useCan } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
+import { useListAuthGate } from '@/hooks/useListAuthGate';
+import { useNotifications } from '@/components/common/NotificationContext';
+import { testKeys, testSetKeys } from '@/constants/query-keys';
+import type { TestDetail } from '@/utils/api-client/interfaces/tests';
+
+interface TestsPageClientProps {
+  /**
+   * Server-fetched first page — when present, skips the initial client fetch.
+   * Absent when an Insights deep link is active: its test-id filter resolves
+   * client-side, so the server can't build the first page's `$filter`.
+   */
+  initialData?: TestDetail[];
+  initialTotalCount?: number;
+}
+
+export default function TestsPageClient({
+  initialData,
+  initialTotalCount = 0,
+}: TestsPageClientProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
+  const notifications = useNotifications();
+  const [fileImportDrawerOpen, setFileImportDrawerOpen] = React.useState(false);
+  const [bulkActions, setBulkActions] = React.useState<
+    Pick<TestsBulkActionsState, 'visible' | 'assignDisabled'>
+  >({ visible: false, assignDisabled: false });
+  const bulkHandlersRef = React.useRef<
+    Pick<TestsBulkActionsState, 'onAssign' | 'onDelete'>
+  >({
+    onAssign: () => {},
+    onDelete: () => {},
+  });
+
+  const handleBulkActionsChange = React.useCallback(
+    (actions: TestsBulkActionsState) => {
+      setBulkActions({
+        visible: actions.visible,
+        assignDisabled: actions.assignDisabled,
+      });
+      bulkHandlersRef.current = {
+        onAssign: actions.onAssign,
+        onDelete: actions.onDelete,
+      };
+    },
+    []
+  );
+  const { activeTour, startTour } = useOnboarding();
+  const gate = useListAuthGate(testsList);
+  const canCreate = useCan(Capability.Test.CREATE);
+
+  const insightsFailedFilter = React.useMemo(
+    () =>
+      searchParams ? parseInsightsFailedTestsSearchParams(searchParams) : null,
+    [searchParams]
+  );
+  const { data: insightsEndpoint } = useEndpoint(
+    insightsFailedFilter?.endpointId ?? '',
+    !!insightsFailedFilter
+  );
+  const insightsEndpointName = insightsEndpoint?.name;
+
+  useDocumentTitle('Tests');
+
+  const tourParam = searchParams?.get('tour');
+  const isOnTestCasesTour =
+    tourParam === 'testCases' || activeTour === 'testCases';
+  const shouldDisableAddButton = activeTour !== null && !isOnTestCasesTour;
+
+  React.useEffect(() => {
+    if (tourParam === 'testCases') {
+      const timeout = setTimeout(() => {
+        startTour('testCases');
+      }, 300);
+      return () => clearTimeout(timeout);
+    }
+  }, [tourParam, startTour]);
+
+  React.useEffect(() => {
+    const openGeneration = searchParams?.get('openGeneration');
+    if (openGeneration === 'true') {
+      router.push('/test-sets/new-generated');
+      const newUrl = new URL(window.location.href);
+      newUrl.searchParams.delete('openGeneration');
+      window.history.replaceState({}, '', newUrl.toString());
+    }
+  }, [searchParams, router]);
+
+  const handleCreateManual = React.useCallback(() => {
+    if (activeTour === 'testCases') return;
+    router.push('/tests/new-manual');
+  }, [activeTour, router]);
+
+  const handleFileImportSuccess = React.useCallback(
+    (testSetId: string) => {
+      setFileImportDrawerOpen(false);
+      queryClient.invalidateQueries({ queryKey: testKeys.all() });
+      queryClient.invalidateQueries({ queryKey: testSetKeys.all() });
+      notifications.show('Tests imported successfully', {
+        severity: 'success',
+      });
+      router.push(`/test-sets/${testSetId}`);
+    },
+    [queryClient, notifications, router]
+  );
+
+  React.useEffect(() => {
+    const handleTourOpenModal = () => {
+      router.push('/test-sets/new-generated');
+    };
+    window.addEventListener('tour-open-test-modal', handleTourOpenModal);
+    return () => {
+      window.removeEventListener('tour-open-test-modal', handleTourOpenModal);
+    };
+  }, [router]);
+
+  if (!gate.ready) return gate.node;
+
+  return (
+    <>
+      <PageLayout
+        title="Tests"
+        description="Individual test cases that evaluate your AI endpoints for quality, safety, and reliability."
+        breadcrumbs={[]}
+        actions={
+          <FabGroup>
+            {bulkActions.visible && (
+              <>
+                <Can capability={Capability.TestSet.UPDATE}>
+                  <Fab
+                    icon={<CategoryIcon sx={{ fontSize: 28 }} />}
+                    tooltip={
+                      bulkActions.assignDisabled
+                        ? 'Select tests with the same test type'
+                        : 'Assign to Test Set'
+                    }
+                    aria-label="Assign to Test Set"
+                    onClick={() => bulkHandlersRef.current.onAssign()}
+                    disabled={bulkActions.assignDisabled}
+                  />
+                </Can>
+                <Can capability={Capability.Test.DELETE}>
+                  <Fab
+                    icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
+                    tooltip="Delete Tests"
+                    aria-label="Delete Tests"
+                    onClick={() => bulkHandlersRef.current.onDelete()}
+                    sx={{
+                      bgcolor: 'error.main',
+                      '&:hover': { bgcolor: 'error.dark' },
+                    }}
+                  />
+                </Can>
+              </>
+            )}
+            <Can capability={Capability.File.IMPORT}>
+              <Fab
+                icon={<DownloadOutlinedIcon />}
+                tooltip="Import tests"
+                onClick={() => setFileImportDrawerOpen(true)}
+              />
+            </Can>
+            <Can capability={Capability.Test.CREATE}>
+              <Fab
+                icon={<EditNoteIcon />}
+                tooltip="Manual test"
+                aria-label="Manual test"
+                onClick={handleCreateManual}
+                disabled={shouldDisableAddButton}
+              />
+            </Can>
+          </FabGroup>
+        }
+      >
+        <Box sx={{ mt: 2, mb: 2 }}>
+          <TestsGrid
+            onNewTest={handleCreateManual}
+            disableAddButton={shouldDisableAddButton}
+            canCreate={canCreate}
+            insightsFailedFilter={insightsFailedFilter}
+            insightsEndpointName={insightsEndpointName}
+            onBulkActionsChange={handleBulkActionsChange}
+            initialData={initialData}
+            initialTotalCount={initialTotalCount}
+          />
+        </Box>
+      </PageLayout>
+
+      <FileImportDrawer
+        open={fileImportDrawerOpen}
+        onClose={() => setFileImportDrawerOpen(false)}
+        onSuccess={handleFileImportSuccess}
+      />
+    </>
+  );
+}

--- a/apps/frontend/src/app/(protected)/tests/components/__tests__/TestsPageClient.test.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/__tests__/TestsPageClient.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import TestsPage from '../page';
+import TestsPageClient from '../TestsPageClient';
 
 const mockPush = jest.fn();
 jest.mock('next/navigation', () => ({
@@ -42,7 +42,7 @@ jest.mock('@/hooks/useEndpoints', () => ({
 
 // TestsGrid owns the query and the loading/empty/populated decision itself —
 // the page's only job is to wire `canCreate`/`onNewTest` through to it.
-jest.mock('../components/TestsGrid', () => {
+jest.mock('../TestsGrid', () => {
   return function MockTestsGrid({
     canCreate,
     onNewTest,
@@ -64,14 +64,14 @@ jest.mock('@/app/(protected)/test-sets/components/FileImportDrawer', () => {
   };
 });
 
-describe('TestsPage', () => {
+describe('TestsPageClient', () => {
   it('passes canCreate through to the grid', () => {
-    render(<TestsPage />);
+    render(<TestsPageClient />);
     expect(screen.getByText('mock-create-test')).toBeEnabled();
   });
 
   it('navigates to the manual test flow when the grid invokes onNewTest', async () => {
-    render(<TestsPage />);
+    render(<TestsPageClient />);
     await userEvent.click(screen.getByText('mock-create-test'));
     expect(mockPush).toHaveBeenCalledWith('/tests/new-manual');
   });

--- a/apps/frontend/src/app/(protected)/tests/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/page.tsx
@@ -1,228 +1,58 @@
-'use client';
-
-import * as React from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import Typography from '@mui/material/Typography';
-import Box from '@mui/material/Box';
-import { useSession } from 'next-auth/react';
-import { useQueryClient } from '@tanstack/react-query';
-import EditNoteIcon from '@mui/icons-material/EditNote';
-import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
-import { CategoryIcon } from '@/components/icons';
-import TestsGrid, { type TestsBulkActionsState } from './components/TestsGrid';
-import FileImportDrawer from '@/app/(protected)/test-sets/components/FileImportDrawer';
-import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { useOnboarding } from '@/contexts/OnboardingContext';
-import { parseInsightsFailedTestsSearchParams } from '@/app/(protected)/insights/utils/insights-failed-tests';
-import { useEndpoint } from '@/hooks/useEndpoints';
-import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
+import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { prefetchList } from '@/utils/server-prefetch';
+import { emptyFilters, listParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
-import AccessDenied from '@/components/common/AccessDenied';
-import PageLoadingState from '@/components/common/PageLoadingState';
-import { useNotifications } from '@/components/common/NotificationContext';
-import { testKeys, testSetKeys } from '@/constants/query-keys';
-import { isAuthenticated, isSessionLoading } from '@/hooks/useIsAuthenticated';
+import { parseInsightsFailedTestsSearchParams } from '@/app/(protected)/insights/utils/insights-failed-tests';
+import TestsPageClient from './components/TestsPageClient';
+import { testsList } from './components/list';
 
-export default function TestsPage() {
-  const { status } = useSession();
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const queryClient = useQueryClient();
-  const notifications = useNotifications();
-  const [fileImportDrawerOpen, setFileImportDrawerOpen] = React.useState(false);
-  const [bulkActions, setBulkActions] = React.useState<
-    Pick<TestsBulkActionsState, 'visible' | 'assignDisabled'>
-  >({ visible: false, assignDisabled: false });
-  const bulkHandlersRef = React.useRef<
-    Pick<TestsBulkActionsState, 'onAssign' | 'onDelete'>
-  >({
-    onAssign: () => {},
-    onDelete: () => {},
+interface TestsPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+/**
+ * Server component: fetches the first page of tests before rendering so the
+ * page arrives with content already in place -- no client-side spinner on
+ * first load. See `prefetchList` for the permission-gating rationale.
+ *
+ * Exception: an Insights "failed tests" deep link resolves its test-id
+ * filter client-side after first render, so the server can't build the
+ * first page's `$filter` -- skip the prefetch and let the client fetch once
+ * the filter resolves.
+ */
+export default async function TestsPage({ searchParams }: TestsPageProps) {
+  const params = await searchParams;
+  const insightsFilter = parseInsightsFailedTestsSearchParams({
+    get: key => {
+      const value = params[key];
+      return (Array.isArray(value) ? value[0] : value) ?? null;
+    },
   });
 
-  const handleBulkActionsChange = React.useCallback(
-    (actions: TestsBulkActionsState) => {
-      setBulkActions({
-        visible: actions.visible,
-        assignDisabled: actions.assignDisabled,
-      });
-      bulkHandlersRef.current = {
-        onAssign: actions.onAssign,
-        onDelete: actions.onDelete,
-      };
-    },
-    []
-  );
-  const { activeTour, startTour } = useOnboarding();
-  const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
-    Capability.Test.READ
-  );
-  const canCreate = useCan(Capability.Test.CREATE);
+  if (insightsFilter) {
+    return <TestsPageClient />;
+  }
 
-  const insightsFailedFilter = React.useMemo(
+  const factory = await createServerApiFactory();
+
+  const { initialData, initialTotalCount } = await prefetchList(
+    Capability.Test.READ,
     () =>
-      searchParams ? parseInsightsFailedTestsSearchParams(searchParams) : null,
-    [searchParams]
+      testsList.list(
+        factory,
+        listParams(testsList, {
+          page: 1,
+          pageSize: testsList.defaultPageSize,
+          sort: testsList.defaultSort,
+          filters: emptyFilters(testsList),
+        })
+      )
   );
-  const { data: insightsEndpoint } = useEndpoint(
-    insightsFailedFilter?.endpointId ?? '',
-    !!insightsFailedFilter
-  );
-  const insightsEndpointName = insightsEndpoint?.name;
-
-  useDocumentTitle('Tests');
-
-  const tourParam = searchParams?.get('tour');
-  const isOnTestCasesTour =
-    tourParam === 'testCases' || activeTour === 'testCases';
-  const shouldDisableAddButton = activeTour !== null && !isOnTestCasesTour;
-
-  React.useEffect(() => {
-    if (tourParam === 'testCases') {
-      const timeout = setTimeout(() => {
-        startTour('testCases');
-      }, 300);
-      return () => clearTimeout(timeout);
-    }
-  }, [tourParam, startTour]);
-
-  React.useEffect(() => {
-    const openGeneration = searchParams?.get('openGeneration');
-    if (openGeneration === 'true') {
-      router.push('/test-sets/new-generated');
-      const newUrl = new URL(window.location.href);
-      newUrl.searchParams.delete('openGeneration');
-      window.history.replaceState({}, '', newUrl.toString());
-    }
-  }, [searchParams, router]);
-
-  const handleCreateManual = React.useCallback(() => {
-    if (activeTour === 'testCases') return;
-    router.push('/tests/new-manual');
-  }, [activeTour, router]);
-
-  const handleFileImportSuccess = React.useCallback(
-    (testSetId: string) => {
-      setFileImportDrawerOpen(false);
-      queryClient.invalidateQueries({ queryKey: testKeys.all() });
-      queryClient.invalidateQueries({ queryKey: testSetKeys.all() });
-      notifications.show('Tests imported successfully', {
-        severity: 'success',
-      });
-      router.push(`/test-sets/${testSetId}`);
-    },
-    [queryClient, notifications, router]
-  );
-
-  React.useEffect(() => {
-    const handleTourOpenModal = () => {
-      router.push('/test-sets/new-generated');
-    };
-    window.addEventListener('tour-open-test-modal', handleTourOpenModal);
-    return () => {
-      window.removeEventListener('tour-open-test-modal', handleTourOpenModal);
-    };
-  }, [router]);
-
-  if (isSessionLoading(status)) {
-    return (
-      <PageLayout title="Tests" breadcrumbs={[]}>
-        <Box sx={{ p: 3 }}>
-          <Typography>Loading...</Typography>
-        </Box>
-      </PageLayout>
-    );
-  }
-
-  if (permsLoading) return <PageLoadingState />;
-  if (!canRead) return <AccessDenied resource="tests" />;
-
-  if (!isAuthenticated(status)) {
-    return (
-      <PageLayout title="Tests" breadcrumbs={[]}>
-        <Box sx={{ p: 3 }}>
-          <Typography color="error">No session token available</Typography>
-        </Box>
-      </PageLayout>
-    );
-  }
 
   return (
-    <>
-      <PageLayout
-        title="Tests"
-        description="Individual test cases that evaluate your AI endpoints for quality, safety, and reliability."
-        breadcrumbs={[]}
-        actions={
-          <FabGroup>
-            {bulkActions.visible && (
-              <>
-                <Can capability={Capability.TestSet.UPDATE}>
-                  <Fab
-                    icon={<CategoryIcon sx={{ fontSize: 28 }} />}
-                    tooltip={
-                      bulkActions.assignDisabled
-                        ? 'Select tests with the same test type'
-                        : 'Assign to Test Set'
-                    }
-                    aria-label="Assign to Test Set"
-                    onClick={() => bulkHandlersRef.current.onAssign()}
-                    disabled={bulkActions.assignDisabled}
-                  />
-                </Can>
-                <Can capability={Capability.Test.DELETE}>
-                  <Fab
-                    icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
-                    tooltip="Delete Tests"
-                    aria-label="Delete Tests"
-                    onClick={() => bulkHandlersRef.current.onDelete()}
-                    sx={{
-                      bgcolor: 'error.main',
-                      '&:hover': { bgcolor: 'error.dark' },
-                    }}
-                  />
-                </Can>
-              </>
-            )}
-            <Can capability={Capability.File.IMPORT}>
-              <Fab
-                icon={<DownloadOutlinedIcon />}
-                tooltip="Import tests"
-                onClick={() => setFileImportDrawerOpen(true)}
-              />
-            </Can>
-            <Can capability={Capability.Test.CREATE}>
-              <Fab
-                icon={<EditNoteIcon />}
-                tooltip="Manual test"
-                aria-label="Manual test"
-                onClick={handleCreateManual}
-                disabled={shouldDisableAddButton}
-              />
-            </Can>
-          </FabGroup>
-        }
-      >
-        <Box sx={{ mt: 2, mb: 2 }}>
-          <TestsGrid
-            onNewTest={handleCreateManual}
-            disableAddButton={shouldDisableAddButton}
-            canCreate={canCreate}
-            insightsFailedFilter={insightsFailedFilter}
-            insightsEndpointName={insightsEndpointName}
-            onBulkActionsChange={handleBulkActionsChange}
-          />
-        </Box>
-      </PageLayout>
-
-      <FileImportDrawer
-        open={fileImportDrawerOpen}
-        onClose={() => setFileImportDrawerOpen(false)}
-        onSuccess={handleFileImportSuccess}
-      />
-    </>
+    <TestsPageClient
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+    />
   );
 }


### PR DESCRIPTION
## Purpose

Tasks, Test Runs, Test Sets, and Tests were the last main list pages rendering with a client-side spinner on first load. This moves them to the same SSR prefetch shape as Metrics and Endpoints, so the first page of data arrives already server-rendered.

## What Changed

- Each `page.tsx` becomes a thin async server component that prefetches page 1 via `prefetchList` and hands `initialData`/`initialTotalCount` to a new `<X>PageClient` component holding the previous page body.
- The per-page session/perms/AccessDenied gate blocks collapse into a single `useListAuthGate(descriptor)` call.
- Tests reads `searchParams` server-side and skips the prefetch when an Insights "failed tests" deep link is present, since its test-id filter resolves client-side.
- Deleted the stale "no SSR prefetch on purpose" comments in TestRunsGrid and TestSetsGrid: Next 15+ doesn't router-cache dynamic pages, so arriving at these pages is always a fresh server fetch.
- Page tests moved next to the client components they render (`components/__tests__/<X>PageClient.test.tsx`), matching the endpoints precedent.

## Additional Context

- Stacked on #2606 (`refactor/uselist-unification`), which this depends on.

## Testing

- `npx tsc --noEmit`, ESLint, Prettier, and `next build` are clean; all four routes compile as dynamic server-rendered.
- Full jest suite passes (228 suites, 2115 tests), including the moved page tests.
- Manual: load each page and confirm content renders without a spinner; Insights deep link into Tests still applies its filter.
