### PR TITLE
Clarify the metric tuning review controls

### DIFF
--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningTab.tsx
@@ -34,11 +34,9 @@ import {
   AutoFixHighIcon,
   CancelIcon,
   CheckCircleIcon,
+  CheckIcon,
+  CloseIcon,
   PlayArrowIcon,
-  ThumbDownFilledIcon,
-  ThumbDownIcon,
-  ThumbUpFilledIcon,
-  ThumbUpIcon,
   TuneIcon,
   WarningAmberIcon,
 } from '@/components/icons';
@@ -167,11 +165,21 @@ function MetricReasoningCell({ params }: { params: GridRenderCellParams }) {
 }
 
 /**
+ * Weight for a mark that records a judgement.
+ *
+ * These icons are filled paths with no bolder variant to switch to, so the
+ * weight has to come from stroking the glyph in its own colour. Colour alone
+ * did not carry the pressed state at this size: a thin green tick and a thin
+ * grey one read as the same mark until you look for the hue.
+ */
+const MARK_PRESSED_SX = { stroke: 'currentColor', strokeWidth: 1.5 };
+
+/**
  * The judgement that stands for this case, and the two buttons that change it.
  *
- * The thumbs are the state as well as the control: the one that was pressed is
- * filled and coloured, the other stays faint. A chip saying "Accepted" beside a
- * green thumb says the same thing twice.
+ * The tick and the cross are the state as well as the control: the one that was
+ * pressed is coloured green or red and drawn heavier, the other stays thin and
+ * faint. A chip saying "Accepted" beside a green tick says the same thing twice.
  *
  * They stay on a judged row on purpose — reading a case and re-judging it are
  * the same moment, and a mis-click has to be correctable where it happened.
@@ -211,10 +219,12 @@ function ReviewCell({
     return (
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
         {invalidated && <InvalidatedMark />}
-        {accepted && <ThumbUpFilledIcon fontSize="small" color="success" />}
+        {accepted && (
+          <CheckIcon fontSize="small" color="success" sx={MARK_PRESSED_SX} />
+        )}
         {rejected && (
           <Tooltip title={review?.comment ?? ''}>
-            <ThumbDownFilledIcon fontSize="small" color="error" />
+            <CloseIcon fontSize="small" color="error" sx={MARK_PRESSED_SX} />
           </Tooltip>
         )}
         {!accepted && !rejected && <span>—</span>}
@@ -236,11 +246,10 @@ function ReviewCell({
           sx={{ opacity: accepted ? 1 : 0.55 }}
           onClick={() => onAccept(tuningCase)}
         >
-          {accepted ? (
-            <ThumbUpFilledIcon fontSize="small" />
-          ) : (
-            <ThumbUpIcon fontSize="small" />
-          )}
+          <CheckIcon
+            fontSize="small"
+            sx={accepted ? MARK_PRESSED_SX : undefined}
+          />
         </IconButton>
       </Tooltip>
       <Tooltip
@@ -258,11 +267,10 @@ function ReviewCell({
           sx={{ opacity: rejected ? 1 : 0.55 }}
           onClick={() => onReject(tuningCase)}
         >
-          {rejected ? (
-            <ThumbDownFilledIcon fontSize="small" />
-          ) : (
-            <ThumbDownIcon fontSize="small" />
-          )}
+          <CloseIcon
+            fontSize="small"
+            sx={rejected ? MARK_PRESSED_SX : undefined}
+          />
         </IconButton>
       </Tooltip>
     </Box>
@@ -936,8 +944,18 @@ export default function MetricTuningTab({
     : isRunning
       ? IMPROVE_WHILE_RUNNING_HINT
       : IMPROVE_HINT;
+  // Right above the grid rather than in the card header: every one of these
+  // acts on the table below it, and the header sits three summary blocks away.
   const actions = (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'flex-end',
+        alignItems: 'center',
+        gap: 1.5,
+        mb: 2,
+      }}
+    >
       {canEdit && cases.length > 0 && (
         <Button
           variant="outlined"
@@ -951,7 +969,7 @@ export default function MetricTuningTab({
       {canEdit && (
         <Button
           variant="outlined"
-          startIcon={<ThumbUpIcon />}
+          startIcon={<CheckIcon />}
           onClick={handleAcceptRest}
           disabled={!unreviewedWithVerdict || acceptingRest}
         >
@@ -992,9 +1010,8 @@ export default function MetricTuningTab({
   return (
     <>
       <SectionCard
-        title="Tuning"
+        title="Improve this metric"
         subtitle="Cases for checking whether this metric judges the way you would."
-        actions={actions}
       >
         {!loading && cases.length === 0 ? (
           <SectionEmptyState
@@ -1016,6 +1033,10 @@ export default function MetricTuningTab({
             )}
             <RunSummary run={run} />
             {improving && <ImprovingSummary rejections={standingRejections} />}
+            {/* Not while the list is still loading: a toolbar that appears and
+                then goes away again when the metric turns out to have no cases
+                is worse than one that arrives with the rows it acts on. */}
+            {cases.length > 0 && actions}
             <BaseDataGrid
               rows={cases as unknown as GridRowModel[]}
               columns={columns}

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
@@ -487,21 +487,21 @@ describe('MetricTuningTab — the grid', () => {
   });
 });
 
