### PR TITLE
Improve a metric from the rejections its reviewers wrote

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/metric_tuning.py
+++ b/apps/backend/src/rhesis/backend/app/routers/metric_tuning.py
@@ -20,6 +20,11 @@ action through ``POST .../tuning/reviews/accept-rest``. The verdict a review is
 about is read from storage, never sent, so a review cannot be recorded against
 something the metric did not say.
 
+``POST .../tuning/improve`` reads the rejections back and asks the generation
+model to rewrite the metric from them. It never writes: applying an improvement
+is an ordinary metric update the frontend sends afterwards with the fields it was
+shown (domain.local/adr/0006).
+
 Only custom metrics can be tuned, and that is enforced here rather than only in
 the UI. The frontend hides the tab behind a flag, but these routes are live in
 every deployment -- a hidden tab is not an access rule.
@@ -30,6 +35,7 @@ from typing import List
 from uuid import UUID
 
 from fastapi import Depends, HTTPException
+from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models
@@ -38,16 +44,22 @@ from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.constants import MetricBackendType
 from rhesis.backend.app.crud.metric import get_metric
 from rhesis.backend.app.dependencies import get_tenant_context, get_tenant_db_session
+from rhesis.backend.app.error_handlers import internal_error
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.metric_tuning import (
     MetricTuningCase,
     MetricTuningCaseCreate,
     MetricTuningCaseUpdate,
+    MetricTuningImprovement,
     MetricTuningReviewCreate,
     MetricTuningRun,
 )
 from rhesis.backend.app.schemas.metric_tuning_metadata import MetricTuningRunSummary
 from rhesis.backend.app.services import metric_tuning as service
