### PR TITLE
Fix detail access for custom metrics

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/metric.py
+++ b/apps/backend/src/rhesis/backend/app/routers/metric.py
@@ -305,10 +305,14 @@ def read_metric(
     db_metric = metric_crud.get_metric(db, metric_id, organization_id, user_id)
     if db_metric is None:
         raise HTTPException(status_code=404, detail="Metric not found")
-    if db_metric.backend_type and db_metric.backend_type.type_value != MetricBackendType.RHESIS:
+    # Custom metrics belong here as much as Rhesis ones: the organization owns their
+    # evaluation prompt, the metrics grid links to them, and metric tuning runs on
+    # nothing else. Only the framework backends have no detail page to serve.
+    allowed_backends = {MetricBackendType.RHESIS, MetricBackendType.CUSTOM}
+    if db_metric.backend_type and db_metric.backend_type.type_value not in allowed_backends:
         raise HTTPException(
             status_code=403,
-            detail="Detail access is restricted to Rhesis metrics",
+            detail="Detail access is restricted to Rhesis and custom metrics",
         )
     return db_metric
 

--- a/tests/backend/routes/test_metric.py
+++ b/tests/backend/routes/test_metric.py
@@ -214,25 +214,33 @@ class TestMetricSoftDeleteContract(MetricTestMixin, BaseEntityTests):
 
 @pytest.mark.integration
 class TestMetricDetailAccessRestriction(MetricTestMixin, BaseEntityTests):
-    """Non-Rhesis metrics must return 403 on detail access."""
+    """Framework metrics must return 403 on detail access; Rhesis and custom must not."""
 
-    @patch("rhesis.sdk.metrics.synthesizer.MetricSynthesizer.generate")
-    def test_get_non_rhesis_metric_returns_403(self, mock_generate, metric_factory):
-        """GET /metrics/{id} returns 403 for a metric with backend_type != rhesis."""
-        mock_generate.return_value = dict(_NUMERIC_SYNTHESIZED)
+    @pytest.mark.parametrize("backend", ["deepeval", "ragas", "garak"])
+    def test_get_framework_metric_returns_403(self, backend, metric_factory):
+        """GET /metrics/{id} returns 403 for a metric owned by an evaluation framework."""
+        data = self.get_sample_data()
+        data["backend_type"] = backend
+        metric = metric_factory.create(data)
 
-        create_resp = metric_factory.client.post(
-            self.endpoints.generate,
-            json={"prompt": "any prompt"},
-        )
-        assert create_resp.status_code == status.HTTP_200_OK
-        metric_id = create_resp.json()["id"]
-
-        get_resp = metric_factory.client.get(self.endpoints.get(metric_id))
+        get_resp = metric_factory.client.get(self.endpoints.get(metric["id"]))
         assert get_resp.status_code == status.HTTP_403_FORBIDDEN
         assert "restricted" in get_resp.json()["detail"].lower()
 
-        metric_factory.client.delete(self.endpoints.remove(metric_id))
+    def test_get_custom_metric_returns_200(self, metric_factory):
+        """GET /metrics/{id} returns 200 for a custom metric.
+
+        The organization owns a custom metric's evaluation prompt, the metrics grid
+        links to it, and metric tuning runs on nothing else -- so the detail route
+        has to serve it.
+        """
+        data = self.get_sample_data()
+        data["backend_type"] = "custom"
+        metric = metric_factory.create(data)
+
+        get_resp = metric_factory.client.get(self.endpoints.get(metric["id"]))
+        assert get_resp.status_code == status.HTTP_200_OK
+        assert get_resp.json()["backend_type"]["type_value"] == "custom"
 
     def test_get_rhesis_metric_returns_200(self, metric_factory):
         """GET /metrics/{id} returns 200 for a standard (no backend_type) metric."""
@@ -542,7 +550,7 @@ class TestMetricGenerate(MetricTestMixin, BaseEntityTests):
 
     @patch("rhesis.sdk.metrics.synthesizer.MetricSynthesizer.generate")
     def test_generate_metric_persists(self, mock_generate, metric_factory):
-        """Generated metric is persisted but detail access is restricted (custom backend_type)."""
+        """Generated metric is persisted and readable back (custom backend_type)."""
         mock_generate.return_value = dict(_NUMERIC_SYNTHESIZED)
 
         create_resp = metric_factory.client.post(
@@ -553,7 +561,8 @@ class TestMetricGenerate(MetricTestMixin, BaseEntityTests):
         metric_id = create_resp.json()["id"]
 
         get_resp = metric_factory.client.get(self.endpoints.get(metric_id))
-        assert get_resp.status_code == status.HTTP_403_FORBIDDEN
+        assert get_resp.status_code == status.HTTP_200_OK
+        assert get_resp.json()["id"] == metric_id
 
         metric_factory.client.delete(self.endpoints.remove(metric_id))
 


### PR DESCRIPTION
## Purpose

`GET /metrics/{metric_id}` returns 403 for custom metrics, so clicking one in the metrics grid fails with "Failed to load metric details". #2558 added the guard to restrict detail access to non-Rhesis metrics, stating it matched "the frontend restrictions already in place" — but the frontend has always allowed two kinds, not one:

- `MetricsDirectoryTab.tsx:441` — a metric card is clickable when the backend type is `custom` **or** `rhesis`.
- `MetricDetailView.tsx:274` — the detail page redirects away only when the type is **neither** `custom` nor `rhesis`.

The guard also shut off metric tuning, which runs on custom metrics and nothing else. `useIsCustomMetric` reads the metric to decide whether to show the Tuning tab; that read is now a 403 and the hook fails closed, so the tab never appeared for any metric at all.

## What Changed

- `read_metric` now allows `rhesis` and `custom`; `deepeval`, `ragas` and `garak` stay blocked, which was the point of the original restriction. The 403 detail message names both allowed kinds.
- `test_get_non_rhesis_metric_returns_403` used a **generated** metric as its non-Rhesis example, and generated metrics are `custom` — so it asserted exactly the behaviour this PR fixes. Replaced with `test_get_framework_metric_returns_403`, parametrized over the three framework backends, plus a new `test_get_custom_metric_returns_200`.
- `test_generate_metric_persists` was changed by #2558 to expect 403; it goes back to expecting 200 and now checks the metric reads back.

## Additional Context

- Reverses part of #2558 (commit `68320932b`), which closed #798. The rest of that PR — blocking the framework backends — is kept.
- Found while working on the metric tuner UI: every custom metric 403'd on click against a clean local database, so this is not environment-specific.
- No migration, no schema change, no API shape change. A route that used to refuse a request now serves it, so nothing that worked before breaks.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/routes/test_metric.py
```

65 passed, including the 6 in `TestMetricDetailAccessRestriction`. Ruff reports two pre-existing errors in `test_metric.py` (lines 17 and 439) that are untouched by this change and also present on `main`.

Manually: open a custom metric from the metrics grid — the detail page loads instead of showing "Failed to load metric details", and the Tuning tab appears.