-const acceptThumb = () =>
+const acceptMark = () =>
   screen.getByRole('button', { name: /accept this verdict/i });
 
-const rejectThumb = () =>
+const rejectMark = () =>
   screen.getByRole('button', { name: /reject this verdict/i });
 
-/** The pressed thumb is the recorded judgement — there is no chip to read. */
+/** The pressed mark is the recorded judgement — there is no chip to read. */
 const findAccepted = async () =>
   await waitFor(() =>
-    expect(acceptThumb()).toHaveAttribute('aria-pressed', 'true')
+    expect(acceptMark()).toHaveAttribute('aria-pressed', 'true')
   );
 
 const findRejected = async () =>
   await waitFor(() =>
-    expect(rejectThumb()).toHaveAttribute('aria-pressed', 'true')
+    expect(rejectMark()).toHaveAttribute('aria-pressed', 'true')
   );
 
 describe('MetricTuningTab — reviewing', () => {
@@ -553,36 +553,36 @@ describe('MetricTuningTab — reviewing', () => {
     mockGetTuningCases.mockResolvedValue([JUDGEABLE_CASE]);
   });
 
-  it('leaves both thumbs unpressed while nobody has judged the verdict', async () => {
+  it('leaves both marks unpressed while nobody has judged the verdict', async () => {
     render(<MetricTuningTab metricId={METRIC_ID} />);
 
-    await waitFor(() => expect(acceptThumb()).toBeInTheDocument());
-    expect(acceptThumb()).toHaveAttribute('aria-pressed', 'false');
-    expect(rejectThumb()).toHaveAttribute('aria-pressed', 'false');
+    await waitFor(() => expect(acceptMark()).toBeInTheDocument());
+    expect(acceptMark()).toHaveAttribute('aria-pressed', 'false');
+    expect(rejectMark()).toHaveAttribute('aria-pressed', 'false');
     // Nothing was taken away, so there is no warning to explain.
     expect(
       screen.queryByLabelText(/review invalidated/i)
     ).not.toBeInTheDocument();
   });
 
-  it('shows an accepted case on the thumb that recorded it', async () => {
+  it('shows an accepted case on the mark that recorded it', async () => {
     mockGetTuningCases.mockResolvedValue([ACCEPTED_CASE]);
 
     render(<MetricTuningTab metricId={METRIC_ID} />);
 
     await findAccepted();
-    expect(rejectThumb()).toHaveAttribute('aria-pressed', 'false');
+    expect(rejectMark()).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it("shows a rejected case on its thumb, with the reviewer's comment", async () => {
+  it("shows a rejected case on its mark, with the reviewer's comment", async () => {
     mockGetTuningCases.mockResolvedValue([REJECTED_CASE]);
 
     render(<MetricTuningTab metricId={METRIC_ID} />);
 
     await findRejected();
-    // The comment rides on the thumb's tooltip, which MUI only mounts once the
-    // thumb is hovered or focused.
-    fireEvent.mouseOver(rejectThumb());
+    // The comment rides on the mark's tooltip, which MUI only mounts once the
+    // mark is hovered or focused.
+    fireEvent.mouseOver(rejectMark());
     expect(
       await screen.findByText('This answer dodges the question.')
     ).toBeInTheDocument();
@@ -594,7 +594,7 @@ describe('MetricTuningTab — reviewing', () => {
     render(<MetricTuningTab metricId={METRIC_ID} />);
 
     await findRejected();
-    expect(acceptThumb()).toBeEnabled();
+    expect(acceptMark()).toBeEnabled();
   });
 
   it('offers no review buttons for a case whose metric call failed', async () => {
@@ -619,8 +619,8 @@ describe('MetricTuningTab — reviewing', () => {
     expect(
       await screen.findByLabelText(/review invalidated/i)
     ).toBeInTheDocument();
-    expect(acceptThumb()).toHaveAttribute('aria-pressed', 'false');
-    expect(rejectThumb()).toHaveAttribute('aria-pressed', 'false');
+    expect(acceptMark()).toHaveAttribute('aria-pressed', 'false');
+    expect(rejectMark()).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('accepts a case in one click', async () => {


### PR DESCRIPTION
## Purpose

Three things on the metric tuning tab were harder to read than they needed to be.

Thumbs up/down read as "I like this", but the judgement being recorded is "the metric got this right" — a different statement. The action toolbar sat in the card header, separated from the grid it acts on by the agreement summary, the run summary and the improving summary. And the card title read "Tuning" directly underneath a tab also reading "Tuning".

## What Changed

- **Tick and cross instead of thumbs.** The pressed mark is coloured green or red *and* stroked heavier; the unpressed one stays thin and faint. These MUI icons are filled paths with no bolder variant to switch to, so the weight comes from stroking the glyph in its own colour — at this size colour alone did not separate a pressed mark from an unpressed one. Tooltips, `aria-label`s and `aria-pressed` are unchanged, so the control reads to a screen reader exactly as before.
- **Toolbar moved down to the grid.** Run metric, Accept the rest, Improve and Add case now sit right-aligned directly above the table. They render only once there are cases, so the toolbar no longer appears and then vanishes when an empty list arrives; the empty state keeps its own Add case, so nothing is lost with zero cases.
- **Card title is now "Improve this metric".** The tab label stays "Tuning", so the duplication is gone.

## Additional Context

- Follows the metric tuning feature (#2446) and needs the custom-metric detail fix (#2612) to be reachable at all — before that fix the Tuning tab could never render, since `useIsCustomMetric` got a 403 and failed closed.
- Frontend only. No API calls, props or data shapes changed.
- Renamed the now-stale "thumb" wording in the test file (`acceptThumb` → `acceptMark`, and three test names). No assertions changed — the tests query by `aria-label`, which this PR does not touch.

## Testing

```bash
cd apps/frontend
npx jest MetricTuningTab   # 65 passed
npx tsc --noEmit           # clean
npx eslint "src/app/(protected)/metrics/[identifier]/tuning"   # clean
```

Manually, on a custom metric's Tuning tab: judge a case with the tick and again with the cross, and check the pressed mark is clearly the heavier one; reload a judged case and confirm the mark persists; open a metric with no cases and confirm the empty state still offers Add case.

One thing worth knowing for review: moving the toolbar into the grid branch initially broke a test, and the cause was real rather than cosmetic. `await findByRole('add case')` resolved on the toolbar button while the list was still loading, and that button then unmounted when the empty list arrived — so the click landed on a detached node and did nothing. Gating the toolbar on `cases.length > 0` fixed it at the source rather than by patching the test.