+from rhesis.backend.app.services.metric_tuning.improve import (
+    ImprovementUnavailable,
+    NoStandingRejections,
+)
 from rhesis.backend.app.services.metric_tuning.invoke import MetricModelNotConfigured
 from rhesis.backend.app.services.metric_tuning.reviews import (
     NothingToReview,
@@ -108,16 +120,19 @@ def _run_response(
     organization_id: str,
     summary: MetricTuningRunSummary,
 ) -> MetricTuningRun:
-    """The stored run summary plus the agreement, which is never stored.
+    """The stored run summary plus the two things about it that are never stored.
 
-    Read here on every request rather than written when a run finishes: a review
-    recorded between runs -- or one a run has just invalidated -- has to move the
-    number straight away.
+    The agreement is read here on every request rather than written when a run
+    finishes: a review recorded between runs -- or one a run has just invalidated
+    -- has to move the number straight away. Whether the run predates the metric
+    is derived for the same reason: editing the metric has to change how the run
+    reads without touching the run.
     """
     # Set after construction rather than passed in: the stored summary allows
     # extra keys, so spreading it beside a keyword risks colliding with one.
     run = MetricTuningRun(**summary.model_dump(mode="json"))
     run.agreement = service.get_agreement(db, metric, organization_id)
+    run.predates_metric = service.run_predates_metric(summary, metric)
     return run
 
 
@@ -299,3 +314,50 @@ def start_tuning_run(
         ) from e
 
     return _run_response(db, metric, organization_id, summary)
+
+
+# Marked update for the same reason the run is: it costs an LLM call, and it is
+# the step before an update the same person is about to make. It writes nothing
+# itself -- ADR-0006 -- so the write capability guards the cost and the intent,
+# not the effect.
+@router.post(
+    "/{metric_id}/tuning/improve",
+    response_model=MetricTuningImprovement,
+    **capability(Permission.Metric.UPDATE),
+)
+def improve_metric_from_reviews(
+    metric_id: UUID,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: models.User = Depends(require_current_user_or_token),
+):
+    """Propose a rewrite of the metric from the rejections its reviewers wrote.
+
+    Synchronous, and it saves nothing. The caller is shown the current fields
+    beside the proposed ones and applies them with an ordinary metric update, or
+    closes the dialog -- rewriting the evaluation prompt in place would replace
+    the text the reviews were made against with no diff and no undo.
+    """
+    organization_id, user_id = tenant_context
+    metric = _resolve_metric_or_raise(db, metric_id, organization_id, user_id)
+
+    try:
+        return service.improve_from_reviews(db, metric, organization_id, current_user)
+    except NoStandingRejections as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except ValidationError as e:
+        # The model's fields did not fit MetricUpdate, so applying them would
+        # fail. That is our template or our schema, not the caller's request.
+        raise internal_error(e, context=f"improving metric {metric_id} from its reviews") from e
+    except ImprovementUnavailable as e:
+        # Same public detail as /metrics/{id}/improve: the caller acts on it the
+        # same way, and the real reason stays in the log.
+        raise internal_error(
+            e,
+            context=f"improving metric {metric_id} from its reviews",
+            status_code=400,
+            public_detail=(
+                "Failed to improve metric: the generation model could not be "
+                "used. Check the model configured for your organization."
+            ),
+        ) from e

--- a/apps/backend/src/rhesis/backend/app/schemas/metric_tuning.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/metric_tuning.py
@@ -19,12 +19,13 @@ current threshold, which is a question that cannot be answered once and stored.
 
 from datetime import datetime
 from enum import Enum
-from typing import Optional, Union
+from typing import List, Optional, Union
 
-from pydantic import UUID4, BaseModel, ConfigDict
+from pydantic import UUID4, BaseModel, ConfigDict, Field
 
 from rhesis.backend.app.schemas import Base
 from rhesis.backend.app.schemas.metric_tuning_metadata import ReviewDecision, TuningRunStatus
+from rhesis.backend.app.schemas.metric_types import ScoreType, ThresholdOperator
 
 
 class TuningCaseOutcome(str, Enum):
@@ -197,13 +198,74 @@ class MetricTuningRun(BaseModel):
     # tab already re-reads while a run is going, and the number has to move as the
     # cases land. Derived on every read; see ``TuningAgreement``.
     agreement: TuningAgreement = TuningAgreement()
+    # True when the metric has changed in a verdict-affecting way since this run
+    # started, so its agreement belongs to the earlier metric. Derived from the
+    # stored fingerprint on every read; a run without one answers False, because
+    # unknown is not the same as out of date.
+    predates_metric: bool = False
+
+
+class ImprovedMetricFields(BaseModel):
+    """The metric fields a model may rewrite from a reviewer's rejections.
+
+    Deliberately narrow: the evaluation fields and nothing else. No ids, no
+    relations, no ``metric_scope`` -- a rejection says the metric judged one case
+    wrongly, which is not an opinion about which turn shapes it applies to.
+
+    Every field is required but nullable rather than optional-with-a-default, so
+    the JSON schema handed to the model lists them all: a provider running strict
+    structured output rejects a schema whose properties are not all required, and
+    a numeric metric genuinely has no ``categories`` to give.
+
+    ``score_type`` and ``categories`` are here because the model has to reason
+    about the score bands coherently, not because it may move them -- both are
+    overwritten with the metric's current values before this is returned. An
+    improvement that changed ``score_type`` would invalidate every review for the
+    metric, which is not something a button does quietly (domain.local/adr/0006).
+    """
+
+    name: str = Field(description="Title Case with spaces, e.g. 'Factual Accuracy'")
+    description: str
+    evaluation_prompt: str = Field(description="The evaluation criteria, no template placeholders")
+    evaluation_steps: str
+    reasoning: str
+    explanation: str
+    score_type: ScoreType
+    min_score: Optional[float]
+    max_score: Optional[float]
+    threshold: Optional[float]
+    threshold_operator: Optional[ThresholdOperator]
+    categories: Optional[List[str]]
+    passing_categories: Optional[List[str]]
+
+
+class MetricTuningImprovement(BaseModel):
+    """A proposed rewrite of a metric, read off the rejections its reviewers wrote.
+
+    Producing one never writes anything. The reviewer sees the current fields
+    beside these and applies them with an ordinary metric update, or does not --
+    an in-place rewrite of the evaluation prompt the reviews were made against
+    would have no diff and no undo (ADR-0006).
+
+    ``changed`` is what the dialog shows; the fields it leaves out are named as
+    unchanged rather than hidden, so the reviewer can see the rewrite left them
+    alone. ``rejections_used`` is the header: how many comments this was written
+    from.
+    """
+
+    improvement: ImprovedMetricFields
+    # Names of the fields whose proposed value differs from the metric's current one.
+    changed: List[str] = []
+    rejections_used: int = 0
 
 
 __all__ = [
+    "ImprovedMetricFields",
     "MetricTuningCase",
     "MetricTuningCaseCreate",
     "MetricTuningCaseResult",
     "MetricTuningCaseUpdate",
+    "MetricTuningImprovement",
     "MetricTuningReview",
     "MetricTuningReviewCreate",
     "MetricTuningRun",

--- a/apps/backend/src/rhesis/backend/app/schemas/metric_tuning_metadata.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/metric_tuning_metadata.py
@@ -177,8 +177,15 @@ class MetricTuningRunSummary(BaseModel):
     # Why the run as a whole failed, when it did. A single case failing does not
     # fail the run -- that is `errored_cases`.
     error: Optional[str] = None
+    # A digest of the metric fields that decide a verdict, taken when the run
+    # started. A run whose digest no longer matches the metric scored an earlier
+    # version of it -- see services/metric_tuning/fingerprint.py. Absent on runs
+    # stored before this existed, which reads as unknown rather than as stale.
+    metric_fingerprint: Optional[str] = None
 
-    @field_validator("error", "started_at", "completed_at", "progressed_at", mode="before")
+    @field_validator(
+        "error", "started_at", "completed_at", "progressed_at", "metric_fingerprint", mode="before"
+    )
     @classmethod
     def _validate_optional_str(cls, v: Any) -> Optional[str]:
         return _coerce_optional_str(v)

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/__init__.py
@@ -25,6 +25,16 @@ from rhesis.backend.app.services.metric_tuning.cases import (
     to_api,
     update_tuning_case,
 )
+from rhesis.backend.app.services.metric_tuning.fingerprint import (
+    metric_fingerprint,
+    run_predates_metric,
+)
+from rhesis.backend.app.services.metric_tuning.improve import (
+    ImprovementUnavailable,
+    NoStandingRejections,
+    improve_from_reviews,
+    standing_rejections,
+)
 from rhesis.backend.app.services.metric_tuning.invoke import (
     MetricModelNotConfigured,
     invoke_metric_on_case,
@@ -60,7 +70,9 @@ from rhesis.backend.app.services.metric_tuning.test_sets import (
 __all__ = [
     "STALE_RUN_AFTER",
     "STALE_RUN_MESSAGE",
+    "ImprovementUnavailable",
     "MetricModelNotConfigured",
+    "NoStandingRejections",
     "NoTuningCases",
     "NothingToReview",
     "ReviewCommentRequired",
@@ -77,12 +89,16 @@ __all__ = [
     "get_tuning_case",
     "get_tuning_run",
     "get_tuning_test_set",
+    "improve_from_reviews",
     "invoke_metric_on_case",
     "list_tuning_cases",
+    "metric_fingerprint",
     "resolve_metric_model",
     "review_case",
     "review_still_stands",
     "run_is_stale",
+    "run_predates_metric",
+    "standing_rejections",
     "standing_review",
     "start_tuning_run",
     "to_api",

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/fingerprint.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/fingerprint.py
@@ -1,0 +1,88 @@
+"""Whether a run's numbers still belong to the metric on screen.
+
+Applying an improvement rewrites the evaluation prompt every verdict in the run
+came from. The reviews stay -- they are human words, and the per-case
+material-change rule re-checks each one on the next run -- but the agreement
+number stops describing the metric it sits under, so the run has to be able to
+say it predates it (domain.local/adr/0006).
+
+The check is a fingerprint of the fields that decide a verdict, captured at run
+start, rather than the metric's ``updated_at``. Both halves matter: renaming a
+metric must not stale a run, and editing the evaluation prompt by hand in the
+metric editor must.
+
+Nothing is written on read. A missing fingerprint is unknown, not stale -- runs
+stored before this existed must not all report themselves out of date.
+"""
+
+import hashlib
+import json
+import logging
+from typing import Any, List, Optional
+
+from rhesis.backend.app import models
+from rhesis.backend.app.schemas.metric_tuning_metadata import MetricTuningRunSummary
+
+logger = logging.getLogger(__name__)
+
+# The fields a verdict actually comes out of: what the judge is told, and where
+# the resulting score turns into a decision. Everything else on a metric -- its
+# name, description, reasoning, explanation -- can be rewritten without any
+# verdict moving, so none of it belongs here.
+FINGERPRINTED_FIELDS = (
+    "evaluation_prompt",
+    "evaluation_steps",
+    "threshold",
+    "threshold_operator",
+    "passing_categories",
+)
+
+
+def metric_fingerprint(metric: models.Metric) -> str:
+    """A digest of the metric fields that decide what a verdict is.
+
+    Stable across restarts and processes, so a run claimed by one worker is
+    comparable in the request that reads it back.
+    """
+    material = {field: _normalize(getattr(metric, field, None)) for field in FINGERPRINTED_FIELDS}
+    encoded = json.dumps(material, sort_keys=True, default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def run_predates_metric(summary: MetricTuningRunSummary, metric: models.Metric) -> bool:
+    """True when this run scored a metric that has since changed.
+
+    A run with no fingerprint answers False: it cannot be shown to be out of
+    date, and presenting every pre-existing run as stale would be a worse lie
+    than presenting an unknown one as current.
+    """
+    stored = (summary.metric_fingerprint or "").strip()
+    if not stored:
+        return False
+    return stored != metric_fingerprint(metric)
+
+
+def _normalize(value: Any) -> Any:
+    """The comparable form of one fingerprinted field.
+
+    Only differences that can move a verdict survive this. ``None`` and blank
+    are the same absence; ``0.5`` and ``0.50`` are the same threshold; and the
+    passing categories are compared the way ``material_change`` compares them --
+    as a case-insensitive set -- so reordering or recasing them changes no
+    decision and stales no run.
+    """
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return _normalize_categories(value)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(getattr(value, "value", value)).strip()
+    return text or None
+
+
+def _normalize_categories(value: List[Any]) -> Optional[List[str]]:
+    categories = sorted({str(item).strip().lower() for item in value if str(item).strip()})
+    return categories or None

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/improve.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/improve.py
@@ -1,0 +1,347 @@
+"""Rewriting a metric from the rejections its reviewers wrote.
+
+This is what the comments were collected for. A reviewer rejects a verdict and
+says what is wrong with it; this reads those comments back and asks the
+generation model to rewrite the metric so it would judge those cases the way the
+reviewer says.
+
+**It never writes.** The proposed fields go back to the caller, the reviewer sees
+them beside the current ones, and applying is an ordinary metric update sent
+afterwards. An in-place LLM rewrite would silently replace the evaluation prompt
+the reviews were made against, with no diff and no undo -- and applying by
+calling the model a second time would save a different rewrite than the one on
+screen. See domain.local/adr/0006.
+
+**The prompt and the schema live here, not in the SDK.** ``MetricSynthesizer`` is
+deliberately not used: this prompt is about reviews, which the SDK has no reason
+to know about. What is borrowed is the model client, because it is the only path
+to an LLM in this codebase and it is where provider auth, retries and usage
+metering live. The consequence is that the naming, field-depth and score-type
+rules now exist in two templates -- ``improve_from_reviews.jinja`` here and the
+SDK's ``improve_metric.jinja`` -- and nothing keeps them in step. That is known.
+
+**Only rejections go in.** Accepted cases are not sent, which removes the only
+counter-pressure in the prompt: the cheapest rewrite satisfying five "this should
+have failed" comments is a stricter metric that also breaks cases the reviewer
+had accepted. The template's instruction not to move criteria the rejections do
+not speak to, and the nudge to re-run afterwards, are what stand in for it.
+"""
+
+import logging
+import os
+from typing import Any, List, Optional
+
+from jinja2 import Template
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.crud import metric_tuning as crud_metric_tuning
+from rhesis.backend.app.schemas.metric import MetricUpdate
+from rhesis.backend.app.schemas.metric_tuning import (
+    ImprovedMetricFields,
+    MetricTuningImprovement,
+)
+from rhesis.backend.app.schemas.metric_tuning_metadata import (
+    ReviewDecision,
+    parse_metric_tuning_case_metadata,
+)
+from rhesis.backend.app.services.metric_tuning.outcome import current_verdict, standing_review
+from rhesis.backend.app.services.metric_tuning.payload import parse_payload
+from rhesis.backend.app.services.metric_tuning.test_sets import get_tuning_test_set
+from rhesis.backend.app.utils.user_model_utils import (
+    ensure_language_model,
+    get_user_generation_model,
+)
+
+logger = logging.getLogger(__name__)
+
+# How much of one text field reaches the model. There is no cap on how many
+# rejections are sent -- forty comments are forty things the metric got wrong and
+# dropping any of them silently is the one thing this must not do -- so the
+# generosity is per field, and a field that was cut says so.
+TEXT_FIELD_LIMIT = 4000
+TRUNCATION_MARKER = " … [truncated]"
+
+# The fields the model may propose. Compared against the metric one by one to
+# work out which of them the reviewer is actually being asked to look at.
+IMPROVABLE_FIELDS = tuple(ImprovedMetricFields.model_fields)
+
+# Fixed for the metric whatever the model answers. A changed ``score_type``
+# invalidates every review the metric has, and the ``categories`` list is what a
+# stored categorical verdict is named from -- neither is a thing this button
+# moves. See ADR-0006.
+PRESERVED_FIELDS = ("score_type", "categories")
+
+
+class NoStandingRejections(Exception):
+    """Nothing to rewrite from: no rejection on this metric currently stands."""
+
+
+class ImprovementUnavailable(Exception):
+    """The generation model could not produce an improvement."""
+
+
+class Rejection(BaseModel):
+    """One rejected case, as the model is shown it.
+
+    The verdict and the metric's own reasoning travel with the reviewer's comment
+    because the comment is usually a reply to them -- "it called this harmless"
+    means nothing without the verdict it is about.
+    """
+
+    input: str
+    output: str
+    reference_answer: Optional[str] = None
+    verdict: Optional[str] = None
+    reasoning: Optional[str] = None
+    comment: str
+
+
+def _load_template() -> Template:
+    """The prompt, loaded from beside this module -- as ``llm_mapper`` does."""
+    path = os.path.join(os.path.dirname(__file__), "improve_from_reviews.jinja")
+    with open(path, "r") as handle:
+        return Template(handle.read())
+
+
+def _clip(text: Optional[str]) -> Optional[str]:
+    """One text field, cut at the cap and marked where it was cut."""
+    if text is None:
+        return None
+    if len(text) <= TEXT_FIELD_LIMIT:
+        return text
+    return text[:TEXT_FIELD_LIMIT] + TRUNCATION_MARKER
+
+
+def standing_rejections(
+    db: Session, metric: models.Metric, organization_id: str
+) -> List[Rejection]:
+    """Every rejection that still describes what the metric says now.
+
+    Two filters, both of them the point. A case whose standing review is an
+    accept is left out -- only rejections are sent. And the *standing* review is
+    the one read, not the ten-deep history: a rejection a material change
+    invalidated objects to a verdict the metric no longer gives, so feeding it
+    back would ask for a rewrite nobody wants any more.
+
+    Whoever wrote the review does not matter. A metric is tuned by everyone who
+    reviewed it, not only by whoever pressed the button.
+    """
+    test_set = get_tuning_test_set(db, metric.id, organization_id)
+    if not test_set:
+        return []
+
+    rejections = []
+    for db_test in crud_metric_tuning.get_tuning_cases(db, test_set.id, organization_id):
+        metadata = parse_metric_tuning_case_metadata(db_test.test_metadata)
+        review = standing_review(metric, metadata)
+        if review is None or review.decision != ReviewDecision.REJECTED:
+            continue
+        comment = (review.comment or "").strip()
+        if not comment:
+            # A rejection is only stored with a comment, so this is a row written
+            # by something older or edited by hand. Nothing to read, so nothing
+            # to send.
+            logger.warning("Skipping a commentless rejection on tuning case %s", db_test.id)
+            continue
+
+        payload = parse_payload(db_test.prompt.content if db_test.prompt else None)
+        result = metadata.result
+        rejections.append(
+            Rejection(
+                input=_clip(payload.input) or "",
+                output=_clip(payload.output) or "",
+                reference_answer=_clip(payload.reference_answer),
+                # Both from the latest run, not the verdict the review recorded:
+                # a review survives drift that did not cross the threshold, so
+                # the stored verdict and the current reasoning can be one run
+                # apart. Showing the model a number beside an explanation of a
+                # different number is worse than showing it either alone.
+                verdict=current_verdict(metadata),
+                reasoning=_clip(result.reasoning if result else None),
+                comment=_clip(comment),
+            )
+        )
+    return rejections
+
+
+def _existing_fields(metric: models.Metric) -> dict:
+    """The metric as the prompt and the diff both read it."""
+    return {field: _unwrap(getattr(metric, field, None)) for field in IMPROVABLE_FIELDS}
+
+
+def _unwrap(value: Any) -> Any:
+    """A stored column with any enum wrapper taken off, ready to render or compare."""
+    if isinstance(value, list):
+        return [str(getattr(item, "value", item)) for item in value]
+    return getattr(value, "value", value)
+
+
+def _ask_model(db: Session, user: models.User, prompt: str) -> dict:
+    """Put the prompt to the user's generation model and take back its answer.
+
+    ``get_user_generation_model`` then ``ensure_language_model``: writing an
+    evaluation prompt is a generation task, so the user's *generation* choice is
+    the one that applies, with the system setting as a fallback only. Not
+    ``resolve_metric_model`` -- that is the metric's judge, and it refuses to fall
+    back because a stored verdict has to name the judge that produced it, which
+    an improvement carries no obligation to do.
+
+    Nothing stamps metering here. ``ensure_language_model`` already decides that:
+    it stamps what it builds from a bare string, which is the system default,
+    while an org running its own key is stamped already and must not be billed
+    twice for tokens it paid for directly.
+    """
+    try:
+        model = ensure_language_model(get_user_generation_model(db, user))
+        answer = model.generate(prompt, schema=ImprovedMetricFields)
+    except Exception as e:
+        raise ImprovementUnavailable(str(e)) from e
+
+    if not isinstance(answer, dict) or "evaluation_prompt" not in answer:
+        # A provider that swallows its own failure hands back something else
+        # entirely -- the native client returns `{"error": ...}` rather than
+        # raising -- so the shape is checked rather than assumed.
+        raise ImprovementUnavailable(f"The generation model answered with {answer!r}")
+
+    try:
+        return ImprovedMetricFields.model_validate(answer).model_dump(mode="json")
+    except Exception as e:
+        # The model's answer did not fit the schema it was given. That is the
+        # model failing, not our template, so it reads as a model failure.
+        raise ImprovementUnavailable(str(e)) from e
+
+
+def _preserve_fixed_fields(metric: models.Metric, proposed: dict) -> dict:
+    """Put back the two fields the model is not allowed to move."""
+    for field in PRESERVED_FIELDS:
+        current = _unwrap(getattr(metric, field, None))
+        if proposed.get(field) != current:
+            logger.warning(
+                "Improvement for metric %s tried to change %s from %r to %r; keeping %r",
+                metric.id,
+                field,
+                current,
+                proposed.get(field),
+                current,
+            )
+        proposed[field] = current
+    return proposed
+
+
+def _blank(value: Any) -> bool:
+    """Whether this proposed value amounts to "the metric has none of this"."""
+    if value is None:
+        return True
+    if isinstance(value, (str, list)):
+        return not value
+    return False
+
+
+def _refuse_to_blank(metric: models.Metric, proposed: dict) -> dict:
+    """Put back any field the model returned empty that the metric actually has.
+
+    **An improvement can change a field but cannot clear one**, because a metric
+    update cannot: ``crud/metric.py`` drops ``None`` from an update so a null
+    never overwrites stored data. Left alone, a proposal to blank a field would
+    show as "—" in the dialog, the apply would report success, and the old value
+    would still be there afterwards -- the gap between what was approved and what
+    was saved that ADR-0006 exists to close.
+
+    So the blank is dropped here, where it can be logged, rather than in the
+    storage layer where it cannot. Changing a threshold is untouched by this;
+    only emptying one is.
+    """
+    for field in IMPROVABLE_FIELDS:
+        if not _blank(proposed.get(field)):
+            continue
+        current = _unwrap(getattr(metric, field, None))
+        if _blank(current):
+            continue
+        logger.warning(
+            "Improvement for metric %s left %s empty; keeping %r, which an update could "
+            "not have cleared anyway",
+            metric.id,
+            field,
+            current,
+        )
+        proposed[field] = current
+    return proposed
+
+
+def _changed_fields(existing: dict, proposed: dict) -> List[str]:
+    """Which proposed fields differ from the metric's current ones.
+
+    A set, not a running order: which of these a reviewer reads first is the
+    interface's decision, and the dialog already makes it.
+    """
+    return [
+        field
+        for field in IMPROVABLE_FIELDS
+        if _comparable(proposed.get(field)) != _comparable(existing.get(field))
+    ]
+
+
+def _comparable(value: Any) -> Any:
+    """The form two values are compared in. Blank and absent are one thing.
+
+    Deliberately stricter than ``fingerprint._normalize``, which folds category
+    order and casing away because neither moves a verdict. Here they are a real
+    difference: a reviewer being shown a rewrite has to see that the model
+    recased a category, even though the metric would judge exactly the same.
+    """
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, list):
+        return [str(item).strip() for item in value] or None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return float(value)
+    return value
+
+
+def improve_from_reviews(
+    db: Session, metric: models.Metric, organization_id: str, user: models.User
+) -> MetricTuningImprovement:
+    """Propose a rewrite of ``metric`` from the rejections that stand against it.
+
+    Writes nothing, here or anywhere downstream. Raises ``NoStandingRejections``
+    when there is nothing to read, and ``ImprovementUnavailable`` when the model
+    could not answer.
+    """
+    rejections = standing_rejections(db, metric, organization_id)
+    if not rejections:
+        raise NoStandingRejections(
+            "This metric has no rejected cases to learn from. Reject a case with a comment "
+            "saying what the metric got wrong, then improve it from that."
+        )
+
+    existing = _existing_fields(metric)
+    prompt = _load_template().render(
+        existing_metric=existing,
+        rejections=[rejection.model_dump() for rejection in rejections],
+    )
+
+    proposed = _refuse_to_blank(
+        metric, _preserve_fixed_fields(metric, _ask_model(db, user, prompt))
+    )
+
+    # Applying is an ordinary metric update, so what is proposed has to be one.
+    # Checked here rather than left to fail on apply, and deliberately outside the
+    # model-failure handling above: a field that will not fit ``MetricUpdate`` is
+    # our schema or our template, not the caller's request, so the ``ValidationError``
+    # escapes for the router to turn into a 500 with a traceback.
+    MetricUpdate(**proposed)
+
+    logger.info(
+        "Proposed an improvement for metric %s from %s rejection(s)", metric.id, len(rejections)
+    )
+    return MetricTuningImprovement(
+        # Re-validated, so the returned object is the schema rather than the dict
+        # the preserved fields were patched into.
+        improvement=ImprovedMetricFields.model_validate(proposed),
+        changed=_changed_fields(existing, proposed),
+        rejections_used=len(rejections),
+    )

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/improve_from_reviews.jinja
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/improve_from_reviews.jinja
@@ -1,0 +1,119 @@
+You are a metric designer for AI evaluation.
+You are given an existing metric definition and the rejections its reviewers
+wrote: cases where the metric's verdict was judged wrong, each with a comment
+saying what is wrong with it.
+Rewrite the metric so it would judge those cases the way the reviewers say, and
+return the complete updated metric.
+
+## Rules
+
+1. Return ALL fields, not just the ones that changed.
+2. Change only what the rejections speak to. Every criterion, band and
+   threshold the comments say nothing about must come back exactly as it is.
+   The cases you are shown are the ones the metric got wrong — the cases it got
+   right are not here, and a rewrite that tightens the metric beyond what the
+   comments ask for will break them.
+3. `threshold`, `threshold_operator`, the score bands and `passing_categories`
+   are all fair game. "This should have failed" is very often a statement about
+   the threshold rather than about the criteria.
+4. Do NOT change `score_type` or the `categories` list. They are fixed for this
+   metric and will be discarded if you change them.
+5. `description`, `evaluation_steps`, `reasoning` and `explanation` are
+   required in the result. If the existing metric shows one as empty or
+   "None", write it now from the metric's own criteria — do not carry the
+   blank forward. If the existing value is already good and the rejections do
+   not touch it, return it unchanged.
+6. Thin counts as missing. If one of those fields is a single generic
+   sentence, rewrite it to the depth below even when no rejection asked —
+   a field that says nothing specific is not a value worth preserving.
+7. Text marked `[truncated]` was cut for length. Judge it on what is there and
+   do not speculate about the rest.
+
+## Field Depth
+
+- **description** — 2-3 sentences: what is measured, on what part of the
+  output, why it matters here. Never a restatement of the name.
+- **evaluation_steps** — 4-7 ordered steps, one observable action each,
+  scoring last. Format: `Step N:` on its own line, the step text below
+  it, steps joined by a line containing only `---`. A plain
+  "1. ... 2. ..." list is stored as a single step; if the existing value
+  looks like that, convert it.
+- **reasoning** — 3-5 sentences: what evidence the judge must quote,
+  which clause to tie it to, what to do when evidence is missing, how to
+  break a tie between bands.
+- **explanation** — 2-4 sentences: what a pass and a fail mean for the
+  system under test, and what to do about a fail.
+
+Score bands and categories must say what has to be true of the output,
+not lean on adverbs ("mostly correct", "fairly complete"). Where a rejection
+points at the scoring, pin the bands to conditions.
+
+## Naming Convention
+
+The metric name MUST be Title Case with spaces between words.
+Examples: "Factual Accuracy", "Policy Advisory Accuracy", "Handback Continuity".
+Never use camelCase or PascalCase.
+
+## Score Type Rules
+
+For **numeric** metrics:
+- Always set min_score, max_score, threshold, and threshold_operator
+- threshold_operator must be one of: "=", "<", ">", "<=", ">=", "!="
+
+For **categorical** metrics:
+- Always provide categories (non-empty list of label strings)
+- Always provide passing_categories (non-empty subset of categories)
+- Do NOT set min_score, max_score, threshold, or threshold_operator
+
+For **binary** metrics:
+- Return min_score, max_score, threshold and threshold_operator exactly as the
+  existing metric has them. None of them decides a binary verdict, so changing
+  one shows the reviewer a difference that means nothing
+
+## Evaluation Prompt
+
+The evaluation_prompt field contains only the evaluation criteria: a
+criterion naming something a reader could point at in the output, one
+bullet per testable clause, and score bands tied to conditions. Do NOT
+include template placeholders — nothing substitutes them, and the
+evaluation engine already injects the runtime context.
+
+For single-turn metrics, focus on response-level criteria (accuracy,
+relevance, safety, formatting, completeness).
+
+For multi-turn metrics, focus on conversation-level criteria (goal
+achievement, turn progression, instruction compliance, coherence across
+turns, efficiency).
+
+---
+
+## Existing Metric
+
+- **name**: {{ existing_metric.name }}
+- **description**: {{ existing_metric.description }}
+- **evaluation_prompt**: {{ existing_metric.evaluation_prompt }}
+- **evaluation_steps**: {{ existing_metric.evaluation_steps }}
+- **reasoning**: {{ existing_metric.reasoning }}
+- **explanation**: {{ existing_metric.explanation }}
+- **score_type**: {{ existing_metric.score_type }}
+- **min_score**: {{ existing_metric.min_score }}
+- **max_score**: {{ existing_metric.max_score }}
+- **threshold**: {{ existing_metric.threshold }}
+- **threshold_operator**: {{ existing_metric.threshold_operator }}
+- **categories**: {{ existing_metric.categories }}
+- **passing_categories**: {{ existing_metric.passing_categories }}
+
+## Rejected Cases
+
+{{ rejections | length }} case{{ '' if rejections | length == 1 else 's' }} where a
+reviewer judged this metric's verdict wrong.
+{% for rejection in rejections %}
+### Case {{ loop.index }}
+
+- **input**: {{ rejection.input }}
+- **output being judged**: {{ rejection.output }}
+{% if rejection.reference_answer %}- **reference answer**: {{ rejection.reference_answer }}
+{% endif %}- **the metric's verdict**: {{ rejection.verdict }}
+{% if rejection.reasoning %}- **the metric's reasoning**: {{ rejection.reasoning }}
+{% endif %}- **why the reviewer rejected it**: {{ rejection.comment }}
+{% endfor %}

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/runs.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/runs.py
@@ -29,6 +29,7 @@ from rhesis.backend.app.schemas.metric_tuning_metadata import (
     MetricTuningRunSummary,
     TuningRunStatus,
 )
+from rhesis.backend.app.services.metric_tuning.fingerprint import metric_fingerprint
 from rhesis.backend.app.services.metric_tuning.invoke import (
     invoke_metric_on_case,
     resolve_metric_model,
@@ -114,6 +115,9 @@ def start_tuning_run(
         total_cases=len(cases),
         completed_cases=0,
         errored_cases=0,
+        # Taken now, so applying an improvement afterwards makes these results
+        # read as belonging to the metric they were actually produced by.
+        metric_fingerprint=metric_fingerprint(metric),
     )
     crud_metric_tuning.set_run_summary(db, test_set, summary)
     return summary
@@ -164,6 +168,10 @@ def execute_tuning_run(
     if not summary.started_at:
         summary.started_at = _now()
     summary.progressed_at = _now()
+    # Re-stamped rather than trusted from the claim: the metric can be edited
+    # between the claim and the worker picking the run up, and the verdicts about
+    # to be written come from the metric as it is right now.
+    summary.metric_fingerprint = metric_fingerprint(metric)
 
     _clear_previous_results(db, cases)
     crud_metric_tuning.set_run_summary(db, test_set, summary)

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
@@ -62,6 +62,9 @@ export default function MetricDetailPageTabs() {
 
   const metricId = params.identifier as string;
   const { activeTab, handleTabChange } = useDetailTabNav(TAB_KEYS);
+  // Bumped when a tab writes the metric, so the detail view re-reads it instead
+  // of serving the copy it fetched on mount.
+  const [metricRevision, setMetricRevision] = useState(0);
   // This page also serves `rhesis` metrics, and the tuning routes refuse
   // anything that is not custom.
   const showTuning = useIsCustomMetric(metricId);
@@ -94,6 +97,7 @@ export default function MetricDetailPageTabs() {
     <MetricDetailView
       metricId={metricId}
       mode="page"
+      refreshKey={metricRevision}
       tabNav={tabNav}
       tabBody={
         activeTab === 1 ? (
@@ -102,7 +106,10 @@ export default function MetricDetailPageTabs() {
             sessionStatus={status}
           />
         ) : activeTab === 2 && showTuning ? (
-          <MetricTuningTab metricId={metricId} />
+          <MetricTuningTab
+            metricId={metricId}
+            onMetricChanged={() => setMetricRevision(revision => revision + 1)}
+          />
         ) : undefined
       }
     />

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailView.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailView.tsx
@@ -180,6 +180,16 @@ export interface MetricDetailViewProps {
   tabNav?: React.ReactNode;
   /** Optional content to replace the detail body (e.g. for secondary tabs). */
   tabBody?: React.ReactNode;
+  /**
+   * Bump to make this view re-read the metric.
+   *
+   * The fetch is guarded to run once per metric id, which is right while this
+   * view is the only thing writing the metric. It is not the only thing: a
+   * sibling tab rendered through `tabBody` can write it too — the Tuning tab
+   * applying an improvement rewrites the evaluation prompt — and this view would
+   * otherwise go on showing the copy it read on mount until the page reloads.
+   */
+  refreshKey?: number;
 }
 
 export function MetricDetailView({
@@ -189,6 +199,7 @@ export function MetricDetailView({
   onSaved,
   tabNav,
   tabBody,
+  refreshKey = 0,
 }: MetricDetailViewProps) {
   const { data: session, status } = useSession();
   const theme = useTheme();
@@ -229,6 +240,14 @@ export function MetricDetailView({
     setMetric(null);
     setMissingError(null);
   }, [metricId]);
+
+  // Declared before the fetch below so it clears the guard on the same render
+  // the key changes. Deliberately does not blank `metric` the way a new id does:
+  // this is the same metric read again, and emptying the view first would flash
+  // a loading state over content that is only slightly out of date.
+  useEffect(() => {
+    dataFetchedRef.current = false;
+  }, [refreshKey]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -280,7 +299,7 @@ export function MetricDetailView({
     };
 
     fetchData();
-  }, [metricId, mode, notifications, router, status]);
+  }, [metricId, mode, notifications, refreshKey, router, status]);
 
   const collectFieldValues = React.useCallback((): Partial<EditData> => {
     const values: Partial<EditData> = {};

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningImproveDialog.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningImproveDialog.tsx
@@ -1,0 +1,450 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import type {
+  Metric,
+  ThresholdOperator,
+} from '@/utils/api-client/interfaces/metric';
+import type {
+  ImprovedMetricFields,
+  MetricTuningImprovement,
+} from '@/utils/api-client/interfaces/metric-tuning';
+
+/** The fields a reviewer reads, in the order they read them. */
+const FIELD_ORDER: (keyof ImprovedMetricFields)[] = [
+  'evaluation_prompt',
+  'evaluation_steps',
+  'reasoning',
+  'explanation',
+  'threshold',
+  'threshold_operator',
+  'min_score',
+  'max_score',
+  'passing_categories',
+  'name',
+  'description',
+  'score_type',
+  'categories',
+];
+
+const FIELD_LABELS: Record<keyof ImprovedMetricFields, string> = {
+  evaluation_prompt: 'Evaluation prompt',
+  evaluation_steps: 'Evaluation steps',
+  reasoning: 'Reasoning',
+  explanation: 'Explanation',
+  threshold: 'Threshold',
+  threshold_operator: 'Threshold operator',
+  min_score: 'Minimum score',
+  max_score: 'Maximum score',
+  passing_categories: 'Passing categories',
+  name: 'Name',
+  description: 'Description',
+  score_type: 'Score type',
+  categories: 'Categories',
+};
+
+/**
+ * How each field is edited, and how its value survives the trip through a box.
+ *
+ * `score_type` and `categories` are `fixed`: the API overwrites both with the
+ * metric's current values whatever the model answers, so they never arrive as
+ * changes and there is nothing here to edit.
+ */
+type FieldKind = 'text' | 'number' | 'operator' | 'list' | 'fixed';
+
+const FIELD_KINDS: Record<keyof ImprovedMetricFields, FieldKind> = {
+  evaluation_prompt: 'text',
+  evaluation_steps: 'text',
+  reasoning: 'text',
+  explanation: 'text',
+  threshold: 'number',
+  threshold_operator: 'operator',
+  min_score: 'number',
+  max_score: 'number',
+  passing_categories: 'list',
+  name: 'text',
+  description: 'text',
+  score_type: 'fixed',
+  categories: 'fixed',
+};
+
+const THRESHOLD_OPERATORS: ThresholdOperator[] = [
+  '>=',
+  '>',
+  '<=',
+  '<',
+  '=',
+  '!=',
+];
+
+/** Every field held as the text in its box, so typing is never fought. */
+type Draft = Partial<Record<keyof ImprovedMetricFields, string>>;
+
+/** Renders any of the field types as the one thing a reader compares: text. */
+function asText(value: unknown): string {
+  if (value === null || value === undefined || value === '') return '—';
+  if (Array.isArray(value)) return value.join(', ');
+  return String(value);
+}
+
+/** The proposed value as the text to start editing from. */
+function toDraftText(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (Array.isArray(value)) return value.join(', ');
+  return String(value);
+}
+
+function draftFor(
+  fields: ImprovedMetricFields,
+  shown: (keyof ImprovedMetricFields)[]
+): Draft {
+  const draft: Draft = {};
+  for (const field of shown) {
+    draft[field] = toDraftText(fields[field]);
+  }
+  return draft;
+}
+
+/**
+ * What is wrong with this box, or null.
+ *
+ * Blank is an error rather than "leave this one alone" because a metric update
+ * cannot clear a field — the API drops a null instead of writing it — so an empty
+ * box would apply successfully and change nothing. That is the silent divergence
+ * between what was approved and what was saved that this dialog exists to stop.
+ */
+function errorFor(kind: FieldKind, text: string): string | null {
+  const trimmed = text.trim();
+  if (!trimmed) return 'Required — an empty field cannot be saved.';
+  if (kind === 'number' && !Number.isFinite(Number(trimmed))) {
+    return 'Must be a number.';
+  }
+  return null;
+}
+
+/** The edited text back in the shape the API takes. */
+function fromDraft(
+  fields: ImprovedMetricFields,
+  draft: Draft
+): ImprovedMetricFields {
+  const edited: ImprovedMetricFields = { ...fields };
+  for (const [key, text] of Object.entries(draft)) {
+    const field = key as keyof ImprovedMetricFields;
+    const trimmed = (text ?? '').trim();
+    switch (FIELD_KINDS[field]) {
+      case 'number':
+        Object.assign(edited, { [field]: Number(trimmed) });
+        break;
+      case 'list':
+        Object.assign(edited, {
+          [field]: trimmed
+            .split(',')
+            .map(item => item.trim())
+            .filter(Boolean),
+        });
+        break;
+      case 'operator':
+        Object.assign(edited, { [field]: trimmed as ThresholdOperator });
+        break;
+      default:
+        Object.assign(edited, { [field]: trimmed });
+    }
+  }
+  return edited;
+}
+
+/**
+ * One field: what the metric says now on the left, what will be saved on the
+ * right.
+ *
+ * The right-hand side is an input rather than text because the model's rewrite
+ * is a draft, not a verdict — a reviewer who can see what is wrong with one
+ * clause should be able to fix that clause instead of discarding the whole
+ * rewrite. What is in the boxes stays exactly what Apply saves.
+ *
+ * The evaluation prompt gets the height: it is the field the whole feature
+ * exists to rewrite, and editing it through a three-line window is editing it
+ * blind.
+ */
+function FieldDiff({
+  label,
+  kind,
+  current,
+  value,
+  error,
+  expanded,
+  onChange,
+}: {
+  label: string;
+  kind: FieldKind;
+  current: unknown;
+  value: string;
+  error: string | null;
+  expanded: boolean;
+  onChange: (next: string) => void;
+}) {
+  const currentSx = expanded
+    ? { whiteSpace: 'pre-wrap' as const }
+    : {
+        whiteSpace: 'pre-wrap' as const,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        display: '-webkit-box',
+        WebkitLineClamp: 6,
+        WebkitBoxOrient: 'vertical' as const,
+      };
+
+  const shared = {
+    value,
+    error: Boolean(error),
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+      onChange(event.target.value),
+    fullWidth: true,
+    size: 'small' as const,
+    label: `${label}, proposed`,
+  };
+
+  return (
+    <Box>
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>
+        {label}
+      </Typography>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+          gap: 2,
+        }}
+      >
+        <Box>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: 'block', mb: 0.5 }}
+          >
+            Current
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={currentSx}>
+            {asText(current)}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: 'block', mb: 0.5 }}
+          >
+            Proposed — edit before applying
+          </Typography>
+          {kind === 'operator' ? (
+            <TextField {...shared} select helperText={error ?? undefined}>
+              {THRESHOLD_OPERATORS.map(operator => (
+                <MenuItem key={operator} value={operator}>
+                  {operator}
+                </MenuItem>
+              ))}
+            </TextField>
+          ) : kind === 'number' ? (
+            <TextField
+              {...shared}
+              type="number"
+              helperText={error ?? undefined}
+            />
+          ) : (
+            <TextField
+              {...shared}
+              multiline
+              minRows={expanded ? 12 : 3}
+              maxRows={expanded ? 24 : 8}
+              helperText={
+                error ?? (kind === 'list' ? 'Comma-separated.' : undefined)
+              }
+            />
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+export interface MetricTuningImproveDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** The improvement to show. Null until the call has come back. */
+  improvement: MetricTuningImprovement | null;
+  /** The metric as it stands, which is the left-hand column. */
+  metric: Metric | null;
+  /** Writes the shown fields onto the metric. All fields, or none. */
+  onApply: (fields: ImprovedMetricFields) => Promise<void>;
+}
+
+/**
+ * The improvement, current fields beside editable proposed ones, and one Apply.
+ *
+ * Nothing has been written when this opens — that is the point of the dialog
+ * existing at all. The proposed side is editable so a reviewer can correct the
+ * rewrite instead of taking it or leaving it whole; what is on screen stays what
+ * gets saved either way, which is the invariant ADR-0006 is about.
+ *
+ * Applying is still all-or-nothing across fields: the score bands, the
+ * evaluation steps and the reasoning are written to agree with each other in one
+ * pass, so a half-applied metric is an incoherent one. Editing a value is not
+ * choosing which values apply.
+ */
+export default function MetricTuningImproveDialog({
+  open,
+  onClose,
+  improvement,
+  metric,
+  onApply,
+}: MetricTuningImproveDialogProps) {
+  const [applying, setApplying] = useState(false);
+  const [error, setError] = useState('');
+  const [draft, setDraft] = useState<Draft>({});
+
+  const changed = useMemo(() => {
+    if (!improvement) return [];
+    const named = new Set(improvement.changed);
+    // Ordered here rather than taken from the API: which field a reviewer reads
+    // first is the interface's decision.
+    return FIELD_ORDER.filter(
+      field => named.has(field) && FIELD_KINDS[field] !== 'fixed'
+    );
+  }, [improvement]);
+
+  // Named rather than hidden: a reviewer has to be able to see that the rewrite
+  // left the rest of the metric where it was.
+  const unchanged = useMemo(() => {
+    if (!improvement) return [];
+    const named = new Set(improvement.changed);
+    return FIELD_ORDER.filter(field => !named.has(field));
+  }, [improvement]);
+
+  // A fresh improvement is a fresh draft — edits belong to the rewrite they were
+  // made against, never to the next one.
+  useEffect(() => {
+    if (!improvement) return;
+    setDraft(draftFor(improvement.improvement, changed));
+    setError('');
+  }, [improvement, changed]);
+
+  const errors = useMemo(() => {
+    const found: Partial<Record<keyof ImprovedMetricFields, string>> = {};
+    for (const field of changed) {
+      const message = errorFor(FIELD_KINDS[field], draft[field] ?? '');
+      if (message) found[field] = message;
+    }
+    return found;
+  }, [changed, draft]);
+
+  const complete = Object.keys(errors).length === 0;
+
+  const handleApply = async () => {
+    if (!improvement || !complete) return;
+    setApplying(true);
+    setError('');
+    try {
+      await onApply(fromDraft(improvement.improvement, draft));
+      onClose();
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : 'Failed to apply the improvement.'
+      );
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const handleReset = () => {
+    if (!improvement) return;
+    setDraft(draftFor(improvement.improvement, changed));
+  };
+
+  const rejections = improvement?.rejections_used ?? 0;
+  const edited =
+    improvement !== null &&
+    changed.some(
+      field => draft[field] !== toDraftText(improvement.improvement[field])
+    );
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>
+        Improve this metric
+        <Typography variant="body2" color="text.secondary">
+          Rewritten from {rejections}{' '}
+          {rejections === 1 ? 'rejection' : 'rejections'}. Edit anything below —
+          nothing is saved until you apply it.
+        </Typography>
+      </DialogTitle>
+      <DialogContent dividers>
+        {changed.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            The rewrite came back the same as the metric you already have.
+            Nothing to apply.
+          </Typography>
+        ) : (
+          <Stack spacing={2.5} divider={<Divider flexItem />}>
+            {changed.map(field => (
+              <FieldDiff
+                key={field}
+                label={FIELD_LABELS[field]}
+                kind={FIELD_KINDS[field]}
+                current={metric ? metric[field as keyof Metric] : null}
+                value={draft[field] ?? ''}
+                error={errors[field] ?? null}
+                // Only the evaluation prompt is worth the height.
+                expanded={field === 'evaluation_prompt'}
+                onChange={next =>
+                  setDraft(prev => ({ ...prev, [field]: next }))
+                }
+              />
+            ))}
+          </Stack>
+        )}
+        {unchanged.length > 0 && changed.length > 0 && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 2.5 }}>
+            Unchanged:{' '}
+            {unchanged
+              .map(field => FIELD_LABELS[field].toLowerCase())
+              .join(', ')}
+            .
+          </Typography>
+        )}
+        {error && (
+          <Typography variant="body2" color="error" sx={{ mt: 2 }}>
+            {error}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        {edited && (
+          <Button onClick={handleReset} sx={{ mr: 'auto' }}>
+            Undo my edits
+          </Button>
+        )}
+        <Button onClick={onClose}>Close</Button>
+        <Button
+          variant="contained"
+          onClick={handleApply}
+          disabled={applying || changed.length === 0 || !complete}
+        >
+          {applying ? 'Applying…' : 'Apply'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningTab.tsx
@@ -31,6 +31,7 @@ import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import {
   AddIcon,
+  AutoFixHighIcon,
   CancelIcon,
   CheckCircleIcon,
   PlayArrowIcon,
@@ -43,14 +44,21 @@ import {
 } from '@/components/icons';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import type { UUID } from 'crypto';
-import type { ScoreType } from '@/utils/api-client/interfaces/metric';
 import type {
+  Metric,
+  MetricUpdate,
+  ScoreType,
+} from '@/utils/api-client/interfaces/metric';
+import type {
+  ImprovedMetricFields,
   MetricTuningAgreement,
   MetricTuningCase,
   MetricTuningCaseCreate,
+  MetricTuningImprovement,
   MetricTuningRun,
 } from '@/utils/api-client/interfaces/metric-tuning';
 import MetricTuningCaseDialog from './MetricTuningCaseDialog';
+import MetricTuningImproveDialog from './MetricTuningImproveDialog';
 import MetricTuningRejectDialog from './MetricTuningRejectDialog';
 
 /** How often to re-read a run that is still going. */
@@ -65,6 +73,15 @@ const INVALIDATED_HINT =
 
 const ERRORED_HINT =
   'The metric call failed for this case, so there is no verdict to judge.';
+
+const NO_REJECTIONS_HINT =
+  'Reject a case with a comment first: Improve reads the comments.';
+
+const IMPROVE_HINT =
+  'Rewrite this metric from the comments on the cases it got wrong. Nothing is saved until you apply it.';
+
+const IMPROVE_WHILE_RUNNING_HINT =
+  'Wait for the run to finish: it is about to replace the verdicts those comments are about.';
 
 const NO_AGREEMENT_HINT =
   'Agreement is the share of judged cases you accepted. Nothing has been judged yet, so there is no share to report — a set nobody has looked at is not a set the metric got right.';
@@ -376,16 +393,87 @@ function RunSummary({ run }: { run: MetricTuningRun | null }) {
       ? ` ${run.errored_cases} of them could not be reached.`
       : '';
   return (
-    <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-      Last run {finished ? finished.toLocaleString() : ''} over{' '}
-      {run.completed_cases} {run.completed_cases === 1 ? 'case' : 'cases'}.
-      {errored}
-    </Typography>
+    <Box sx={{ mb: 1.5 }}>
+      <Typography variant="body2" color="text.secondary">
+        Last run {finished ? finished.toLocaleString() : ''} over{' '}
+        {run.completed_cases} {run.completed_cases === 1 ? 'case' : 'cases'}.
+        {errored}
+      </Typography>
+      {/* Every verdict above came out of the metric as it was then, so the
+          agreement is that metric's rather than this one's. */}
+      {run.predates_metric && (
+        <Typography variant="body2" color="warning.main">
+          This metric has changed since that run, so the numbers above belong to
+          the earlier version. Press Run metric to score it again.
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+/**
+ * The improvement as a metric update: every field it showed that has a value.
+ *
+ * A metric update cannot clear a field — the API drops a null rather than
+ * writing it — so a null sent here would be a field the dialog showed and the
+ * save quietly skipped. The API refuses to propose blanking anything the metric
+ * has, so every null left is a field the metric does not have either, and
+ * leaving it out writes exactly what was on screen.
+ */
+function toMetricUpdate(fields: ImprovedMetricFields): MetricUpdate {
+  const update: MetricUpdate = {
+    name: fields.name,
+    description: fields.description,
+    evaluation_prompt: fields.evaluation_prompt,
+    evaluation_steps: fields.evaluation_steps,
+    reasoning: fields.reasoning,
+    explanation: fields.explanation,
+    score_type: fields.score_type,
+  };
+  if (fields.min_score !== null) update.min_score = fields.min_score;
+  if (fields.max_score !== null) update.max_score = fields.max_score;
+  if (fields.threshold !== null) update.threshold = fields.threshold;
+  if (fields.threshold_operator !== null) {
+    update.threshold_operator = fields.threshold_operator;
+  }
+  if (fields.categories !== null) update.categories = fields.categories;
+  if (fields.passing_categories !== null) {
+    update.passing_categories = fields.passing_categories;
+  }
+  return update;
+}
+
+/**
+ * One line saying a rewrite is being written, while it is being written.
+ *
+ * Deliberately the same shape as ``RunSummary``'s in-progress line: both are a
+ * slow thing the tab started, and a second visual language for the second one
+ * would be two ways of saying "wait". The label on the button alone is too quiet
+ * for a call that can take most of a minute.
+ *
+ * The rejection count is in it because that is what makes the wait legible --
+ * three comments is quick, forty is not.
+ */
+function ImprovingSummary({ rejections }: { rejections: number }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+      <CircularProgress size={16} />
+      <Typography variant="body2" color="text.secondary">
+        Rewriting this metric from {rejections}{' '}
+        {rejections === 1 ? 'rejection' : 'rejections'} — this takes a moment,
+        the model is reading every comment.
+      </Typography>
+    </Box>
   );
 }
 
 export interface MetricTuningTabProps {
   metricId: string;
+  /**
+   * Called after an improvement is applied, so the rest of the page re-reads the
+   * metric. Applying writes the evaluation prompt every other tab is showing.
+   */
+  onMetricChanged?: () => void;
 }
 
 /**
@@ -401,13 +489,17 @@ export interface MetricTuningTabProps {
  * only the id, and threading the whole metric through it would couple this
  * feature to a component that otherwise knows nothing about it.
  */
-export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
+export default function MetricTuningTab({
+  metricId,
+  onMetricChanged,
+}: MetricTuningTabProps) {
   const notifications = useNotifications();
   const canEdit = useCan(Capability.Metric.UPDATE);
 
   const [cases, setCases] = useState<MetricTuningCase[]>([]);
-  const [scoreType, setScoreType] = useState<ScoreType>('binary');
-  const [groundTruthRequired, setGroundTruthRequired] = useState(false);
+  // The whole metric, because the Improve dialog shows the current fields beside
+  // the proposed ones and the grid needs the score type to render a verdict.
+  const [metric, setMetric] = useState<Metric | null>(null);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editing, setEditing] = useState<MetricTuningCase | null>(null);
@@ -415,6 +507,9 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
   const [run, setRun] = useState<MetricTuningRun | null>(null);
   const [starting, setStarting] = useState(false);
   const [acceptingRest, setAcceptingRest] = useState(false);
+  const [improving, setImproving] = useState(false);
+  const [improvement, setImprovement] =
+    useState<MetricTuningImprovement | null>(null);
   const [paginationModel, setPaginationModel] = useState({
     page: 0,
     pageSize: 25,
@@ -424,13 +519,12 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
     setLoading(true);
     try {
       const factory = new ApiClientFactory();
-      const [metric, tuningCases, tuningRun] = await Promise.all([
+      const [tuningMetric, tuningCases, tuningRun] = await Promise.all([
         factory.getMetricsClient().getMetric(metricId as UUID),
         factory.getMetricTuningClient().getTuningCases(metricId),
         factory.getMetricTuningClient().getTuningRun(metricId),
       ]);
-      setScoreType(metric.score_type ?? 'binary');
-      setGroundTruthRequired(metric.ground_truth_required === true);
+      setMetric(tuningMetric);
       setCases(tuningCases);
       setRun(tuningRun);
     } catch (error) {
@@ -624,6 +718,53 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
     }
   }, [metricId, notifications, refreshRun]);
 
+  // Read off the metric rather than kept beside it, so there is one answer to
+  // "what score type is this" while the metric is being reloaded.
+  const scoreType: ScoreType = metric?.score_type ?? 'binary';
+  const groundTruthRequired = metric?.ground_truth_required === true;
+
+  const handleImprove = useCallback(async () => {
+    setImproving(true);
+    try {
+      const client = new ApiClientFactory().getMetricTuningClient();
+      // The dialog opens on the answer, not on the click — there is nothing to
+      // show until the rewrite is back, and no cancelling a call this short.
+      setImprovement(await client.improveFromReviews(metricId));
+    } catch (error) {
+      notifications.show(
+        error instanceof Error
+          ? `Failed to improve the metric: ${error.message}`
+          : 'Failed to improve the metric',
+        { severity: 'error', autoHideDuration: 6000 }
+      );
+    } finally {
+      setImproving(false);
+    }
+  }, [metricId, notifications]);
+
+  // Throws on failure so the dialog keeps the proposal on screen: losing a
+  // rewrite to a network blip would mean asking the model again for a different
+  // one. Re-reads everything afterwards — the metric has changed, so the run on
+  // screen now predates it.
+  const handleApplyImprovement = useCallback(
+    async (fields: ImprovedMetricFields) => {
+      const client = new ApiClientFactory().getMetricsClient();
+      await client.updateMetric(metricId as UUID, toMetricUpdate(fields));
+      await fetchCases();
+      // The evaluation prompt just changed, and the tabs beside this one are
+      // still showing the copy they read when the page loaded.
+      onMetricChanged?.();
+      notifications.show(
+        'Applied the improvement. Run the metric again to score it.',
+        {
+          severity: 'success',
+          autoHideDuration: 6000,
+        }
+      );
+    },
+    [metricId, fetchCases, notifications, onMetricChanged]
+  );
+
   const openAdd = useCallback(() => {
     setEditing(null);
     setDialogOpen(true);
@@ -782,6 +923,19 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
   );
 
   const isRunning = run?.status === 'running';
+  // Improve reads the comments on rejections, so without one there is nothing
+  // for it to read. Only rejections that still stand count — the API refuses on
+  // the same rule, and it is the outcome the grid is already showing.
+  const standingRejections = cases.filter(c => c.outcome === 'rejected').length;
+  const hasStandingRejection = standingRejections > 0;
+  const canImprove = hasStandingRejection && !isRunning && !improving;
+  // Keyed off why it is off, not off one of the reasons: a tooltip that explains
+  // what Improve does while the button is disabled explains the wrong thing.
+  const improveHint = !hasStandingRejection
+    ? NO_REJECTIONS_HINT
+    : isRunning
+      ? IMPROVE_WHILE_RUNNING_HINT
+      : IMPROVE_HINT;
   const actions = (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
       {canEdit && cases.length > 0 && (
@@ -803,6 +957,29 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
         >
           Accept the rest
         </Button>
+      )}
+      {/* The tooltip sits on a span because MUI drops pointer events on a
+          disabled button, and the disabled state is the one whose reason a
+          reader actually needs. */}
+      {canEdit && (
+        <Tooltip title={improveHint}>
+          <span>
+            <Button
+              variant="outlined"
+              startIcon={
+                improving ? (
+                  <CircularProgress size={16} color="inherit" />
+                ) : (
+                  <AutoFixHighIcon />
+                )
+              }
+              onClick={handleImprove}
+              disabled={!canImprove}
+            >
+              {improving ? 'Improving…' : 'Improve'}
+            </Button>
+          </span>
+        </Tooltip>
       )}
       {canEdit && (
         <Button variant="contained" startIcon={<AddIcon />} onClick={openAdd}>
@@ -838,6 +1015,7 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
               <AgreementSummary agreement={run.agreement} />
             )}
             <RunSummary run={run} />
+            {improving && <ImprovingSummary rejections={standingRejections} />}
             <BaseDataGrid
               rows={cases as unknown as GridRowModel[]}
               columns={columns}
@@ -868,6 +1046,14 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
         onClose={() => setRejecting(null)}
         verdict={rejecting?.result?.verdict ?? null}
         onSubmit={handleReject}
+      />
+
+      <MetricTuningImproveDialog
+        open={improvement !== null}
+        onClose={() => setImprovement(null)}
+        improvement={improvement}
+        metric={metric}
+        onApply={handleApplyImprovement}
       />
     </>
   );

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
@@ -3,8 +3,10 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MetricTuningTab from '../MetricTuningTab';
 import type {
+  ImprovedMetricFields,
   MetricTuningAgreement,
   MetricTuningCase,
+  MetricTuningImprovement,
   MetricTuningRun,
 } from '@/utils/api-client/interfaces/metric-tuning';
 
@@ -16,7 +18,9 @@ const mockGetTuningRun = jest.fn();
 const mockStartTuningRun = jest.fn();
 const mockReviewTuningCase = jest.fn();
 const mockAcceptRemainingTuningCases = jest.fn();
+const mockImproveFromReviews = jest.fn();
 const mockGetMetric = jest.fn();
+const mockUpdateMetric = jest.fn();
 
 jest.mock('@/utils/api-client/client-factory', () => ({
   ApiClientFactory: jest.fn().mockImplementation(() => ({
@@ -29,9 +33,11 @@ jest.mock('@/utils/api-client/client-factory', () => ({
       startTuningRun: mockStartTuningRun,
       reviewTuningCase: mockReviewTuningCase,
       acceptRemainingTuningCases: mockAcceptRemainingTuningCases,
+      improveFromReviews: mockImproveFromReviews,
     }),
     getMetricsClient: () => ({
       getMetric: mockGetMetric,
+      updateMetric: mockUpdateMetric,
     }),
   })),
 }));
@@ -102,6 +108,7 @@ const NEVER_RUN: MetricTuningRun = {
   errored_cases: 0,
   error: null,
   agreement: NO_AGREEMENT,
+  predates_metric: false,
 };
 
 describe('MetricTuningTab', () => {
@@ -249,6 +256,7 @@ describe('MetricTuningTab — runs', () => {
     errored_cases: 0,
     error: null,
     agreement: NO_AGREEMENT,
+    predates_metric: false,
   };
 
   const COMPLETED: MetricTuningRun = {
@@ -260,6 +268,7 @@ describe('MetricTuningTab — runs', () => {
     errored_cases: 0,
     error: null,
     agreement: NO_AGREEMENT,
+    predates_metric: false,
   };
 
   const SCORED_CASE: MetricTuningCase = {
@@ -642,12 +651,12 @@ describe('MetricTuningTab — reviewing', () => {
     const save = await screen.findByRole('button', { name: 'Save' });
     expect(save).toBeDisabled();
 
-    fireEvent.change(screen.getByLabelText(/comment/i), {
+    fireEvent.change(screen.getByRole('textbox', { name: /comment/i }), {
       target: { value: '   ' },
     });
     expect(save).toBeDisabled();
 
-    fireEvent.change(screen.getByLabelText(/comment/i), {
+    fireEvent.change(screen.getByRole('textbox', { name: /comment/i }), {
       target: { value: 'Far too lenient.' },
     });
     expect(save).toBeEnabled();
@@ -668,7 +677,7 @@ describe('MetricTuningTab — reviewing', () => {
     fireEvent.click(
       await screen.findByRole('button', { name: /reject this verdict/i })
     );
-    fireEvent.change(await screen.findByLabelText(/comment/i), {
+    fireEvent.change(await screen.findByRole('textbox', { name: /comment/i }), {
       target: { value: 'Far too lenient.' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
@@ -845,5 +854,479 @@ describe('MetricTuningTab — agreement', () => {
     expect(await screen.findByText(/1 done/i)).toBeInTheDocument();
     expect(screen.queryByText('Agreement')).not.toBeInTheDocument();
     expect(screen.queryByText('100%')).not.toBeInTheDocument();
+  });
+});
+
+describe('MetricTuningTab — improving from reviews', () => {
+  /** A metric with the fields the dialog shows on its "current" side. */
+  const FULL_METRIC = {
+    ...BINARY_METRIC,
+    name: 'Toxicity',
+    description: 'Whether the answer is toxic.',
+    evaluation_prompt: 'Score how toxic the answer is.',
+    evaluation_steps: 'Step 1:\nRead the answer.',
+    reasoning: 'Say which phrase decided it.',
+    explanation: 'A fail means the answer is toxic.',
+    min_score: null,
+    max_score: null,
+    threshold: null,
+    threshold_operator: null,
+    categories: null,
+    passing_categories: null,
+  };
+
+  const REJECTED_CASE: MetricTuningCase = {
+    ...JUDGEABLE_CASE,
+    outcome: 'rejected',
+    unreviewed_reason: null,
+    review: {
+      decision: 'rejected',
+      comment: 'This answer dodges the question.',
+      verdict: 'pass',
+      reviewed_at: '2026-08-14T09:00:00Z',
+    },
+  };
+
+  const PROPOSED: ImprovedMetricFields = {
+    name: 'Toxicity',
+    description: 'Whether the answer is toxic.',
+    evaluation_prompt: 'Fail any answer that dodges the question.',
+    evaluation_steps: 'Step 1:\nRead the answer.',
+    reasoning: 'Quote the phrase that dodges.',
+    explanation: 'A fail means the answer is toxic.',
+    score_type: 'binary',
+    min_score: null,
+    max_score: null,
+    threshold: null,
+    threshold_operator: null,
+    categories: null,
+    passing_categories: null,
+  };
+
+  const IMPROVEMENT: MetricTuningImprovement = {
+    improvement: PROPOSED,
+    changed: ['evaluation_prompt', 'reasoning'],
+    rejections_used: 3,
+  };
+
+  const RUNNING: MetricTuningRun = {
+    ...NEVER_RUN,
+    status: 'running',
+    started_at: '2026-08-13T10:00:00Z',
+    total_cases: 1,
+  };
+
+  const improveButton = () => screen.getByRole('button', { name: /improve/i });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetMetric.mockResolvedValue(FULL_METRIC);
+    mockGetTuningRun.mockResolvedValue(NEVER_RUN);
+    mockGetTuningCases.mockResolvedValue([REJECTED_CASE]);
+    mockImproveFromReviews.mockResolvedValue(IMPROVEMENT);
+    mockUpdateMetric.mockResolvedValue(FULL_METRIC);
+  });
+
+  it('offers Improve once a rejection stands', async () => {
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+  });
+
+  it('refuses to improve with nothing to read, and says why', async () => {
+    mockGetTuningCases.mockResolvedValue([JUDGEABLE_CASE]);
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    await waitFor(() => expect(improveButton()).toBeDisabled());
+    expect(
+      screen.getByLabelText(/reject a case with a comment first/i)
+    ).toBeInTheDocument();
+  });
+
+  it('does not improve while a run is in flight, and says that is why', async () => {
+    // The verdicts are about to be replaced, so a rewrite of them is premature.
+    mockGetTuningRun.mockResolvedValue(RUNNING);
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    await waitFor(() => expect(improveButton()).toBeDisabled());
+    expect(
+      screen.getByLabelText(/wait for the run to finish/i)
+    ).toBeInTheDocument();
+  });
+
+  it('says a rewrite is being written, and how much it is reading', async () => {
+    // The button label alone is too quiet for a call that runs most of a minute.
+    let arrive: (value: MetricTuningImprovement) => void = () => {};
+    mockImproveFromReviews.mockReturnValue(
+      new Promise<MetricTuningImprovement>(resolve => {
+        arrive = resolve;
+      })
+    );
+    mockGetTuningCases.mockResolvedValue([
+      REJECTED_CASE,
+      { ...REJECTED_CASE, id: 'other-id' as MetricTuningCase['id'] },
+    ]);
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+    fireEvent.click(improveButton());
+
+    expect(
+      await screen.findByText(/rewriting this metric from 2 rejections/i)
+    ).toBeInTheDocument();
+
+    arrive(IMPROVEMENT);
+    await screen.findByRole('dialog');
+    // The dialog says the same thing now, so the line has nothing left to add.
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/rewriting this metric from/i)
+      ).not.toBeInTheDocument()
+    );
+  });
+
+  it('says nothing about rewriting when no call is out', async () => {
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+    expect(
+      screen.queryByText(/rewriting this metric from/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('says it is improving, and opens nothing until the rewrite arrives', async () => {
+    let arrive: (value: MetricTuningImprovement) => void = () => {};
+    mockImproveFromReviews.mockReturnValue(
+      new Promise<MetricTuningImprovement>(resolve => {
+        arrive = resolve;
+      })
+    );
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+    fireEvent.click(improveButton());
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /improving/i })).toBeDisabled()
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    arrive(IMPROVEMENT);
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('says how many rejections the rewrite came from', async () => {
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+
+    fireEvent.click(improveButton());
+
+    expect(
+      await screen.findByText(/rewritten from 3 rejections/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows the current field beside the proposed one', async () => {
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+
+    fireEvent.click(improveButton());
+
+    await screen.findByRole('dialog');
+    expect(
+      screen.getByText('Score how toxic the answer is.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Fail any answer that dodges the question.')
+    ).toBeInTheDocument();
+  });
+
+  it('shows only the changed fields, and names the rest as unchanged', async () => {
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+
+    fireEvent.click(improveButton());
+
+    const dialog = await screen.findByRole('dialog');
+    // The field the whole feature exists to rewrite is the one read first.
+    const headings = Array.from(
+      dialog.querySelectorAll('.MuiTypography-subtitle2')
+    ).map(node => node.textContent);
+    expect(headings).toEqual(['Evaluation prompt', 'Reasoning']);
+    // Unchanged, so it is named rather than shown as a diff.
+    expect(screen.queryByText('Description')).not.toBeInTheDocument();
+    expect(screen.getByText(/unchanged:/i)).toHaveTextContent('description');
+  });
+
+  it('applies every field it showed, not only the changed ones', async () => {
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+    fireEvent.click(improveButton());
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByRole('button', { name: /^apply$/i }));
+
+    // All-or-nothing: a half-applied metric has bands and steps that disagree.
+    // The fields this metric does not have are left out rather than sent as
+    // nulls — the API drops a null on update, so sending one writes nothing and
+    // only makes the request disagree with what the reviewer approved.
+    await waitFor(() =>
+      expect(mockUpdateMetric).toHaveBeenCalledWith(METRIC_ID, {
+        name: PROPOSED.name,
+        description: PROPOSED.description,
+        evaluation_prompt: PROPOSED.evaluation_prompt,
+        evaluation_steps: PROPOSED.evaluation_steps,
+        reasoning: PROPOSED.reasoning,
+        explanation: PROPOSED.explanation,
+        score_type: PROPOSED.score_type,
+      })
+    );
+  });
+
+  it('sends the score bands of a metric that has them', async () => {
+    const scored: ImprovedMetricFields = {
+      ...PROPOSED,
+      score_type: 'numeric',
+      min_score: 0,
+      max_score: 1,
+      threshold: 0.9,
+      threshold_operator: '>=',
+    };
+    mockImproveFromReviews.mockResolvedValue({
+      ...IMPROVEMENT,
+      improvement: scored,
+      changed: ['evaluation_prompt', 'threshold'],
+    });
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+    fireEvent.click(improveButton());
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByRole('button', { name: /^apply$/i }));
+
+    await waitFor(() =>
+      expect(mockUpdateMetric).toHaveBeenCalledWith(
+        METRIC_ID,
+        expect.objectContaining({ threshold: 0.9, threshold_operator: '>=' })
+      )
+    );
+  });
+
+  it('tells the page the metric changed, so the other tabs re-read it', async () => {
+    // The detail view fetches the metric once per id. Without this it goes on
+    // showing the evaluation prompt from before the apply until a page reload.
+    const onMetricChanged = jest.fn();
+    render(
+      <MetricTuningTab metricId={METRIC_ID} onMetricChanged={onMetricChanged} />
+    );
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+    fireEvent.click(improveButton());
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByRole('button', { name: /^apply$/i }));
+
+    await waitFor(() => expect(onMetricChanged).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not say the metric changed when the apply failed', async () => {
+    const onMetricChanged = jest.fn();
+    mockUpdateMetric.mockRejectedValue(new Error('conflict'));
+    render(
+      <MetricTuningTab metricId={METRIC_ID} onMetricChanged={onMetricChanged} />
+    );
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+    fireEvent.click(improveButton());
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByRole('button', { name: /^apply$/i }));
+
+    await screen.findByText('conflict');
+    expect(onMetricChanged).not.toHaveBeenCalled();
+  });
+
+  it('re-reads the tab after applying, so the run reads as out of date', async () => {
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+    fireEvent.click(improveButton());
+    await screen.findByRole('dialog');
+    const readsBefore = mockGetTuningRun.mock.calls.length;
+
+    fireEvent.click(screen.getByRole('button', { name: /^apply$/i }));
+
+    await waitFor(() =>
+      expect(mockGetTuningRun.mock.calls.length).toBeGreaterThan(readsBefore)
+    );
+  });
+
+  const proposedBox = (label: RegExp) =>
+    screen.getByRole('textbox', { name: label });
+
+  const openDialog = async () => {
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+    fireEvent.click(improveButton());
+    await screen.findByRole('dialog');
+  };
+
+  it('applies the reviewer edit rather than what the model proposed', async () => {
+    // The rewrite is a draft: someone who can see what is wrong with one clause
+    // should be able to fix that clause instead of discarding the whole thing.
+    await openDialog();
+
+    fireEvent.change(proposedBox(/evaluation prompt, proposed/i), {
+      target: { value: 'Fail any answer that dodges, unless it says why.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^apply$/i }));
+
+    await waitFor(() =>
+      expect(mockUpdateMetric).toHaveBeenCalledWith(
+        METRIC_ID,
+        expect.objectContaining({
+          evaluation_prompt: 'Fail any answer that dodges, unless it says why.',
+        })
+      )
+    );
+  });
+
+  it('will not apply a field left empty', async () => {
+    // An update drops a null instead of writing it, so an empty box would apply
+    // successfully and change nothing.
+    await openDialog();
+
+    fireEvent.change(proposedBox(/evaluation prompt, proposed/i), {
+      target: { value: '   ' },
+    });
+
+    expect(screen.getByRole('button', { name: /^apply$/i })).toBeDisabled();
+    expect(
+      screen.getByText(/an empty field cannot be saved/i)
+    ).toBeInTheDocument();
+    expect(mockUpdateMetric).not.toHaveBeenCalled();
+  });
+
+  it('puts the proposal back when the edits are undone', async () => {
+    await openDialog();
+    fireEvent.change(proposedBox(/evaluation prompt, proposed/i), {
+      target: { value: 'Something I typed by mistake.' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /undo my edits/i }));
+
+    expect(proposedBox(/evaluation prompt, proposed/i)).toHaveValue(
+      PROPOSED.evaluation_prompt
+    );
+  });
+
+  it('offers nothing to undo until something is edited', async () => {
+    await openDialog();
+
+    expect(
+      screen.queryByRole('button', { name: /undo my edits/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('applies an edited threshold as a number, not as its text', async () => {
+    mockImproveFromReviews.mockResolvedValue({
+      ...IMPROVEMENT,
+      improvement: {
+        ...PROPOSED,
+        score_type: 'numeric',
+        min_score: 0,
+        max_score: 1,
+        threshold: 0.9,
+        threshold_operator: '>=',
+      },
+      changed: ['threshold'],
+    });
+    await openDialog();
+
+    fireEvent.change(
+      screen.getByRole('spinbutton', { name: /threshold, proposed/i }),
+      {
+        target: { value: '0.75' },
+      }
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^apply$/i }));
+
+    await waitFor(() =>
+      expect(mockUpdateMetric).toHaveBeenCalledWith(
+        METRIC_ID,
+        expect.objectContaining({ threshold: 0.75 })
+      )
+    );
+  });
+
+  it('writes nothing when the dialog is closed', async () => {
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+    fireEvent.click(improveButton());
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    );
+    expect(mockUpdateMetric).not.toHaveBeenCalled();
+  });
+
+  it('keeps the proposal on screen when applying fails', async () => {
+    mockUpdateMetric.mockRejectedValue(new Error('conflict'));
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+    await waitFor(() => expect(improveButton()).toBeEnabled());
+    fireEvent.click(improveButton());
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByRole('button', { name: /^apply$/i }));
+
+    // Asking again returns a different rewrite, so losing this one is not free.
+    expect(await screen.findByText('conflict')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+
+describe('MetricTuningTab — a run that predates its metric', () => {
+  const STALE_RUN: MetricTuningRun = {
+    ...NEVER_RUN,
+    status: 'completed',
+    started_at: '2026-08-13T10:00:00Z',
+    completed_at: '2026-08-13T10:01:00Z',
+    total_cases: 1,
+    completed_cases: 1,
+    predates_metric: true,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetMetric.mockResolvedValue(BINARY_METRIC);
+    mockGetTuningCases.mockResolvedValue([JUDGEABLE_CASE]);
+  });
+
+  it('says the numbers belong to the earlier metric, and points at Run metric', async () => {
+    mockGetTuningRun.mockResolvedValue(STALE_RUN);
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    expect(
+      await screen.findByText(/belong to the earlier version/i)
+    ).toHaveTextContent(/press run metric/i);
+  });
+
+  it('says nothing of the sort about a run of the current metric', async () => {
+    mockGetTuningRun.mockResolvedValue({
+      ...STALE_RUN,
+      predates_metric: false,
+    });
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    await screen.findByText(/last run/i);
+    expect(
+      screen.queryByText(/belong to the earlier version/i)
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/utils/__tests__/backend-proxy.test.ts
+++ b/apps/frontend/src/utils/__tests__/backend-proxy.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment node
+ *
+ * The module under test imports `next/server`, which needs the Web `Request`
+ * global that the default jsdom environment does not provide.
+ */
+import { resolveTimeoutMs } from '../backend-proxy';
+
+/**
+ * The timeout budget the BFF proxy gives an upstream call.
+ *
+ * A path missing from the long-running lists gets the 10s CRUD budget, and any
+ * call that waits on a model blows through it — the caller sees a 504 from the
+ * proxy while the backend is still working, which reads as a broken feature
+ * rather than a slow one.
+ */
+describe('resolveTimeoutMs', () => {
+  const CRUD_MS = 10_000;
+  const LONG_MS = 300_000;
+
+  it('gives ordinary CRUD the short budget', () => {
+    expect(resolveTimeoutMs('/metrics/abc/tuning/cases')).toBe(CRUD_MS);
+    expect(resolveTimeoutMs('/metrics')).toBe(CRUD_MS);
+  });
+
+  it('gives a metric rewritten from its reviews the long budget', () => {
+    // Synchronous and one generation call, so the response is held until the
+    // model answers.
+    expect(resolveTimeoutMs('/metrics/abc/tuning/improve')).toBe(LONG_MS);
+  });
+
+  it('gives a tuning run the short budget', () => {
+    // Starting a run returns 202 straight away — the work is a background task.
+    expect(resolveTimeoutMs('/metrics/abc/tuning/run')).toBe(CRUD_MS);
+  });
+
+  it('still recognises the paths that were already long-running', () => {
+    expect(resolveTimeoutMs('/services/generate/tests')).toBe(LONG_MS);
+    expect(resolveTimeoutMs('/test_sets/abc/generate_outputs')).toBe(LONG_MS);
+  });
+});

--- a/apps/frontend/src/utils/api-client/__tests__/metric-tuning-client.test.ts
+++ b/apps/frontend/src/utils/api-client/__tests__/metric-tuning-client.test.ts
@@ -123,6 +123,21 @@ describe('MetricTuningClient', () => {
     expect(result).toHaveLength(1);
   });
 
+  it('asks for an improvement with no body at all', async () => {
+    fetchMock.mockResolvedValue(
+      makeFetch({ improvement: {}, changed: [], rejections_used: 2 })
+    );
+
+    const result = await client.improveFromReviews(METRIC_ID);
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE_URL}/metrics/${METRIC_ID}/tuning/improve`);
+    expect(options.method).toBe('POST');
+    // The rejections are read server-side; there is nothing for a caller to send.
+    expect(options.body).toBeUndefined();
+    expect(result.rejections_used).toBe(2);
+  });
+
   it('deletes a tuning case', async () => {
     fetchMock.mockResolvedValue(makeFetch({ deleted: true, case_id: TEST_ID }));
 

--- a/apps/frontend/src/utils/api-client/interfaces/metric-tuning.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/metric-tuning.ts
@@ -1,4 +1,5 @@
 import { UUID } from 'crypto';
+import type { ScoreType, ThresholdOperator } from './metric';
 
 /**
  * What the metric said about a case in the latest run.
@@ -107,6 +108,50 @@ export interface MetricTuningRun {
    * between runs moves it without a run.
    */
   agreement: MetricTuningAgreement;
+  /**
+   * True when the metric has changed in a verdict-affecting way since this run
+   * started — so its agreement belongs to the earlier metric, not the one on
+   * screen. Renaming a metric does not set this; editing its evaluation prompt
+   * does.
+   */
+  predates_metric: boolean;
+}
+
+/**
+ * The metric fields a model may rewrite from a reviewer's rejections.
+ *
+ * `score_type` and `categories` always come back as the metric already has
+ * them — an improvement that moved either would invalidate every review for the
+ * metric.
+ */
+export interface ImprovedMetricFields {
+  name: string;
+  description: string;
+  evaluation_prompt: string;
+  evaluation_steps: string;
+  reasoning: string;
+  explanation: string;
+  score_type: ScoreType;
+  min_score: number | null;
+  max_score: number | null;
+  threshold: number | null;
+  threshold_operator: ThresholdOperator | null;
+  categories: string[] | null;
+  passing_categories: string[] | null;
+}
+
+/**
+ * A proposed rewrite of a metric, read off the rejections its reviewers wrote.
+ *
+ * Producing one saves nothing. The reviewer sees the current fields beside these
+ * and applies them with an ordinary metric update, or closes the dialog.
+ */
+export interface MetricTuningImprovement {
+  improvement: ImprovedMetricFields;
+  /** Fields whose proposed value differs from the metric's current one. */
+  changed: (keyof ImprovedMetricFields)[];
+  /** How many rejections it was written from. */
+  rejections_used: number;
 }
 
 export interface MetricTuningCaseCreate {

--- a/apps/frontend/src/utils/api-client/metric-tuning-client.ts
+++ b/apps/frontend/src/utils/api-client/metric-tuning-client.ts
@@ -5,6 +5,7 @@ import {
   MetricTuningCaseCreate,
   MetricTuningCaseDeleteResponse,
   MetricTuningCaseUpdate,
+  MetricTuningImprovement,
   MetricTuningReviewCreate,
   MetricTuningRun,
 } from './interfaces/metric-tuning';
@@ -27,6 +28,10 @@ export class MetricTuningClient extends BaseApiClient {
 
   private reviewsPath(metricId: UUID | string): string {
     return `${API_ENDPOINTS.metrics}/${metricId}/tuning/reviews`;
+  }
+
+  private improvePath(metricId: UUID | string): string {
+    return `${API_ENDPOINTS.metrics}/${metricId}/tuning/improve`;
   }
 
   /** Cases for a metric. Empty when it has no tuning test set yet. */
@@ -120,6 +125,21 @@ export class MetricTuningClient extends BaseApiClient {
    */
   async startTuningRun(metricId: UUID | string): Promise<MetricTuningRun> {
     return this.fetch<MetricTuningRun>(this.runPath(metricId), {
+      method: 'POST',
+    });
+  }
+
+  /**
+   * Proposes a rewrite of the metric from the rejections its reviewers wrote.
+   *
+   * Saves nothing — applying is an ordinary `updateMetric` with the fields this
+   * returned. Synchronous and one LLM call, so it is only ever called from an
+   * explicit action. Refused when no rejection currently stands.
+   */
+  async improveFromReviews(
+    metricId: UUID | string
+  ): Promise<MetricTuningImprovement> {
+    return this.fetch<MetricTuningImprovement>(this.improvePath(metricId), {
       method: 'POST',
     });
   }

--- a/apps/frontend/src/utils/backend-proxy.ts
+++ b/apps/frontend/src/utils/backend-proxy.ts
@@ -29,6 +29,9 @@ const LONG_RUNNING_PATH_SUFFIXES = [
   '/generate_outputs',
   '/evaluate',
   '/load-initial-data',
+  // Rewrites a whole metric from its reviews in one generation call, and holds
+  // the response until the model answers.
+  '/tuning/improve',
 ];
 
 const LONG_RUNNING_TIMEOUT_MS = 300_000;

--- a/tests/backend/routes/test_metric_tuning_improve.py
+++ b/tests/backend/routes/test_metric_tuning_improve.py
@@ -1,0 +1,988 @@
+"""Integration tests for improving a metric from the rejections its reviewers wrote.
+
+Tests one endpoint:
+- POST /metrics/{metric_id}/tuning/improve
+
+This is the reader the comments were collected for. What it must get right is
+mostly about restraint: it proposes and never writes, only rejections that still
+stand reach the model, and the two fields a rewrite is not allowed to move come
+back as the metric has them. See domain.local/adr/0006.
+
+The generation model is stubbed throughout, so these are deterministic and free
+of LLM calls. The metric invocation is stubbed too -- a rejection needs a verdict
+to be a rejection of, so most of these run the metric first.
+
+The test that matters most is ``test_it_writes_nothing``. Every alternative
+ADR-0006 rejected fails it: rewriting in place, or applying by asking the model a
+second time, both leave the metric changed by a request that was only meant to
+propose.
+
+Run with: python -m pytest tests/backend/routes/test_metric_tuning_improve.py -v
+"""
+
+import uuid
+from typing import List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.crud import metric_tuning as crud_metric_tuning
+from rhesis.backend.app.schemas.metric import MetricScope
+from rhesis.backend.app.schemas.metric_tuning_metadata import (
+    MetricTuningReview,
+    ReviewDecision,
+    parse_metric_tuning_case_metadata,
+)
+from rhesis.backend.app.services import metric_tuning as service
+from rhesis.backend.app.services.metric_tuning.improve import (
+    TEXT_FIELD_LIMIT,
+    TRUNCATION_MARKER,
+)
+from rhesis.backend.app.utils.crud_utils import get_or_create_type_lookup
+
+IMPROVE = "rhesis.backend.app.services.metric_tuning.improve"
+
+CASE_INPUT = "How are you?"
+CASE_OUTPUT = "I am fine you fucking basterd"
+CASE_REFERENCE_ANSWER = "I am fine, thanks for asking."
+REVIEW_COMMENT = "the metric called this harmless, but it is plainly toxic"
+
+# What the metric said, and what it said about saying it.
+VERDICT_REASON = "No slur or threat is present in the answer."
+
+# The provider string the user configured for generation. The point of the
+# sentinel is that nothing else in the request could have produced it.
+GENERATION_MODEL = "openai/gpt-4o-configured-for-generation"
+
+NEW_PROMPT = "Fail any answer containing an insult, however mild the rest of it is."
+
+BASE_IMPROVEMENT = {
+    "name": "Toxicity",
+    "description": "Whether the answer insults the person it is answering.",
+    "evaluation_prompt": NEW_PROMPT,
+    "evaluation_steps": "Step 1:\nRead the answer.\n---\nStep 2:\nScore it.",
+    "reasoning": "Quote the phrase judged insulting and tie it to the clause it breaks.",
+    "explanation": "A fail means the answer insults the user. Rewrite it before shipping.",
+    "score_type": "binary",
+    "min_score": None,
+    "max_score": None,
+    "threshold": None,
+    "threshold_operator": None,
+    "categories": None,
+    "passing_categories": None,
+}
+
+
+def _make_model(db: Session, organization_id, user_id) -> models.Model:
+    """A judging model for the metric, so a run is not refused before it starts.
+
+    Deliberately present in every metric here: the improvement must use the
+    *generation* model regardless, and a metric with a judge of its own is what
+    makes that assertion mean something.
+    """
+    provider_lookup = get_or_create_type_lookup(
+        db=db,
+        type_name="ProviderType",
+        type_value="openai",
+        organization_id=organization_id,
+        user_id=user_id,
+        commit=False,
+    )
+    model = models.Model(
+        name=f"Judge {uuid.uuid4().hex[:6]}",
+        model_name="gpt-4o-mini",
+        key="sk-not-a-real-key",
+        provider_type_id=provider_lookup.id,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+    db.add(model)
+    db.flush()
+    return model
+
+
+def _make_metric(
+    db: Session,
+    name: str,
+    organization_id,
+    user_id,
+    *,
+    score_type: str = "binary",
+    backend_type: str = "custom",
+    **columns,
+) -> models.Metric:
+    backend_type_lookup = get_or_create_type_lookup(
+        db=db,
+        type_name="BackendType",
+        type_value=backend_type,
+        organization_id=organization_id,
+        user_id=user_id,
+        commit=False,
+    )
+    model = _make_model(db, organization_id, user_id)
+    metric = models.Metric(
+        name=name,
+        description="Metric under tuning",
+        evaluation_prompt="Score how toxic the answer is.",
+        evaluation_steps="Step 1:\nRead the answer.",
+        reasoning="Say which phrase decided it.",
+        explanation="A fail means the answer is toxic.",
+        score_type=score_type,
+        metric_scope=[MetricScope.SINGLE_TURN.value],
+        backend_type_id=backend_type_lookup.id,
+        model_id=model.id,
+        organization_id=organization_id,
+        user_id=user_id,
+        **columns,
+    )
+    db.add(metric)
+    db.flush()
+    db.commit()
+    db.refresh(metric)
+    return metric
+
+
+@pytest.fixture
+def tuning_metric(test_db: Session, test_org_id, authenticated_user_id) -> models.Metric:
+    """A binary custom metric with no tuning test set yet."""
+    return _make_metric(
+        test_db, f"Toxicity Improve {uuid.uuid4().hex[:6]}", test_org_id, authenticated_user_id
+    )
+
+
+@pytest.fixture
+def numeric_metric(test_db: Session, test_org_id, authenticated_user_id) -> models.Metric:
+    """A numeric metric — its threshold is what decides whether a review stands."""
+    return _make_metric(
+        test_db,
+        f"Numeric Improve {uuid.uuid4().hex[:6]}",
+        test_org_id,
+        authenticated_user_id,
+        score_type="numeric",
+        min_score=0.0,
+        max_score=1.0,
+        threshold=0.5,
+        threshold_operator=">=",
+    )
+
+
+@pytest.fixture
+def categorical_metric(test_db: Session, test_org_id, authenticated_user_id) -> models.Metric:
+    return _make_metric(
+        test_db,
+        f"Categorical Improve {uuid.uuid4().hex[:6]}",
+        test_org_id,
+        authenticated_user_id,
+        score_type="categorical",
+        categories=["helpful", "harmful"],
+        passing_categories=["helpful"],
+    )
+
+
+@pytest.fixture
+def framework_metric(test_db: Session, test_org_id, authenticated_user_id) -> models.Metric:
+    """A framework-provided metric — its prompt is not the org's to rewrite."""
+    return _make_metric(
+        test_db,
+        f"Framework Improve {uuid.uuid4().hex[:6]}",
+        test_org_id,
+        authenticated_user_id,
+        backend_type="deepeval",
+    )
+
+
+@pytest.fixture
+def unknown_score_type_metric(test_db: Session, test_org_id, authenticated_user_id):
+    """A metric whose stored score type no schema of ours knows.
+
+    The column is a plain string, so this is reachable, and it is the one way the
+    fields we would apply can fail validation: the score type is put back exactly
+    as stored, and ``MetricUpdate`` refuses it.
+    """
+    return _make_metric(
+        test_db,
+        f"Rubric Improve {uuid.uuid4().hex[:6]}",
+        test_org_id,
+        authenticated_user_id,
+        score_type="rubric",
+    )
+
+
+class _GenerationModel:
+    """The stubbed generation model, plus what it was asked."""
+
+    def __init__(self, picked: MagicMock, ensure: MagicMock, model: MagicMock):
+        self.picked = picked
+        self.ensure = ensure
+        self.model = model
+        self.answers()
+
+    def answers(self, **overrides) -> None:
+        """Make the model answer with the base improvement, patched by overrides."""
+        self.model.generate.side_effect = None
+        self.model.generate.return_value = {**BASE_IMPROVEMENT, **overrides}
+
+    def answers_with(self, answer) -> None:
+        """Make the model answer with something else entirely."""
+        self.model.generate.side_effect = None
+        self.model.generate.return_value = answer
+
+    def raises(self, error: Exception) -> None:
+        self.model.generate.side_effect = error
+
+    @property
+    def asked(self) -> bool:
+        return self.model.generate.called
+
+    @property
+    def prompt(self) -> str:
+        """The prompt the model was actually given."""
+        assert self.model.generate.call_args is not None, "the model was never asked"
+        return self.model.generate.call_args.args[0]
+
+
+@pytest.fixture
+def generation_model():
+    """Stub the user's generation model and the client built from it.
+
+    Both halves are patched so a test can assert the model came from the user's
+    *generation* setting — the metric's own judge is a different model, and every
+    metric here has one.
+    """
+    with patch(f"{IMPROVE}.get_user_generation_model", return_value=GENERATION_MODEL) as picked:
+        with patch(f"{IMPROVE}.ensure_language_model") as ensure:
+            model = MagicMock()
+            ensure.return_value = model
+            yield _GenerationModel(picked, ensure, model)
+
+
+def _create_case(client: TestClient, metric_id, **overrides) -> dict:
+    body = {
+        "input": CASE_INPUT,
+        "output": CASE_OUTPUT,
+        "reference_answer": CASE_REFERENCE_ANSWER,
+    }
+    body.update(overrides)
+    response = client.post(f"/metrics/{metric_id}/tuning/cases", json=body)
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    return response.json()
+
+
+def _evaluator_returning(*results, by_input=None):
+    """A stubbed MetricEvaluator whose evaluate() yields the given results.
+
+    ``by_input`` keys the results on the case's input rather than on call order,
+    which is the only way to land a particular verdict on a particular case:
+    every case created inside one test shares a ``created_at``, so the run walks
+    them in id order rather than insertion order.
+    """
+    calls = list(results)
+    evaluator = MagicMock()
+
+    def _evaluate(**kwargs):
+        if by_input is not None:
+            outcome = by_input[kwargs["input_text"]]
+        else:
+            outcome = calls.pop(0) if calls else {"score": 0.0, "reason": VERDICT_REASON}
+        if isinstance(outcome, Exception):
+            raise outcome
+        return {"Metric": outcome}
+
+    evaluator.evaluate.side_effect = _evaluate
+    return MagicMock(return_value=evaluator)
+
+
+def _run(db: Session, metric: models.Metric, org_id, *results, by_input=None) -> None:
+    """Execute a run with the metric invocation stubbed.
+
+    Expires the session first: the cases were written by requests on their own
+    sessions, and a background worker always starts from a fresh one.
+    """
+    db.expire_all()
+    factory = _evaluator_returning(*results, by_input=by_input)
+    with patch("rhesis.backend.metrics.evaluator.MetricEvaluator", factory):
+        service.execute_tuning_run(db, metric, org_id, None)
+
+
+def _review(client: TestClient, metric_id, case_id, decision: str, comment=None) -> dict:
+    body = {"decision": decision}
+    if comment is not None:
+        body["comment"] = comment
+    response = client.post(f"/metrics/{metric_id}/tuning/cases/{case_id}/review", json=body)
+    assert response.status_code == status.HTTP_200_OK, response.text
+    return response.json()
+
+
+def _reject(client: TestClient, metric_id, case_id, comment: str = REVIEW_COMMENT) -> dict:
+    return _review(client, metric_id, case_id, "rejected", comment)
+
+
+def _accept(client: TestClient, metric_id, case_id) -> dict:
+    return _review(client, metric_id, case_id, "accepted")
+
+
+def _write_review(
+    db: Session,
+    case_id,
+    *,
+    decision: ReviewDecision,
+    verdict: str,
+    score_type: str,
+    comment: Optional[str] = None,
+    reviewer_id: Optional[str] = None,
+) -> None:
+    """Append a review to a case's history directly.
+
+    The review endpoint always stamps the caller as the reviewer, so a review
+    written by somebody else has to be written here. Everything else about the
+    row is exactly what the endpoint would have stored.
+    """
+    db.expire_all()
+    db_test = db.query(models.Test).filter(models.Test.id == uuid.UUID(str(case_id))).first()
+    metadata = parse_metric_tuning_case_metadata(db_test.test_metadata)
+    reviews = list(metadata.reviews)
+    reviews.append(
+        MetricTuningReview(
+            decision=decision,
+            comment=comment,
+            verdict=verdict,
+            score_type=score_type,
+            reviewer_id=reviewer_id,
+            reviewed_at="2026-08-20T10:00:00+00:00",
+        )
+    )
+    crud_metric_tuning.set_case_reviews(db, db_test, reviews)
+    db.commit()
+
+
+def _improve(client: TestClient, metric_id):
+    return client.post(f"/metrics/{metric_id}/tuning/improve")
+
+
+def _improved(client: TestClient, metric_id) -> dict:
+    response = _improve(client, metric_id)
+    assert response.status_code == status.HTTP_200_OK, response.text
+    return response.json()
+
+
+def _stored_reviews(db: Session, case_id) -> List[dict]:
+    db.expire_all()
+    db_test = db.query(models.Test).filter(models.Test.id == uuid.UUID(str(case_id))).first()
+    return (db_test.test_metadata or {}).get("reviews", [])
+
+
+def _rejected_case(client: TestClient, db: Session, metric: models.Metric, org_id, **case) -> dict:
+    """One case, run over, and rejected with a comment. The usual starting point."""
+    created = _create_case(client, metric.id, **case)
+    _run(db, metric, org_id)
+    return _reject(client, metric.id, created["id"])
+
+
+@pytest.mark.integration
+class TestRefusals:
+    """When there is nothing to read, or nothing that may be rewritten."""
+
+    def test_a_metric_with_no_cases_is_refused(
+        self, authenticated_client: TestClient, tuning_metric, generation_model
+    ):
+        response = _improve(authenticated_client, tuning_metric.id)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "reject" in response.json()["detail"].lower()
+
+    def test_a_metric_whose_cases_are_all_accepted_is_refused(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        created = _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id)
+        _accept(authenticated_client, tuning_metric.id, created["id"])
+
+        response = _improve(authenticated_client, tuning_metric.id)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_an_unreviewed_case_is_not_something_to_learn_from(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id)
+
+        assert (
+            _improve(authenticated_client, tuning_metric.id).status_code
+            == status.HTTP_400_BAD_REQUEST
+        )
+
+    def test_nothing_is_asked_of_the_model_when_there_is_nothing_to_read(
+        self, authenticated_client: TestClient, tuning_metric, generation_model
+    ):
+        """A refusal must not cost an LLM call."""
+        _improve(authenticated_client, tuning_metric.id)
+
+        assert generation_model.asked is False
+
+    def test_a_framework_metric_is_refused(
+        self, authenticated_client: TestClient, framework_metric, generation_model
+    ):
+        response = _improve(authenticated_client, framework_metric.id)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "custom" in response.json()["detail"].lower()
+
+    def test_an_unknown_metric_404s(self, authenticated_client: TestClient, generation_model):
+        response = _improve(authenticated_client, uuid.uuid4())
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.integration
+class TestTheImprovement:
+    """The shape of what comes back, and what it leaves behind."""
+
+    def test_it_returns_the_proposed_fields_and_the_rejection_count(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+
+        body = _improved(authenticated_client, tuning_metric.id)
+
+        assert body["improvement"]["evaluation_prompt"] == NEW_PROMPT
+        assert body["rejections_used"] == 1
+
+    def test_it_counts_every_rejection_it_used(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        first = _create_case(authenticated_client, tuning_metric.id, input="One")
+        second = _create_case(authenticated_client, tuning_metric.id, input="Two")
+        _run(test_db, tuning_metric, test_org_id)
+        _reject(authenticated_client, tuning_metric.id, first["id"])
+        _reject(authenticated_client, tuning_metric.id, second["id"])
+
+        assert _improved(authenticated_client, tuning_metric.id)["rejections_used"] == 2
+
+    def test_it_names_the_fields_that_changed(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+        generation_model.answers(name=tuning_metric.name)
+
+        changed = _improved(authenticated_client, tuning_metric.id)["changed"]
+
+        assert "evaluation_prompt" in changed
+        # Returned unchanged, so the dialog says so rather than showing it.
+        assert "name" not in changed
+
+    def test_a_rewrite_that_changed_nothing_names_nothing(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+        generation_model.answers(
+            name=tuning_metric.name,
+            description=tuning_metric.description,
+            evaluation_prompt=tuning_metric.evaluation_prompt,
+            evaluation_steps=tuning_metric.evaluation_steps,
+            reasoning=tuning_metric.reasoning,
+            explanation=tuning_metric.explanation,
+            # A binary metric carries a threshold operator it never uses -- the
+            # column defaults to one. The template tells the model to hand those
+            # back untouched, so a difference here would be noise.
+            threshold_operator=tuning_metric.threshold_operator,
+        )
+
+        assert _improved(authenticated_client, tuning_metric.id)["changed"] == []
+
+    def test_it_writes_nothing(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """Producing an improvement never saves one. This is the whole of ADR-0006."""
+        before = tuning_metric.evaluation_prompt
+        _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+
+        _improved(authenticated_client, tuning_metric.id)
+
+        test_db.expire_all()
+        after = test_db.query(models.Metric).filter(models.Metric.id == tuning_metric.id).first()
+        assert after.evaluation_prompt == before
+
+    def test_it_leaves_the_reviews_alone(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """Reading the comments is not judging them again."""
+        case = _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+        before = _stored_reviews(test_db, case["id"])
+
+        _improved(authenticated_client, tuning_metric.id)
+
+        assert _stored_reviews(test_db, case["id"]) == before
+
+    def test_the_score_type_comes_back_as_the_metric_has_it(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        categorical_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """Changing it would invalidate every review the metric has."""
+        _create_case(authenticated_client, categorical_metric.id)
+        _run(test_db, categorical_metric, test_org_id, {"score": "helpful", "reason": "polite"})
+        cases = authenticated_client.get(f"/metrics/{categorical_metric.id}/tuning/cases").json()
+        _reject(authenticated_client, categorical_metric.id, cases[0]["id"])
+        generation_model.answers(score_type="numeric", categories=["good", "bad"])
+
+        improvement = _improved(authenticated_client, categorical_metric.id)["improvement"]
+
+        assert improvement["score_type"] == "categorical"
+        assert improvement["categories"] == ["helpful", "harmful"]
+
+    def test_a_field_the_metric_has_is_never_proposed_empty(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        numeric_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """An improvement can change a field but cannot clear one.
+
+        A metric update drops a null instead of writing it, so a blank proposal
+        would show as "—" in the dialog, apply successfully, and leave the old
+        value in place -- exactly the gap between approved and saved that
+        ADR-0006 exists to close.
+        """
+        _create_case(authenticated_client, numeric_metric.id)
+        _run(test_db, numeric_metric, test_org_id, {"score": 0.7, "reason": VERDICT_REASON})
+        cases = authenticated_client.get(f"/metrics/{numeric_metric.id}/tuning/cases").json()
+        _reject(authenticated_client, numeric_metric.id, cases[0]["id"])
+        generation_model.answers(score_type="numeric", threshold=None, threshold_operator=None)
+
+        body = _improved(authenticated_client, numeric_metric.id)
+
+        assert body["improvement"]["threshold"] == 0.5
+        assert body["improvement"]["threshold_operator"] == ">="
+        assert "threshold" not in body["changed"]
+
+    def test_a_field_the_metric_lacks_stays_empty(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """Nothing is invented to fill a field the metric never had."""
+        _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+
+        assert _improved(authenticated_client, tuning_metric.id)["improvement"]["threshold"] is None
+
+    def test_the_threshold_may_change(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        numeric_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """ "This should have failed" is very often a threshold statement."""
+        _create_case(authenticated_client, numeric_metric.id)
+        _run(test_db, numeric_metric, test_org_id, {"score": 0.7, "reason": VERDICT_REASON})
+        cases = authenticated_client.get(f"/metrics/{numeric_metric.id}/tuning/cases").json()
+        _reject(authenticated_client, numeric_metric.id, cases[0]["id"])
+        generation_model.answers(
+            score_type="numeric",
+            min_score=0.0,
+            max_score=1.0,
+            threshold=0.9,
+            threshold_operator=">=",
+        )
+
+        body = _improved(authenticated_client, numeric_metric.id)
+
+        assert body["improvement"]["threshold"] == 0.9
+        assert "threshold" in body["changed"]
+
+
+@pytest.mark.integration
+class TestWhatTheModelIsShown:
+    """Which rejections reach the prompt, and what each one carries."""
+
+    def test_a_rejection_carries_the_case_the_verdict_and_the_comment(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+
+        _improved(authenticated_client, tuning_metric.id)
+        prompt = generation_model.prompt
+
+        assert CASE_INPUT in prompt
+        assert CASE_OUTPUT in prompt
+        assert CASE_REFERENCE_ANSWER in prompt
+        assert VERDICT_REASON in prompt
+        assert REVIEW_COMMENT in prompt
+
+    def test_the_verdict_and_the_reasoning_come_from_the_same_run(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        numeric_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """A review outlives drift that did not cross the threshold, so the
+        verdict it recorded can be a run behind the reasoning beside it.
+
+        Showing the model a score next to an explanation of a different score is
+        worse than showing it either alone.
+        """
+        case = _create_case(authenticated_client, numeric_metric.id)
+        _run(test_db, numeric_metric, test_org_id, {"score": 0.79, "reason": "mostly relevant"})
+        _reject(authenticated_client, numeric_metric.id, case["id"])
+        # Same side of the 0.5 threshold, so the rejection still stands.
+        _run(test_db, numeric_metric, test_org_id, {"score": 0.81, "reason": "still relevant"})
+
+        _improved(authenticated_client, numeric_metric.id)
+        prompt = generation_model.prompt
+
+        assert "0.81" in prompt
+        assert "still relevant" in prompt
+        assert "0.79" not in prompt
+        assert "mostly relevant" not in prompt
+
+    def test_an_accepted_case_is_not_sent(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        rejected = _create_case(authenticated_client, tuning_metric.id, input="The rejected one")
+        accepted = _create_case(authenticated_client, tuning_metric.id, input="The accepted one")
+        _run(test_db, tuning_metric, test_org_id)
+        _reject(authenticated_client, tuning_metric.id, rejected["id"])
+        _accept(authenticated_client, tuning_metric.id, accepted["id"])
+
+        body = _improved(authenticated_client, tuning_metric.id)
+
+        assert body["rejections_used"] == 1
+        assert "The rejected one" in generation_model.prompt
+        assert "The accepted one" not in generation_model.prompt
+
+    def test_a_rejection_a_material_change_invalidated_is_not_sent(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        numeric_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """It objects to a verdict the metric no longer gives."""
+        standing = _create_case(authenticated_client, numeric_metric.id, input="Still wrong")
+        invalidated = _create_case(authenticated_client, numeric_metric.id, input="Fixed since")
+        _run(
+            test_db,
+            numeric_metric,
+            test_org_id,
+            by_input={
+                "Still wrong": {"score": 0.8, "reason": "ok"},
+                "Fixed since": {"score": 0.8, "reason": "ok"},
+            },
+        )
+        _reject(authenticated_client, numeric_metric.id, standing["id"], "still too generous")
+        _reject(
+            authenticated_client, numeric_metric.id, invalidated["id"], "should not have passed"
+        )
+        # A second run drops one verdict below the threshold, which is what makes
+        # that review stop describing the metric.
+        _run(
+            test_db,
+            numeric_metric,
+            test_org_id,
+            by_input={
+                "Still wrong": {"score": 0.8, "reason": "ok"},
+                "Fixed since": {"score": 0.2, "reason": "ok"},
+            },
+        )
+
+        body = _improved(authenticated_client, numeric_metric.id)
+
+        assert body["rejections_used"] == 1
+        assert "still too generous" in generation_model.prompt
+        assert "should not have passed" not in generation_model.prompt
+
+    def test_only_the_latest_review_of_a_case_is_sent(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """The ten-deep history is storage, not the judgement in force."""
+        case = _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id)
+        _reject(authenticated_client, tuning_metric.id, case["id"], "an earlier objection")
+        _reject(authenticated_client, tuning_metric.id, case["id"], "what I actually think")
+
+        body = _improved(authenticated_client, tuning_metric.id)
+
+        assert body["rejections_used"] == 1
+        assert "what I actually think" in generation_model.prompt
+        assert "an earlier objection" not in generation_model.prompt
+
+    def test_a_case_rejected_then_accepted_is_not_sent(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        case = _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+        _accept(authenticated_client, tuning_metric.id, case["id"])
+
+        assert (
+            _improve(authenticated_client, tuning_metric.id).status_code
+            == status.HTTP_400_BAD_REQUEST
+        )
+
+    def test_another_reviewers_rejection_is_sent_too(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """A metric is tuned by everyone who reviewed it, not by whoever pressed
+        the button."""
+        case = _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id)
+        _write_review(
+            test_db,
+            case["id"],
+            decision=ReviewDecision.REJECTED,
+            verdict="fail",
+            score_type="binary",
+            comment="somebody else noticed this",
+            reviewer_id=str(uuid.uuid4()),
+        )
+
+        body = _improved(authenticated_client, tuning_metric.id)
+
+        assert body["rejections_used"] == 1
+        assert "somebody else noticed this" in generation_model.prompt
+
+    def test_every_rejection_is_sent_however_many_there_are(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """No cap and no silent truncation: a dropped comment is a lost finding."""
+        comments = [f"objection number {index}" for index in range(12)]
+        created = [
+            _create_case(authenticated_client, tuning_metric.id, input=f"Case {index}")
+            for index in range(len(comments))
+        ]
+        _run(test_db, tuning_metric, test_org_id)
+        for case, comment in zip(created, comments):
+            _reject(authenticated_client, tuning_metric.id, case["id"], comment)
+
+        body = _improved(authenticated_client, tuning_metric.id)
+
+        assert body["rejections_used"] == len(comments)
+        for comment in comments:
+            assert comment in generation_model.prompt
+
+    def test_a_long_field_is_cut_and_says_so(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """Capped generously, and marked — never trimmed in silence."""
+        long_output = "x" * (TEXT_FIELD_LIMIT + 500)
+        _rejected_case(
+            authenticated_client, test_db, tuning_metric, test_org_id, output=long_output
+        )
+
+        _improved(authenticated_client, tuning_metric.id)
+
+        assert long_output not in generation_model.prompt
+        assert TRUNCATION_MARKER in generation_model.prompt
+
+    def test_the_metrics_current_fields_are_shown_beside_the_rejections(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """A rewrite of a prompt has to be shown the prompt."""
+        _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+
+        _improved(authenticated_client, tuning_metric.id)
+
+        assert tuning_metric.evaluation_prompt in generation_model.prompt
+
+
+@pytest.mark.integration
+class TestTheModelItUses:
+    def test_it_uses_the_users_generation_model(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """Not the metric's judge, which every metric here also has.
+
+        Writing an evaluation prompt is a generation task, so the user's
+        generation choice is the one that applies — and it goes through
+        ``ensure_language_model``, which is what decides metering.
+        """
+        _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+
+        _improved(authenticated_client, tuning_metric.id)
+
+        generation_model.ensure.assert_called_once_with(GENERATION_MODEL)
+
+
+@pytest.mark.integration
+class TestFailures:
+    def test_a_generation_model_failure_is_a_400(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+        generation_model.raises(RuntimeError("the provider returned 401"))
+
+        response = _improve(authenticated_client, tuning_metric.id)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == (
+            "Failed to improve metric: the generation model could not be used. "
+            "Check the model configured for your organization."
+        )
+
+    def test_a_failure_does_not_leak_the_providers_own_words(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+        generation_model.raises(RuntimeError("sk-secret-key rejected"))
+
+        assert "sk-secret-key" not in _improve(authenticated_client, tuning_metric.id).text
+
+    def test_an_answer_in_the_wrong_shape_is_a_400(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """Some providers report their own failure as an answer rather than raising."""
+        _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+        generation_model.answers_with({"error": "An error occurred while processing the request."})
+
+        assert (
+            _improve(authenticated_client, tuning_metric.id).status_code
+            == status.HTTP_400_BAD_REQUEST
+        )
+
+    def test_an_answer_missing_a_required_field_is_a_400(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        tuning_metric,
+        test_org_id,
+        generation_model,
+    ):
+        _rejected_case(authenticated_client, test_db, tuning_metric, test_org_id)
+        answer = dict(BASE_IMPROVEMENT)
+        del answer["reasoning"]
+        generation_model.answers_with(answer)
+
+        assert (
+            _improve(authenticated_client, tuning_metric.id).status_code
+            == status.HTTP_400_BAD_REQUEST
+        )
+
+    def test_fields_that_could_not_be_applied_are_a_500(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        unknown_score_type_metric,
+        test_org_id,
+        generation_model,
+    ):
+        """Our schema, not the caller's request — so it is ours to see in a log."""
+        _rejected_case(authenticated_client, test_db, unknown_score_type_metric, test_org_id)
+
+        response = _improve(authenticated_client, unknown_score_type_metric.id)
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/tests/backend/routes/test_metric_tuning_runs.py
+++ b/tests/backend/routes/test_metric_tuning_runs.py
@@ -1424,3 +1424,161 @@ class TestADispatchThatNeverReachesAWorker:
         response = authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
 
         assert response.status_code == status.HTTP_202_ACCEPTED
+
+
+@pytest.mark.integration
+@pytest.mark.routes
+class TestARunThatPredatesItsMetric:
+    """Whether the numbers on screen still belong to the metric above them.
+
+    Applying an improvement rewrites the evaluation prompt every verdict in the
+    run came from, so the run has to be able to say it predates the metric rather
+    than go on reporting an agreement for something that changed underneath it.
+    The check is a fingerprint of the verdict-affecting fields, not the metric's
+    ``updated_at`` — see domain.local/adr/0006.
+    """
+
+    def _edit(self, test_db: Session, metric: models.Metric, **columns) -> None:
+        """Edit the metric the way the metric editor — or an apply — would."""
+        test_db.expire_all()
+        row = test_db.query(models.Metric).filter(models.Metric.id == metric.id).first()
+        for field, value in columns.items():
+            setattr(row, field, value)
+        test_db.commit()
+
+    def test_a_fresh_run_belongs_to_the_metric_it_scored(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id, {"score": True, "reason": "polite"})
+
+        body = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+
+        assert body["predates_metric"] is False
+
+    def test_editing_the_evaluation_prompt_makes_the_run_predate_the_metric(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """Every verdict in that run came out of the text that just changed."""
+        _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id, {"score": True, "reason": "polite"})
+
+        self._edit(test_db, tuning_metric, evaluation_prompt="Fail any answer with an insult.")
+
+        body = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+        assert body["predates_metric"] is True
+
+    def test_moving_the_threshold_makes_the_run_predate_the_metric(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        numeric_metric: models.Metric,
+    ):
+        """A threshold is where a score becomes a decision, so it decides verdicts."""
+        _create_case(authenticated_client, numeric_metric.id)
+        _run(test_db, numeric_metric, test_org_id, {"score": 0.7, "reason": "mostly relevant"})
+
+        self._edit(test_db, numeric_metric, threshold=0.9)
+
+        body = authenticated_client.get(f"/metrics/{numeric_metric.id}/tuning/run").json()
+        assert body["predates_metric"] is True
+
+    def test_renaming_the_metric_does_not(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """The whole reason this is a fingerprint rather than ``updated_at``."""
+        _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id, {"score": True, "reason": "polite"})
+
+        self._edit(
+            test_db,
+            tuning_metric,
+            name=f"Renamed {uuid.uuid4().hex[:6]}",
+            description="Rewritten description.",
+        )
+
+        body = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+        assert body["predates_metric"] is False
+
+    def test_a_run_stored_without_a_fingerprint_is_not_read_as_out_of_date(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """Unknown is not stale — runs recorded before this existed still read."""
+        _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id, {"score": True, "reason": "polite"})
+        test_set = service.get_tuning_test_set(test_db, tuning_metric.id, test_org_id)
+        summary = crud_metric_tuning.get_run_summary(test_set)
+        summary.metric_fingerprint = None
+        crud_metric_tuning.set_run_summary(test_db, test_set, summary)
+        test_db.commit()
+
+        self._edit(test_db, tuning_metric, evaluation_prompt="Fail any answer with an insult.")
+
+        body = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+        assert body["predates_metric"] is False
+
+    def test_a_metric_that_has_never_been_run_does_not_predate_itself(
+        self,
+        authenticated_client: TestClient,
+        tuning_metric: models.Metric,
+    ):
+        body = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+
+        assert body["status"] == "never_run"
+        assert body["predates_metric"] is False
+
+    def test_editing_the_prompt_does_not_invalidate_the_reviews(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """An apply stales the run, not the judgements.
+
+        The per-case material-change rule does that work, and it needs a verdict
+        from the new prompt to do it — which only the next run produces.
+        """
+        case = _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id, {"score": True, "reason": "polite"})
+        _review(authenticated_client, tuning_metric.id, case["id"], "rejected", REVIEW_COMMENT)
+
+        self._edit(test_db, tuning_metric, evaluation_prompt="Fail any answer with an insult.")
+
+        after = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/cases").json()[0]
+        assert after["outcome"] == "rejected"
+        assert after["review"]["comment"] == REVIEW_COMMENT
+
+    def test_the_next_run_belongs_to_the_metric_again(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """Which is what makes Run metric the way out of a stale scorecard."""
+        _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id, {"score": True, "reason": "polite"})
+        self._edit(test_db, tuning_metric, evaluation_prompt="Fail any answer with an insult.")
+
+        _run(test_db, tuning_metric, test_org_id, {"score": False, "reason": "an insult"})
+
+        body = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+        assert body["predates_metric"] is False

--- a/tests/backend/services/metric_tuning/test_fingerprint.py
+++ b/tests/backend/services/metric_tuning/test_fingerprint.py
@@ -1,0 +1,123 @@
+"""Unit tests for the run fingerprint — whether a run predates the metric it scored.
+
+A fingerprint covers the fields that decide a verdict and nothing else. The two
+halves of that are equally load-bearing: renaming a metric must not stale a run,
+and editing the evaluation prompt by hand must (domain.local/adr/0006).
+
+A pure function over a metric and a stored summary, so it is tested directly
+rather than through a run. Run with:
+python -m pytest tests/backend/services/metric_tuning/test_fingerprint.py -v
+"""
+
+from types import SimpleNamespace
+
+from rhesis.backend.app.schemas.metric_tuning_metadata import MetricTuningRunSummary
+from rhesis.backend.app.services.metric_tuning.fingerprint import (
+    metric_fingerprint,
+    run_predates_metric,
+)
+
+
+def _metric(**overrides):
+    """A metric-shaped object carrying only what the fingerprint reads."""
+    fields = {
+        "name": "Toxicity",
+        "description": "How toxic the answer is.",
+        "evaluation_prompt": "Score how toxic the answer is.",
+        "evaluation_steps": "Step 1:\nRead the answer.",
+        "reasoning": "Quote the phrase you judged.",
+        "explanation": "A fail means the answer is toxic.",
+        "threshold": 0.5,
+        "threshold_operator": ">=",
+        "passing_categories": ["helpful"],
+        "categories": ["helpful", "harmful"],
+        "score_type": "numeric",
+        "min_score": 0.0,
+        "max_score": 1.0,
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+class TestMetricFingerprint:
+    """What the digest covers, and what it deliberately ignores."""
+
+    def test_the_same_metric_fingerprints_the_same(self):
+        assert metric_fingerprint(_metric()) == metric_fingerprint(_metric())
+
+    def test_editing_the_evaluation_prompt_changes_it(self):
+        assert metric_fingerprint(_metric()) != metric_fingerprint(
+            _metric(evaluation_prompt="Score how helpful the answer is.")
+        )
+
+    def test_editing_the_evaluation_steps_changes_it(self):
+        assert metric_fingerprint(_metric()) != metric_fingerprint(
+            _metric(evaluation_steps="Step 1:\nRead it twice.")
+        )
+
+    def test_moving_the_threshold_changes_it(self):
+        assert metric_fingerprint(_metric()) != metric_fingerprint(_metric(threshold=0.8))
+
+    def test_changing_the_threshold_operator_changes_it(self):
+        assert metric_fingerprint(_metric()) != metric_fingerprint(_metric(threshold_operator=">"))
+
+    def test_changing_the_passing_categories_changes_it(self):
+        assert metric_fingerprint(_metric()) != metric_fingerprint(
+            _metric(passing_categories=["helpful", "harmful"])
+        )
+
+    def test_renaming_the_metric_does_not_change_it(self):
+        """The whole reason this is not the metric's ``updated_at``."""
+        assert metric_fingerprint(_metric()) == metric_fingerprint(_metric(name="Toxicity v2"))
+
+    def test_rewriting_the_prose_fields_does_not_change_it(self):
+        """None of these reach the judge, so none of them stale a run."""
+        assert metric_fingerprint(_metric()) == metric_fingerprint(
+            _metric(
+                description="Rewritten.",
+                reasoning="Rewritten.",
+                explanation="Rewritten.",
+            )
+        )
+
+    def test_reordering_the_passing_categories_does_not_change_it(self):
+        """The same passing set, so the same decision for every verdict."""
+        one = _metric(passing_categories=["helpful", "polite"])
+        other = _metric(passing_categories=["polite", "helpful"])
+        assert metric_fingerprint(one) == metric_fingerprint(other)
+
+    def test_recasing_the_passing_categories_does_not_change_it(self):
+        """Buckets are compared case-insensitively, so casing decides nothing."""
+        assert metric_fingerprint(_metric()) == metric_fingerprint(
+            _metric(passing_categories=["Helpful"])
+        )
+
+    def test_an_absent_field_and_an_empty_one_fingerprint_alike(self):
+        assert metric_fingerprint(_metric(evaluation_steps=None)) == metric_fingerprint(
+            _metric(evaluation_steps="")
+        )
+
+    def test_a_threshold_written_differently_fingerprints_alike(self):
+        assert metric_fingerprint(_metric(threshold=0.5)) == metric_fingerprint(
+            _metric(threshold=0.50)
+        )
+
+
+class TestRunPredatesMetric:
+    def test_a_run_of_the_current_metric_does_not_predate_it(self):
+        metric = _metric()
+        summary = MetricTuningRunSummary(metric_fingerprint=metric_fingerprint(metric))
+        assert run_predates_metric(summary, metric) is False
+
+    def test_a_run_of_an_earlier_prompt_predates_it(self):
+        summary = MetricTuningRunSummary(metric_fingerprint=metric_fingerprint(_metric()))
+        edited = _metric(evaluation_prompt="Score how helpful the answer is.")
+        assert run_predates_metric(summary, edited) is True
+
+    def test_a_run_with_no_fingerprint_is_unknown_rather_than_stale(self):
+        """Runs stored before this existed must not all read as out of date."""
+        assert run_predates_metric(MetricTuningRunSummary(), _metric()) is False
+
+    def test_a_blank_fingerprint_is_unknown_too(self):
+        summary = MetricTuningRunSummary(metric_fingerprint="   ")
+        assert run_predates_metric(summary, _metric()) is False


### PR DESCRIPTION
## Purpose

A metric author can now collect tuning cases, run their metric over them, and reject the verdicts it got wrong with a comment saying what is wrong. Those comments are the thing the whole tuning feature exists to produce — and until now nothing read them. This is that reader: an **Improve** button that asks the generation model to rewrite the metric from the rejections, shows the current fields beside the proposed ones, and writes nothing until the reviewer applies it.

Ticket 06 of the tuning-runs set. Contract fixed by `domain.local/adr/0006`.

## What Changed

**Backend — `POST /metrics/{metric_id}/tuning/improve`**, synchronous, no request body, returns `{improvement, changed, rejections_used}`.

- `services/metric_tuning/improve.py` gathers the rejections that still stand, one per case, from every reviewer — not the ten-deep history, and not a rejection a material change has invalidated, since that objects to a verdict the metric no longer gives. Accepted cases are not sent.
- `improve_from_reviews.jinja` sits beside the service and carries its own copy of the naming, field-depth, score-type and evaluation-prompt rules, plus an explicit instruction not to move criteria the rejections do not speak to.
- `ImprovedMetricFields` in `schemas/metric_tuning.py` is the narrow output schema — the evaluation fields only, no ids and no relations.
- The model is `ensure_language_model(get_user_generation_model(db, user))`. Not `resolve_metric_model`, which is the metric's judge, and metering is left to `ensure_language_model` so an org running its own key is not billed twice.
- `services/metric_tuning/fingerprint.py` digests the verdict-affecting fields (`evaluation_prompt`, `evaluation_steps`, `threshold`, `threshold_operator`, `passing_categories`) at run start. A run whose fingerprint no longer matches reads as predating the metric, so its agreement is presented as the earlier metric's. Additive on the run summary — a run stored without one reads as unknown, not as stale.

**Frontend** — Improve joins the tuner toolbar; the dialog is two columns with only the changed fields, the evaluation prompt first and expanded, and a line naming what did not change. Apply is all-or-nothing across fields. Two fixes the feature needed: the BFF proxy was giving the call the 10s CRUD budget and returning a 504 while the backend was still working, and `MetricDetailView` fetched the metric once per id so Basic Information kept showing the pre-apply prompt until a page reload.

## Additional Context

**This targets `feat/metric-tuning-test-sets`, not `main`** — see the Branching section of the tuning-runs spec. Every ticket in this effort is cut from that integration branch and merges back into it, so that the effort's migrations can still be rewritten in place; `main` sees exactly one merge when the feature is finished. A PR from here to `main` would drag every earlier ticket along with it.

It is also over the repo's ideal 1–200 line PR size, which the integration branch knowingly accepts: the four commits are the reviewable units, and each is one logical change.

Three things worth a reviewer's attention, all deliberate:

- **Proposing rather than writing is the whole point**, and it is why `/metrics/{id}/improve` is not reused. That endpoint rewrites in place from free-text instructions, with no diff and no undo over the very text the reviews were made against. ADR-0006 also records why applying by calling improve a second time with a save flag was rejected outright: the second call returns a *different* rewrite than the one on screen.
- **The SDK synthesizer is not reused at all.** The prompt is about reviews, which the SDK has no reason to know about, so the tuning service owns it end to end and only the model client is borrowed. Consequence to keep in view: the prompt rules now live in two templates and nothing keeps them in step.
- **Excluding accepted cases has a known cost.** Nothing in the prompt pushes back on over-tightening — the cheapest rewrite satisfying five rejections may break cases the reviewer had accepted, and the model will not know it did. The template instruction and the nudge to re-run stand in for it. If agreement starts dropping after improves, sending a handful of accepted cases as anchors is the first thing to try.

**One deviation from the ticket.** It describes the dialog as a read-only side-by-side; the proposed column is editable here. The model's rewrite is a draft rather than a verdict, and a reviewer who can see what is wrong with one clause should be able to fix that clause instead of discarding the whole rewrite. What is on screen is still exactly what gets saved, which is the invariant ADR-0006 protects, and Apply is still all-or-nothing across fields — editing a value is not choosing which values apply. Flagging it so the ticket and ADR can be updated if this is wanted as recorded behaviour.

## Testing

Backend, from `apps/backend` (needs Docker for Testcontainers):

```bash
uv run pytest ../../tests/backend/routes/test_metric_tuning_improve.py ../../tests/backend/services/metric_tuning/test_fingerprint.py ../../tests/backend/routes/test_metric_tuning_runs.py -v
```

31 route tests, 18 fingerprint unit tests, 9 new run-staleness route tests. The generation model is stubbed throughout, so they are deterministic and free of LLM calls. Covered: only standing rejections are sent, an accepted or invalidated case is not, only the latest review per case, every reviewer's rejections, no cap on how many, a long field cut and marked, `score_type` and `categories` coming back as the metric has them, a field the metric has never proposed empty, the verdict and reasoning coming from the same run, the four refusals, and — the one that matters most — that producing an improvement writes nothing.

Frontend, from `apps/frontend`:

```bash
npx jest MetricTuningTab backend-proxy metric-tuning-client
```

Full suites both green: 7605 backend, 2023 frontend. `ruff`, `prettier`, `tsc --noEmit` and `eslint` clean.

By hand: open a custom metric → Tuning → add a case → Run metric → reject the verdict with a comment → Improve. The button is disabled with a tooltip until a rejection stands. Apply, then check Basic Information shows the new prompt without a reload, and that the run panel says it predates the metric.
