### PR TITLE
Unify list grids behind a single EntityGrid component

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/crud/explorer.py
@@ -40,6 +40,15 @@ logger = logging.getLogger(__name__)
 # --- Test sets ---------------------------------------------------------------------
 
 
+def only_explorer_test_sets(query):
+    """Row selection for the Explorer list: test sets flagged via ``explorer_row``.
+
+    Shared with the route's ``with_count_header`` so X-Total-Count counts exactly
+    the rows the list returns.
+    """
+    return query.filter(models.TestSet.explorer_row.is_(True))
+
+
 def get_explorer_test_sets(
     db: Session,
     organization_id: str,
@@ -47,6 +56,7 @@ def get_explorer_test_sets(
     limit: int = 100,
     sort_by: str = "created_at",
     sort_order: str = "desc",
+    filter: Optional[str] = None,
 ) -> List[models.TestSet]:
     """Get Explorer test sets -- the inverse of ``get_test_sets``' exclusion clause.
 
@@ -67,16 +77,14 @@ def get_explorer_test_sets(
         Field to sort by
     sort_order : str
         Sort direction ('asc' or 'desc')
+    filter : str, optional
+        OData filter expression
 
     Returns
     -------
     list of models.TestSet
         Test sets flagged as Explorer-owned.
     """
-
-    def only_explorer_test_sets(query):
-        return query.filter(models.TestSet.explorer_row.is_(True))
-
     # Paginated outside the builder on purpose: with_pagination caps limit at 100
     # (validate_pagination) and this endpoint has never capped. with_sorting already
     # appends id ASC as a tiebreaker, so pagination stays stable.
@@ -86,6 +94,7 @@ def get_explorer_test_sets(
         .with_default_derived_field_loads()
         .with_organization_filter(organization_id)
         .with_custom_filter(only_explorer_test_sets)
+        .with_odata_filter(filter)
         .with_sorting(sort_by, sort_order)
         .build()
     )

--- a/apps/backend/src/rhesis/backend/app/routers/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/routers/explorer.py
@@ -12,12 +12,13 @@ from typing import List, Optional
 from uuid import UUID
 
 import pydantic
-from fastapi import Body, Depends, HTTPException, Query
+from fastapi import Body, Depends, HTTPException, Query, Response
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app import crud, schemas
+from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
+from rhesis.backend.app.crud.explorer import only_explorer_test_sets
 from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
@@ -71,6 +72,7 @@ from rhesis.backend.app.services.explorer import (
     update_test_node,
     update_topic_node,
 )
+from rhesis.backend.app.utils.decorators import with_count_header
 
 logger = logging.getLogger(__name__)
 
@@ -188,18 +190,22 @@ def export_regular_test_set_from_explorer_endpoint(
     "/",
     response_model=List[schemas.TestSetDetail],
 )
+@with_count_header(model=models.TestSet, extra_filter=only_explorer_test_sets)
 def list_explorer_test_sets(
+    response: Response,
     skip: int = 0,
     limit: int = 100,
     sort_by: str = "created_at",
     sort_order: str = "desc",
+    filter: Optional[str] = Query(None, alias="$filter", description="OData filter expression"),
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
 ):
     """List explorer test sets.
 
-    Returns test sets flagged as Explorer-owned.
+    Returns test sets flagged as Explorer-owned, with X-Total-Count set to the
+    filtered total.
     """
     organization_id, _user_id = tenant_context
     return get_explorer_test_sets(
@@ -209,6 +215,7 @@ def list_explorer_test_sets(
         limit=limit,
         sort_by=sort_by,
         sort_order=sort_order,
+        filter=filter,
     )
 
 

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -97,6 +97,7 @@ def get_explorer_test_sets(
     limit: int = 100,
     sort_by: str = "created_at",
     sort_order: str = "desc",
+    filter: Optional[str] = None,
 ) -> List[models.TestSet]:
     """Get all test sets flagged as Explorer-owned.
 
@@ -116,6 +117,8 @@ def get_explorer_test_sets(
         Field to sort by
     sort_order : str
         Sort direction ('asc' or 'desc')
+    filter : str, optional
+        OData filter expression
 
     Returns
     -------
@@ -129,6 +132,7 @@ def get_explorer_test_sets(
         limit=limit,
         sort_by=sort_by,
         sort_order=sort_order,
+        filter=filter,
     )
 
     logger.info(f"Found {len(test_sets)} explorer test sets for organization={organization_id}")

--- a/apps/frontend/src/app/(protected)/annotations/components/AnnotationsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/annotations/components/AnnotationsGrid.tsx
@@ -1,23 +1,13 @@
 'use client';
 
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
-import {
-  GridColDef,
-  GridRowParams,
-  GridToolbarColumnsButton,
-  GridToolbarDensitySelector,
-  GridToolbarExport,
-} from '@mui/x-data-grid';
-import { Alert, Box, Typography } from '@mui/material';
+import React, { useCallback, useMemo, useRef } from 'react';
+import { GridColDef, GridRowParams } from '@mui/x-data-grid';
+import { Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
-import BaseDataGrid from '@/components/common/BaseDataGrid';
-import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
+import EntityGrid, {
+  type EntityGridDrawerAdapter,
+  type EntityGridFilterState,
+} from '@/components/common/EntityGrid';
 import GridBadge from '@/components/common/GridBadge';
 import { MentionText } from '@/components/common/MentionTextInput';
 import {
@@ -26,13 +16,11 @@ import {
   ANNOTATION_SOURCE_LABELS,
   ANNOTATION_TARGET_LABELS,
 } from '@/utils/api-client/interfaces/annotation';
-import { useList } from '@/hooks/useList';
 import { annotationsList } from './list';
 import { isPassedStatusName } from '@/utils/test-result-status';
 import AnnotationFilterDrawer, {
   type AnnotationFilters,
   EMPTY_ANNOTATION_FILTERS,
-  hasActiveAnnotationFilters,
   countActiveAnnotationFilters,
 } from './AnnotationFilterDrawer';
 
@@ -47,64 +35,30 @@ const STATUS_PILL_TABS = [
   { label: 'All', value: 'all' },
   { label: 'Open', value: 'open' },
   { label: 'Resolved', value: 'resolved' },
-] as const;
+];
 
-interface AnnotationsToolbarState {
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-  statusFilter: string;
-  setStatusFilter: (v: string) => void;
-  openFilterDrawer: () => void;
-  hasActiveDrawerFilters: boolean;
-  activeFilterCount: number;
+function toFilters(state: EntityGridFilterState<AnnotationFilters>) {
+  return {
+    search: state.search,
+    status: state.pill,
+    source: state.drawer.source,
+    rating: state.drawer.rating,
+    targetType: state.drawer.target_type,
+  };
 }
 
-const AnnotationsToolbarContext = React.createContext<AnnotationsToolbarState>({
-  searchQuery: '',
-  setSearchQuery: () => {},
-  statusFilter: 'all',
-  setStatusFilter: () => {},
-  openFilterDrawer: () => {},
-  hasActiveDrawerFilters: false,
-  activeFilterCount: 0,
-});
-
-function AnnotationsUnifiedToolbar() {
-  const {
-    searchQuery,
-    setSearchQuery,
-    statusFilter,
-    setStatusFilter,
-    openFilterDrawer,
-    hasActiveDrawerFilters,
-    activeFilterCount,
-  } = useContext(AnnotationsToolbarContext);
-
-  return (
-    <GridToolbar
-      searchQuery={searchQuery}
-      onSearchChange={setSearchQuery}
-      searchPlaceholder="Search annotations…"
-      onFilterClick={openFilterDrawer}
-      hasActiveFilters={hasActiveDrawerFilters}
-      activeFilterCount={activeFilterCount}
-      middleContent={
-        <ToolbarPillTabs
-          tabs={[...STATUS_PILL_TABS]}
-          activeValue={statusFilter}
-          onChange={setStatusFilter}
-        />
-      }
-      rightContent={
-        <>
-          <GridToolbarColumnsButton />
-          <GridToolbarDensitySelector />
-          <GridToolbarExport />
-        </>
-      }
+const drawerAdapter: EntityGridDrawerAdapter<AnnotationFilters> = {
+  empty: EMPTY_ANNOTATION_FILTERS,
+  countActive: countActiveAnnotationFilters,
+  render: props => (
+    <AnnotationFilterDrawer
+      open={props.open}
+      onClose={props.onClose}
+      filters={props.filters}
+      onApply={props.onApply}
     />
-  );
-}
+  ),
+};
 
 function formatTarget(item: AnnotationListItem): string {
   const type = item.target?.type || '';
@@ -115,69 +69,37 @@ function formatTarget(item: AnnotationListItem): string {
   return label;
 }
 
+// Rows carry a synthesized id: an annotation is a (source, review) pair, not
+// an entity with its own id.
+function mapRows(annotations: AnnotationListItem[]) {
+  return annotations.map(item => ({
+    ...item,
+    id: `${item.source}-${item.review_id}`,
+  }));
+}
+
 export default function AnnotationsGrid({
   onTotalCountChange,
   initialData,
   initialTotalCount,
 }: AnnotationsGridProps) {
   const theme = useTheme();
-  const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState('all');
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [drawerFilters, setDrawerFilters] = useState<AnnotationFilters>(
-    EMPTY_ANNOTATION_FILTERS
+
+  const onTotalCountChangeRef = useRef(onTotalCountChange);
+  onTotalCountChangeRef.current = onTotalCountChange;
+  const handleDataChange = useCallback(
+    (
+      _data: AnnotationListItem[],
+      totalCount: number,
+      filtersActive: boolean
+    ) => {
+      // Report the unfiltered total only — the page header shows the overall count.
+      if (!filtersActive) {
+        onTotalCountChangeRef.current?.(totalCount);
+      }
+    },
+    []
   );
-  const [errorDismissed, setErrorDismissed] = useState(false);
-
-  const filters = useMemo(
-    () => ({
-      search: searchQuery,
-      status: statusFilter === 'all' ? '' : statusFilter,
-      source: drawerFilters.source,
-      rating: drawerFilters.rating,
-      targetType: drawerFilters.target_type,
-    }),
-    [searchQuery, statusFilter, drawerFilters]
-  );
-
-  const {
-    data: annotations,
-    totalCount,
-    isLoading: loading,
-    error: rawError,
-    paginationModel,
-    onPaginationModelChange: handlePaginationModelChange,
-  } = useList(annotationsList, {
-    filters,
-    initialData,
-    initialTotalCount,
-    onError: () => setErrorDismissed(false),
-  });
-
-  useEffect(() => {
-    setErrorDismissed(false);
-  }, [rawError]);
-
-  const error = rawError && !errorDismissed ? rawError : null;
-  const dismissError = useCallback(() => setErrorDismissed(true), []);
-
-  useEffect(() => {
-    if (loading) return;
-    const filtersActive =
-      !!searchQuery.trim() ||
-      statusFilter !== 'all' ||
-      hasActiveAnnotationFilters(drawerFilters);
-    if (!filtersActive) {
-      onTotalCountChange?.(totalCount);
-    }
-  }, [
-    loading,
-    onTotalCountChange,
-    searchQuery,
-    statusFilter,
-    drawerFilters,
-    totalCount,
-  ]);
 
   const columns: GridColDef[] = useMemo(
     () => [
@@ -310,6 +232,8 @@ export default function AnnotationsGrid({
     [theme]
   );
 
+  // Annotations live on other entities — a click opens the review where it
+  // was made, in a new tab so the annotations list isn't lost.
   const handleRowClick = useCallback((params: GridRowParams) => {
     const row = params.row as AnnotationListItem;
     let url: string | null = null;
@@ -328,64 +252,30 @@ export default function AnnotationsGrid({
     }
   }, []);
 
-  const toolbarState = useMemo(
-    () => ({
-      searchQuery,
-      setSearchQuery,
-      statusFilter,
-      setStatusFilter,
-      openFilterDrawer: () => setFilterDrawerOpen(true),
-      hasActiveDrawerFilters: hasActiveAnnotationFilters(drawerFilters),
-      activeFilterCount: countActiveAnnotationFilters(drawerFilters),
-    }),
-    [searchQuery, statusFilter, drawerFilters]
-  );
-
-  const rows = useMemo(
-    () =>
-      annotations.map(item => ({
-        ...item,
-        id: `${item.source}-${item.review_id}`,
-      })),
-    [annotations]
-  );
-
   return (
-    <AnnotationsToolbarContext.Provider value={toolbarState}>
-      <Box>
-        {error && (
-          <Alert severity="error" onClose={dismissError} sx={{ mb: 2 }}>
-            {error}
-          </Alert>
-        )}
-        <BaseDataGrid
-          rows={rows}
-          columns={columns}
-          loading={loading}
-          getRowId={row => row.id}
-          onRowClick={handleRowClick}
-          paginationModel={paginationModel}
-          onPaginationModelChange={handlePaginationModelChange}
-          serverSidePagination={true}
-          totalRows={totalCount}
-          pageSizeOptions={[10, 25, 50]}
-          showToolbar={true}
-          toolbarSlot={AnnotationsUnifiedToolbar}
-          disablePaperWrapper={true}
-          disableRowSelectionOnClick
-          sx={{
-            '& .MuiDataGrid-row': {
-              cursor: 'pointer',
-            },
-          }}
-        />
-        <AnnotationFilterDrawer
-          open={filterDrawerOpen}
-          onClose={() => setFilterDrawerOpen(false)}
-          filters={drawerFilters}
-          onApply={setDrawerFilters}
-        />
-      </Box>
-    </AnnotationsToolbarContext.Provider>
+    <EntityGrid<
+      AnnotationListItem,
+      typeof annotationsList.filters,
+      AnnotationFilters
+    >
+      descriptor={annotationsList}
+      columns={columns}
+      toFilters={toFilters}
+      emptyState={null}
+      embedded
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+      onDataChange={handleDataChange}
+      mapRows={mapRows}
+      searchPlaceholder="Search annotations…"
+      pills={{ tabs: STATUS_PILL_TABS }}
+      drawer={drawerAdapter}
+      onRowClick={handleRowClick}
+      editAction={false}
+      persistState={false}
+      serverSort={false}
+      pageSizeOptions={[10, 25, 50]}
+      sx={{ '& .MuiDataGrid-row': { cursor: 'pointer' } }}
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -1,55 +1,30 @@
 'use client';
 
-import React, {
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react';
-import { useRouter } from 'next/navigation';
-import { Box, Typography, useTheme, Alert, Paper } from '@mui/material';
-import GridBadge from '@/components/common/GridBadge';
-import GridToolbar from '@/components/common/GridToolbar';
-import SelectionModeToggle from '@/components/common/SelectionModeToggle';
-import {
-  GridColDef,
-  GridToolbarColumnsButton,
-  GridToolbarDensitySelector,
-  GridToolbarExport,
-} from '@mui/x-data-grid';
-import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
-import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
-import { Project } from '@/utils/api-client/interfaces/project';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { Box, Typography, useTheme } from '@mui/material';
+import { GridColDef } from '@mui/x-data-grid';
 import { useSession } from 'next-auth/react';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { DeleteModal } from '@/components/common/DeleteModal';
-import { useList } from '@/hooks/useList';
-import { escapeODataValue } from '@/utils/odata-filter';
-import { endpointsList } from './list';
-import EndpointFilterDrawer, {
-  type EndpointFilters,
-  EMPTY_ENDPOINT_FILTERS,
-  hasActiveEndpointFilters,
-  countActiveEndpointFilters,
-} from './EndpointFilterDrawer';
-import {
-  createRowActionsColumn,
-  rowActionsHoverSx,
-} from '@/components/common/createRowActionsColumn';
-import { useCan } from '@/components/common/Can';
-import { Capability } from '@/constants/capabilities';
-import { getProjectIcon } from './endpoint-icon-utils';
-import {
-  useBulkDelete,
-  type BulkDeleteActionsState,
-} from '@/hooks/useBulkDelete';
-import { isAuthenticated } from '@/hooks/useIsAuthenticated';
-import GridStateGate from '@/components/common/GridStateGate';
+import EntityGrid, {
+  type EntityGridDrawerAdapter,
+  type EntityGridFilterState,
+} from '@/components/common/EntityGrid';
+import GridBadge from '@/components/common/GridBadge';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import EndpointsIcon from '@/components/EndpointsIcon';
+import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
+import { Project } from '@/utils/api-client/interfaces/project';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { escapeODataValue } from '@/utils/odata-filter';
+import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import type { BulkDeleteActionsState } from '@/hooks/useBulkDelete';
+import { endpointsList } from './list';
+import { getProjectIcon } from './endpoint-icon-utils';
+import EndpointFilterDrawer, {
+  type EndpointFilters,
+  EMPTY_ENDPOINT_FILTERS,
+  countActiveEndpointFilters,
+} from './EndpointFilterDrawer';
 
 interface EndpointsGridProps {
   projectId?: string;
@@ -70,60 +45,27 @@ interface EndpointsGridProps {
   refreshTrigger?: number;
 }
 
-interface EndpointsToolbarState {
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-  openFilterDrawer: () => void;
-  hasActiveDrawerFilters: boolean;
-  activeFilterCount: number;
-  checkboxSelectionMode: boolean;
-  setCheckboxSelectionMode: (v: boolean) => void;
+function toFilters(state: EntityGridFilterState<EndpointFilters>) {
+  return {
+    search: state.search,
+    connectionType: state.drawer.connectionType,
+    environment: state.drawer.environment,
+    status: state.drawer.status,
+  };
 }
 
-const EndpointsToolbarContext = React.createContext<EndpointsToolbarState>({
-  searchQuery: '',
-  setSearchQuery: () => {},
-  openFilterDrawer: () => {},
-  hasActiveDrawerFilters: false,
-  activeFilterCount: 0,
-  checkboxSelectionMode: false,
-  setCheckboxSelectionMode: () => {},
-});
-
-function EndpointsUnifiedToolbar() {
-  const {
-    searchQuery,
-    setSearchQuery,
-    openFilterDrawer,
-    hasActiveDrawerFilters,
-    activeFilterCount,
-    checkboxSelectionMode,
-    setCheckboxSelectionMode,
-  } = useContext(EndpointsToolbarContext);
-
-  return (
-    <GridToolbar
-      searchQuery={searchQuery}
-      onSearchChange={setSearchQuery}
-      searchPlaceholder="Search endpoints…"
-      onFilterClick={openFilterDrawer}
-      hasActiveFilters={hasActiveDrawerFilters}
-      activeFilterCount={activeFilterCount}
-      rightContent={
-        <>
-          <SelectionModeToggle
-            checked={checkboxSelectionMode}
-            onChange={setCheckboxSelectionMode}
-            label="Select endpoints"
-          />
-          <GridToolbarColumnsButton />
-          <GridToolbarDensitySelector />
-          <GridToolbarExport />
-        </>
-      }
+const drawerAdapter: EntityGridDrawerAdapter<EndpointFilters> = {
+  empty: EMPTY_ENDPOINT_FILTERS,
+  countActive: countActiveEndpointFilters,
+  render: props => (
+    <EndpointFilterDrawer
+      open={props.open}
+      onClose={props.onClose}
+      filters={props.filters}
+      onApply={props.onApply}
     />
-  );
-}
+  ),
+};
 
 export default function EndpointsGrid({
   projectId,
@@ -135,88 +77,15 @@ export default function EndpointsGrid({
   refreshTrigger,
 }: EndpointsGridProps) {
   const theme = useTheme();
-  const router = useRouter();
   const { status } = useSession();
-  const canEditEndpoint = useCan(Capability.Endpoint.UPDATE);
-  const canDeleteEndpoint = useCan(Capability.Endpoint.DELETE);
 
-  const [searchQuery, setSearchQuery] = useState('');
-  const [drawerFilters, setDrawerFilters] = useState<EndpointFilters>(
-    EMPTY_ENDPOINT_FILTERS
-  );
   const [projects, setProjects] = useState<Record<string, Project>>({});
   const [loadingProjects, setLoadingProjects] = useState(true);
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [errorDismissed, setErrorDismissed] = useState(false);
-
-  const filters = useMemo(
-    () => ({
-      search: searchQuery,
-      connectionType: drawerFilters.connectionType,
-      environment: drawerFilters.environment,
-      status: drawerFilters.status,
-    }),
-    [searchQuery, drawerFilters]
-  );
 
   const extraODataClauses = useMemo(
     () => (projectId ? [`project_id eq '${escapeODataValue(projectId)}'`] : []),
     [projectId]
   );
-
-  const {
-    data: endpoints,
-    totalCount,
-    isLoading: loading,
-    error: rawError,
-    refresh,
-    paginationModel,
-    onPaginationModelChange: handlePaginationModelChange,
-  } = useList(endpointsList, {
-    filters,
-    extraFilters: extraODataClauses,
-    initialData,
-    initialTotalCount,
-    onError: () => setErrorDismissed(false),
-  });
-
-  useEffect(() => {
-    setErrorDismissed(false);
-  }, [rawError]);
-
-  const error = rawError && !errorDismissed ? rawError : null;
-  const dismissError = useCallback(() => setErrorDismissed(true), []);
-
-  const {
-    checkboxSelectionMode,
-    setCheckboxSelectionMode,
-    selectedRows,
-    handleSelectionChange,
-    pendingDeleteId,
-    deleteModalOpen,
-    isDeleting,
-    requestDelete,
-    confirmDelete,
-    cancelDelete,
-  } = useBulkDelete({
-    bulkDeleteFn: (ids: string[]) =>
-      new ApiClientFactory().getEndpointsClient().bulkDeleteEndpoints(ids),
-    onSuccess: refresh,
-    itemLabelSingular: 'endpoint',
-    itemLabelPlural: 'endpoints',
-    onBulkActionsChange,
-  });
-
-  const isFirstRefreshTrigger = useRef(true);
-  useEffect(() => {
-    if (isFirstRefreshTrigger.current) {
-      isFirstRefreshTrigger.current = false;
-      return;
-    }
-    refresh();
-    // Only refreshTrigger (bumped by the page after a create) should re-run this.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshTrigger]);
 
   useEffect(() => {
     const fetchProjects = async () => {
@@ -251,16 +120,16 @@ export default function EndpointsGrid({
     }
   }, [status]);
 
-  const columns: GridColDef[] = useMemo(() => {
-    const actionsCol = createRowActionsColumn({
-      onEdit: id => {
-        router.push(`/endpoints/${id}`);
-      },
-      onDelete: id => requestDelete(id),
-      canEdit: () => canEditEndpoint,
-      canDelete: () => canDeleteEndpoint,
-    });
-    return [
+  const getRowUrl = useCallback(
+    (row: Endpoint) =>
+      projectId
+        ? `/projects/${projectId}/endpoints/${row.id}`
+        : `/endpoints/${row.id}`,
+    [projectId]
+  );
+
+  const columns: GridColDef[] = useMemo(
+    () => [
       {
         field: 'name',
         headerName: 'Name',
@@ -282,6 +151,7 @@ export default function EndpointsGrid({
         field: 'project',
         headerName: 'Project',
         flex: 1,
+        sortable: false,
         renderCell: params => {
           const endpoint = params.row as Endpoint;
           const project = endpoint.project_id
@@ -313,6 +183,7 @@ export default function EndpointsGrid({
         field: 'status',
         headerName: 'Status',
         flex: 0.7,
+        sortable: false,
         renderCell: params => {
           const endpoint = params.row as Endpoint;
           const status = endpoint.status;
@@ -320,106 +191,19 @@ export default function EndpointsGrid({
           return <GridBadge label={status?.name ?? 'Unknown'} />;
         },
       },
-      actionsCol,
-    ];
-  }, [projects, theme.typography.h5.fontSize, requestDelete, router]);
-
-  const hasActiveDrawerFilters = hasActiveEndpointFilters(drawerFilters);
-  const activeFilterCount = countActiveEndpointFilters(drawerFilters);
-
-  const toolbarContextValue = useMemo(
-    () => ({
-      searchQuery,
-      setSearchQuery,
-      openFilterDrawer: () => setFilterDrawerOpen(true),
-      hasActiveDrawerFilters,
-      activeFilterCount,
-      checkboxSelectionMode,
-      setCheckboxSelectionMode,
-    }),
-    [
-      searchQuery,
-      hasActiveDrawerFilters,
-      activeFilterCount,
-      checkboxSelectionMode,
-      setCheckboxSelectionMode,
-    ]
+    ],
+    [projects, theme.typography.h5.fontSize]
   );
 
   // Only the top-level Endpoints page passes `onCreateClick` — that's when
   // this grid owns its own loading/empty presentation and Paper wrapper.
   const isStandalone = onCreateClick !== undefined;
-  const filtersActive = !!searchQuery || hasActiveDrawerFilters;
-
-  const content = (
-    <EndpointsToolbarContext.Provider value={toolbarContextValue}>
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
-          {error}
-        </Alert>
-      )}
-      <Box sx={{ position: 'relative' }}>
-        <BaseDataGrid
-          rows={endpoints}
-          columns={columns}
-          loading={loading || loadingProjects}
-          density="comfortable"
-          linkPath={
-            checkboxSelectionMode
-              ? undefined
-              : projectId
-                ? `/projects/${projectId}/endpoints`
-                : '/endpoints'
-          }
-          linkField="id"
-          serverSidePagination={true}
-          totalRows={totalCount}
-          paginationModel={paginationModel}
-          onPaginationModelChange={handlePaginationModelChange}
-          pageSizeOptions={[10, 25, 50]}
-          toolbarSlot={EndpointsUnifiedToolbar}
-          showToolbar={true}
-          disablePaperWrapper={true}
-          persistState
-          sx={rowActionsHoverSx}
-          checkboxSelection={checkboxSelectionMode}
-          disableRowSelectionOnClick={checkboxSelectionMode || undefined}
-          rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
-          onRowSelectionModelChange={
-            checkboxSelectionMode ? handleSelectionChange : undefined
-          }
-        />
-
-        <DeleteModal
-          open={deleteModalOpen}
-          onClose={cancelDelete}
-          onConfirm={confirmDelete}
-          isLoading={isDeleting}
-          title={pendingDeleteId ? 'Delete Endpoint' : 'Delete Endpoints'}
-          message={
-            pendingDeleteId
-              ? 'Are you sure you want to delete this endpoint? Related data will not be deleted.'
-              : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'endpoint' : 'endpoints'}? Related data will not be deleted.`
-          }
-          itemType="endpoints"
-        />
-      </Box>
-
-      <EndpointFilterDrawer
-        open={filterDrawerOpen}
-        onClose={() => setFilterDrawerOpen(false)}
-        filters={drawerFilters}
-        onApply={setDrawerFilters}
-      />
-    </EndpointsToolbarContext.Provider>
-  );
 
   return (
-    <GridStateGate
-      active={isStandalone}
-      data={loading ? null : {}}
-      error={error}
-      isEmpty={totalCount === 0 && !filtersActive}
+    <EntityGrid<Endpoint, typeof endpointsList.filters, EndpointFilters>
+      descriptor={endpointsList}
+      columns={columns}
+      toFilters={toFilters}
       emptyState={
         <EntityEmptyState
           card
@@ -431,8 +215,20 @@ export default function EndpointsGrid({
           enrichment={getEntityEmptyStateEnrichment('endpoints')}
         />
       }
-    >
-      {isStandalone ? <Paper sx={GRID_PAPER_SX}>{content}</Paper> : content}
-    </GridStateGate>
+      embedded={!isStandalone}
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+      refreshTrigger={refreshTrigger}
+      extraFilters={extraODataClauses}
+      extraLoading={loadingProjects}
+      searchPlaceholder="Search endpoints…"
+      drawer={drawerAdapter}
+      selectionLabel="Select endpoints"
+      getRowUrl={getRowUrl}
+      onBulkActionsChange={onBulkActionsChange}
+      density="comfortable"
+      pageSizeOptions={[10, 25, 50]}
+      serverSort={false}
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/endpoints/components/list.ts
+++ b/apps/frontend/src/app/(protected)/endpoints/components/list.ts
@@ -20,4 +20,16 @@ export const endpointsList = defineList({
   filters: ENDPOINTS_FILTERS,
   list: (factory: ApiClientFactory, params) =>
     factory.getEndpointsClient().getEndpoints(params),
+  delete: {
+    bulk: (factory: ApiClientFactory, ids: string[]) =>
+      factory.getEndpointsClient().bulkDeleteEndpoints(ids),
+    capability: Capability.Endpoint.DELETE,
+    capabilityMode: 'ambient',
+    labelSingular: 'endpoint',
+    labelPlural: 'endpoints',
+    confirmMessage: count =>
+      count === 1
+        ? 'Are you sure you want to delete this endpoint? Related data will not be deleted.'
+        : `Are you sure you want to delete ${count} endpoints? Related data will not be deleted.`,
+  },
 });

--- a/apps/frontend/src/app/(protected)/experiments/components/ExperimentFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/components/ExperimentFilterDrawer.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React from 'react';
+import { Box } from '@mui/material';
+import {
+  FilterDrawerShell,
+  FilterSection,
+  filterChipSx,
+  useFilterDrawerDraft,
+} from '@/components/common/FilterDrawer';
+
+export interface ExperimentFilters {
+  visibility: string;
+}
+
+export const EMPTY_EXPERIMENT_FILTERS: ExperimentFilters = { visibility: '' };
+
+export function countActiveExperimentFilters(
+  filters: ExperimentFilters
+): number {
+  return filters.visibility ? 1 : 0;
+}
+
+export default function ExperimentFilterDrawer({
+  open,
+  onClose,
+  filters,
+  onApply,
+}: {
+  open: boolean;
+  onClose: () => void;
+  filters: ExperimentFilters;
+  onApply: (filters: ExperimentFilters) => void;
+}) {
+  const { draft, setDraft, handleReset, handleApply } = useFilterDrawerDraft(
+    open,
+    filters,
+    EMPTY_EXPERIMENT_FILTERS,
+    onApply,
+    onClose
+  );
+
+  return (
+    <FilterDrawerShell
+      open={open}
+      onClose={onClose}
+      onReset={handleReset}
+      onApply={handleApply}
+    >
+      <FilterSection title="Visibility">
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+          {(['', 'private', 'shared'] as const).map(v => (
+            <Box
+              key={v || 'all'}
+              component="button"
+              onClick={() => setDraft(d => ({ ...d, visibility: v }))}
+              sx={filterChipSx(draft.visibility === v)}
+            >
+              {v === '' ? 'All' : v.charAt(0).toUpperCase() + v.slice(1)}
+            </Box>
+          ))}
+        </Box>
+      </FilterSection>
+    </FilterDrawerShell>
+  );
+}

--- a/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
@@ -1,32 +1,17 @@
 'use client';
 
-import React, { useContext, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Box, Chip, Typography } from '@mui/material';
-import {
-  GridColDef,
-  GridToolbarColumnsButton,
-  GridToolbarDensitySelector,
-  GridToolbarExport,
-} from '@mui/x-data-grid';
+import { GridColDef } from '@mui/x-data-grid';
 import { useRouter } from 'next/navigation';
 import { PageLayout } from '@/components/layout/PageLayout';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
-import BaseDataGrid from '@/components/common/BaseDataGrid';
-import {
-  FilterDrawerShell,
-  FilterSection,
-  filterChipSx,
-  useFilterDrawerDraft,
-} from '@/components/common/FilterDrawer';
-import GridToolbar from '@/components/common/GridToolbar';
-import { DeleteModal } from '@/components/common/DeleteModal';
-import {
-  createRowActionsColumn,
-  rowActionsHoverSx,
-} from '@/components/common/createRowActionsColumn';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import EntityGrid, {
+  type EntityGridDrawerAdapter,
+  type EntityGridFilterState,
+} from '@/components/common/EntityGrid';
 import {
   ExperimentRead,
   shortVersion,
@@ -36,111 +21,36 @@ import { can } from '@/utils/affordances';
 import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
-import GridStateGate from '@/components/common/GridStateGate';
 import { BiotechIcon } from '@/components/icons';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
-import { useNotifications } from '@/components/common/NotificationContext';
-import { useList } from '@/hooks/useList';
 import { experimentsList } from './list';
 import CreateExperimentDialog from './CreateExperimentDialog';
+import ExperimentFilterDrawer, {
+  type ExperimentFilters,
+  EMPTY_EXPERIMENT_FILTERS,
+  countActiveExperimentFilters,
+} from './ExperimentFilterDrawer';
 import { formatDate } from '@/utils/date';
 
-// ─── Toolbar context ───────────────────────────────────────────────────────────
-
-interface ExperimentsToolbarState {
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-  openFilterDrawer: () => void;
-  hasActiveFilters: boolean;
-  activeFilterCount: number;
+function toFilters(state: EntityGridFilterState<ExperimentFilters>) {
+  return {
+    search: state.search,
+    visibility: state.drawer.visibility,
+  };
 }
 
-const ExperimentsToolbarContext = React.createContext<ExperimentsToolbarState>({
-  searchQuery: '',
-  setSearchQuery: () => {},
-  openFilterDrawer: () => {},
-  hasActiveFilters: false,
-  activeFilterCount: 0,
-});
-
-function ExperimentsUnifiedToolbar() {
-  const {
-    searchQuery,
-    setSearchQuery,
-    openFilterDrawer,
-    hasActiveFilters,
-    activeFilterCount,
-  } = useContext(ExperimentsToolbarContext);
-  return (
-    <GridToolbar
-      searchQuery={searchQuery}
-      onSearchChange={setSearchQuery}
-      searchPlaceholder="Search experiments…"
-      onFilterClick={openFilterDrawer}
-      hasActiveFilters={hasActiveFilters}
-      activeFilterCount={activeFilterCount}
-      rightContent={
-        <>
-          <GridToolbarColumnsButton />
-          <GridToolbarDensitySelector />
-          <GridToolbarExport />
-        </>
-      }
+const drawerAdapter: EntityGridDrawerAdapter<ExperimentFilters> = {
+  empty: EMPTY_EXPERIMENT_FILTERS,
+  countActive: countActiveExperimentFilters,
+  render: props => (
+    <ExperimentFilterDrawer
+      open={props.open}
+      onClose={props.onClose}
+      filters={props.filters}
+      onApply={props.onApply}
     />
-  );
-}
-
-// ─── Filter drawer ─────────────────────────────────────────────────────────────
-
-const EMPTY_FILTERS = { visibility: '' };
-
-function ExperimentsFilterDrawer({
-  open,
-  onClose,
-  visibilityFilter,
-  onApply,
-}: {
-  open: boolean;
-  onClose: () => void;
-  visibilityFilter: string;
-  onApply: (visibility: string) => void;
-}) {
-  const committed = useMemo(
-    () => ({ visibility: visibilityFilter }),
-    [visibilityFilter]
-  );
-  const { draft, setDraft, handleReset, handleApply } = useFilterDrawerDraft(
-    open,
-    committed,
-    EMPTY_FILTERS,
-    f => onApply(f.visibility),
-    onClose
-  );
-
-  return (
-    <FilterDrawerShell
-      open={open}
-      onClose={onClose}
-      onReset={handleReset}
-      onApply={handleApply}
-    >
-      <FilterSection title="Visibility">
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-          {(['', 'private', 'shared'] as const).map(v => (
-            <Box
-              key={v || 'all'}
-              component="button"
-              onClick={() => setDraft(d => ({ ...d, visibility: v }))}
-              sx={filterChipSx(draft.visibility === v)}
-            >
-              {v === '' ? 'All' : v.charAt(0).toUpperCase() + v.slice(1)}
-            </Box>
-          ))}
-        </Box>
-      </FilterSection>
-    </FilterDrawerShell>
-  );
-}
+  ),
+};
 
 interface ExperimentsClientWrapperProps {
   /** Server-fetched first page — when present, skips the initial client fetch. */
@@ -153,155 +63,102 @@ export default function ExperimentsClientWrapper({
   initialTotalCount,
 }: ExperimentsClientWrapperProps) {
   const router = useRouter();
-  const notifications = useNotifications();
   const { activeProject } = useActiveProject();
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
     Capability.Experiment.READ
   );
   const canCreateExperiment = useCan(Capability.Experiment.CREATE);
   const [createOpen, setCreateOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [visibilityFilter, setVisibilityFilter] = useState<string>('');
-  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
-  const [deleting, setDeleting] = useState(false);
-
-  const filters = useMemo(
-    () => ({ search: searchQuery, visibility: visibilityFilter }),
-    [searchQuery, visibilityFilter]
-  );
-
-  const {
-    data: experiments,
-    totalCount,
-    isLoading: loading,
-    refresh,
-    paginationModel,
-    onPaginationModelChange: handlePaginationModelChange,
-  } = useList(experimentsList, {
-    filters,
-    initialData,
-    initialTotalCount,
-    onError: () =>
-      notifications.show('Failed to load experiments', { severity: 'error' }),
-  });
-
-  const handleDeleteExperiment = async () => {
-    if (!deleteTargetId) return;
-    setDeleting(true);
-    try {
-      const parametersClient = new ApiClientFactory().getParametersClient();
-      await parametersClient.deleteExperiment(deleteTargetId);
-      notifications.show('Experiment deleted', { severity: 'success' });
-      setDeleteTargetId(null);
-      refresh();
-    } catch {
-      notifications.show('Failed to delete experiment', { severity: 'error' });
-    } finally {
-      setDeleting(false);
-    }
-  };
 
   const columns: GridColDef[] = useMemo(
     () => [
-      ...([
-        {
-          field: 'name',
-          headerName: 'Name',
-          flex: 1.2,
-          minWidth: 160,
-          filterable: true,
-          renderCell: params => (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <BiotechIcon fontSize="small" color="action" />
-              <Typography variant="body2">{params.row.name}</Typography>
-            </Box>
-          ),
-        },
-        {
-          field: 'description',
-          headerName: 'Description',
-          flex: 1.8,
-          minWidth: 200,
-          filterable: false,
-          sortable: false,
-          renderCell: params => (
-            <Typography variant="body2" color="text.secondary" noWrap>
-              {params.value || '—'}
-            </Typography>
-          ),
-        },
-        {
-          field: 'projectName',
-          headerName: 'Project',
-          flex: 0.9,
-          minWidth: 120,
-          filterable: true,
-          valueGetter: (_value: unknown, row: ExperimentRead) =>
-            row.project_name || '—',
-        },
-        {
-          field: 'visibility',
-          headerName: 'Visibility',
-          flex: 0.6,
-          minWidth: 90,
-          filterable: true,
-          type: 'singleSelect',
-          valueOptions: ['private', 'shared'],
-          renderCell: params => (
+      {
+        field: 'name',
+        headerName: 'Name',
+        flex: 1.2,
+        minWidth: 160,
+        filterable: true,
+        renderCell: params => (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <BiotechIcon fontSize="small" color="action" />
+            <Typography variant="body2">{params.row.name}</Typography>
+          </Box>
+        ),
+      },
+      {
+        field: 'description',
+        headerName: 'Description',
+        flex: 1.8,
+        minWidth: 200,
+        filterable: false,
+        sortable: false,
+        renderCell: params => (
+          <Typography variant="body2" color="text.secondary" noWrap>
+            {params.value || '—'}
+          </Typography>
+        ),
+      },
+      {
+        field: 'projectName',
+        headerName: 'Project',
+        flex: 0.9,
+        minWidth: 120,
+        filterable: true,
+        sortable: false,
+        valueGetter: (_value: unknown, row: ExperimentRead) =>
+          row.project_name || '—',
+      },
+      {
+        field: 'visibility',
+        headerName: 'Visibility',
+        flex: 0.6,
+        minWidth: 90,
+        filterable: true,
+        type: 'singleSelect',
+        valueOptions: ['private', 'shared'],
+        renderCell: params => (
+          <Chip
+            size="small"
+            label={params.value}
+            color={params.value === 'shared' ? 'primary' : 'default'}
+            variant="outlined"
+          />
+        ),
+      },
+      {
+        field: 'latest_version',
+        headerName: 'Latest',
+        flex: 0.5,
+        minWidth: 80,
+        filterable: false,
+        sortable: false,
+        renderCell: params =>
+          params.value ? (
             <Chip
               size="small"
-              label={params.value}
-              color={params.value === 'shared' ? 'primary' : 'default'}
-              variant="outlined"
+              label={shortVersion(params.value)}
+              sx={{ fontFamily: 'monospace' }}
             />
-          ),
-        },
-        {
-          field: 'latest_version',
-          headerName: 'Latest',
-          flex: 0.5,
-          minWidth: 80,
-          filterable: false,
-          sortable: false,
-          renderCell: params =>
-            params.value ? (
-              <Chip
-                size="small"
-                label={shortVersion(params.value)}
-                sx={{ fontFamily: 'monospace' }}
-              />
-            ) : (
-              <Typography variant="caption" color="text.disabled">
-                —
-              </Typography>
-            ),
-        },
-        {
-          field: 'created_at',
-          headerName: 'Created',
-          flex: 0.8,
-          minWidth: 120,
-          filterable: false,
-          renderCell: params => (
-            <Typography variant="body2" color="text.secondary">
-              {params.value ? formatDate(params.value) : '—'}
+          ) : (
+            <Typography variant="caption" color="text.disabled">
+              —
             </Typography>
           ),
-        },
-      ] as GridColDef[]),
-      createRowActionsColumn({
-        onEdit: id => router.push(`/experiments/${id}`),
-        onDelete: id => setDeleteTargetId(id),
-        canEdit: row =>
-          can(row as unknown as ExperimentRead, Capability.Experiment.UPDATE),
-        canDelete: row =>
-          can(row as unknown as ExperimentRead, Capability.Experiment.DELETE),
-        editTooltip: 'Open experiment',
-        deleteTooltip: 'Delete experiment',
-      }),
+      },
+      {
+        field: 'created_at',
+        headerName: 'Created',
+        flex: 0.8,
+        minWidth: 120,
+        filterable: false,
+        renderCell: params => (
+          <Typography variant="body2" color="text.secondary">
+            {params.value ? formatDate(params.value) : '—'}
+          </Typography>
+        ),
+      },
     ],
-    [router]
+    []
   );
 
   if (permsLoading) return <PageLoadingState />;
@@ -325,11 +182,14 @@ export default function ExperimentsClientWrapper({
         </FabGroup>
       }
     >
-      <GridStateGate
-        data={loading ? null : experiments}
-        isEmpty={
-          experiments.length === 0 && !searchQuery.trim() && !visibilityFilter
-        }
+      <EntityGrid<
+        ExperimentRead,
+        typeof experimentsList.filters,
+        ExperimentFilters
+      >
+        descriptor={experimentsList}
+        columns={columns}
+        toFilters={toFilters}
         emptyState={
           <EntityEmptyState
             card
@@ -344,34 +204,17 @@ export default function ExperimentsClientWrapper({
             enrichment={getEntityEmptyStateEnrichment('experiments')}
           />
         }
-      >
-        <ExperimentsToolbarContext.Provider
-          value={{
-            searchQuery,
-            setSearchQuery,
-            openFilterDrawer: () => setFilterDrawerOpen(true),
-            hasActiveFilters: !!visibilityFilter,
-            activeFilterCount: visibilityFilter ? 1 : 0,
-          }}
-        >
-          <BaseDataGrid
-            rows={experiments}
-            columns={columns}
-            loading={loading}
-            linkPath="/experiments"
-            linkField="id"
-            paginationModel={paginationModel}
-            onPaginationModelChange={handlePaginationModelChange}
-            serverSidePagination={true}
-            totalRows={totalCount}
-            pageSizeOptions={[10, 25, 50]}
-            showToolbar={true}
-            toolbarSlot={ExperimentsUnifiedToolbar}
-            persistState
-            sx={rowActionsHoverSx}
-          />
-        </ExperimentsToolbarContext.Provider>
-      </GridStateGate>
+        initialData={initialData}
+        initialTotalCount={initialTotalCount}
+        searchPlaceholder="Search experiments…"
+        drawer={drawerAdapter}
+        getRowUrl={row => `/experiments/${row.id}`}
+        editAction={{
+          can: (row: ExperimentRead) => can(row, Capability.Experiment.UPDATE),
+        }}
+        pageSizeOptions={[10, 25, 50]}
+        serverSort={false}
+      />
 
       <CreateExperimentDialog
         open={createOpen}
@@ -380,23 +223,6 @@ export default function ExperimentsClientWrapper({
           setCreateOpen(false);
           router.push(`/experiments/${experiment.id}`);
         }}
-      />
-
-      <ExperimentsFilterDrawer
-        open={filterDrawerOpen}
-        onClose={() => setFilterDrawerOpen(false)}
-        visibilityFilter={visibilityFilter}
-        onApply={v => setVisibilityFilter(v)}
-      />
-
-      <DeleteModal
-        open={!!deleteTargetId}
-        onClose={() => setDeleteTargetId(null)}
-        onConfirm={handleDeleteExperiment}
-        isLoading={deleting}
-        title="Delete Experiment"
-        message="Are you sure you want to delete this experiment? This action cannot be undone."
-        itemType="experiment"
       />
     </PageLayout>
   );

--- a/apps/frontend/src/app/(protected)/experiments/components/list.ts
+++ b/apps/frontend/src/app/(protected)/experiments/components/list.ts
@@ -42,4 +42,13 @@ export const experimentsList = defineList({
       },
     };
   },
+  // Experiments have no bulk-delete endpoint -- row-level delete only.
+  delete: {
+    one: (factory: ApiClientFactory, id: string) =>
+      factory.getParametersClient().deleteExperiment(id),
+    capability: Capability.Experiment.DELETE,
+    capabilityMode: 'row',
+    labelSingular: 'experiment',
+    labelPlural: 'experiments',
+  },
 });

--- a/apps/frontend/src/app/(protected)/explorer/ExplorerClient.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/ExplorerClient.tsx
@@ -5,9 +5,9 @@ import { useRouter } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import FileUploadIcon from '@mui/icons-material/FileUploadOutlined';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import IosShareOutlinedIcon from '@mui/icons-material/IosShareOutlined';
 import { useSession } from 'next-auth/react';
-import { useQueryClient } from '@tanstack/react-query';
-import { explorerKeys } from '@/constants/query-keys';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
@@ -15,26 +15,54 @@ import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import { useNotifications } from '@/components/common/NotificationContext';
-import type { ImportExplorerTestSetResponse } from '@/utils/api-client/interfaces/explorer';
-import ExplorerGrid from './components/ExplorerGrid';
+import type {
+  ExplorerTestSetDetail,
+  ImportExplorerTestSetResponse,
+} from '@/utils/api-client/interfaces/explorer';
+import ExplorerGrid, {
+  type ExplorerBulkActionsState,
+} from './components/ExplorerGrid';
 import ExplorerCreateDialog from './components/ExplorerCreateDialog';
 import ImportExplorerTestSetDialog from './components/ImportExplorerTestSetDialog';
 import { isAuthenticated, isSessionLoading } from '@/hooks/useIsAuthenticated';
 
-export default function ExplorerClient() {
+interface ExplorerClientProps {
+  /** Server-fetched first page — when present, skips the initial client fetch. */
+  initialData?: ExplorerTestSetDetail[];
+  initialTotalCount?: number;
+}
+
+const HIDDEN_BULK_ACTIONS: ExplorerBulkActionsState = {
+  visible: false,
+  onDelete: () => {},
+  onSave: () => {},
+  saveDisabled: true,
+};
+
+export default function ExplorerClient({
+  initialData,
+  initialTotalCount,
+}: ExplorerClientProps) {
   const { status } = useSession();
   const router = useRouter();
-  const queryClient = useQueryClient();
   const notifications = useNotifications();
 
   const [createDialogOpen, setCreateDialogOpen] = React.useState(false);
   const [importDialogOpen, setImportDialogOpen] = React.useState(false);
+  const [refreshTrigger, setRefreshTrigger] = React.useState(0);
+  const [bulkActions, setBulkActions] =
+    React.useState<ExplorerBulkActionsState>(HIDDEN_BULK_ACTIONS);
 
   useDocumentTitle('Explorer');
 
   const canCreateSession = useCan(Capability.Explorer.CREATE);
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
     Capability.Explorer.READ
+  );
+
+  const bumpRefresh = React.useCallback(
+    () => setRefreshTrigger(prev => prev + 1),
+    []
   );
 
   const handleImportedExplorerSet = React.useCallback(
@@ -49,10 +77,10 @@ export default function ExplorerClient() {
         autoHideDuration: 5000,
       });
       setImportDialogOpen(false);
-      queryClient.invalidateQueries({ queryKey: explorerKeys.all() });
+      bumpRefresh();
       router.push(`/explorer/${created.id}?openSettings=1`);
     },
-    [queryClient, notifications, router]
+    [bumpRefresh, notifications, router]
   );
 
   if (isSessionLoading(status) || permsLoading) {
@@ -85,6 +113,28 @@ export default function ExplorerClient() {
         breadcrumbs={[]}
         actions={
           <FabGroup>
+            {bulkActions.visible && !bulkActions.saveDisabled && (
+              <Fab
+                icon={<IosShareOutlinedIcon />}
+                tooltip="Save to Test Set"
+                aria-label="Save to Test Set"
+                onClick={bulkActions.onSave}
+              />
+            )}
+            {bulkActions.visible && (
+              <Can capability={Capability.Explorer.DELETE}>
+                <Fab
+                  icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
+                  tooltip="Delete sessions"
+                  aria-label="Delete sessions"
+                  onClick={bulkActions.onDelete}
+                  sx={{
+                    bgcolor: 'error.main',
+                    '&:hover': { bgcolor: 'error.dark' },
+                  }}
+                />
+              </Can>
+            )}
             <Can capability={Capability.Explorer.CREATE}>
               <Fab
                 icon={<FileUploadIcon />}
@@ -104,6 +154,10 @@ export default function ExplorerClient() {
           <ExplorerGrid
             canCreate={canCreateSession}
             onCreateClick={() => setCreateDialogOpen(true)}
+            onBulkActionsChange={setBulkActions}
+            refreshTrigger={refreshTrigger}
+            initialData={initialData}
+            initialTotalCount={initialTotalCount}
           />
         </Box>
       </PageLayout>
@@ -111,9 +165,7 @@ export default function ExplorerClient() {
       <ExplorerCreateDialog
         open={createDialogOpen}
         onClose={() => setCreateDialogOpen(false)}
-        onCreated={() =>
-          queryClient.invalidateQueries({ queryKey: explorerKeys.all() })
-        }
+        onCreated={bumpRefresh}
         onNavigateToSession={sessionId => {
           router.push(`/explorer/${sessionId}?openSettings=1`);
         }}

--- a/apps/frontend/src/app/(protected)/explorer/[identifier]/components/ExplorerDetail.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/[identifier]/components/ExplorerDetail.tsx
@@ -40,7 +40,6 @@ import { alpha, useTheme } from '@mui/material/styles';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useQueryClient } from '@tanstack/react-query';
 import {
   GridColDef,
   GridPaginationModel,
@@ -55,7 +54,6 @@ import { Fab, FabGroup } from '@/components/common/Fab';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import { Can } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
-import { explorerKeys } from '@/constants/query-keys';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import FolderIcon from '@mui/icons-material/Folder';
@@ -1833,7 +1831,6 @@ function TestsList({
             rows={filteredTests}
             loading={loading}
             getRowId={row => row.id}
-            showToolbar={hasToolbar}
             toolbarSlot={hasToolbar ? TestsListUnifiedToolbar : undefined}
             paginationModel={paginationModel}
             onPaginationModelChange={handlePaginationModelChange}
@@ -1975,7 +1972,7 @@ export default function ExplorerDetail({
   const notifications = useNotifications();
   const searchParams = useSearchParams();
   const router = useRouter();
-  const queryClient = useQueryClient();
+
   const pathname = usePathname();
   const selectedTopicForApi =
     selectedTopic && selectedTopic !== NO_TOPIC_FILTER ? selectedTopic : null;
@@ -2908,7 +2905,7 @@ export default function ExplorerDetail({
         severity: 'success',
         autoHideDuration: 4000,
       });
-      queryClient.invalidateQueries({ queryKey: explorerKeys.all() });
+      // No cache to invalidate: navigating back re-fetches the sessions list.
       router.push('/explorer');
     } catch (err) {
       notifications.show(
@@ -2919,7 +2916,7 @@ export default function ExplorerDetail({
     } finally {
       setDeleteSessionDialogOpen(false);
     }
-  }, [testSetId, notifications, queryClient, router]);
+  }, [testSetId, notifications, router]);
 
   return (
     <PageLayout

--- a/apps/frontend/src/app/(protected)/explorer/[identifier]/components/SuggestionsDialog.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/[identifier]/components/SuggestionsDialog.tsx
@@ -881,7 +881,6 @@ export default function SuggestionsDialog({
           rows={suggestions}
           loading={acceptAllInProgress}
           getRowId={row => row._id}
-          showToolbar={false}
           paginationModel={{ page: 0, pageSize: 25 }}
           serverSidePagination={false}
           totalRows={suggestions.length}

--- a/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
@@ -1,78 +1,44 @@
 'use client';
 
-import React, {
-  useState,
-  useCallback,
-  useEffect,
-  useContext,
-  useMemo,
-} from 'react';
-import {
-  GridColDef,
-  GridPaginationModel,
-  GridRowParams,
-  GridRowSelectionModel,
-  GridToolbarColumnsButton,
-  GridToolbarDensitySelector,
-  GridToolbarExport,
-} from '@mui/x-data-grid';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useSession } from 'next-auth/react';
-import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
-import GridToolbar from '@/components/common/GridToolbar';
-import GridStateGate from '@/components/common/GridStateGate';
+import React, { useState, useCallback, useMemo } from 'react';
+import { GridColDef } from '@mui/x-data-grid';
+import { useRouter } from 'next/navigation';
+import { Box, Typography } from '@mui/material';
+import EntityGrid, {
+  type EntityGridSelectionContext,
+} from '@/components/common/EntityGrid';
+import GridBadge from '@/components/common/GridBadge';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { AccountTreeIcon } from '@/components/icons';
-import { useRouter } from 'next/navigation';
-import { Alert, Box, Paper, Typography } from '@mui/material';
-import GridBadge from '@/components/common/GridBadge';
-import DeleteIcon from '@mui/icons-material/Delete';
-import IosShareOutlinedIcon from '@mui/icons-material/IosShareOutlined';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { DeleteModal } from '@/components/common/DeleteModal';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { formatDate } from '@/utils/date';
-import { explorerKeys } from '@/constants/query-keys';
-import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 import { UserAvatar } from '@/components/common/UserAvatar';
 import { AVATAR_SIZES } from '@/constants/avatar-sizes';
+import type { ExplorerTestSetDetail } from '@/utils/api-client/interfaces/explorer';
 import type { UserReference } from '@/utils/api-client/interfaces/tests';
-import { createRowActionsColumn } from '@/components/common/createRowActionsColumn';
-import { useCan } from '@/components/common/Can';
-import { Capability } from '@/constants/capabilities';
+import type { BulkDeleteActionsState } from '@/hooks/useBulkDelete';
+import { explorerList } from './list';
+
+export interface ExplorerBulkActionsState extends BulkDeleteActionsState {
+  /** Export the selection to a regular test set; enabled for exactly one row. */
+  onSave: () => void;
+  saveDisabled: boolean;
+}
 
 interface ExplorerGridProps {
   canCreate?: boolean;
   onCreateClick?: () => void;
+  onBulkActionsChange?: (actions: ExplorerBulkActionsState) => void;
+  /** Bumped by the page after a create/import succeeds, to trigger a re-fetch. */
+  refreshTrigger?: number;
+  /** Server-fetched first page — when present, skips the initial client fetch. */
+  initialData?: ExplorerTestSetDetail[];
+  initialTotalCount?: number;
 }
 
-interface ExplorerToolbarState {
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-}
-
-const ExplorerToolbarContext = React.createContext<ExplorerToolbarState>({
-  searchQuery: '',
-  setSearchQuery: () => {},
-});
-
-function ExplorerUnifiedToolbar() {
-  const { searchQuery, setSearchQuery } = useContext(ExplorerToolbarContext);
-
-  return (
-    <GridToolbar
-      searchQuery={searchQuery}
-      onSearchChange={setSearchQuery}
-      searchPlaceholder="Search sessions…"
-      rightContent={
-        <>
-          <GridToolbarColumnsButton />
-          <GridToolbarDensitySelector />
-          <GridToolbarExport />
-        </>
-      }
-    />
-  );
+function toFilters(state: { search: string }) {
+  return { search: state.search };
 }
 
 /** Same name cascade the other grids use, so sorting and export match the cell. */
@@ -89,61 +55,61 @@ function userDisplayName(user?: UserReference): string {
 export default function ExplorerGrid({
   canCreate,
   onCreateClick,
+  onBulkActionsChange,
+  refreshTrigger,
+  initialData,
+  initialTotalCount,
 }: ExplorerGridProps) {
   const router = useRouter();
-  const { status } = useSession();
-  const queryClient = useQueryClient();
   const notifications = useNotifications();
-  const [searchQuery, setSearchQuery] = useState('');
-  const [paginationModel, setPaginationModel] = useState({
-    page: 0,
-    pageSize: 25,
-  });
-  const [selectedRows, setSelectedRows] = useState<GridRowSelectionModel>([]);
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  const [isDeleting, setIsDeleting] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
-  const canDeleteSession = useCan(Capability.Explorer.DELETE);
 
-  const {
-    data,
-    isLoading: loading,
-    error,
-  } = useQuery({
-    queryKey: explorerKeys.all(),
-    queryFn: () =>
-      new ApiClientFactory().getExplorerClient().getExplorerTestSets(),
-    enabled: isAuthenticated(status),
-  });
+  const handleExportSelected = useCallback(
+    async (selectedIds: string[]) => {
+      if (selectedIds.length !== 1 || isExporting) return;
 
-  const allRows = data ?? [];
-
-  useEffect(() => {
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
-  }, [searchQuery]);
-
-  const rows = searchQuery.trim()
-    ? allRows.filter(r => {
-        const q = searchQuery.toLowerCase();
-        return (
-          r.name?.toLowerCase().includes(q) ||
-          (r.description ?? '').toLowerCase().includes(q)
+      setIsExporting(true);
+      try {
+        const client = new ApiClientFactory().getExplorerClient();
+        const result = await client.exportRegularTestSetFromExplorer(
+          selectedIds[0]
         );
-      })
-    : allRows;
-
-  const handlePaginationModelChange = useCallback(
-    (newModel: GridPaginationModel) => {
-      setPaginationModel(newModel);
+        const { exported, skipped, test_set: created } = result;
+        const parts = [
+          `Created "${created.name}"`,
+          `exported ${exported} test(s)`,
+        ];
+        if (skipped > 0) {
+          parts.push(`skipped ${skipped}`);
+        }
+        notifications.show(parts.join('. '), {
+          severity: 'success',
+          autoHideDuration: 6000,
+        });
+        router.push(`/test-sets/${created.id}`);
+      } catch (err) {
+        notifications.show(
+          err instanceof Error ? err.message : 'Failed to export test set.',
+          { severity: 'error', autoHideDuration: 6000 }
+        );
+      } finally {
+        setIsExporting(false);
+      }
     },
-    []
+    [notifications, router, isExporting]
   );
 
-  const handleRowDeleteAction = useCallback((id: string) => {
-    setPendingDeleteId(id);
-    setDeleteModalOpen(true);
-  }, []);
+  const buildBulkActions = useCallback(
+    (
+      base: BulkDeleteActionsState,
+      ctx: EntityGridSelectionContext<ExplorerTestSetDetail>
+    ): ExplorerBulkActionsState => ({
+      ...base,
+      onSave: () => void handleExportSelected(ctx.selectedIds),
+      saveDisabled: ctx.selectedIds.length !== 1,
+    }),
+    [handleExportSelected]
+  );
 
   const columns = useMemo<GridColDef[]>(
     () => [
@@ -176,6 +142,7 @@ export default function ExplorerGrid({
         field: 'status',
         headerName: 'Status',
         width: 120,
+        sortable: false,
         valueGetter: (_, row) => row.status?.name || '',
         renderCell: params => {
           if (!params.value) return '-';
@@ -198,6 +165,7 @@ export default function ExplorerGrid({
         headerName: 'Creator',
         width: 160,
         minWidth: 120,
+        sortable: false,
         valueGetter: (_, row) => userDisplayName(row.user),
         renderCell: params => {
           if (!params.value) return '-';
@@ -213,144 +181,20 @@ export default function ExplorerGrid({
           );
         },
       },
-      createRowActionsColumn({
-        onDelete: id => handleRowDeleteAction(id),
-        canDelete: () => canDeleteSession,
-        deleteTooltip: 'Delete session',
-        width: 56,
-      }),
     ],
-    [canDeleteSession, handleRowDeleteAction]
+    []
   );
 
-  const handleRowClick = (params: GridRowParams) => {
-    router.push(`/explorer/${params.id}`);
-  };
-
-  const handleDeleteTestSets = () => {
-    setPendingDeleteId(null);
-    setDeleteModalOpen(true);
-  };
-
-  const handleDeleteCancel = () => {
-    setDeleteModalOpen(false);
-    setPendingDeleteId(null);
-  };
-
-  const handleExportSelected = useCallback(async () => {
-    if (selectedRows.length !== 1) return;
-
-    setIsExporting(true);
-    try {
-      const client = new ApiClientFactory().getExplorerClient();
-      const result = await client.exportRegularTestSetFromExplorer(
-        String(selectedRows[0])
-      );
-      const { exported, skipped, test_set: created } = result;
-      const parts = [
-        `Created "${created.name}"`,
-        `exported ${exported} test(s)`,
-      ];
-      if (skipped > 0) {
-        parts.push(`skipped ${skipped}`);
-      }
-      notifications.show(parts.join('. '), {
-        severity: 'success',
-        autoHideDuration: 6000,
-      });
-      router.push(`/test-sets/${created.id}`);
-    } catch (err) {
-      notifications.show(
-        err instanceof Error ? err.message : 'Failed to export test set.',
-        { severity: 'error', autoHideDuration: 6000 }
-      );
-    } finally {
-      setIsExporting(false);
-    }
-  }, [notifications, router, selectedRows]);
-
-  const handleDeleteConfirm = async () => {
-    const idsToDelete = pendingDeleteId
-      ? [pendingDeleteId]
-      : selectedRows.map(String);
-    if (idsToDelete.length === 0) return;
-
-    try {
-      setIsDeleting(true);
-      const client = new ApiClientFactory().getExplorerClient();
-      if (pendingDeleteId) {
-        await client.deleteExplorerTestSet(pendingDeleteId);
-      } else {
-        await client.bulkDeleteExplorerTestSets(idsToDelete);
-      }
-
-      notifications.show(
-        `Successfully deleted ${idsToDelete.length} ${idsToDelete.length === 1 ? 'session' : 'sessions'}`,
-        { severity: 'success', autoHideDuration: 4000 }
-      );
-
-      setSelectedRows([]);
-      queryClient.invalidateQueries({ queryKey: explorerKeys.all() });
-    } catch {
-      notifications.show('Failed to delete sessions', {
-        severity: 'error',
-        autoHideDuration: 6000,
-      });
-    } finally {
-      setIsDeleting(false);
-      setDeleteModalOpen(false);
-      // Clear here, not on success only: a stale id would retarget the next bulk delete.
-      setPendingDeleteId(null);
-    }
-  };
-
-  const getActionButtons = () => {
-    if (selectedRows.length === 0) return [];
-
-    const buttons: {
-      label: string;
-      icon: React.ReactNode;
-      variant: 'text' | 'outlined' | 'contained';
-      color?:
-        | 'inherit'
-        | 'primary'
-        | 'secondary'
-        | 'success'
-        | 'error'
-        | 'info'
-        | 'warning';
-      onClick: () => void;
-      disabled?: boolean;
-    }[] = [];
-
-    if (selectedRows.length === 1) {
-      buttons.push({
-        label: 'Save to Test Set',
-        icon: <IosShareOutlinedIcon />,
-        variant: 'outlined' as const,
-        onClick: () => void handleExportSelected(),
-        disabled: isExporting,
-      });
-    }
-
-    if (canDeleteSession) {
-      buttons.push({
-        label: selectedRows.length > 1 ? 'Delete sessions' : 'Delete session',
-        icon: <DeleteIcon />,
-        variant: 'outlined' as const,
-        color: 'error' as const,
-        onClick: handleDeleteTestSets,
-      });
-    }
-
-    return buttons;
-  };
-
   return (
-    <GridStateGate
-      data={data}
-      error={error ? 'Failed to load explorer sessions' : null}
-      isEmpty={allRows.length === 0 && !searchQuery.trim()}
+    <EntityGrid<
+      ExplorerTestSetDetail,
+      typeof explorerList.filters,
+      Record<string, never>,
+      ExplorerBulkActionsState
+    >
+      descriptor={explorerList}
+      columns={columns}
+      toFilters={toFilters}
       emptyState={
         <EntityEmptyState
           card
@@ -361,58 +205,17 @@ export default function ExplorerGrid({
           onAction={canCreate ? onCreateClick : undefined}
         />
       }
-    >
-      <Paper sx={GRID_PAPER_SX}>
-        <ExplorerToolbarContext.Provider
-          value={{ searchQuery, setSearchQuery }}
-        >
-          <Box>
-            {error && (
-              <Alert severity="error" sx={{ mb: 2 }}>
-                Failed to load explorer sessions
-              </Alert>
-            )}
-            <BaseDataGrid
-              columns={columns}
-              rows={rows}
-              loading={loading}
-              getRowId={row => row.id}
-              showToolbar={true}
-              toolbarSlot={ExplorerUnifiedToolbar}
-              actionButtons={getActionButtons()}
-              onRowClick={handleRowClick}
-              paginationModel={paginationModel}
-              onPaginationModelChange={handlePaginationModelChange}
-              serverSidePagination={false}
-              totalRows={rows.length}
-              pageSizeOptions={[10, 25, 50]}
-              disablePaperWrapper={true}
-              persistState
-              checkboxSelection
-              disableRowSelectionOnClick
-              onRowSelectionModelChange={setSelectedRows}
-              rowSelectionModel={selectedRows}
-            />
-            <DeleteModal
-              open={deleteModalOpen}
-              onClose={handleDeleteCancel}
-              onConfirm={handleDeleteConfirm}
-              isLoading={isDeleting}
-              title={
-                pendingDeleteId || selectedRows.length === 1
-                  ? 'Delete explorer session'
-                  : 'Delete explorer sessions'
-              }
-              message={
-                pendingDeleteId
-                  ? 'Are you sure you want to delete this session? Its tests and topics are deleted with it.'
-                  : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'session' : 'sessions'}? Their tests and topics are deleted with them.`
-              }
-              itemType="explorer sessions"
-            />
-          </Box>
-        </ExplorerToolbarContext.Provider>
-      </Paper>
-    </GridStateGate>
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+      refreshTrigger={refreshTrigger}
+      searchPlaceholder="Search sessions…"
+      selectionLabel="Select sessions"
+      getRowUrl={row => `/explorer/${row.id}`}
+      editAction={false}
+      rowActionsWidth={56}
+      onBulkActionsChange={onBulkActionsChange}
+      buildBulkActions={buildBulkActions}
+      pageSizeOptions={[10, 25, 50]}
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/explorer/components/list.ts
+++ b/apps/frontend/src/app/(protected)/explorer/components/list.ts
@@ -1,0 +1,30 @@
+import type { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { Capability } from '@/constants/capabilities';
+import { defineList } from '@/utils/list';
+
+const EXPLORER_FILTERS = {
+  search: { kind: 'search', columns: ['name', 'description'] },
+} as const;
+
+/** Explorer sessions are TestSet rows flagged `explorer_row` -- same columns. */
+export const explorerList = defineList({
+  title: 'Explorer',
+  resource: 'explorer sessions',
+  capability: Capability.Explorer.READ,
+  defaultPageSize: 25,
+  filters: EXPLORER_FILTERS,
+  list: (factory: ApiClientFactory, params) =>
+    factory.getExplorerClient().getExplorerTestSets(params),
+  delete: {
+    bulk: (factory: ApiClientFactory, ids: string[]) =>
+      factory.getExplorerClient().bulkDeleteExplorerTestSets(ids),
+    capability: Capability.Explorer.DELETE,
+    capabilityMode: 'ambient',
+    labelSingular: 'session',
+    labelPlural: 'sessions',
+    confirmMessage: count =>
+      count === 1
+        ? 'Are you sure you want to delete this session? Its tests and topics are deleted with it.'
+        : `Are you sure you want to delete ${count} sessions? Their tests and topics are deleted with them.`,
+  },
+});

--- a/apps/frontend/src/app/(protected)/explorer/page.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/page.tsx
@@ -1,5 +1,35 @@
+import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { prefetchList } from '@/utils/server-prefetch';
+import { emptyFilters, listParams } from '@/utils/list';
+import { Capability } from '@/constants/capabilities';
 import ExplorerClient from './ExplorerClient';
+import { explorerList } from './components/list';
 
-export default function ExplorerPage() {
-  return <ExplorerClient />;
+/**
+ * Server component: fetches the first page of explorer sessions before
+ * rendering so the page arrives with content already in place -- no
+ * client-side spinner on first load.
+ */
+export default async function ExplorerPage() {
+  const client = (await createServerApiFactory()).getExplorerClient();
+
+  const { initialData, initialTotalCount } = await prefetchList(
+    Capability.Explorer.READ,
+    () =>
+      client.getExplorerTestSets(
+        listParams(explorerList, {
+          page: 1,
+          pageSize: explorerList.defaultPageSize,
+          sort: explorerList.defaultSort,
+          filters: emptyFilters(explorerList),
+        })
+      )
+  );
+
+  return (
+    <ExplorerClient
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+    />
+  );
 }

--- a/apps/frontend/src/app/(protected)/jobs/components/JobsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/jobs/components/JobsGrid.tsx
@@ -1,22 +1,20 @@
 'use client';
 
 import * as React from 'react';
-import { useCallback, useContext, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useCallback, useMemo } from 'react';
 import { Box, Chip, LinearProgress, Tooltip, Typography } from '@mui/material';
 import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 
-import BaseDataGrid from '@/components/common/BaseDataGrid';
-import GridStateGate from '@/components/common/GridStateGate';
+import EntityGrid, {
+  type EntityGridDrawerAdapter,
+  type EntityGridFilterState,
+} from '@/components/common/EntityGrid';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
-import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
-import { useList } from '@/hooks/useList';
 import { jobsList } from './list';
 import type { Job } from '@/utils/api-client/interfaces/job';
 import {
   countActiveJobFilters,
   EMPTY_JOB_FILTERS,
-  hasActiveJobFilters,
   type JobFilters,
 } from '@/utils/odata-filter';
 import { JOB_STATUS_COLOR, JOB_STATUS_LABEL } from '@/constants/jobs';
@@ -26,67 +24,50 @@ import JobFilterDrawer from './JobFilterDrawer';
 /**
  * Pill tabs are the coarse cut people actually want ("what is running", "what
  * broke"); everything finer lives in the drawer. 'active' is not a status the
- * backend has -- it expands to queued/running/cancelling below.
+ * backend has -- the descriptor's statusPill filter expands it.
  */
 const STATUS_PILL_TABS = [
   { label: 'All', value: 'all' },
   { label: 'Active', value: 'active' },
   { label: 'Failed', value: 'failed' },
-] as const;
+];
 
-const PILL_TO_FILTER: Record<string, JobFilters['status']> = {
-  failed: 'failed',
-};
+const LIVE_POLL_MS = 3000;
 
-interface JobsToolbarState {
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-  statusPill: string;
-  setStatusPill: (v: string) => void;
-  openFilterDrawer: () => void;
-  hasActiveDrawerFilters: boolean;
-  activeFilterCount: number;
+/**
+ * The pill narrows the drawer's status rather than fighting it: a user who
+ * picked "failed" in the drawer and then clicks the Active pill should see
+ * active jobs, so the pill wins for the one field they overlap on.
+ */
+function toFilters(state: EntityGridFilterState<JobFilters>) {
+  return {
+    search: state.search,
+    status:
+      state.pill === ''
+        ? state.drawer.status
+        : state.pill === 'failed'
+          ? ('failed' as const)
+          : ('' as const),
+    statusPill: state.pill === 'active' ? 'active' : '',
+    jobType: state.drawer.jobType,
+    triggeredBy: state.drawer.triggeredBy,
+    createdFrom: state.drawer.createdFrom,
+    createdTo: state.drawer.createdTo,
+  };
 }
 
-const JobsToolbarContext = React.createContext<JobsToolbarState>({
-  searchQuery: '',
-  setSearchQuery: () => {},
-  statusPill: 'all',
-  setStatusPill: () => {},
-  openFilterDrawer: () => {},
-  hasActiveDrawerFilters: false,
-  activeFilterCount: 0,
-});
-
-function JobsUnifiedToolbar() {
-  const {
-    searchQuery,
-    setSearchQuery,
-    statusPill,
-    setStatusPill,
-    openFilterDrawer,
-    hasActiveDrawerFilters,
-    activeFilterCount,
-  } = useContext(JobsToolbarContext);
-
-  return (
-    <GridToolbar
-      searchQuery={searchQuery}
-      onSearchChange={setSearchQuery}
-      searchPlaceholder="Search jobs…"
-      onFilterClick={openFilterDrawer}
-      hasActiveFilters={hasActiveDrawerFilters}
-      activeFilterCount={activeFilterCount}
-      middleContent={
-        <ToolbarPillTabs
-          tabs={[...STATUS_PILL_TABS]}
-          activeValue={statusPill}
-          onChange={setStatusPill}
-        />
-      }
+const drawerAdapter: EntityGridDrawerAdapter<JobFilters> = {
+  empty: EMPTY_JOB_FILTERS,
+  countActive: countActiveJobFilters,
+  render: props => (
+    <JobFilterDrawer
+      open={props.open}
+      onClose={props.onClose}
+      filters={props.filters}
+      onApply={props.onApply}
     />
-  );
-}
+  ),
+};
 
 function StatusCell({ job }: { job: Job }) {
   const status = job.status as keyof typeof JOB_STATUS_COLOR;
@@ -177,65 +158,11 @@ export default function JobsGrid({
   initialData,
   initialTotalCount,
 }: JobsGridProps) {
-  const router = useRouter();
-
-  const [searchQuery, setSearchQuery] = useState('');
-  const [statusPill, setStatusPill] = useState('all');
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [drawerFilters, setDrawerFilters] =
-    useState<JobFilters>(EMPTY_JOB_FILTERS);
-
-  /**
-   * The pill narrows the drawer's status rather than fighting it: a user who
-   * picked "failed" in the drawer and then clicks the Active pill should see
-   * active jobs, so the pill wins for the one field they overlap on.
-   */
-  const filters = useMemo(
-    () => ({
-      search: searchQuery,
-      status:
-        statusPill === 'all'
-          ? drawerFilters.status
-          : (PILL_TO_FILTER[statusPill] ?? ''),
-      jobType: drawerFilters.jobType,
-      triggeredBy: drawerFilters.triggeredBy,
-      createdFrom: drawerFilters.createdFrom,
-      createdTo: drawerFilters.createdTo,
-    }),
-    [searchQuery, statusPill, drawerFilters]
+  const getRowUrl = useCallback((row: Job) => `/jobs/${row.id}`, []);
+  const pollMs = useCallback(
+    (data: Job[]) => (data.some(j => !j.is_terminal) ? LIVE_POLL_MS : false),
+    []
   );
-
-  // 'active' is the complement of the terminal states. Expressed as a status
-  // list rather than "not terminal" because OData has no notion of which of
-  // our statuses are terminal.
-  const extraFilters = useMemo(
-    () =>
-      statusPill === 'active'
-        ? [
-            "(status eq 'queued' or status eq 'running' or status eq 'cancelling')",
-          ]
-        : undefined,
-    [statusPill]
-  );
-
-  const LIVE_POLL_MS = 3000;
-
-  const {
-    data: jobs,
-    totalCount,
-    isLoading: loading,
-    error,
-    paginationModel,
-    onPaginationModelChange: handlePaginationModelChange,
-    sortModel,
-    onSortModelChange: handleSortModelChange,
-  } = useList(jobsList, {
-    filters,
-    extraFilters,
-    initialData,
-    initialTotalCount,
-    pollMs: data => (data.some(j => !j.is_terminal) ? LIVE_POLL_MS : false),
-  });
 
   const columns: GridColDef[] = useMemo(
     () => [
@@ -307,67 +234,28 @@ export default function JobsGrid({
     []
   );
 
-  const toolbarState = useMemo<JobsToolbarState>(
-    () => ({
-      searchQuery,
-      setSearchQuery,
-      statusPill,
-      setStatusPill,
-      openFilterDrawer: () => setFilterDrawerOpen(true),
-      hasActiveDrawerFilters: hasActiveJobFilters(drawerFilters),
-      activeFilterCount: countActiveJobFilters(drawerFilters),
-    }),
-    [searchQuery, statusPill, drawerFilters]
-  );
-
-  const handleRowClick = useCallback(
-    (jobId: string) => router.push(`/jobs/${jobId}`),
-    [router]
-  );
-
-  const isFiltered =
-    searchQuery !== '' ||
-    statusPill !== 'all' ||
-    hasActiveJobFilters(drawerFilters);
-
   return (
-    <JobsToolbarContext.Provider value={toolbarState}>
-      <GridStateGate
-        data={loading ? null : {}}
-        error={error}
-        isEmpty={jobs.length === 0 && !isFiltered}
-        emptyState={
-          <EntityEmptyState
-            icon={JobsIcon}
-            title="No jobs yet"
-            description="Background work shows up here when you generate a test set, run tests, or import from Garak."
-          />
-        }
-      >
-        <BaseDataGrid
-          rows={jobs}
-          columns={columns}
-          getRowId={row => String(row.id)}
-          loading={loading}
-          serverSidePagination
-          totalRows={totalCount}
-          paginationModel={paginationModel}
-          onPaginationModelChange={handlePaginationModelChange}
-          sortModel={sortModel}
-          onSortModelChange={handleSortModelChange}
-          pageSizeOptions={[10, 25, 50, 100]}
-          toolbarSlot={JobsUnifiedToolbar}
-          onRowClick={params => handleRowClick(String(params.id))}
-          persistState
+    <EntityGrid<Job, typeof jobsList.filters, JobFilters>
+      descriptor={jobsList}
+      columns={columns}
+      toFilters={toFilters}
+      emptyState={
+        <EntityEmptyState
+          icon={JobsIcon}
+          title="No jobs yet"
+          description="Background work shows up here when you generate a test set, run tests, or import from Garak."
         />
-      </GridStateGate>
-
-      <JobFilterDrawer
-        open={filterDrawerOpen}
-        onClose={() => setFilterDrawerOpen(false)}
-        filters={drawerFilters}
-        onApply={setDrawerFilters}
-      />
-    </JobsToolbarContext.Provider>
+      }
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+      pollMs={pollMs}
+      searchPlaceholder="Search jobs…"
+      pills={{ tabs: STATUS_PILL_TABS }}
+      drawer={drawerAdapter}
+      getRowUrl={getRowUrl}
+      showGridButtons={false}
+      pageSizeOptions={[10, 25, 50, 100]}
+      editAction={false}
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/jobs/components/list.ts
+++ b/apps/frontend/src/app/(protected)/jobs/components/list.ts
@@ -27,6 +27,15 @@ const JOBS_FILTERS = {
     toOData: (value: string) =>
       value ? `created_at le ${value}T23:59:59Z` : undefined,
   },
+  // The toolbar's Active pill. Not a backend status -- it expands to the
+  // non-terminal states, because OData has no notion of which are terminal.
+  statusPill: {
+    kind: 'raw',
+    toOData: (value: string) =>
+      value === 'active'
+        ? "(status eq 'queued' or status eq 'running' or status eq 'cancelling')"
+        : undefined,
+  },
 } as const;
 
 export const jobsList = defineList<Job, typeof JOBS_FILTERS>({

--- a/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
@@ -1,53 +1,25 @@
 'use client';
 
-import React, {
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react';
-import {
-  GridColDef,
-  GridRowParams,
-  GridToolbarColumnsButton,
-  GridToolbarDensitySelector,
-  GridToolbarExport,
-} from '@mui/x-data-grid';
-import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
-import { useRouter } from 'next/navigation';
-import { Source } from '@/utils/api-client/interfaces/source';
-import { Box, Chip, Typography, Paper } from '@mui/material';
-import GridToolbar from '@/components/common/GridToolbar';
+import React, { useCallback, useMemo } from 'react';
+import { GridColDef } from '@mui/x-data-grid';
+import { Box, Chip, Typography } from '@mui/material';
+import EntityGrid, {
+  type EntityGridDrawerAdapter,
+  type EntityGridFilterState,
+} from '@/components/common/EntityGrid';
 import GridBadge from '@/components/common/GridBadge';
-import {
-  createRowActionsColumn,
-  rowActionsHoverSx,
-} from '@/components/common/createRowActionsColumn';
-import { useCan } from '@/components/common/Can';
-import { Capability } from '@/constants/capabilities';
-import SelectionModeToggle from '@/components/common/SelectionModeToggle';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { DeleteModal } from '@/components/common/DeleteModal';
-import styles from '@/styles/Knowledge.module.css';
-import { useList } from '@/hooks/useList';
-import { sourcesList } from './list';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { Source } from '@/utils/api-client/interfaces/source';
 import { ChatIcon, MenuBookIcon } from '@/components/icons';
 import { formatFileSize, getFileExtension } from '@/constants/knowledge';
 import { formatDate } from '@/utils/date';
+import type { BulkDeleteActionsState } from '@/hooks/useBulkDelete';
+import { sourcesList } from './list';
 import SourceFilterDrawer, {
   type SourceFilters,
   EMPTY_SOURCE_FILTERS,
-  hasActiveSourceFilters,
   countActiveSourceFilters,
 } from './SourceFilterDrawer';
-import {
-  useBulkDelete,
-  type BulkDeleteActionsState,
-} from '@/hooks/useBulkDelete';
-import GridStateGate from '@/components/common/GridStateGate';
-import EntityEmptyState from '@/components/common/EntityEmptyState';
 
 interface SourcesGridProps {
   canCreate?: boolean;
@@ -60,60 +32,27 @@ interface SourcesGridProps {
   refreshTrigger?: number;
 }
 
-interface SourcesToolbarState {
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-  openFilterDrawer: () => void;
-  hasActiveDrawerFilters: boolean;
-  activeFilterCount: number;
-  checkboxSelectionMode: boolean;
-  setCheckboxSelectionMode: (v: boolean) => void;
+function toFilters(state: EntityGridFilterState<SourceFilters>) {
+  return {
+    search: state.search,
+    sourceType: state.drawer.sourceType,
+    creator: state.drawer.creator,
+    tag: state.drawer.tag,
+  };
 }
 
-const SourcesToolbarContext = React.createContext<SourcesToolbarState>({
-  searchQuery: '',
-  setSearchQuery: () => {},
-  openFilterDrawer: () => {},
-  hasActiveDrawerFilters: false,
-  activeFilterCount: 0,
-  checkboxSelectionMode: false,
-  setCheckboxSelectionMode: () => {},
-});
-
-function SourcesUnifiedToolbar() {
-  const {
-    searchQuery,
-    setSearchQuery,
-    openFilterDrawer,
-    hasActiveDrawerFilters,
-    activeFilterCount,
-    checkboxSelectionMode,
-    setCheckboxSelectionMode,
-  } = useContext(SourcesToolbarContext);
-
-  return (
-    <GridToolbar
-      searchQuery={searchQuery}
-      onSearchChange={setSearchQuery}
-      searchPlaceholder="Search sources…"
-      onFilterClick={openFilterDrawer}
-      hasActiveFilters={hasActiveDrawerFilters}
-      activeFilterCount={activeFilterCount}
-      rightContent={
-        <>
-          <SelectionModeToggle
-            checked={checkboxSelectionMode}
-            onChange={setCheckboxSelectionMode}
-            label="Select sources"
-          />
-          <GridToolbarColumnsButton />
-          <GridToolbarDensitySelector />
-          <GridToolbarExport />
-        </>
-      }
+const drawerAdapter: EntityGridDrawerAdapter<SourceFilters> = {
+  empty: EMPTY_SOURCE_FILTERS,
+  countActive: countActiveSourceFilters,
+  render: props => (
+    <SourceFilterDrawer
+      open={props.open}
+      onClose={props.onClose}
+      filters={props.filters}
+      onApply={props.onApply}
     />
-  );
-}
+  ),
+};
 
 export default function SourcesGrid({
   canCreate,
@@ -123,109 +62,10 @@ export default function SourcesGrid({
   initialTotalCount,
   refreshTrigger,
 }: SourcesGridProps) {
-  const router = useRouter();
-  const canEditSource = useCan(Capability.Source.UPDATE);
-  const canDeleteSource = useCan(Capability.Source.DELETE);
+  const getRowUrl = useCallback((row: Source) => `/knowledge/${row.id}`, []);
 
-  // Component state
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [drawerFilters, setDrawerFilters] =
-    useState<SourceFilters>(EMPTY_SOURCE_FILTERS);
-  const [searchQuery, setSearchQuery] = useState('');
-
-  const filters = useMemo(
-    () => ({
-      search: searchQuery,
-      sourceType: drawerFilters.sourceType,
-      creator: drawerFilters.creator,
-      tag: drawerFilters.tag,
-    }),
-    [searchQuery, drawerFilters]
-  );
-
-  const {
-    data: sources,
-    totalCount,
-    isLoading: loading,
-    error,
-    refresh,
-    paginationModel,
-    onPaginationModelChange: handlePaginationModelChange,
-    sortModel,
-    onSortModelChange: handleSortModelChange,
-  } = useList(sourcesList, {
-    filters,
-    initialData,
-    initialTotalCount,
-  });
-
-  const {
-    checkboxSelectionMode,
-    setCheckboxSelectionMode,
-    selectedRows,
-    handleSelectionChange,
-    pendingDeleteId,
-    deleteModalOpen,
-    isDeleting,
-    requestDelete,
-    confirmDelete,
-    cancelDelete,
-  } = useBulkDelete({
-    bulkDeleteFn: (ids: string[]) =>
-      new ApiClientFactory().getSourcesClient().bulkDeleteSources(ids),
-    onSuccess: refresh,
-    itemLabelSingular: 'source',
-    itemLabelPlural: 'sources',
-    onBulkActionsChange,
-  });
-
-  const isFirstRefreshTrigger = useRef(true);
-  useEffect(() => {
-    if (isFirstRefreshTrigger.current) {
-      isFirstRefreshTrigger.current = false;
-      return;
-    }
-    refresh();
-    // Only refreshTrigger (bumped by the page after an upload/import) should re-run this.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshTrigger]);
-
-  // Handle row click to navigate to preview
-  const handleRowClick = useCallback(
-    (params: GridRowParams) => {
-      const sourceId = String(params.id);
-      router.push(`/knowledge/${sourceId}`);
-    },
-    [router]
-  );
-
-  const toolbarContextValue = useMemo(
-    () => ({
-      searchQuery,
-      setSearchQuery,
-      openFilterDrawer: () => setFilterDrawerOpen(true),
-      hasActiveDrawerFilters: hasActiveSourceFilters(drawerFilters),
-      activeFilterCount: countActiveSourceFilters(drawerFilters),
-      checkboxSelectionMode,
-      setCheckboxSelectionMode,
-    }),
-    [
-      searchQuery,
-      drawerFilters,
-      checkboxSelectionMode,
-      setCheckboxSelectionMode,
-    ]
-  );
-
-  // Column definitions
-  const columns: GridColDef[] = React.useMemo(() => {
-    const actionsCol = createRowActionsColumn({
-      onEdit: id => router.push(`/knowledge/${id}`),
-      onDelete: id => requestDelete(id),
-      canEdit: () => canEditSource,
-      canDelete: () => canDeleteSource,
-    });
-    return [
+  const columns: GridColDef[] = useMemo(
+    () => [
       {
         field: 'title',
         headerName: 'Title',
@@ -415,7 +255,7 @@ export default function SourcesGrid({
                 overflow: 'hidden',
               }}
             >
-              {source.tags.slice(0, 2).map((tag, _index) => (
+              {source.tags.slice(0, 2).map(tag => (
                 <Chip
                   key={tag.id}
                   label={tag.name}
@@ -435,30 +275,15 @@ export default function SourcesGrid({
           );
         },
       },
-      actionsCol,
-    ];
-  }, [router, requestDelete]);
-
-  if (error) {
-    return (
-      <Box className={styles.errorContainer}>
-        <Typography color="error" variant="h6" gutterBottom>
-          Error Loading Sources
-        </Typography>
-        <Typography color="text.secondary" paragraph>
-          {error}
-        </Typography>
-      </Box>
-    );
-  }
-
-  const filtersActive = !!searchQuery || hasActiveSourceFilters(drawerFilters);
+    ],
+    []
+  );
 
   return (
-    <GridStateGate
-      data={loading ? null : {}}
-      error={error}
-      isEmpty={totalCount === 0 && !filtersActive}
+    <EntityGrid<Source, typeof sourcesList.filters, SourceFilters>
+      descriptor={sourcesList}
+      columns={columns}
+      toFilters={toFilters}
       emptyState={
         <EntityEmptyState
           card
@@ -469,58 +294,15 @@ export default function SourcesGrid({
           onAction={canCreate ? onCreateClick : undefined}
         />
       }
-    >
-      <Paper sx={GRID_PAPER_SX}>
-        <SourcesToolbarContext.Provider value={toolbarContextValue}>
-          <BaseDataGrid
-            columns={columns}
-            rows={sources}
-            loading={loading}
-            getRowId={row => row.id}
-            showToolbar={true}
-            paginationModel={paginationModel}
-            onPaginationModelChange={handlePaginationModelChange}
-            sortModel={sortModel}
-            onSortModelChange={handleSortModelChange}
-            serverSidePagination={true}
-            sortingMode="server"
-            totalRows={totalCount}
-            pageSizeOptions={[10, 25, 50]}
-            disablePaperWrapper={true}
-            onRowClick={checkboxSelectionMode ? undefined : handleRowClick}
-            toolbarSlot={SourcesUnifiedToolbar}
-            persistState
-            sx={rowActionsHoverSx}
-            checkboxSelection={checkboxSelectionMode}
-            disableRowSelectionOnClick={checkboxSelectionMode || undefined}
-            rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
-            onRowSelectionModelChange={
-              checkboxSelectionMode ? handleSelectionChange : undefined
-            }
-          />
-
-          <DeleteModal
-            open={deleteModalOpen}
-            onClose={cancelDelete}
-            onConfirm={confirmDelete}
-            isLoading={isDeleting}
-            title={pendingDeleteId ? 'Delete Source' : 'Delete Sources'}
-            message={
-              pendingDeleteId
-                ? 'Are you sure you want to delete this source? This action cannot be undone.'
-                : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'source' : 'sources'}? This action cannot be undone.`
-            }
-            itemType="sources"
-          />
-
-          <SourceFilterDrawer
-            open={filterDrawerOpen}
-            onClose={() => setFilterDrawerOpen(false)}
-            filters={drawerFilters}
-            onApply={f => setDrawerFilters(f)}
-          />
-        </SourcesToolbarContext.Provider>
-      </Paper>
-    </GridStateGate>
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+      refreshTrigger={refreshTrigger}
+      searchPlaceholder="Search sources…"
+      drawer={drawerAdapter}
+      selectionLabel="Select sources"
+      getRowUrl={getRowUrl}
+      onBulkActionsChange={onBulkActionsChange}
+      pageSizeOptions={[10, 25, 50]}
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/knowledge/components/list.ts
+++ b/apps/frontend/src/app/(protected)/knowledge/components/list.ts
@@ -35,4 +35,12 @@ export const sourcesList = defineList({
   filters: SOURCES_FILTERS,
   list: (factory: ApiClientFactory, params) =>
     factory.getSourcesClient().getSources(params),
+  delete: {
+    bulk: (factory: ApiClientFactory, ids: string[]) =>
+      factory.getSourcesClient().bulkDeleteSources(ids),
+    capability: Capability.Source.DELETE,
+    capabilityMode: 'ambient',
+    labelSingular: 'source',
+    labelPlural: 'sources',
+  },
 });

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningTab.tsx
@@ -1046,7 +1046,6 @@ export default function MetricTuningTab({
               paginationModel={paginationModel}
               onPaginationModelChange={setPaginationModel}
               pageSizeOptions={[10, 25, 50, 100]}
-              showToolbar={false}
               disableMultipleRowSelection
               sx={rowActionsHoverSx}
             />

--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
@@ -1,46 +1,21 @@
 'use client';
 
 import * as React from 'react';
-import { useState, useEffect, useRef, useCallback } from 'react';
-import {
-  Alert,
-  Avatar,
-  Box,
-  CircularProgress,
-  IconButton,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Tooltip,
-  Typography,
-} from '@mui/material';
-import type { SxProps, Theme } from '@mui/material/styles';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Avatar, Box, Typography } from '@mui/material';
+import type { GridColDef, GridRowParams } from '@mui/x-data-grid';
 import PersonIcon from '@mui/icons-material/Person';
-import GridToolbar, {
-  linkedGridToolbarSx,
-  sectionCardGridTableEdgeCellResetSx,
-  sectionCardGridTableInsetSx,
-} from '@/components/common/GridToolbar';
-import { ROW_ACTIONS_CLASS } from '@/components/common/createRowActionsColumn';
-import {
-  SectionOverviewHeaderCell,
-  SectionOverviewPagination,
-  sectionOverviewBodyCellSx,
-  sectionOverviewRowActionIconButtonSx,
-  sectionOverviewTableSx,
-} from '@/components/common/SectionOverviewTable';
+import EntityGrid, {
+  type EntityGridDrawerAdapter,
+  type EntityGridFilterState,
+} from '@/components/common/EntityGrid';
 import { DeleteIcon } from '@/components/icons';
 import { useSession } from 'next-auth/react';
 import { User } from '@/utils/api-client/interfaces/user';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { DeleteModal } from '@/components/common/DeleteModal';
-import { useList } from '@/hooks/useList';
 import {
   EMPTY_TEAM_FILTERS,
-  hasActiveTeamFilters,
   countActiveTeamFilters,
   teamList,
   type TeamFilters,
@@ -69,6 +44,32 @@ function getDisplayName(user: User): string {
   return user.email;
 }
 
+function toFilters(state: EntityGridFilterState<TeamFilters>) {
+  return {
+    search: state.search,
+    email: state.drawer.email,
+    name: state.drawer.name,
+    memberStatus: state.drawer.memberStatus,
+    accountStatus:
+      state.drawer.accountStatus === null
+        ? ''
+        : String(state.drawer.accountStatus),
+  };
+}
+
+const drawerAdapter: EntityGridDrawerAdapter<TeamFilters> = {
+  empty: EMPTY_TEAM_FILTERS,
+  countActive: countActiveTeamFilters,
+  render: props => (
+    <TeamFilterDrawer
+      open={props.open}
+      onClose={props.onClose}
+      filters={props.filters}
+      onApply={props.onApply}
+    />
+  ),
+};
+
 export default function TeamMembersGrid({
   refreshTrigger,
   onTotalCountChange,
@@ -77,108 +78,19 @@ export default function TeamMembersGrid({
   const canDeleteMember = useCan(Capability.Member.DELETE);
   const canManageMembers = useCan(Capability.Member.MANAGE);
   const notifications = useNotifications();
-  const [error, setError] = useState<string | null>(null);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [drawerFilters, setDrawerFilters] =
-    useState<TeamFilters>(EMPTY_TEAM_FILTERS);
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
   const [userToDelete, setUserToDelete] = useState<User | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [accessDrawerOpen, setAccessDrawerOpen] = useState(false);
   const [accessDrawerUser, setAccessDrawerUser] = useState<User | null>(null);
 
-  const filters = React.useMemo(
-    () => ({
-      search: searchQuery,
-      email: drawerFilters.email,
-      name: drawerFilters.name,
-      memberStatus: drawerFilters.memberStatus,
-      accountStatus:
-        drawerFilters.accountStatus === null
-          ? ''
-          : String(drawerFilters.accountStatus),
-    }),
-    [searchQuery, drawerFilters]
-  );
-
-  const {
-    data: users,
-    totalCount,
-    isLoading: loading,
-    page,
-    rowsPerPage: pageSize,
-    onPageChange: setPage,
-    onRowsPerPageChange,
-    refresh,
-  } = useList(teamList, {
-    filters,
-    onError: () => setError('Failed to load team members. Please try again.'),
-  });
-
-  useEffect(() => {
-    onTotalCountChange?.(totalCount);
-  }, [totalCount, onTotalCountChange]);
-
-  const isFirstRefreshTrigger = useRef(true);
-  useEffect(() => {
-    if (isFirstRefreshTrigger.current) {
-      isFirstRefreshTrigger.current = false;
-      return;
-    }
-    refresh();
-    // Only refreshTrigger (bumped by the parent after an invite) should re-run this.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshTrigger]);
-
-  const handleDeleteUser = useCallback((user: User) => {
-    setUserToDelete(user);
-    setDeleteDialogOpen(true);
+  const onTotalCountChangeRef = React.useRef(onTotalCountChange);
+  onTotalCountChangeRef.current = onTotalCountChange;
+  const handleDataChange = useCallback((_data: User[], totalCount: number) => {
+    onTotalCountChangeRef.current?.(totalCount);
   }, []);
 
   const deleteUser = useDeleteUser();
-
-  const handleConfirmDelete = async () => {
-    if (!userToDelete || !isAuthenticated(status)) {
-      return;
-    }
-
-    try {
-      setDeleting(true);
-
-      await deleteUser(userToDelete.id);
-
-      notifications.show(
-        `Successfully removed ${getDisplayName(userToDelete)} from the organization.`,
-        { severity: 'success' }
-      );
-
-      refresh();
-    } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error
-          ? error.message
-          : 'Failed to remove user from organization. Please try again.';
-
-      notifications.show(errorMessage, {
-        severity: 'error',
-      });
-    } finally {
-      setDeleting(false);
-      setDeleteDialogOpen(false);
-      setUserToDelete(null);
-    }
-  };
-
-  const handleCancelDelete = () => {
-    setDeleteDialogOpen(false);
-    setUserToDelete(null);
-  };
-
-  const handleRowClick = useCallback((user: User) => {
-    setAccessDrawerUser(user);
-    setAccessDrawerOpen(true);
-  }, []);
 
   const rbacEnabled = useFeature(FeatureName.RBAC);
   const { OrgRoleCell: RawOrgRoleCell, prewarmCaches } =
@@ -191,248 +103,201 @@ export default function TeamMembersGrid({
     }
   }, [rbacEnabled, prewarmCaches, canManageMembers, status]);
 
-  const showRoleColumn = Boolean(OrgRoleCell);
   const currentUserId = session?.user?.id;
 
+  const makeConfirmDelete = useCallback(
+    (refresh: () => void) => async () => {
+      if (!userToDelete || !isAuthenticated(status)) {
+        return;
+      }
+
+      try {
+        setDeleting(true);
+
+        await deleteUser(userToDelete.id);
+
+        notifications.show(
+          `Successfully removed ${getDisplayName(userToDelete)} from the organization.`,
+          { severity: 'success' }
+        );
+
+        refresh();
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : 'Failed to remove user from organization. Please try again.';
+
+        notifications.show(errorMessage, {
+          severity: 'error',
+        });
+      } finally {
+        setDeleting(false);
+        setUserToDelete(null);
+      }
+    },
+    [userToDelete, status, deleteUser, notifications]
+  );
+
+  const handleCancelDelete = useCallback(() => setUserToDelete(null), []);
+
+  const handleRowClick = useCallback((params: GridRowParams) => {
+    setAccessDrawerUser(params.row as User);
+    setAccessDrawerOpen(true);
+  }, []);
+
+  // Removal is org-specific ("remove from organization", name in the confirm
+  // text, self-removal blocked), so it stays a grid-local extra action rather
+  // than a descriptor delete spec.
+  const extraRowActions = useMemo(
+    () => [
+      {
+        key: 'remove',
+        icon: DeleteIcon,
+        tooltip: 'Remove from organization',
+        onClick: (_id: string, row: Record<string, unknown>) =>
+          setUserToDelete(row as unknown as User),
+        can: (row: Record<string, unknown>) =>
+          canDeleteMember && String(row.id) !== currentUserId,
+        hoverColor: 'error.main' as const,
+      },
+    ],
+    [canDeleteMember, currentUserId]
+  );
+
+  const columns: GridColDef[] = useMemo(() => {
+    const cols: GridColDef[] = [
+      {
+        field: 'name',
+        headerName: 'Name',
+        flex: 1.2,
+        minWidth: 180,
+        sortable: false,
+        valueGetter: (_, row) => getDisplayName(row as User),
+        renderCell: params => {
+          const user = params.row as User;
+          const memberStatus = getMemberJoinStatus(user);
+          return (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.5,
+                minWidth: 0,
+              }}
+            >
+              <Avatar
+                src={user.picture || undefined}
+                sx={{
+                  width: 32,
+                  height: 32,
+                  flexShrink: 0,
+                  bgcolor:
+                    memberStatus === 'active' ? 'primary.main' : 'grey.400',
+                }}
+              >
+                {user.picture ? null : <PersonIcon fontSize="small" />}
+              </Avatar>
+              <Typography
+                variant="body2"
+                sx={{
+                  fontWeight: 500,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {params.value}
+              </Typography>
+            </Box>
+          );
+        },
+      },
+      {
+        field: 'email',
+        headerName: 'Email',
+        flex: 1.2,
+        minWidth: 200,
+        sortable: false,
+        renderCell: params => (
+          <Typography variant="body2" color="text.secondary">
+            {params.value}
+          </Typography>
+        ),
+      },
+    ];
+
+    if (OrgRoleCell) {
+      cols.push({
+        field: 'orgRole',
+        headerName: 'Role',
+        width: 150,
+        sortable: false,
+        renderCell: params => (
+          <Box
+            onClick={e => e.stopPropagation()}
+            onMouseDown={e => e.stopPropagation()}
+            sx={{ width: '100%' }}
+          >
+            <OrgRoleCell userId={String(params.id)} />
+          </Box>
+        ),
+      });
+    }
+
+    cols.push({
+      field: 'status',
+      headerName: 'Status',
+      width: 120,
+      sortable: false,
+      valueGetter: (_, row) =>
+        getMemberJoinStatus(row as User) === 'active' ? 'Active' : 'Invited',
+    });
+
+    return cols;
+  }, [OrgRoleCell]);
+
   return (
-    <>
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
+    <EntityGrid<User, typeof teamList.filters, TeamFilters>
+      descriptor={teamList}
+      columns={columns}
+      toFilters={toFilters}
+      emptyState={null}
+      embedded
+      refreshTrigger={refreshTrigger}
+      onDataChange={handleDataChange}
+      searchPlaceholder="Search team members…"
+      drawer={drawerAdapter}
+      onRowClick={handleRowClick}
+      editAction={false}
+      extraRowActions={extraRowActions}
+      rowActionsWidth={56}
+      showGridButtons={false}
+      persistState={false}
+      serverSort={false}
+      pageSizeOptions={[10, 25, 50]}
+      sx={{ '& .MuiDataGrid-row': { cursor: 'pointer' } }}
+      renderSelectionExtras={ctx => (
+        <>
+          <MemberAccessDrawer
+            open={accessDrawerOpen}
+            onClose={() => setAccessDrawerOpen(false)}
+            user={accessDrawerUser}
+          />
+          <DeleteModal
+            open={userToDelete !== null}
+            onClose={handleCancelDelete}
+            onConfirm={makeConfirmDelete(ctx.refresh)}
+            isLoading={deleting}
+            title="Remove from Organization"
+            message={`Are you sure you want to remove ${userToDelete ? getDisplayName(userToDelete) : ''} from the organization?\n\nThey will lose access to all organization resources but can be re-invited in the future. Their contributions to projects and tests will remain intact.`}
+            itemType="user"
+            confirmButtonText={
+              deleting ? 'Removing...' : 'Remove from Organization'
+            }
+          />
+        </>
       )}
-
-      <GridToolbar
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
-        searchPlaceholder="Search team members…"
-        onFilterClick={() => setFilterDrawerOpen(true)}
-        hasActiveFilters={hasActiveTeamFilters(drawerFilters)}
-        activeFilterCount={countActiveTeamFilters(drawerFilters)}
-        sx={linkedGridToolbarSx}
-      />
-
-      <TableContainer
-        sx={
-          [
-            sectionOverviewTableSx,
-            sectionCardGridTableInsetSx,
-            sectionCardGridTableEdgeCellResetSx,
-          ] as SxProps<Theme>
-        }
-      >
-        <Table>
-          <TableHead>
-            <TableRow>
-              <SectionOverviewHeaderCell>Name</SectionOverviewHeaderCell>
-              <SectionOverviewHeaderCell showDivider>
-                Email
-              </SectionOverviewHeaderCell>
-              {showRoleColumn && (
-                <SectionOverviewHeaderCell showDivider width={150}>
-                  Role
-                </SectionOverviewHeaderCell>
-              )}
-              <SectionOverviewHeaderCell showDivider width={120}>
-                Status
-              </SectionOverviewHeaderCell>
-              {canDeleteMember && (
-                <SectionOverviewHeaderCell showDivider width={56} />
-              )}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {loading ? (
-              <TableRow>
-                <TableCell
-                  colSpan={
-                    showRoleColumn
-                      ? canDeleteMember
-                        ? 5
-                        : 4
-                      : canDeleteMember
-                        ? 4
-                        : 3
-                  }
-                  sx={{ ...sectionOverviewBodyCellSx, borderTop: 'none' }}
-                >
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      justifyContent: 'center',
-                      py: 4,
-                    }}
-                  >
-                    <CircularProgress size={24} />
-                  </Box>
-                </TableCell>
-              </TableRow>
-            ) : users.length === 0 ? (
-              <TableRow>
-                <TableCell
-                  colSpan={
-                    showRoleColumn
-                      ? canDeleteMember
-                        ? 5
-                        : 4
-                      : canDeleteMember
-                        ? 4
-                        : 3
-                  }
-                  sx={{ ...sectionOverviewBodyCellSx, borderTop: 'none' }}
-                >
-                  <Typography variant="body2" color="text.secondary">
-                    No team members match your search.
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            ) : (
-              users.map(user => {
-                const status = getMemberJoinStatus(user);
-                const displayName = getDisplayName(user);
-
-                return (
-                  <TableRow
-                    key={user.id}
-                    hover
-                    onClick={() => handleRowClick(user)}
-                    sx={{ height: 48, cursor: 'pointer' }}
-                  >
-                    <TableCell sx={sectionOverviewBodyCellSx}>
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 1.5,
-                          minWidth: 0,
-                        }}
-                      >
-                        <Avatar
-                          src={user.picture || undefined}
-                          sx={{
-                            width: 32,
-                            height: 32,
-                            flexShrink: 0,
-                            bgcolor:
-                              status === 'active' ? 'primary.main' : 'grey.400',
-                          }}
-                        >
-                          {user.picture ? null : (
-                            <PersonIcon fontSize="small" />
-                          )}
-                        </Avatar>
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            fontWeight: 500,
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                          }}
-                        >
-                          {displayName}
-                        </Typography>
-                      </Box>
-                    </TableCell>
-                    <TableCell sx={sectionOverviewBodyCellSx}>
-                      <Typography variant="body2" color="text.secondary">
-                        {user.email}
-                      </Typography>
-                    </TableCell>
-                    {showRoleColumn && OrgRoleCell && (
-                      <TableCell
-                        sx={sectionOverviewBodyCellSx}
-                        data-field="orgRole"
-                        onClick={e => e.stopPropagation()}
-                        onMouseDown={e => e.stopPropagation()}
-                      >
-                        <OrgRoleCell userId={user.id} />
-                      </TableCell>
-                    )}
-                    <TableCell sx={sectionOverviewBodyCellSx}>
-                      {status === 'active' ? 'Active' : 'Invited'}
-                    </TableCell>
-                    {canDeleteMember && (
-                      <TableCell
-                        align="right"
-                        sx={{ ...sectionOverviewBodyCellSx, width: 56 }}
-                      >
-                        {user.id !== currentUserId && (
-                          <Box
-                            className={ROW_ACTIONS_CLASS}
-                            sx={{
-                              display: 'flex',
-                              justifyContent: 'flex-end',
-                              width: '100%',
-                            }}
-                          >
-                            <Tooltip title="Remove from organization">
-                              <IconButton
-                                size="small"
-                                aria-label="Remove from organization"
-                                onClick={e => {
-                                  e.stopPropagation();
-                                  handleDeleteUser(user);
-                                }}
-                                sx={{
-                                  ...sectionOverviewRowActionIconButtonSx,
-                                  '&:hover': {
-                                    color: 'error.main',
-                                    bgcolor: 'action.hover',
-                                  },
-                                }}
-                              >
-                                <DeleteIcon sx={{ fontSize: 18 }} />
-                              </IconButton>
-                            </Tooltip>
-                          </Box>
-                        )}
-                      </TableCell>
-                    )}
-                  </TableRow>
-                );
-              })
-            )}
-          </TableBody>
-        </Table>
-      </TableContainer>
-
-      <SectionOverviewPagination
-        page={page}
-        pageSize={pageSize}
-        totalRows={totalCount}
-        onPageChange={setPage}
-        onPageSizeChange={onRowsPerPageChange}
-      />
-
-      <TeamFilterDrawer
-        open={filterDrawerOpen}
-        onClose={() => setFilterDrawerOpen(false)}
-        filters={drawerFilters}
-        onApply={f => {
-          setDrawerFilters(f);
-          setFilterDrawerOpen(false);
-        }}
-      />
-
-      <MemberAccessDrawer
-        open={accessDrawerOpen}
-        onClose={() => setAccessDrawerOpen(false)}
-        user={accessDrawerUser}
-      />
-
-      <DeleteModal
-        open={deleteDialogOpen}
-        onClose={handleCancelDelete}
-        onConfirm={handleConfirmDelete}
-        isLoading={deleting}
-        title="Remove from Organization"
-        message={`Are you sure you want to remove ${userToDelete ? getDisplayName(userToDelete) : ''} from the organization?\n\nThey will lose access to all organization resources but can be re-invited in the future. Their contributions to projects and tests will remain intact.`}
-        itemType="user"
-        confirmButtonText={
-          deleting ? 'Removing...' : 'Remove from Organization'
-        }
-      />
-    </>
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectEnvironments.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectEnvironments.tsx
@@ -493,7 +493,6 @@ export default forwardRef<ProjectEnvironmentsHandle, ProjectEnvironmentsProps>(
               getRowId={row => row.name}
               loading={loading}
               toolbarSlot={EnvironmentsToolbar}
-              showToolbar
               disablePaperWrapper
               pageSizeOptions={[10, 25, 50]}
               initialState={{

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectTraceMetrics.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectTraceMetrics.tsx
@@ -386,7 +386,6 @@ export default forwardRef<ProjectTraceMetricsHandle, ProjectTraceMetricsProps>(
                 getRowId={row => row.id}
                 loading={loading}
                 toolbarSlot={TraceMetricsToolbar}
-                showToolbar
                 disablePaperWrapper
                 pageSizeOptions={[10, 25, 50]}
                 initialState={{

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -1,56 +1,27 @@
 'use client';
 
-import React, {
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react';
-import {
-  GridColDef,
-  GridRowParams,
-  GridToolbarColumnsButton,
-  GridToolbarDensitySelector,
-  GridToolbarExport,
-} from '@mui/x-data-grid';
-import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
-import { useRouter } from 'next/navigation';
+import React, { useCallback, useMemo } from 'react';
+import { GridColDef } from '@mui/x-data-grid';
+import { Typography, Box, Avatar } from '@mui/material';
+import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined';
+import EntityGrid, {
+  type EntityGridDrawerAdapter,
+  type EntityGridFilterState,
+} from '@/components/common/EntityGrid';
+import GridBadge from '@/components/common/GridBadge';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { Task } from '@/utils/api-client/interfaces/task';
 import { can } from '@/utils/affordances';
 import { Capability } from '@/constants/capabilities';
-import { Typography, Box, Alert, Avatar, Paper } from '@mui/material';
-import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined';
-import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
-import SelectionModeToggle from '@/components/common/SelectionModeToggle';
-import GridBadge from '@/components/common/GridBadge';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { useList } from '@/hooks/useList';
-import { tasksList } from './list';
+import { NotificationSection } from '@/constants/notifications';
 import { AVATAR_SIZES } from '@/constants/avatar-sizes';
+import type { BulkDeleteActionsState } from '@/hooks/useBulkDelete';
+import { tasksList } from './list';
 import TaskFilterDrawer, {
   type TaskFilters,
   EMPTY_TASK_FILTERS,
-  hasActiveTaskFilters,
   countActiveTaskFilters,
 } from './TaskFilterDrawer';
-import {
-  createRowActionsColumn,
-  rowActionsHoverSx,
-} from '@/components/common/createRowActionsColumn';
-import { DeleteModal } from '@/components/common/DeleteModal';
-import { useNotifications as useJobNotifications } from '@/contexts/NotificationsContext';
-import {
-  HIGHLIGHTED_ROW_CLASS,
-  NotificationSection,
-} from '@/constants/notifications';
-import {
-  useBulkDelete,
-  type BulkDeleteActionsState,
-} from '@/hooks/useBulkDelete';
-import GridStateGate from '@/components/common/GridStateGate';
-import EntityEmptyState from '@/components/common/EntityEmptyState';
 
 interface TasksGridProps {
   canCreate?: boolean;
@@ -69,75 +40,35 @@ const STATUS_PILL_TABS = [
   { label: 'In Progress', value: 'In Progress' },
   { label: 'Completed', value: 'Completed' },
   { label: 'Cancelled', value: 'Cancelled' },
-] as const;
+];
 
-interface TasksToolbarState {
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-  statusFilter: string;
-  setStatusFilter: (v: string) => void;
-  openFilterDrawer: () => void;
-  hasActiveDrawerFilters: boolean;
-  activeFilterCount: number;
-  checkboxSelectionMode: boolean;
-  setCheckboxSelectionMode: (v: boolean) => void;
+// A pill click wins over the drawer's own status value (the pill is applied
+// after drawer filters).
+function toFilters(state: EntityGridFilterState<TaskFilters>) {
+  return {
+    search: state.search,
+    status: state.pill || state.drawer.status,
+    priority: state.drawer.priority,
+    assignee: state.drawer.assignee,
+  };
 }
 
-const TasksToolbarContext = React.createContext<TasksToolbarState>({
-  searchQuery: '',
-  setSearchQuery: () => {},
-  statusFilter: 'all',
-  setStatusFilter: () => {},
-  openFilterDrawer: () => {},
-  hasActiveDrawerFilters: false,
-  activeFilterCount: 0,
-  checkboxSelectionMode: false,
-  setCheckboxSelectionMode: () => {},
-});
-
-function TasksUnifiedToolbar() {
-  const {
-    searchQuery,
-    setSearchQuery,
-    statusFilter,
-    setStatusFilter,
-    openFilterDrawer,
-    hasActiveDrawerFilters,
-    activeFilterCount,
-    checkboxSelectionMode,
-    setCheckboxSelectionMode,
-  } = useContext(TasksToolbarContext);
-
-  return (
-    <GridToolbar
-      searchQuery={searchQuery}
-      onSearchChange={setSearchQuery}
-      searchPlaceholder="Search tasks…"
-      onFilterClick={openFilterDrawer}
-      hasActiveFilters={hasActiveDrawerFilters}
-      activeFilterCount={activeFilterCount}
-      middleContent={
-        <ToolbarPillTabs
-          tabs={[...STATUS_PILL_TABS]}
-          activeValue={statusFilter}
-          onChange={setStatusFilter}
-        />
-      }
-      rightContent={
-        <>
-          <SelectionModeToggle
-            checked={checkboxSelectionMode}
-            onChange={setCheckboxSelectionMode}
-            label="Select tasks"
-          />
-          <GridToolbarColumnsButton />
-          <GridToolbarDensitySelector />
-          <GridToolbarExport />
-        </>
-      }
+const drawerAdapter: EntityGridDrawerAdapter<TaskFilters> = {
+  empty: EMPTY_TASK_FILTERS,
+  countActive: countActiveTaskFilters,
+  render: props => (
+    <TaskFilterDrawer
+      open={props.open}
+      onClose={props.onClose}
+      filters={props.filters}
+      onApply={props.onApply}
     />
-  );
-}
+  ),
+  // Applying a status in the drawer syncs the pill; clearing it resets the
+  // pill only when no drawer status was active before.
+  pillFromApply: (applied, previous) =>
+    applied.status ? applied.status : !previous.status ? '' : undefined,
+};
 
 export default function TasksGrid({
   canCreate,
@@ -147,107 +78,10 @@ export default function TasksGrid({
   initialData,
   initialTotalCount,
 }: TasksGridProps) {
-  const router = useRouter();
-  const { highlightedIds, clearHighlight } = useJobNotifications();
+  const getRowUrl = useCallback((row: Task) => `/tasks/${row.id}`, []);
 
-  const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState('all');
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [drawerFilters, setDrawerFilters] =
-    useState<TaskFilters>(EMPTY_TASK_FILTERS);
-  const [errorDismissed, setErrorDismissed] = useState(false);
-
-  // A pill click wins over the drawer's own status value (the pill is
-  // applied after drawer filters).
-  const effectiveStatus =
-    statusFilter !== 'all' ? statusFilter : drawerFilters.status;
-
-  const filters = useMemo(
-    () => ({
-      search: searchQuery,
-      status: effectiveStatus,
-      priority: drawerFilters.priority,
-      assignee: drawerFilters.assignee,
-    }),
-    [
-      searchQuery,
-      effectiveStatus,
-      drawerFilters.priority,
-      drawerFilters.assignee,
-    ]
-  );
-
-  const {
-    data: tasks,
-    totalCount,
-    isLoading: loading,
-    error: rawError,
-    refresh,
-    paginationModel,
-    onPaginationModelChange: handlePaginationModelChange,
-  } = useList(tasksList, {
-    filters,
-    initialData,
-    initialTotalCount,
-    onError: () => setErrorDismissed(false),
-  });
-
-  useEffect(() => {
-    setErrorDismissed(false);
-  }, [rawError]);
-
-  const error = rawError && !errorDismissed ? rawError : null;
-  const dismissError = useCallback(() => setErrorDismissed(true), []);
-
-  const {
-    checkboxSelectionMode,
-    setCheckboxSelectionMode,
-    selectedRows,
-    handleSelectionChange,
-    pendingDeleteId,
-    deleteModalOpen,
-    isDeleting,
-    requestDelete,
-    confirmDelete,
-    cancelDelete,
-  } = useBulkDelete({
-    bulkDeleteFn: (ids: string[]) =>
-      new ApiClientFactory().getTasksClient().bulkDeleteTasks(ids),
-    onSuccess: refresh,
-    itemLabelSingular: 'task',
-    itemLabelPlural: 'tasks',
-    getSkippedCount: response => response.forbidden_ids.length,
-    skippedReason: 'not yours to delete',
-    onBulkActionsChange,
-  });
-
-  const isFirstRefreshTrigger = useRef(true);
-  useEffect(() => {
-    if (isFirstRefreshTrigger.current) {
-      isFirstRefreshTrigger.current = false;
-      return;
-    }
-    refresh();
-    // Only refreshTrigger (bumped by the page after a create) should re-run this.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshTrigger]);
-
-  const handleRowClick = useCallback(
-    (params: GridRowParams) => {
-      clearHighlight(NotificationSection.TASKS, String(params.id));
-      router.push(`/tasks/${params.id}`);
-    },
-    [router, clearHighlight]
-  );
-
-  const columns: GridColDef[] = useMemo(() => {
-    const actionsCol = createRowActionsColumn({
-      onEdit: id => router.push(`/tasks/${id}`),
-      canEdit: row => can(row as unknown as Task, Capability.Task.UPDATE),
-      onDelete: id => requestDelete(id),
-      canDelete: row => can(row as unknown as Task, Capability.Task.DELETE),
-    });
-    return [
+  const columns: GridColDef[] = useMemo(
+    () => [
       {
         field: 'title',
         headerName: 'Title',
@@ -286,6 +120,7 @@ export default function TasksGrid({
         width: 120,
         minWidth: 90,
         resizable: true,
+        sortable: false,
         renderCell: params => (
           <GridBadge label={params.row.status?.name || 'Unknown'} />
         ),
@@ -296,6 +131,7 @@ export default function TasksGrid({
         width: 150,
         minWidth: 120,
         resizable: true,
+        sortable: false,
         renderCell: params => {
           if (!params.row.assignee?.name) {
             return null;
@@ -321,17 +157,15 @@ export default function TasksGrid({
           );
         },
       },
-      actionsCol,
-    ];
-  }, [router, requestDelete]);
-
-  const filtersActive = !!searchQuery || hasActiveTaskFilters(drawerFilters);
+    ],
+    []
+  );
 
   return (
-    <GridStateGate
-      data={loading ? null : {}}
-      error={error}
-      isEmpty={totalCount === 0 && !filtersActive}
+    <EntityGrid<Task, typeof tasksList.filters, TaskFilters>
+      descriptor={tasksList}
+      columns={columns}
+      toFilters={toFilters}
       emptyState={
         <EntityEmptyState
           icon={AssignmentOutlinedIcon}
@@ -341,98 +175,19 @@ export default function TasksGrid({
           onAction={canCreate ? onCreateClick : undefined}
         />
       }
-    >
-      <Paper sx={GRID_PAPER_SX}>
-        <TasksToolbarContext.Provider
-          value={{
-            searchQuery,
-            setSearchQuery,
-            statusFilter,
-            setStatusFilter,
-            openFilterDrawer: () => setFilterDrawerOpen(true),
-            hasActiveDrawerFilters: hasActiveTaskFilters(drawerFilters),
-            activeFilterCount: countActiveTaskFilters(drawerFilters),
-            checkboxSelectionMode,
-            setCheckboxSelectionMode,
-          }}
-        >
-          <Box sx={{ position: 'relative' }}>
-            {error && (
-              <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
-                {error}
-              </Alert>
-            )}
-
-            <BaseDataGrid
-              rows={tasks}
-              columns={columns}
-              loading={loading}
-              getRowId={row => row.id}
-              paginationModel={paginationModel}
-              onPaginationModelChange={handlePaginationModelChange}
-              disableRowSelectionOnClick={checkboxSelectionMode || undefined}
-              onRowClick={checkboxSelectionMode ? undefined : handleRowClick}
-              getRowClassName={params =>
-                highlightedIds(NotificationSection.TASKS).includes(
-                  String(params.id)
-                )
-                  ? HIGHLIGHTED_ROW_CLASS
-                  : ''
-              }
-              serverSidePagination={true}
-              totalRows={totalCount}
-              pageSizeOptions={[10, 25, 50, 100]}
-              serverSideFiltering={true}
-              showToolbar={true}
-              toolbarSlot={TasksUnifiedToolbar}
-              disablePaperWrapper={true}
-              persistState
-              sx={{
-                ...rowActionsHoverSx,
-                '& .MuiDataGrid-row': {
-                  cursor: 'pointer',
-                },
-              }}
-              checkboxSelection={checkboxSelectionMode}
-              isRowSelectable={(params: GridRowParams) =>
-                can(params.row as unknown as Task, Capability.Task.DELETE)
-              }
-              rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
-              onRowSelectionModelChange={
-                checkboxSelectionMode ? handleSelectionChange : undefined
-              }
-            />
-
-            <DeleteModal
-              open={deleteModalOpen}
-              onClose={cancelDelete}
-              onConfirm={confirmDelete}
-              isLoading={isDeleting}
-              title={pendingDeleteId ? 'Delete Task' : 'Delete Tasks'}
-              message={
-                pendingDeleteId
-                  ? 'Are you sure you want to delete this task? This action cannot be undone.'
-                  : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'task' : 'tasks'}? This action cannot be undone.`
-              }
-              itemType="tasks"
-            />
-
-            <TaskFilterDrawer
-              open={filterDrawerOpen}
-              onClose={() => setFilterDrawerOpen(false)}
-              filters={drawerFilters}
-              onApply={f => {
-                setDrawerFilters(f);
-                if (f.status) {
-                  setStatusFilter(f.status);
-                } else if (!drawerFilters.status) {
-                  setStatusFilter('all');
-                }
-              }}
-            />
-          </Box>
-        </TasksToolbarContext.Provider>
-      </Paper>
-    </GridStateGate>
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+      refreshTrigger={refreshTrigger}
+      searchPlaceholder="Search tasks…"
+      pills={{ tabs: STATUS_PILL_TABS }}
+      drawer={drawerAdapter}
+      selectionLabel="Select tasks"
+      getRowUrl={getRowUrl}
+      highlightSection={NotificationSection.TASKS}
+      editAction={{ can: (row: Task) => can(row, Capability.Task.UPDATE) }}
+      onBulkActionsChange={onBulkActionsChange}
+      pageSizeOptions={[10, 25, 50, 100]}
+      sx={{ '& .MuiDataGrid-row': { cursor: 'pointer' } }}
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/tasks/components/list.ts
+++ b/apps/frontend/src/app/(protected)/tasks/components/list.ts
@@ -22,4 +22,14 @@ export const tasksList = defineList({
   filters: TASKS_FILTERS,
   list: (factory: ApiClientFactory, params) =>
     factory.getTasksClient().getTasks(params),
+  delete: {
+    bulk: (factory: ApiClientFactory, ids: string[]) =>
+      factory.getTasksClient().bulkDeleteTasks(ids),
+    capability: Capability.Task.DELETE,
+    capabilityMode: 'row',
+    labelSingular: 'task',
+    labelPlural: 'tasks',
+    getSkippedCount: response => response.forbidden_ids.length,
+    skippedReason: 'not yours to delete',
+  },
 });

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsTableView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsTableView.tsx
@@ -699,7 +699,6 @@ export default function TestsTableView({
           openTestDrawer(params.row);
         }}
         disablePaperWrapper={embedded}
-        showToolbar={false}
         sx={{
           '& .test-row-actions': {
             opacity: 0,

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -1,42 +1,29 @@
 'use client';
 
-import React, {
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react';
-import {
-  useBulkDelete,
-  type BulkDeleteActionsState,
-} from '@/hooks/useBulkDelete';
-import ListIcon from '@mui/icons-material/List';
-import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
-import SelectionModeToggle from '@/components/common/SelectionModeToggle';
-import GridBadge from '@/components/common/GridBadge';
-import TagLabel from '@/components/common/Tag';
-import {
-  GridColDef,
-  GridRowParams,
-  GridToolbarColumnsButton,
-  GridToolbarDensitySelector,
-  GridToolbarExport,
-} from '@mui/x-data-grid';
-import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
-import { useRouter } from 'next/navigation';
+import React, { useState, useCallback, useMemo } from 'react';
+import { GridColDef } from '@mui/x-data-grid';
 import {
   Typography,
   Box,
-  Alert,
   Avatar,
   Chip,
   Button,
   ButtonGroup,
   Tooltip,
-  Paper,
 } from '@mui/material';
+import ListIcon from '@mui/icons-material/List';
+import PersonIcon from '@mui/icons-material/Person';
+import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
+import RateReviewOutlinedIcon from '@mui/icons-material/RateReviewOutlined';
+import EntityGrid, {
+  type EntityGridDrawerAdapter,
+  type EntityGridFilterState,
+} from '@/components/common/EntityGrid';
+import GridBadge from '@/components/common/GridBadge';
+import TagLabel from '@/components/common/Tag';
+import { DeleteModal } from '@/components/common/DeleteModal';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import {
   ChatIcon,
   DescriptionIcon,
@@ -45,36 +32,19 @@ import {
   PlayArrowIcon,
 } from '@/components/icons';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import PersonIcon from '@mui/icons-material/Person';
-import RateReviewOutlinedIcon from '@mui/icons-material/RateReviewOutlined';
 import { useNotifications } from '@/components/common/NotificationContext';
-// Renamed on import: distinct from the toast system's useNotifications above --
-// this one tracks the persistent unread badge and row highlight.
-import { useNotifications as useNotificationBadges } from '@/contexts/NotificationsContext';
-import {
-  HIGHLIGHTED_ROW_CLASS,
-  NotificationSection,
-} from '@/constants/notifications';
+import { NotificationSection } from '@/constants/notifications';
 import { TestRun, TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 import { can } from '@/utils/affordances';
 import { Capability } from '@/constants/capabilities';
 import { Tag } from '@/utils/api-client/interfaces/tag';
-import { DeleteModal } from '@/components/common/DeleteModal';
-import { useList } from '@/hooks/useList';
+import type { BulkDeleteActionsState } from '@/hooks/useBulkDelete';
 import { testRunsList } from './list';
 import TestRunFilterDrawer, {
   type TestRunFilters,
   EMPTY_TEST_RUN_FILTERS,
-  hasActiveTestRunFilters,
   countActiveTestRunFilters,
 } from './TestRunFilterDrawer';
-import {
-  createRowActionsColumn,
-  rowActionsHoverSx,
-} from '@/components/common/createRowActionsColumn';
-import GridStateGate from '@/components/common/GridStateGate';
-import EntityEmptyState from '@/components/common/EntityEmptyState';
-import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 
 type RunKindFilter = 'all' | 'tests' | 'experiments';
 
@@ -97,8 +67,6 @@ function formatReviewTooltip(reviewed: number, corrected: number): string {
   return reviewedLabel;
 }
 
-// ── Status pill tabs ─────────────────────────────────────────────────────────
-
 const STATUS_TABS = [
   { label: 'All', value: 'all' },
   { label: 'In Progress', value: 'Progress' },
@@ -107,79 +75,43 @@ const STATUS_TABS = [
   { label: 'Failed', value: 'Failed' },
 ];
 
-// ── Toolbar context ──────────────────────────────────────────────────────────
-
-interface TestRunsToolbarState {
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-  statusFilter: string;
-  setStatusFilter: (v: string) => void;
-  openFilterDrawer: () => void;
-  hasActiveDrawerFilters: boolean;
-  activeFilterCount: number;
-  checkboxSelectionMode: boolean;
-  setCheckboxSelectionMode: (v: boolean) => void;
+function toFilters(state: EntityGridFilterState<TestRunFilters>) {
+  return {
+    search: state.search,
+    status: state.pill,
+    testSet: state.drawer.testSet,
+    executor: state.drawer.executor,
+    tag: state.drawer.tag,
+    tagsPresence: state.drawer.tags,
+    commentsPresence: state.drawer.comments,
+    tasksPresence: state.drawer.tasks,
+    // Owned by the toolbar's run-kind toggle, merged in via externalFilters.
+    runKind: 'all',
+    reviews: state.drawer.reviews ?? 'all',
+  };
 }
 
-const TestRunsToolbarContext = React.createContext<TestRunsToolbarState>({
-  searchQuery: '',
-  setSearchQuery: () => {},
-  statusFilter: 'all',
-  setStatusFilter: () => {},
-  openFilterDrawer: () => {},
-  hasActiveDrawerFilters: false,
-  activeFilterCount: 0,
-  checkboxSelectionMode: false,
-  setCheckboxSelectionMode: () => {},
-});
-
-function TestRunsUnifiedToolbar() {
-  const {
-    searchQuery,
-    setSearchQuery,
-    statusFilter,
-    setStatusFilter,
-    openFilterDrawer,
-    hasActiveDrawerFilters,
-    activeFilterCount,
-    checkboxSelectionMode,
-    setCheckboxSelectionMode,
-  } = useContext(TestRunsToolbarContext);
-
-  return (
-    <GridToolbar
-      searchQuery={searchQuery}
-      onSearchChange={setSearchQuery}
-      searchPlaceholder="Search test runs…"
-      onFilterClick={openFilterDrawer}
-      hasActiveFilters={hasActiveDrawerFilters}
-      activeFilterCount={activeFilterCount}
-      middleContent={
-        <ToolbarPillTabs
-          tabs={STATUS_TABS}
-          activeValue={statusFilter}
-          onChange={setStatusFilter}
-        />
-      }
-      rightContent={
-        <>
-          <SelectionModeToggle
-            checked={checkboxSelectionMode}
-            onChange={setCheckboxSelectionMode}
-            label="Select test runs"
-          />
-          <GridToolbarColumnsButton />
-          <GridToolbarDensitySelector />
-          <GridToolbarExport />
-        </>
-      }
+const drawerAdapter: EntityGridDrawerAdapter<TestRunFilters> = {
+  empty: EMPTY_TEST_RUN_FILTERS,
+  countActive: countActiveTestRunFilters,
+  render: props => (
+    <TestRunFilterDrawer
+      open={props.open}
+      onClose={props.onClose}
+      filters={props.filters}
+      onApply={props.onApply}
     />
-  );
+  ),
+};
+
+function isCancellableRun(row: Record<string, unknown>): boolean {
+  const statusName = (
+    (row.status as { name?: string } | undefined)?.name ?? ''
+  ).toLowerCase();
+  return statusName === 'queued' || statusName === 'progress';
 }
 
-// ── Grid component ────────────────────────────────────────────────────────────
-
-function TestRunsGrid({
+export default function TestRunsGrid({
   canCreate,
   onCreateClick,
   onBulkActionsChange,
@@ -187,141 +119,87 @@ function TestRunsGrid({
   initialData,
   initialTotalCount,
 }: TestRunsGridProps) {
-  const router = useRouter();
   const notifications = useNotifications();
-  const { highlightedIds, clearHighlight } = useNotificationBadges();
-  const testRunHighlights = highlightedIds(NotificationSection.TEST_RUNS);
 
-  // ── Search + status filter ─────────────────────────────────────────────────
-  const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState('all');
-
-  // ── Filter drawer state ────────────────────────────────────────────────────
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [drawerFilters, setDrawerFilters] = useState<TestRunFilters>(
-    EMPTY_TEST_RUN_FILTERS
-  );
-
-  // ── Other UI state ─────────────────────────────────────────────────────────
-  const [cancelModalOpen, setCancelModalOpen] = useState(false);
-  const [isCancelling, setIsCancelling] = useState(false);
-  const [pendingCancelId, setPendingCancelId] = useState<string | null>(null);
   const [runKindFilter, setRunKindFilter] = useState<RunKindFilter>('all');
-  const [errorDismissed, setErrorDismissed] = useState(false);
+  const [pendingCancelId, setPendingCancelId] = useState<string | null>(null);
+  const [isCancelling, setIsCancelling] = useState(false);
 
-  // ── Grid state (pagination, filter, sort) ─────────────────────────────────
-
-  const filters = useMemo(
-    () => ({
-      search: searchQuery,
-      status: statusFilter === 'all' ? '' : statusFilter,
-      testSet: drawerFilters.testSet,
-      executor: drawerFilters.executor,
-      tag: drawerFilters.tag,
-      tagsPresence: drawerFilters.tags,
-      commentsPresence: drawerFilters.comments,
-      tasksPresence: drawerFilters.tasks,
-      runKind: runKindFilter,
-      reviews: drawerFilters.reviews ?? 'all',
-    }),
-    [searchQuery, statusFilter, drawerFilters, runKindFilter]
+  const externalFilters = useMemo(
+    () => ({ runKind: runKindFilter }),
+    [runKindFilter]
   );
 
-  // ── Data fetching ─────────────────────────────────────────────────────────
+  const runKindToolbar = useMemo(
+    () => (
+      <ButtonGroup size="small" variant="outlined">
+        <Button
+          onClick={() => setRunKindFilter('all')}
+          variant={runKindFilter === 'all' ? 'contained' : 'outlined'}
+          startIcon={<ListIcon fontSize="small" />}
+        >
+          All
+        </Button>
+        <Button
+          onClick={() => setRunKindFilter('tests')}
+          variant={runKindFilter === 'tests' ? 'contained' : 'outlined'}
+          startIcon={<ScienceIcon fontSize="small" />}
+        >
+          Tests
+        </Button>
+        <Button
+          onClick={() => setRunKindFilter('experiments')}
+          variant={runKindFilter === 'experiments' ? 'contained' : 'outlined'}
+          startIcon={<BiotechIcon fontSize="small" />}
+        >
+          Experiments
+        </Button>
+      </ButtonGroup>
+    ),
+    [runKindFilter]
+  );
 
-  const {
-    data: testRuns,
-    totalCount,
-    isLoading: loading,
-    error: rawError,
-    refresh,
-    paginationModel,
-    onPaginationModelChange: handlePaginationModelChange,
-    sortModel,
-    onSortModelChange: handleSortModelChange,
-  } = useList(testRunsList, {
-    filters,
-    initialData,
-    initialTotalCount,
-    onError: () => setErrorDismissed(false),
-  });
+  const handleCancelClose = useCallback(() => {
+    setPendingCancelId(null);
+  }, []);
 
-  useEffect(() => {
-    setErrorDismissed(false);
-  }, [rawError]);
-
-  const error = rawError && !errorDismissed ? rawError : null;
-  const dismissError = useCallback(() => setErrorDismissed(true), []);
-
-  // ── Bulk selection + delete ──────────────────────────────────────────────────
-  const {
-    checkboxSelectionMode,
-    setCheckboxSelectionMode,
-    selectedRows,
-    handleSelectionChange,
-    pendingDeleteId,
-    deleteModalOpen,
-    isDeleting,
-    requestDelete,
-    confirmDelete,
-    cancelDelete,
-  } = useBulkDelete({
-    bulkDeleteFn: (ids: string[]) =>
-      new ApiClientFactory().getTestRunsClient().bulkDeleteTestRuns(ids),
-    onSuccess: refresh,
-    itemLabelSingular: 'test run',
-    itemLabelPlural: 'test runs',
-    getSkippedCount: response => response.forbidden_ids.length,
-    skippedReason: 'not yours to delete',
-    onBulkActionsChange,
-  });
-
-  const isFirstRefreshTrigger = useRef(true);
-  useEffect(() => {
-    if (isFirstRefreshTrigger.current) {
-      isFirstRefreshTrigger.current = false;
-      return;
-    }
-    refresh();
-    // Only refreshTrigger (bumped by the page after a create) should re-run this.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshTrigger]);
-
-  // ── Row action handlers ────────────────────────────────────────────────────
-
-  const handleRowEditAction = useCallback(
-    (id: string) => {
-      router.push(`/test-runs/${id}`);
+  const makeCancelConfirm = useCallback(
+    (refresh: () => void) => async () => {
+      if (!pendingCancelId) return;
+      try {
+        setIsCancelling(true);
+        await new ApiClientFactory()
+          .getTestRunsClient()
+          .cancelTestRun(pendingCancelId);
+        notifications.show('Successfully cancelled test run', {
+          severity: 'success',
+        });
+        refresh();
+      } catch {
+        notifications.show('Failed to cancel test run', { severity: 'error' });
+      } finally {
+        setIsCancelling(false);
+        setPendingCancelId(null);
+      }
     },
-    [router]
+    [pendingCancelId, notifications]
   );
 
-  const handleRowCancelAction = useCallback((id: string) => {
-    setPendingCancelId(id);
-    setCancelModalOpen(true);
-  }, []);
+  const extraRowActions = useMemo(
+    () => [
+      {
+        key: 'cancel',
+        icon: StopCircleOutlinedIcon,
+        tooltip: 'Cancel',
+        onClick: (id: string) => setPendingCancelId(id),
+        can: isCancellableRun,
+      },
+    ],
+    []
+  );
 
-  const isCancellableRun = useCallback((row: Record<string, unknown>) => {
-    const statusName = (
-      (row.status as { name?: string } | undefined)?.name ?? ''
-    ).toLowerCase();
-    return statusName === 'queued' || statusName === 'progress';
-  }, []);
-
-  // ── Column definitions ────────────────────────────────────────────────────
-
-  const columns: GridColDef[] = useMemo(() => {
-    const actionsCol = createRowActionsColumn({
-      onEdit: id => handleRowEditAction(id),
-      canEdit: row => can(row as unknown as TestRun, Capability.TestRun.UPDATE),
-      onCancel: id => handleRowCancelAction(id),
-      canCancel: isCancellableRun,
-      onDelete: id => requestDelete(id),
-      canDelete: row =>
-        can(row as unknown as TestRun, Capability.TestRun.DELETE),
-      width: 112,
-    });
-    return [
+  const columns: GridColDef[] = useMemo(
+    () => [
       {
         field: 'name',
         headerName: 'Name',
@@ -621,96 +499,16 @@ function TestRunsGrid({
           );
         },
       },
-      actionsCol,
-    ];
-  }, [
-    handleRowEditAction,
-    handleRowCancelAction,
-    isCancellableRun,
-    requestDelete,
-  ]);
-
-  // ── Row handlers ──────────────────────────────────────────────────────────
-
-  const handleRowClick = useCallback(
-    (params: { id: string | number }) => {
-      clearHighlight(NotificationSection.TEST_RUNS, String(params.id));
-      router.push(`/test-runs/${params.id}`);
-    },
-    [router, clearHighlight]
+    ],
+    []
   );
-
-  // ── Cancel handlers ───────────────────────────────────────────────────────
-
-  const handleCancelConfirm = useCallback(async () => {
-    if (!pendingCancelId) {
-      setCancelModalOpen(false);
-      return;
-    }
-
-    try {
-      setIsCancelling(true);
-      const clientFactory = new ApiClientFactory();
-      const testRunsClient = clientFactory.getTestRunsClient();
-      await testRunsClient.cancelTestRun(pendingCancelId);
-      notifications.show('Successfully cancelled test run', {
-        severity: 'success',
-      });
-      setPendingCancelId(null);
-      refresh();
-    } catch (_error) {
-      notifications.show('Failed to cancel test run', { severity: 'error' });
-    } finally {
-      setIsCancelling(false);
-      setCancelModalOpen(false);
-    }
-  }, [pendingCancelId, notifications, refresh]);
-
-  const handleCancelClose = useCallback(() => {
-    setCancelModalOpen(false);
-    setPendingCancelId(null);
-  }, []);
-
-  const handleRunKindFilterChange = useCallback((value: RunKindFilter) => {
-    setRunKindFilter(value);
-  }, []);
-
-  const runKindToolbar = useMemo(
-    () => (
-      <ButtonGroup size="small" variant="outlined">
-        <Button
-          onClick={() => handleRunKindFilterChange('all')}
-          variant={runKindFilter === 'all' ? 'contained' : 'outlined'}
-          startIcon={<ListIcon fontSize="small" />}
-        >
-          All
-        </Button>
-        <Button
-          onClick={() => handleRunKindFilterChange('tests')}
-          variant={runKindFilter === 'tests' ? 'contained' : 'outlined'}
-          startIcon={<ScienceIcon fontSize="small" />}
-        >
-          Tests
-        </Button>
-        <Button
-          onClick={() => handleRunKindFilterChange('experiments')}
-          variant={runKindFilter === 'experiments' ? 'contained' : 'outlined'}
-          startIcon={<BiotechIcon fontSize="small" />}
-        >
-          Experiments
-        </Button>
-      </ButtonGroup>
-    ),
-    [runKindFilter, handleRunKindFilterChange]
-  );
-
-  const filtersActive = !!searchQuery || hasActiveTestRunFilters(drawerFilters);
 
   return (
-    <GridStateGate
-      data={loading ? null : {}}
-      error={error}
-      isEmpty={totalCount === 0 && !filtersActive}
+    <EntityGrid<TestRunDetail, typeof testRunsList.filters, TestRunFilters>
+      descriptor={testRunsList}
+      columns={columns}
+      toFilters={toFilters}
+      externalFilters={externalFilters}
       emptyState={
         <EntityEmptyState
           card
@@ -722,106 +520,38 @@ function TestRunsGrid({
           enrichment={getEntityEmptyStateEnrichment('test-runs')}
         />
       }
-    >
-      <Paper sx={GRID_PAPER_SX}>
-        <TestRunsToolbarContext.Provider
-          value={{
-            searchQuery,
-            setSearchQuery,
-            statusFilter,
-            setStatusFilter,
-            openFilterDrawer: () => setFilterDrawerOpen(true),
-            hasActiveDrawerFilters: hasActiveTestRunFilters(drawerFilters),
-            activeFilterCount: countActiveTestRunFilters(drawerFilters),
-            checkboxSelectionMode,
-            setCheckboxSelectionMode,
-          }}
-        >
-          {error && (
-            <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
-              {error}
-            </Alert>
-          )}
-
-          <BaseDataGrid
-            rows={testRuns}
-            columns={columns}
-            loading={loading}
-            getRowId={row => row.id}
-            paginationModel={paginationModel}
-            onPaginationModelChange={handlePaginationModelChange}
-            sortingMode="server"
-            sortModel={sortModel}
-            onSortModelChange={handleSortModelChange}
-            onRowClick={checkboxSelectionMode ? undefined : handleRowClick}
-            getRowClassName={params =>
-              testRunHighlights.includes(String(params.id))
-                ? HIGHLIGHTED_ROW_CLASS
-                : ''
-            }
-            getRowUrl={
-              checkboxSelectionMode ? undefined : row => `/test-runs/${row.id}`
-            }
-            serverSidePagination={true}
-            totalRows={totalCount}
-            pageSizeOptions={[10, 25, 50]}
-            gridToolbarExtra={runKindToolbar}
-            disablePaperWrapper={true}
-            showToolbar={true}
-            toolbarSlot={TestRunsUnifiedToolbar}
-            persistState
-            storageKey="test-runs-grid-v2"
-            sx={rowActionsHoverSx}
-            checkboxSelection={checkboxSelectionMode}
-            disableRowSelectionOnClick={checkboxSelectionMode || undefined}
-            isRowSelectable={(params: GridRowParams) =>
-              can(params.row as unknown as TestRun, Capability.TestRun.DELETE)
-            }
-            rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
-            onRowSelectionModelChange={
-              checkboxSelectionMode ? handleSelectionChange : undefined
-            }
-          />
-
-          <DeleteModal
-            open={deleteModalOpen}
-            onClose={cancelDelete}
-            onConfirm={confirmDelete}
-            isLoading={isDeleting}
-            title={pendingDeleteId ? 'Delete Test Run' : 'Delete Test Runs'}
-            message={
-              pendingDeleteId
-                ? 'Are you sure you want to delete this test run? Related data will not be deleted.'
-                : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'test run' : 'test runs'}? Related data will not be deleted.`
-            }
-            itemType="test runs"
-          />
-
-          <DeleteModal
-            open={cancelModalOpen}
-            onClose={handleCancelClose}
-            onConfirm={handleCancelConfirm}
-            isLoading={isCancelling}
-            title="Cancel Test Run"
-            message="Are you sure you want to cancel this test run? It will be stopped and marked as Cancelled."
-            itemType="test run"
-            confirmButtonText={isCancelling ? 'Cancelling...' : 'Cancel Run'}
-            cancelButtonText="Keep Running"
-          />
-
-          {/* Filter drawer */}
-          <TestRunFilterDrawer
-            open={filterDrawerOpen}
-            onClose={() => setFilterDrawerOpen(false)}
-            filters={drawerFilters}
-            onApply={f => {
-              setDrawerFilters(f);
-            }}
-          />
-        </TestRunsToolbarContext.Provider>
-      </Paper>
-    </GridStateGate>
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+      refreshTrigger={refreshTrigger}
+      searchPlaceholder="Search test runs…"
+      pills={{ tabs: STATUS_TABS }}
+      drawer={drawerAdapter}
+      toolbarRight={runKindToolbar}
+      selectionLabel="Select test runs"
+      getRowUrl={row => `/test-runs/${row.id}`}
+      highlightSection={NotificationSection.TEST_RUNS}
+      editAction={{
+        can: (row: TestRunDetail) =>
+          can(row as TestRun, Capability.TestRun.UPDATE),
+      }}
+      extraRowActions={extraRowActions}
+      rowActionsWidth={112}
+      onBulkActionsChange={onBulkActionsChange}
+      storageKey="test-runs-grid-v2"
+      pageSizeOptions={[10, 25, 50]}
+      renderSelectionExtras={ctx => (
+        <DeleteModal
+          open={pendingCancelId !== null}
+          onClose={handleCancelClose}
+          onConfirm={makeCancelConfirm(ctx.refresh)}
+          isLoading={isCancelling}
+          title="Cancel Test Run"
+          message="Are you sure you want to cancel this test run? It will be stopped and marked as Cancelled."
+          itemType="test run"
+          confirmButtonText={isCancelling ? 'Cancelling...' : 'Cancel Run'}
+          cancelButtonText="Keep Running"
+        />
+      )}
+    />
   );
 }
-
-export default React.memo(TestRunsGrid);

--- a/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsGrid.test.tsx
@@ -72,7 +72,6 @@ jest.mock('@/components/common/BaseDataGrid', () => {
     }>;
     onRowClick?: (p: { id: unknown; row: Record<string, unknown> }) => void;
     toolbarSlot?: unknown;
-    showToolbar?: boolean;
   }) {
     if (loading) return <div data-testid="grid-loading">Loading…</div>;
     const actionsCol = columns?.find(c => c.field === 'actions');
@@ -341,7 +340,7 @@ describe('TestRunsGrid', () => {
     );
   });
 
-  it('passes showToolbar and toolbarSlot props to BaseDataGrid', async () => {
+  it('passes toolbarSlot prop to BaseDataGrid', async () => {
     render(<TestRunsGrid />);
     // The grid renders without error, confirming toolbarSlot prop is accepted
     expect(await screen.findByTestId('base-data-grid')).toBeInTheDocument();

--- a/apps/frontend/src/app/(protected)/test-runs/components/list.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/components/list.ts
@@ -1,5 +1,8 @@
 import type { ApiClientFactory } from '@/utils/api-client/client-factory';
-import type { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
+import type {
+  TestRunBulkDeleteResponse,
+  TestRunDetail,
+} from '@/utils/api-client/interfaces/test-run';
 import { Capability } from '@/constants/capabilities';
 import { defineList } from '@/utils/list';
 import { escapeODataValue } from '@/utils/odata-filter';
@@ -83,6 +86,21 @@ export const testRunsList = defineList<TestRunDetail, typeof TEST_RUNS_FILTERS>(
       return factory
         .getTestRunsClient()
         .getTestRuns({ ...rest, filter: $filter });
+    },
+    delete: {
+      bulk: (factory: ApiClientFactory, ids: string[]) =>
+        factory.getTestRunsClient().bulkDeleteTestRuns(ids),
+      capability: Capability.TestRun.DELETE,
+      capabilityMode: 'row',
+      labelSingular: 'test run',
+      labelPlural: 'test runs',
+      getSkippedCount: (response: TestRunBulkDeleteResponse) =>
+        response.forbidden_ids.length,
+      skippedReason: 'not yours to delete',
+      confirmMessage: count =>
+        count === 1
+          ? 'Are you sure you want to delete this test run? Related data will not be deleted.'
+          : `Are you sure you want to delete ${count} test runs? Related data will not be deleted.`,
     },
   }
 );

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -1,35 +1,8 @@
 'use client';
 
-import React, {
-  useState,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
-import {
-  GridColDef,
-  GridRowParams,
-  GridToolbarColumnsButton,
-  GridToolbarDensitySelector,
-  GridToolbarExport,
-} from '@mui/x-data-grid';
-import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
-import { useRouter } from 'next/navigation';
-import { useList } from '@/hooks/useList';
-import { testSetsList } from './list';
-import type { TestSet } from '@/utils/api-client/interfaces/test-set';
-import { Tag } from '@/utils/api-client/interfaces/tag';
-import {
-  Box,
-  Tooltip,
-  Typography,
-  Avatar,
-  Alert,
-  Chip,
-  Paper,
-} from '@mui/material';
+import React, { useState, useCallback, useMemo } from 'react';
+import { GridColDef, GridRowModel } from '@mui/x-data-grid';
+import { Box, Tooltip, Typography, Avatar, Chip } from '@mui/material';
 import {
   ChatIcon,
   DescriptionIcon,
@@ -37,37 +10,30 @@ import {
 } from '@/components/icons';
 import InsertDriveFileOutlined from '@mui/icons-material/InsertDriveFileOutlined';
 import PersonIcon from '@mui/icons-material/Person';
-import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
-import SelectionModeToggle from '@/components/common/SelectionModeToggle';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useSession } from 'next-auth/react';
+import EntityGrid, {
+  type EntityGridDrawerAdapter,
+  type EntityGridFilterState,
+} from '@/components/common/EntityGrid';
+import GridBadge from '@/components/common/GridBadge';
 import RunDrawer from '@/components/common/RunDrawer';
-import { DeleteModal } from '@/components/common/DeleteModal';
-import { useNotifications as useJobNotifications } from '@/contexts/NotificationsContext';
-import {
-  HIGHLIGHTED_ROW_CLASS,
-  NotificationSection,
-} from '@/constants/notifications';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
+import type { TestSet } from '@/utils/api-client/interfaces/test-set';
+import { Tag } from '@/utils/api-client/interfaces/tag';
+import { NotificationSection } from '@/constants/notifications';
 import { formatDate } from '@/utils/date';
-import TestSetFilterDrawer, {
-  type TestSetFilters,
-  EMPTY_TEST_SET_FILTERS,
-  hasActiveTestSetFilters,
-  countActiveTestSetFilters,
-} from './TestSetFilterDrawer';
-import {
-  createRowActionsColumn,
-  rowActionsHoverSx,
-} from '@/components/common/createRowActionsColumn';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { TEST_TYPE_PILL_TABS } from '@/constants/test-types';
-import GridBadge from '@/components/common/GridBadge';
-import { useBulkDelete } from '@/hooks/useBulkDelete';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
-import GridStateGate from '@/components/common/GridStateGate';
-import EntityEmptyState from '@/components/common/EntityEmptyState';
-import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
+import type { BulkDeleteActionsState } from '@/hooks/useBulkDelete';
+import { testSetsList } from './list';
+import TestSetFilterDrawer, {
+  type TestSetFilters,
+  EMPTY_TEST_SET_FILTERS,
+  countActiveTestSetFilters,
+} from './TestSetFilterDrawer';
 
 interface TestSetsGridProps {
   canCreate?: boolean;
@@ -80,85 +46,63 @@ interface TestSetsGridProps {
   initialTotalCount?: number;
 }
 
-export interface TestSetsBulkActionsState {
-  visible: boolean;
+export interface TestSetsBulkActionsState extends BulkDeleteActionsState {
   onRun: () => void;
-  onDelete: () => void;
 }
 
-// ─── Toolbar context ────────────────────────────────────────────────────────────
-
-interface TestSetsToolbarState {
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-  typeFilter: string;
-  setTypeFilter: (v: string) => void;
-  openFilterDrawer: () => void;
-  hasActiveDrawerFilters: boolean;
-  activeFilterCount: number;
-  checkboxSelectionMode: boolean;
-  setCheckboxSelectionMode: (v: boolean) => void;
+// A pill click wins over the drawer's own testSetType value (the pill is
+// applied after drawer filters).
+function toFilters(state: EntityGridFilterState<TestSetFilters>) {
+  return {
+    search: state.search,
+    testSetType: state.pill || state.drawer.testSetType,
+    status: state.drawer.status,
+    creator: state.drawer.creator,
+    tag: state.drawer.tag,
+    tagsPresence: state.drawer.tags,
+    commentsPresence: state.drawer.comments,
+    tasksPresence: state.drawer.tasks,
+  };
 }
 
-const TestSetsToolbarContext = React.createContext<TestSetsToolbarState>({
-  searchQuery: '',
-  setSearchQuery: () => {},
-  typeFilter: 'all',
-  setTypeFilter: () => {},
-  openFilterDrawer: () => {},
-  hasActiveDrawerFilters: false,
-  activeFilterCount: 0,
-  checkboxSelectionMode: false,
-  setCheckboxSelectionMode: () => {},
-});
-
-const PILL_TABS = TEST_TYPE_PILL_TABS;
-
-function TestSetsUnifiedToolbar() {
-  const {
-    searchQuery,
-    setSearchQuery,
-    typeFilter,
-    setTypeFilter,
-    openFilterDrawer,
-    hasActiveDrawerFilters,
-    activeFilterCount,
-    checkboxSelectionMode,
-    setCheckboxSelectionMode,
-  } = useContext(TestSetsToolbarContext);
-
-  return (
-    <GridToolbar
-      searchQuery={searchQuery}
-      onSearchChange={setSearchQuery}
-      searchPlaceholder="Search test sets…"
-      onFilterClick={openFilterDrawer}
-      hasActiveFilters={hasActiveDrawerFilters}
-      activeFilterCount={activeFilterCount}
-      middleContent={
-        <ToolbarPillTabs
-          tabs={PILL_TABS}
-          activeValue={typeFilter}
-          onChange={setTypeFilter}
-        />
-      }
-      rightContent={
-        <>
-          <SelectionModeToggle
-            checked={checkboxSelectionMode}
-            onChange={setCheckboxSelectionMode}
-            label="Select test sets"
-          />
-          <GridToolbarColumnsButton />
-          <GridToolbarDensitySelector />
-          <GridToolbarExport />
-        </>
-      }
+const drawerAdapter: EntityGridDrawerAdapter<TestSetFilters> = {
+  empty: EMPTY_TEST_SET_FILTERS,
+  countActive: countActiveTestSetFilters,
+  render: props => (
+    <TestSetFilterDrawer
+      open={props.open}
+      onClose={props.onClose}
+      filters={props.filters}
+      onApply={props.onApply}
     />
-  );
-}
+  ),
+  // Applying a type in the drawer syncs the pill; clearing it resets the pill
+  // only when no drawer type was active before.
+  pillFromApply: (applied, previous) =>
+    applied.testSetType
+      ? applied.testSetType
+      : !previous.testSetType
+        ? ''
+        : undefined,
+};
 
-// ─── Helper: chip container for multi-value fields ──────────────────────────────
+// The grid renders a flattened projection of the test set, not the entity
+// itself -- most columns live under attributes.metadata.
+function mapRows(testSets: TestSet[]): GridRowModel[] {
+  return testSets.map(testSet => ({
+    id: testSet.id,
+    name: testSet.name,
+    testSetType: testSet.test_set_type?.type_value || '',
+    requirements: testSet.attributes?.metadata?.requirements || [],
+    categories: testSet.attributes?.metadata?.categories || [],
+    totalTests: testSet.attributes?.metadata?.total_tests || 0,
+    creator: testSet.user,
+    counts: testSet.counts,
+    sources: testSet.attributes?.metadata?.sources || [],
+    tags: testSet.tags || [],
+    created_at: testSet.created_at,
+  }));
+}
 
 const ChipContainer = ({ items }: { items: string[] }) => {
   if (items.length === 0) return '-';
@@ -197,179 +141,20 @@ export default function TestSetsGrid({
   initialData,
   initialTotalCount,
 }: TestSetsGridProps) {
-  const router = useRouter();
   const { status } = useSession();
-  const { highlightedIds, clearHighlight } = useJobNotifications();
-  const testSetHighlights = highlightedIds(NotificationSection.TEST_SETS);
   const canEditTestSet = useCan(Capability.TestSet.UPDATE);
-  const canDeleteTestSet = useCan(Capability.TestSet.DELETE);
-
-  // ── Search + type filter ────────────────────────────────────────────────────
-  const [searchQuery, setSearchQuery] = useState('');
-  const [typeFilter, setTypeFilter] = useState('all');
-
-  // ── Drawer / dialog state ───────────────────────────────────────────────────
-  const [drawerFilters, setDrawerFilters] = useState<TestSetFilters>(
-    EMPTY_TEST_SET_FILTERS
-  );
   const [testRunDrawerOpen, setTestRunDrawerOpen] = useState(false);
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [errorDismissed, setErrorDismissed] = useState(false);
 
-  // A pill click wins over the drawer's own testSetType value (the pill is
-  // applied after drawer filters).
-  const effectiveTestSetType =
-    typeFilter !== 'all' ? typeFilter : drawerFilters.testSetType;
-
-  // ── Data fetching ────────────────────────────────────────────────────────
-
-  const filters = useMemo(
-    () => ({
-      search: searchQuery,
-      testSetType: effectiveTestSetType,
-      status: drawerFilters.status,
-      creator: drawerFilters.creator,
-      tag: drawerFilters.tag,
-      tagsPresence: drawerFilters.tags,
-      commentsPresence: drawerFilters.comments,
-      tasksPresence: drawerFilters.tasks,
+  const buildBulkActions = useCallback(
+    (base: BulkDeleteActionsState): TestSetsBulkActionsState => ({
+      ...base,
+      onRun: () => setTestRunDrawerOpen(true),
     }),
-    [searchQuery, effectiveTestSetType, drawerFilters]
+    []
   );
 
-  const {
-    data: testSets,
-    totalCount,
-    isLoading: loading,
-    error: rawError,
-    refresh,
-    paginationModel,
-    onPaginationModelChange: handlePaginationModelChange,
-    sortModel,
-    onSortModelChange: handleSortModelChange,
-  } = useList(testSetsList, {
-    filters,
-    initialData,
-    initialTotalCount,
-    onError: () => setErrorDismissed(false),
-  });
-
-  useEffect(() => {
-    setErrorDismissed(false);
-  }, [rawError]);
-
-  const error = rawError && !errorDismissed ? rawError : null;
-  const dismissError = useCallback(() => setErrorDismissed(true), []);
-
-  const isFirstRefreshTrigger = useRef(true);
-  useEffect(() => {
-    if (isFirstRefreshTrigger.current) {
-      isFirstRefreshTrigger.current = false;
-      return;
-    }
-    refresh();
-    // Only refreshTrigger (bumped by the page after a create/import/generate) should re-run this.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshTrigger]);
-
-  // ── Bulk selection + delete ──────────────────────────────────────────────────
-  // TestSets has a second bulk action (Run), so it bridges to the page's
-  // FabGroup itself below instead of using useBulkDelete's built-in
-  // onBulkActionsChange, which only knows about delete.
-  const {
-    checkboxSelectionMode,
-    setCheckboxSelectionMode,
-    selectedRows,
-    handleSelectionChange,
-    pendingDeleteId,
-    deleteModalOpen,
-    isDeleting,
-    requestDelete,
-    confirmDelete,
-    cancelDelete,
-  } = useBulkDelete({
-    bulkDeleteFn: (ids: string[]) =>
-      new ApiClientFactory().getTestSetsClient().bulkDeleteTestSets(ids),
-    onSuccess: refresh,
-    itemLabelSingular: 'test set',
-    itemLabelPlural: 'test sets',
-  });
-
-  // ── Row + selection handlers ─────────────────────────────────────────────────
-
-  const handleRowClick = useCallback(
-    (params: GridRowParams) => {
-      clearHighlight(NotificationSection.TEST_SETS, String(params.id));
-      router.push(`/test-sets/${params.id}`);
-    },
-    [router, clearHighlight]
-  );
-
-  const handleRowEditAction = useCallback(
-    (id: string) => {
-      router.push(`/test-sets/${id}`);
-    },
-    [router]
-  );
-
-  // ── Bulk actions bridge (Run + Delete) to the page's FabGroup ───────────────
-
-  const showBulkActions = checkboxSelectionMode && selectedRows.length > 0;
-  const bulkHandlersRef = useRef({
-    onRun: () => setTestRunDrawerOpen(true),
-    onDelete: () => requestDelete(),
-  });
-  bulkHandlersRef.current = {
-    onRun: () => setTestRunDrawerOpen(true),
-    onDelete: () => requestDelete(),
-  };
-
-  useEffect(() => {
-    onBulkActionsChange?.({
-      visible: showBulkActions,
-      onRun: () => bulkHandlersRef.current.onRun(),
-      onDelete: () => bulkHandlersRef.current.onDelete(),
-    });
-  }, [showBulkActions, onBulkActionsChange]);
-
-  useEffect(() => {
-    return () => {
-      onBulkActionsChange?.({
-        visible: false,
-        onRun: () => {},
-        onDelete: () => {},
-      });
-    };
-  }, [onBulkActionsChange]);
-
-  // ── Column definitions ───────────────────────────────────────────────────────
-
-  const processedTestSets = useMemo(
-    () =>
-      testSets.map(testSet => ({
-        id: testSet.id,
-        name: testSet.name,
-        testSetType: testSet.test_set_type?.type_value || '',
-        requirements: testSet.attributes?.metadata?.requirements || [],
-        categories: testSet.attributes?.metadata?.categories || [],
-        totalTests: testSet.attributes?.metadata?.total_tests || 0,
-        creator: testSet.user,
-        counts: testSet.counts,
-        sources: testSet.attributes?.metadata?.sources || [],
-        tags: testSet.tags || [],
-        created_at: testSet.created_at,
-      })),
-    [testSets]
-  );
-
-  const columns: GridColDef[] = useMemo(() => {
-    const actionsCol = createRowActionsColumn({
-      onEdit: id => handleRowEditAction(id),
-      onDelete: id => requestDelete(id),
-      canEdit: () => canEditTestSet,
-      canDelete: () => canDeleteTestSet,
-    });
-    return [
+  const columns: GridColDef[] = useMemo(
+    () => [
       {
         field: 'name',
         headerName: 'Name',
@@ -384,6 +169,7 @@ export default function TestSetsGrid({
         width: 160,
         minWidth: 100,
         resizable: true,
+        sortable: false,
         renderCell: params => (
           <ChipContainer items={params.row.requirements || []} />
         ),
@@ -394,6 +180,7 @@ export default function TestSetsGrid({
         width: 160,
         minWidth: 100,
         resizable: true,
+        sortable: false,
         renderCell: params => (
           <ChipContainer items={params.row.categories || []} />
         ),
@@ -405,6 +192,7 @@ export default function TestSetsGrid({
         minWidth: 90,
         resizable: true,
         filterable: true,
+        sortable: false,
         valueGetter: (_, row) => row.testSetType || '',
         renderCell: params =>
           params.value ? <GridBadge label={params.value} /> : null,
@@ -428,6 +216,7 @@ export default function TestSetsGrid({
         width: 80,
         minWidth: 60,
         resizable: true,
+        sortable: false,
         valueGetter: (_, row) => row.totalTests,
       },
       {
@@ -436,7 +225,7 @@ export default function TestSetsGrid({
         width: 160,
         minWidth: 120,
         resizable: true,
-        sortable: true,
+        sortable: false,
         filterable: true,
         valueGetter: (_, row) =>
           row.creator?.name ||
@@ -580,17 +369,20 @@ export default function TestSetsGrid({
           );
         },
       },
-      actionsCol,
-    ];
-  }, [handleRowEditAction, requestDelete]);
-
-  const filtersActive = !!searchQuery || hasActiveTestSetFilters(drawerFilters);
+    ],
+    []
+  );
 
   return (
-    <GridStateGate
-      data={loading ? null : {}}
-      error={error}
-      isEmpty={totalCount === 0 && !filtersActive}
+    <EntityGrid<
+      TestSet,
+      typeof testSetsList.filters,
+      TestSetFilters,
+      TestSetsBulkActionsState
+    >
+      descriptor={testSetsList}
+      columns={columns}
+      toFilters={toFilters}
       emptyState={
         <EntityEmptyState
           card
@@ -602,108 +394,38 @@ export default function TestSetsGrid({
           enrichment={getEntityEmptyStateEnrichment('test-sets')}
         />
       }
-    >
-      <Paper sx={GRID_PAPER_SX}>
-        <TestSetsToolbarContext.Provider
-          value={{
-            searchQuery,
-            setSearchQuery,
-            typeFilter,
-            setTypeFilter,
-            openFilterDrawer: () => setFilterDrawerOpen(true),
-            hasActiveDrawerFilters: hasActiveTestSetFilters(drawerFilters),
-            activeFilterCount: countActiveTestSetFilters(drawerFilters),
-            checkboxSelectionMode,
-            setCheckboxSelectionMode,
-          }}
-        >
-          {error && (
-            <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
-              {error}
-            </Alert>
-          )}
-
-          <BaseDataGrid
-            columns={columns}
-            rows={processedTestSets}
-            loading={loading}
-            getRowId={row => row.id}
-            showToolbar={true}
-            checkboxSelection={checkboxSelectionMode}
-            disableRowSelectionOnClick={checkboxSelectionMode || undefined}
-            onRowSelectionModelChange={
-              checkboxSelectionMode ? handleSelectionChange : undefined
-            }
-            rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
-            onRowClick={checkboxSelectionMode ? undefined : handleRowClick}
-            getRowClassName={params =>
-              testSetHighlights.includes(String(params.id))
-                ? HIGHLIGHTED_ROW_CLASS
-                : ''
-            }
-            getRowUrl={
-              checkboxSelectionMode ? undefined : row => `/test-sets/${row.id}`
-            }
-            paginationModel={paginationModel}
-            onPaginationModelChange={handlePaginationModelChange}
-            serverSidePagination={true}
-            totalRows={totalCount}
-            pageSizeOptions={[10, 25, 50]}
-            sortingMode="server"
-            sortModel={sortModel}
-            onSortModelChange={handleSortModelChange}
-            toolbarSlot={TestSetsUnifiedToolbar}
-            disablePaperWrapper={true}
-            persistState
-            initialState={{
-              columns: {
-                columnVisibilityModel: {
-                  sources: false,
-                },
-              },
-            }}
-            sx={rowActionsHoverSx}
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+      refreshTrigger={refreshTrigger}
+      mapRows={mapRows}
+      searchPlaceholder="Search test sets…"
+      pills={{ tabs: TEST_TYPE_PILL_TABS }}
+      drawer={drawerAdapter}
+      selectionLabel="Select test sets"
+      getRowUrl={row => `/test-sets/${row.id}`}
+      highlightSection={NotificationSection.TEST_SETS}
+      editAction={{ can: () => canEditTestSet }}
+      onBulkActionsChange={onBulkActionsChange}
+      buildBulkActions={buildBulkActions}
+      pageSizeOptions={[10, 25, 50]}
+      initialState={{
+        columns: {
+          columnVisibilityModel: {
+            sources: false,
+          },
+        },
+      }}
+      renderSelectionExtras={ctx =>
+        isAuthenticated(status) && (
+          <RunDrawer
+            mode="createFromGrid"
+            open={testRunDrawerOpen}
+            onClose={() => setTestRunDrawerOpen(false)}
+            data={{ selectedTestSetIds: ctx.selectedIds }}
+            onSuccess={() => setTestRunDrawerOpen(false)}
           />
-
-          {/* Test Run Drawer */}
-          {isAuthenticated(status) && (
-            <>
-              <RunDrawer
-                mode="createFromGrid"
-                open={testRunDrawerOpen}
-                onClose={() => setTestRunDrawerOpen(false)}
-                data={{ selectedTestSetIds: selectedRows as string[] }}
-                onSuccess={() => setTestRunDrawerOpen(false)}
-              />
-              <DeleteModal
-                open={deleteModalOpen}
-                onClose={cancelDelete}
-                onConfirm={confirmDelete}
-                isLoading={isDeleting}
-                title={pendingDeleteId ? 'Delete Test Set' : 'Delete Test Sets'}
-                message={
-                  pendingDeleteId
-                    ? 'Are you sure you want to delete this test set? Related data will not be deleted.'
-                    : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'test set' : 'test sets'}? Don't worry, related data will not be deleted, only ${selectedRows.length === 1 ? 'this record' : 'these records'}.`
-                }
-                itemType="test sets"
-              />
-            </>
-          )}
-
-          {/* Filter drawer */}
-          <TestSetFilterDrawer
-            open={filterDrawerOpen}
-            onClose={() => setFilterDrawerOpen(false)}
-            filters={drawerFilters}
-            onApply={f => {
-              setDrawerFilters(f);
-              if (f.testSetType) setTypeFilter(f.testSetType);
-              else if (!drawerFilters.testSetType) setTypeFilter('all');
-            }}
-          />
-        </TestSetsToolbarContext.Provider>
-      </Paper>
-    </GridStateGate>
+        )
+      }
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/test-sets/components/list.ts
+++ b/apps/frontend/src/app/(protected)/test-sets/components/list.ts
@@ -63,4 +63,16 @@ export const testSetsList = defineList({
   filters: TEST_SETS_FILTERS,
   list: (factory: ApiClientFactory, params) =>
     factory.getTestSetsClient().getTestSets(params),
+  delete: {
+    bulk: (factory: ApiClientFactory, ids: string[]) =>
+      factory.getTestSetsClient().bulkDeleteTestSets(ids),
+    capability: Capability.TestSet.DELETE,
+    capabilityMode: 'ambient',
+    labelSingular: 'test set',
+    labelPlural: 'test sets',
+    confirmMessage: count =>
+      count === 1
+        ? 'Are you sure you want to delete this test set? Related data will not be deleted.'
+        : `Are you sure you want to delete ${count} test sets? Don't worry, related data will not be deleted, only these records.`,
+  },
 });

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -1,37 +1,19 @@
 'use client';
 
-import React, {
-  useEffect,
-  useRef,
-  useState,
-  useContext,
-  useCallback,
-  useMemo,
-} from 'react';
-import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
-import {
-  GridColDef,
-  GridRowParams,
-  GridRowSelectionModel,
-  GridRenderCellParams,
-  GridToolbarColumnsButton,
-  GridToolbarDensitySelector,
-  GridToolbarExport,
-} from '@mui/x-data-grid';
-import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
-import { useRouter } from 'next/navigation';
+import React, { useState, useCallback, useMemo } from 'react';
+import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
+import { Typography, Box, Alert, Chip } from '@mui/material';
+import { useSession } from 'next-auth/react';
+import EntityGrid, {
+  type EntityGridDrawerAdapter,
+  type EntityGridFilterState,
+  type EntityGridSelectionContext,
+} from '@/components/common/EntityGrid';
+import GridBadge from '@/components/common/GridBadge';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import { TestDetail } from '@/utils/api-client/interfaces/tests';
 import { Tag } from '@/utils/api-client/interfaces/tag';
-import {
-  Typography,
-  Box,
-  Alert,
-  Chip,
-  FormControlLabel,
-  Switch,
-  Paper,
-} from '@mui/material';
-import GridBadge from '@/components/common/GridBadge';
 import {
   AttachFileIcon,
   ChatIcon,
@@ -39,26 +21,17 @@ import {
   ScienceIcon,
 } from '@/components/icons';
 import InsertDriveFileOutlined from '@mui/icons-material/InsertDriveFileOutlined';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { useSession } from 'next-auth/react';
 import TestDrawer from './TestDrawer';
 import TestSetSelectionDrawer from './TestSetSelectionDrawer';
 import { TestSet } from '@/utils/api-client/interfaces/test-set';
 import { TestSetsClient } from '@/utils/api-client/test-sets-client';
 import { useNotifications } from '@/components/common/NotificationContext';
-import { DeleteModal } from '@/components/common/DeleteModal';
-import { useList } from '@/hooks/useList';
 import { testsList } from './list';
 import TestFilterDrawer, {
   type TestFilters,
   EMPTY_TEST_FILTERS,
-  hasActiveTestFilters,
   countActiveTestFilters,
 } from './TestFilterDrawer';
-import {
-  createRowActionsColumn,
-  rowActionsHoverSx,
-} from '@/components/common/createRowActionsColumn';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import {
@@ -74,9 +47,7 @@ import {
 } from '@/app/(protected)/insights/utils/insights-failed-tests';
 import { useInsightsFailedTestIds } from '@/hooks/useInsightsFailedTestIds';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
-import GridStateGate from '@/components/common/GridStateGate';
-import EntityEmptyState from '@/components/common/EntityEmptyState';
-import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
+import type { BulkDeleteActionsState } from '@/hooks/useBulkDelete';
 
 interface TestsTableProps {
   onNewTest?: () => void;
@@ -90,97 +61,51 @@ interface TestsTableProps {
   initialTotalCount?: number;
 }
 
-export interface TestsBulkActionsState {
-  visible: boolean;
+export interface TestsBulkActionsState extends BulkDeleteActionsState {
   assignDisabled: boolean;
   onAssign: () => void;
-  onDelete: () => void;
 }
 
-// ─── Toolbar context (passes search/filter state into the DataGrid slot) ──────
-
-interface TestsToolbarState {
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-  typeFilter: string;
-  setTypeFilter: (v: string) => void;
-  openFilterDrawer: () => void;
-  hasActiveDrawerFilters: boolean;
-  activeFilterCount: number;
-  checkboxSelectionMode: boolean;
-  setCheckboxSelectionMode: (v: boolean) => void;
+// A pill click wins over the drawer's own testType value (the pill is applied
+// after drawer filters).
+function toFilters(state: EntityGridFilterState<TestFilters>) {
+  return {
+    search: state.search,
+    testType: state.pill || state.drawer.testType,
+    requirement: state.drawer.requirement,
+    category: state.drawer.category,
+    topic: state.drawer.topic,
+    tagsPresence: state.drawer.tags,
+    commentsPresence: state.drawer.comments,
+    tasksPresence: state.drawer.tasks,
+  };
 }
 
-const TestsToolbarContext = React.createContext<TestsToolbarState>({
-  searchQuery: '',
-  setSearchQuery: () => {},
-  typeFilter: 'all',
-  setTypeFilter: () => {},
-  openFilterDrawer: () => {},
-  hasActiveDrawerFilters: false,
-  activeFilterCount: 0,
-  checkboxSelectionMode: false,
-  setCheckboxSelectionMode: () => {},
-});
-
-const PILL_TABS = TEST_TYPE_PILL_TABS;
-
-function TestsUnifiedToolbar() {
-  const canExport = useCan(Capability.TestSet.EXPORT);
-  const {
-    searchQuery,
-    setSearchQuery,
-    typeFilter,
-    setTypeFilter,
-    openFilterDrawer,
-    hasActiveDrawerFilters,
-    activeFilterCount,
-    checkboxSelectionMode,
-    setCheckboxSelectionMode,
-  } = useContext(TestsToolbarContext);
-
-  return (
-    <GridToolbar
-      searchQuery={searchQuery}
-      onSearchChange={setSearchQuery}
-      searchPlaceholder="Search tests…"
-      onFilterClick={openFilterDrawer}
-      hasActiveFilters={hasActiveDrawerFilters}
-      activeFilterCount={activeFilterCount}
-      middleContent={
-        <ToolbarPillTabs
-          tabs={PILL_TABS}
-          activeValue={typeFilter}
-          onChange={setTypeFilter}
-        />
-      }
-      rightContent={
-        <>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={checkboxSelectionMode}
-                onChange={event =>
-                  setCheckboxSelectionMode(event.target.checked)
-                }
-                size="small"
-                color="primary"
-              />
-            }
-            label={
-              <Typography variant="button" color="primary">
-                Select tests
-              </Typography>
-            }
-            sx={{ m: 0, whiteSpace: 'nowrap' }}
-          />
-          <GridToolbarColumnsButton />
-          <GridToolbarDensitySelector />
-          {canExport && <GridToolbarExport />}
-        </>
-      }
+const drawerAdapter: EntityGridDrawerAdapter<TestFilters> = {
+  empty: EMPTY_TEST_FILTERS,
+  countActive: countActiveTestFilters,
+  render: props => (
+    <TestFilterDrawer
+      open={props.open}
+      onClose={props.onClose}
+      filters={props.filters}
+      onApply={props.onApply}
     />
+  ),
+  // If the drawer sets a test type, sync the pill tab too.
+  pillFromApply: (applied, previous) =>
+    applied.testType ? applied.testType : !previous.testType ? '' : undefined,
+};
+
+function selectedTestTypes(selectedTests: TestDetail[]) {
+  const typeValues = new Set(
+    selectedTests.map(t => t.test_type?.type_value ?? null)
   );
+  return {
+    isMixed: typeValues.size > 1,
+    commonTypeValue:
+      typeValues.size === 1 ? ([...typeValues][0] ?? undefined) : undefined,
+  };
 }
 
 export default function TestsTable({
@@ -193,30 +118,16 @@ export default function TestsTable({
   initialData,
   initialTotalCount,
 }: TestsTableProps) {
-  const router = useRouter();
   const notifications = useNotifications();
   const canEditTest = useCan(Capability.Test.UPDATE);
-  const canDeleteTest = useCan(Capability.Test.DELETE);
+  const canExport = useCan(Capability.TestSet.EXPORT);
   const { status } = useSession();
 
-  // Search + tab filter — managed here, shared to toolbar via context
-  const [searchQuery, setSearchQuery] = useState('');
-  const [typeFilter, setTypeFilter] = useState('all');
-  const [drawerFilters, setDrawerFilters] =
-    useState<TestFilters>(EMPTY_TEST_FILTERS);
-  const [errorDismissed, setErrorDismissed] = useState(false);
-
-  // Component state
-  const [checkboxSelectionMode, setCheckboxSelectionMode] = useState(false);
-  const [selectedRows, setSelectedRows] = useState<GridRowSelectionModel>([]);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [selectedTest, setSelectedTest] = useState<TestDetail | undefined>();
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [testSetDrawerOpen, setTestSetDrawerOpen] = useState(false);
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
 
+  // ── Insights deep link: resolve failed-test ids into an extra OData filter ──
   const {
     data: insightsFailedTestIds,
     isLoading: insightsFilterLoading,
@@ -244,94 +155,114 @@ export default function TestsTable({
       ? buildTestIdsODataFilter(resolvedInsightsFailedTestIds)
       : '';
 
-  // A pill click wins over the drawer's own testType value (the pill is
-  // applied after drawer filters).
-  const effectiveTestType =
-    typeFilter !== 'all' ? typeFilter : drawerFilters.testType;
-
-  const filters = useMemo(
-    () => ({
-      search: searchQuery,
-      testType: effectiveTestType,
-      requirement: drawerFilters.requirement,
-      category: drawerFilters.category,
-      topic: drawerFilters.topic,
-      tagsPresence: drawerFilters.tags,
-      commentsPresence: drawerFilters.comments,
-      tasksPresence: drawerFilters.tasks,
-    }),
-    [searchQuery, effectiveTestType, drawerFilters]
+  const extraFilters = useMemo(
+    () => (insightsIdFilter ? [insightsIdFilter] : undefined),
+    [insightsIdFilter]
   );
 
-  const {
-    data: tests,
-    totalCount,
-    isLoading: loading,
-    error: rawError,
-    page,
-    onPageChange,
-    refresh,
-    paginationModel,
-    onPaginationModelChange: handlePaginationModelChange,
-    sortModel,
-    onSortModelChange: handleSortModelChange,
-  } = useList(testsList, {
-    filters,
-    extraFilters: insightsIdFilter ? [insightsIdFilter] : undefined,
-    enabled: insightsFilterReady,
-    initialData,
-    initialTotalCount,
-    onError: () => setErrorDismissed(false),
-  });
+  const insightsBanner = insightsFailedFilter ? (
+    <Alert severity="info" sx={{ mb: 2 }}>
+      {insightsFilterLoading
+        ? 'Loading test cases from Insights…'
+        : insightsFilterError ||
+          formatInsightsFailedTestsBanner(
+            insightsFailedFilter,
+            resolvedInsightsFailedTestIds?.length ?? 0,
+            insightsEndpointName
+          )}
+    </Alert>
+  ) : undefined;
 
-  useEffect(() => {
-    setErrorDismissed(false);
-  }, [rawError]);
-
-  const error = rawError && !errorDismissed ? rawError : null;
-  const dismissError = useCallback(() => setErrorDismissed(true), []);
-
-  // Compute whether selected tests have mixed types
-  const selectedTestTypes = useMemo(() => {
-    const selectedTests = tests.filter(t =>
-      selectedRows.includes(t.id as string)
-    );
-    const typeValues = new Set(
-      selectedTests.map(t => t.test_type?.type_value ?? null)
-    );
-    return {
-      isMixed: typeValues.size > 1,
-      commonTypeValue:
-        typeValues.size === 1 ? ([...typeValues][0] ?? undefined) : undefined,
-    };
-  }, [selectedRows, tests]);
-
-  // Row action handlers
-  const handleRowDeleteAction = useCallback((id: string) => {
-    setPendingDeleteId(id);
-    setDeleteModalOpen(true);
+  // ── Edit drawer + bulk assign ───────────────────────────────────────────────
+  const handleEditTest = useCallback((_id: string, row: TestDetail) => {
+    setSelectedTest(row);
+    setDrawerOpen(true);
   }, []);
 
-  const handleRowEditAction = useCallback(
-    (id: string) => {
-      const test = tests.find(t => t.id === id);
-      if (test) {
-        setSelectedTest(test);
-        setDrawerOpen(true);
-      }
-    },
-    [tests]
+  const handleDrawerClose = useCallback(() => {
+    setDrawerOpen(false);
+    setSelectedTest(undefined);
+  }, []);
+
+  const buildBulkActions = useCallback(
+    (
+      base: BulkDeleteActionsState,
+      ctx: EntityGridSelectionContext<TestDetail>
+    ): TestsBulkActionsState => ({
+      ...base,
+      assignDisabled: selectedTestTypes(ctx.selectedRows).isMixed,
+      onAssign: () => setTestSetDrawerOpen(true),
+    }),
+    []
   );
 
-  // Column definitions
-  const columns: GridColDef[] = React.useMemo(() => {
-    const actionsCol = createRowActionsColumn({
-      onEdit: id => handleRowEditAction(id),
-      onDelete: id => handleRowDeleteAction(id),
-      canEdit: () => canEditTest,
-      canDelete: () => canDeleteTest,
-    });
-    return [
+  const makeTestSetsAssign = useCallback(
+    (ctx: EntityGridSelectionContext<TestDetail>) =>
+      async (testSets: TestSet[]) => {
+        if (!isAuthenticated(status) || testSets.length === 0) return;
+
+        const testIds = ctx.selectedIds;
+        const testSetsClient = new TestSetsClient();
+        let successCount = 0;
+        let alreadyAssociatedCount = 0;
+        let failureCount = 0;
+
+        for (const testSet of testSets) {
+          try {
+            await testSetsClient.associateTestsWithTestSet(testSet.id, testIds);
+            successCount++;
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : '';
+            if (errorMessage.toLowerCase().includes('already associated')) {
+              alreadyAssociatedCount++;
+            } else {
+              failureCount++;
+            }
+          }
+        }
+
+        if (failureCount > 0) {
+          notifications.show('Failed to associate tests with some test sets', {
+            severity: 'error',
+            autoHideDuration: 6000,
+          });
+          return;
+        }
+
+        if (successCount > 0) {
+          const destinationLabel =
+            testSets.length === 1
+              ? `test set "${testSets[0].name}"`
+              : `${testSets.length} test sets`;
+
+          notifications.show(
+            `Successfully associated ${testIds.length} ${testIds.length === 1 ? 'test' : 'tests'} with ${destinationLabel}`,
+            {
+              severity: 'success',
+              autoHideDuration: 6000,
+            }
+          );
+          setTestSetDrawerOpen(false);
+          return;
+        }
+
+        if (alreadyAssociatedCount > 0) {
+          notifications.show(
+            'Selected tests are already in the chosen test set(s)',
+            {
+              severity: 'warning',
+              autoHideDuration: 6000,
+            }
+          );
+          setTestSetDrawerOpen(false);
+        }
+      },
+    [notifications, status]
+  );
+
+  // ── Column definitions ──────────────────────────────────────────────────────
+  const columns: GridColDef[] = useMemo(
+    () => [
       {
         field: 'prompt.content',
         headerName: 'Content',
@@ -560,204 +491,20 @@ export default function TestsTable({
           );
         },
       },
-      actionsCol,
-    ];
-  }, [handleRowEditAction, handleRowDeleteAction]);
-
-  // Event handlers
-  const handleRowClick = useCallback(
-    (params: GridRowParams) => {
-      const testId = params.id;
-      router.push(`/tests/${testId}`);
-    },
-    [router]
-  );
-
-  const handleSelectionChange = useCallback(
-    (newSelection: GridRowSelectionModel) => {
-      setSelectedRows(newSelection);
-    },
+    ],
     []
   );
 
-  const handleCreateTestSet = useCallback(() => {
-    if (selectedRows.length > 0) {
-      setTestSetDrawerOpen(true);
-    }
-  }, [selectedRows]);
-
-  const handleTestSetsAssign = useCallback(
-    async (testSets: TestSet[]) => {
-      if (!isAuthenticated(status) || testSets.length === 0) return;
-
-      const testIds = selectedRows as string[];
-      const testSetsClient = new TestSetsClient();
-      let successCount = 0;
-      let alreadyAssociatedCount = 0;
-      let failureCount = 0;
-
-      for (const testSet of testSets) {
-        try {
-          await testSetsClient.associateTestsWithTestSet(testSet.id, testIds);
-          successCount++;
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : '';
-          if (errorMessage.toLowerCase().includes('already associated')) {
-            alreadyAssociatedCount++;
-          } else {
-            failureCount++;
-          }
-        }
-      }
-
-      if (failureCount > 0) {
-        notifications.show('Failed to associate tests with some test sets', {
-          severity: 'error',
-          autoHideDuration: 6000,
-        });
-        return;
-      }
-
-      if (successCount > 0) {
-        const destinationLabel =
-          testSets.length === 1
-            ? `test set "${testSets[0].name}"`
-            : `${testSets.length} test sets`;
-
-        notifications.show(
-          `Successfully associated ${testIds.length} ${testIds.length === 1 ? 'test' : 'tests'} with ${destinationLabel}`,
-          {
-            severity: 'success',
-            autoHideDuration: 6000,
-          }
-        );
-        setTestSetDrawerOpen(false);
-        return;
-      }
-
-      if (alreadyAssociatedCount > 0) {
-        notifications.show(
-          'Selected tests are already in the chosen test set(s)',
-          {
-            severity: 'warning',
-            autoHideDuration: 6000,
-          }
-        );
-        setTestSetDrawerOpen(false);
-      }
-    },
-    [selectedRows, notifications, status]
-  );
-
-  const handleDeleteTests = useCallback(() => {
-    if (selectedRows.length > 0) {
-      setDeleteModalOpen(true);
-    }
-  }, [selectedRows]);
-
-  const handleDeleteConfirm = useCallback(async () => {
-    const idsToDelete = pendingDeleteId
-      ? [pendingDeleteId]
-      : (selectedRows as string[]);
-    if (idsToDelete.length === 0) return;
-
-    try {
-      setIsDeleting(true);
-      const clientFactory = new ApiClientFactory();
-      const testsClient = clientFactory.getTestsClient();
-
-      await testsClient.bulkDeleteTests(idsToDelete);
-
-      notifications.show(
-        `Successfully deleted ${idsToDelete.length} ${idsToDelete.length === 1 ? 'test' : 'tests'}`,
-        { severity: 'success', autoHideDuration: 4000 }
-      );
-
-      setPendingDeleteId(null);
-      setSelectedRows([]);
-      refresh();
-    } catch (_error) {
-      notifications.show('Failed to delete tests', {
-        severity: 'error',
-        autoHideDuration: 6000,
-      });
-    } finally {
-      setIsDeleting(false);
-      setDeleteModalOpen(false);
-    }
-  }, [pendingDeleteId, selectedRows, notifications, refresh]);
-
-  const handleDeleteCancel = useCallback(() => {
-    setDeleteModalOpen(false);
-    setPendingDeleteId(null);
-  }, []);
-
-  const _handleNewTest = useCallback(() => {
-    setSelectedTest(undefined);
-    setDrawerOpen(true);
-  }, []);
-
-  const handleDrawerClose = useCallback(() => {
-    setDrawerOpen(false);
-    setSelectedTest(undefined);
-  }, []);
-
-  const handleCheckboxSelectionModeChange = useCallback((enabled: boolean) => {
-    setCheckboxSelectionMode(enabled);
-    if (!enabled) {
-      setSelectedRows([]);
-    }
-  }, []);
-
-  const handleTestSaved = useCallback(() => {
-    if (page > 0) {
-      onPageChange(0);
-    } else {
-      refresh();
-    }
-  }, [page, onPageChange, refresh]);
-
-  const filtersActive =
-    !!searchQuery ||
-    hasActiveTestFilters(drawerFilters) ||
-    !!insightsFailedFilter;
-
-  const showSelectionActions = checkboxSelectionMode && selectedRows.length > 0;
-
-  const bulkHandlersRef = useRef({
-    onAssign: handleCreateTestSet,
-    onDelete: handleDeleteTests,
-  });
-  bulkHandlersRef.current = {
-    onAssign: handleCreateTestSet,
-    onDelete: handleDeleteTests,
-  };
-
-  useEffect(() => {
-    onBulkActionsChange?.({
-      visible: showSelectionActions,
-      assignDisabled: selectedTestTypes.isMixed,
-      onAssign: () => bulkHandlersRef.current.onAssign(),
-      onDelete: () => bulkHandlersRef.current.onDelete(),
-    });
-  }, [showSelectionActions, selectedTestTypes.isMixed, onBulkActionsChange]);
-
-  useEffect(() => {
-    return () => {
-      onBulkActionsChange?.({
-        visible: false,
-        assignDisabled: false,
-        onAssign: () => {},
-        onDelete: () => {},
-      });
-    };
-  }, [onBulkActionsChange]);
-
   return (
-    <GridStateGate
-      data={loading ? null : {}}
-      error={error}
-      isEmpty={totalCount === 0 && !filtersActive}
+    <EntityGrid<
+      TestDetail,
+      typeof testsList.filters,
+      TestFilters,
+      TestsBulkActionsState
+    >
+      descriptor={testsList}
+      columns={columns}
+      toFilters={toFilters}
       emptyState={
         <EntityEmptyState
           card
@@ -770,121 +517,49 @@ export default function TestsTable({
           enrichment={getEntityEmptyStateEnrichment('tests')}
         />
       }
-    >
-      <Paper sx={GRID_PAPER_SX}>
-        <TestsToolbarContext.Provider
-          value={{
-            searchQuery,
-            setSearchQuery,
-            typeFilter,
-            setTypeFilter,
-            openFilterDrawer: () => setFilterDrawerOpen(true),
-            hasActiveDrawerFilters: hasActiveTestFilters(drawerFilters),
-            activeFilterCount: countActiveTestFilters(drawerFilters),
-            checkboxSelectionMode,
-            setCheckboxSelectionMode: handleCheckboxSelectionModeChange,
-          }}
-        >
-          {error && (
-            <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
-              {error}
-            </Alert>
-          )}
-
-          {insightsFailedFilter && (
-            <Alert severity="info" sx={{ mb: 2 }}>
-              {insightsFilterLoading
-                ? 'Loading test cases from Insights…'
-                : insightsFilterError ||
-                  formatInsightsFailedTestsBanner(
-                    insightsFailedFilter,
-                    resolvedInsightsFailedTestIds?.length ?? 0,
-                    insightsEndpointName
-                  )}
-            </Alert>
-          )}
-
-          <BaseDataGrid
-            rows={tests}
-            columns={columns}
-            loading={loading}
-            getRowId={row => row.id}
-            paginationModel={paginationModel}
-            onPaginationModelChange={handlePaginationModelChange}
-            checkboxSelection={checkboxSelectionMode}
-            disableRowSelectionOnClick={checkboxSelectionMode || undefined}
-            onRowSelectionModelChange={
-              checkboxSelectionMode ? handleSelectionChange : undefined
-            }
-            rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
-            onRowClick={checkboxSelectionMode ? undefined : handleRowClick}
-            getRowUrl={
-              checkboxSelectionMode ? undefined : row => `/tests/${row.id}`
-            }
-            serverSidePagination={true}
-            totalRows={totalCount}
-            pageSizeOptions={[10, 25, 50]}
-            sortingMode="server"
-            sortModel={sortModel}
-            onSortModelChange={handleSortModelChange}
-            toolbarSlot={TestsUnifiedToolbar}
-            showToolbar={true}
-            disablePaperWrapper={true}
-            persistState={!insightsFailedFilter}
-            initialState={{
-              columns: {
-                columnVisibilityModel: {
-                  'test_metadata.sources': false,
-                },
-              },
-            }}
-            sx={rowActionsHoverSx}
-          />
-
-          {isAuthenticated(status) && (
-            <>
-              <TestDrawer
-                open={drawerOpen}
-                onClose={handleDrawerClose}
-                test={selectedTest}
-                onSuccess={handleTestSaved}
-              />
-              <TestSetSelectionDrawer
-                open={testSetDrawerOpen}
-                onClose={() => setTestSetDrawerOpen(false)}
-                onSelect={handleTestSetsAssign}
-                testTypeValue={selectedTestTypes.commonTypeValue}
-              />
-              <DeleteModal
-                open={deleteModalOpen}
-                onClose={handleDeleteCancel}
-                onConfirm={handleDeleteConfirm}
-                isLoading={isDeleting}
-                title={pendingDeleteId ? 'Delete Test' : 'Delete Tests'}
-                message={
-                  pendingDeleteId
-                    ? 'Are you sure you want to delete this test? Related data will not be deleted.'
-                    : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'test' : 'tests'}? Don't worry, related data will not be deleted, only ${selectedRows.length === 1 ? 'this record' : 'these records'}.`
-                }
-                itemType="tests"
-              />
-            </>
-          )}
-
-          {/* Filter drawer */}
-          <TestFilterDrawer
-            open={filterDrawerOpen}
-            onClose={() => setFilterDrawerOpen(false)}
-            filters={drawerFilters}
-            onApply={f => {
-              setDrawerFilters(f);
-              // If drawer sets a test type, sync the pill tab too
-              if (f.testType) setTypeFilter(f.testType);
-              else if (!drawerFilters.testType) setTypeFilter('all');
-            }}
-          />
-        </TestsToolbarContext.Provider>
-      </Paper>
-    </GridStateGate>
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+      extraFilters={extraFilters}
+      enabled={insightsFilterReady}
+      banner={insightsBanner}
+      searchPlaceholder="Search tests…"
+      pills={{ tabs: TEST_TYPE_PILL_TABS }}
+      drawer={drawerAdapter}
+      selectionLabel="Select tests"
+      showExport={canExport}
+      getRowUrl={row => `/tests/${row.id}`}
+      editAction={{ onClick: handleEditTest, can: () => canEditTest }}
+      onBulkActionsChange={onBulkActionsChange}
+      buildBulkActions={buildBulkActions}
+      persistState={!insightsFailedFilter}
+      pageSizeOptions={[10, 25, 50]}
+      initialState={{
+        columns: {
+          columnVisibilityModel: {
+            'test_metadata.sources': false,
+          },
+        },
+      }}
+      renderSelectionExtras={ctx =>
+        isAuthenticated(status) && (
+          <>
+            <TestDrawer
+              open={drawerOpen}
+              onClose={handleDrawerClose}
+              test={selectedTest}
+              onSuccess={ctx.refresh}
+            />
+            <TestSetSelectionDrawer
+              open={testSetDrawerOpen}
+              onClose={() => setTestSetDrawerOpen(false)}
+              onSelect={makeTestSetsAssign(ctx)}
+              testTypeValue={
+                selectedTestTypes(ctx.selectedRows).commonTypeValue
+              }
+            />
+          </>
+        )
+      }
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/tests/components/list.ts
+++ b/apps/frontend/src/app/(protected)/tests/components/list.ts
@@ -58,4 +58,16 @@ export const testsList = defineList<TestDetail, typeof TESTS_FILTERS>({
     const { $filter, ...rest } = params;
     return factory.getTestsClient().getTests({ ...rest, filter: $filter });
   },
+  delete: {
+    bulk: (factory: ApiClientFactory, ids: string[]) =>
+      factory.getTestsClient().bulkDeleteTests(ids),
+    capability: Capability.Test.DELETE,
+    capabilityMode: 'ambient',
+    labelSingular: 'test',
+    labelPlural: 'tests',
+    confirmMessage: count =>
+      count === 1
+        ? 'Are you sure you want to delete this test? Related data will not be deleted.'
+        : `Are you sure you want to delete ${count} tests? Don't worry, related data will not be deleted, only these records.`,
+  },
 });

--- a/apps/frontend/src/app/(protected)/tokens/components/TokensGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokensGrid.tsx
@@ -1,285 +1,183 @@
 'use client';
 
-import React, { useContext, useState } from 'react';
-import { Box, Tooltip, IconButton } from '@mui/material';
-import {
-  GridPaginationModel,
-  type GridRenderCellParams,
-  type GridColDef,
-  type GridRowSelectionModel,
-  GridToolbarColumnsButton,
-  GridToolbarDensitySelector,
-  GridToolbarExport,
-} from '@mui/x-data-grid';
-import BaseDataGrid from '@/components/common/BaseDataGrid';
-import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
-import SelectionModeToggle from '@/components/common/SelectionModeToggle';
-import { Token } from '@/utils/api-client/interfaces/token';
+import React, { useState, useCallback, useMemo } from 'react';
+import { type GridRenderCellParams, type GridColDef } from '@mui/x-data-grid';
 import RefreshIcon from '@mui/icons-material/Refresh';
-import { DeleteIcon } from '@/components/icons';
 import { formatDistanceToNow } from 'date-fns';
-import RefreshTokenModal from './RefreshTokenModal';
+import EntityGrid, {
+  type EntityGridDrawerAdapter,
+  type EntityGridFilterState,
+} from '@/components/common/EntityGrid';
 import GridBadge from '@/components/common/GridBadge';
-import {
-  ROW_ACTIONS_CLASS,
-  rowActionsHoverSx,
-} from '@/components/common/createRowActionsColumn';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { VpnKeyIcon } from '@/components/icons';
+import { Token } from '@/utils/api-client/interfaces/token';
+import type { BulkDeleteActionsState } from '@/hooks/useBulkDelete';
+import RefreshTokenModal from './RefreshTokenModal';
+import { tokensList } from './list';
+import TokenFilterDrawer, {
+  type TokenFilters,
+  EMPTY_TOKEN_FILTERS,
+  countActiveTokenFilters,
+} from './TokenFilterDrawer';
 
-// ── Toolbar status filter options ────────────────────────────────────────────
-
-export type TokenStatusFilter = 'all' | 'active' | 'expired';
-
-export const STATUS_OPTIONS: { value: TokenStatusFilter; label: string }[] = [
-  { value: 'all', label: 'All' },
-  { value: 'active', label: 'Active' },
-  { value: 'expired', label: 'Expired' },
+const STATUS_PILL_TABS = [
+  { label: 'All', value: 'all' },
+  { label: 'Active', value: 'active' },
+  { label: 'Expired', value: 'expired' },
 ];
 
-// ── Toolbar context (passes search/filter state into the DataGrid slot) ──────
-
-export interface TokensToolbarState {
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-  statusFilter: TokenStatusFilter;
-  setStatusFilter: (v: TokenStatusFilter) => void;
-  openFilterDrawer: () => void;
-  hasActiveDrawerFilters: boolean;
-  activeFilterCount: number;
-  checkboxSelectionMode: boolean;
-  setCheckboxSelectionMode: (v: boolean) => void;
+// The pill wins over the drawer's status for the one field they overlap on.
+function toFilters(state: EntityGridFilterState<TokenFilters>) {
+  return {
+    search: state.search,
+    status:
+      state.pill || (state.drawer.status === 'all' ? '' : state.drawer.status),
+    usage: state.drawer.usage === 'all' ? '' : state.drawer.usage,
+  };
 }
 
-export const TokensToolbarContext = React.createContext<TokensToolbarState>({
-  searchQuery: '',
-  setSearchQuery: () => {},
-  statusFilter: 'all',
-  setStatusFilter: () => {},
-  openFilterDrawer: () => {},
-  hasActiveDrawerFilters: false,
-  activeFilterCount: 0,
-  checkboxSelectionMode: false,
-  setCheckboxSelectionMode: () => {},
-});
-
-function TokensUnifiedToolbar() {
-  const {
-    searchQuery,
-    setSearchQuery,
-    statusFilter,
-    setStatusFilter,
-    openFilterDrawer,
-    hasActiveDrawerFilters,
-    activeFilterCount,
-    checkboxSelectionMode,
-    setCheckboxSelectionMode,
-  } = useContext(TokensToolbarContext);
-
-  return (
-    <GridToolbar
-      searchQuery={searchQuery}
-      onSearchChange={setSearchQuery}
-      searchPlaceholder="Search tokens…"
-      onFilterClick={openFilterDrawer}
-      hasActiveFilters={hasActiveDrawerFilters}
-      activeFilterCount={activeFilterCount}
-      middleContent={
-        <ToolbarPillTabs
-          tabs={STATUS_OPTIONS}
-          activeValue={statusFilter}
-          onChange={v => setStatusFilter(v as TokenStatusFilter)}
-        />
-      }
-      rightContent={
-        <>
-          <SelectionModeToggle
-            checked={checkboxSelectionMode}
-            onChange={setCheckboxSelectionMode}
-            label="Select tokens"
-          />
-          <GridToolbarColumnsButton />
-          <GridToolbarDensitySelector />
-          <GridToolbarExport />
-        </>
-      }
+const drawerAdapter: EntityGridDrawerAdapter<TokenFilters> = {
+  empty: EMPTY_TOKEN_FILTERS,
+  countActive: countActiveTokenFilters,
+  render: props => (
+    <TokenFilterDrawer
+      open={props.open}
+      onClose={props.onClose}
+      filters={props.filters}
+      onApply={props.onApply}
     />
-  );
-}
-
-// ── Grid component ────────────────────────────────────────────────────────────
+  ),
+};
 
 interface TokensGridProps {
-  tokens: Token[];
+  canCreate?: boolean;
+  onCreateClick?: () => void;
+  /** Called with the refreshed token so the page can show it once. */
   onRefreshToken: (
     tokenId: string,
     expiresInDays: number | null
   ) => Promise<void>;
-  onDeleteToken: (tokenId: string) => void;
-  loading: boolean;
-  totalCount: number;
-  onPaginationModelChange?: (model: GridPaginationModel) => void;
-  paginationModel?: GridPaginationModel;
-  checkboxSelectionMode: boolean;
-  selectedRows: GridRowSelectionModel;
-  onSelectionChange: (model: GridRowSelectionModel) => void;
+  onBulkActionsChange?: (actions: BulkDeleteActionsState) => void;
+  /** Bumped by the page after a create succeeds, to trigger a re-fetch. */
+  refreshTrigger?: number;
 }
 
 export default function TokensGrid({
-  tokens,
+  canCreate,
+  onCreateClick,
   onRefreshToken,
-  onDeleteToken,
-  loading,
-  totalCount,
-  onPaginationModelChange,
-  paginationModel = {
-    page: 0,
-    pageSize: 10,
-  },
-  checkboxSelectionMode,
-  selectedRows,
-  onSelectionChange,
+  onBulkActionsChange,
+  refreshTrigger,
 }: TokensGridProps) {
-  const [refreshModalOpen, setRefreshModalOpen] = useState(false);
-  const [selectedTokenId, setSelectedTokenId] = useState<string | null>(null);
+  const [refreshTarget, setRefreshTarget] = useState<Token | null>(null);
 
-  const handleRefreshClick = (tokenId: string) => {
-    setSelectedTokenId(tokenId);
-    setRefreshModalOpen(true);
-  };
+  const extraRowActions = useMemo(
+    () => [
+      {
+        key: 'refresh',
+        icon: RefreshIcon,
+        tooltip: 'Invalidate and refresh',
+        onClick: (_id: string, row: Record<string, unknown>) =>
+          setRefreshTarget(row as unknown as Token),
+        hoverColor: 'primary.main' as const,
+      },
+    ],
+    []
+  );
 
-  const columns: GridColDef[] = [
-    {
-      field: 'name',
-      headerName: 'Name',
-      flex: 1,
-      renderCell: (params: GridRenderCellParams) => (
-        <span style={{ fontWeight: 500 }}>{params.row.name}</span>
-      ),
-    },
-    {
-      field: 'token',
-      headerName: 'Token',
-      flex: 1.5,
-      renderCell: (params: GridRenderCellParams) => params.row.token_obfuscated,
-    },
-    {
-      field: 'last_used',
-      headerName: 'Last Used',
-      flex: 1,
-      renderCell: (params: GridRenderCellParams) =>
-        params.row.last_used_at
-          ? formatDistanceToNow(new Date(params.row.last_used_at), {
-              addSuffix: true,
-            })
-          : 'Never',
-    },
-    {
-      field: 'expires',
-      headerName: 'Expires',
-      flex: 1,
-      renderCell: (params: GridRenderCellParams) => (
-        <GridBadge
-          label={
-            params.row.expires_at
-              ? formatDistanceToNow(new Date(params.row.expires_at), {
-                  addSuffix: true,
-                })
-              : 'Never'
-          }
-        />
-      ),
-    },
-    {
-      field: 'actions',
-      headerName: '',
-      width: 88,
-      sortable: false,
-      disableColumnMenu: true,
-      align: 'center',
-      headerAlign: 'center',
-      renderCell: (params: GridRenderCellParams) => (
-        <Box
-          className={ROW_ACTIONS_CLASS}
-          sx={{
-            display: 'flex',
-            gap: '4px',
-            justifyContent: 'center',
-            alignItems: 'center',
-            width: '100%',
-          }}
-        >
-          <Tooltip title="Invalidate and refresh">
-            <IconButton
-              size="small"
-              onClick={e => {
-                e.stopPropagation();
-                handleRefreshClick(params.row.id);
-              }}
-              sx={{
-                p: 0.5,
-                color: 'text.secondary',
-                '&:hover': { color: 'primary.main', bgcolor: 'action.hover' },
-              }}
-            >
-              <RefreshIcon sx={{ fontSize: 18 }} />
-            </IconButton>
-          </Tooltip>
-          <Tooltip title="Delete Token">
-            <IconButton
-              size="small"
-              onClick={e => {
-                e.stopPropagation();
-                onDeleteToken(params.row.id);
-              }}
-              sx={{
-                p: 0.5,
-                color: 'text.secondary',
-                '&:hover': { color: 'error.main', bgcolor: 'action.hover' },
-              }}
-            >
-              <DeleteIcon sx={{ fontSize: 18 }} />
-            </IconButton>
-          </Tooltip>
-        </Box>
-      ),
-    } as GridColDef,
-  ];
+  const handleRefreshClose = useCallback(() => setRefreshTarget(null), []);
+
+  const columns: GridColDef[] = useMemo(
+    () => [
+      {
+        field: 'name',
+        headerName: 'Name',
+        flex: 1,
+        renderCell: (params: GridRenderCellParams) => (
+          <span style={{ fontWeight: 500 }}>{params.row.name}</span>
+        ),
+      },
+      {
+        field: 'token',
+        headerName: 'Token',
+        flex: 1.5,
+        sortable: false,
+        renderCell: (params: GridRenderCellParams) =>
+          params.row.token_obfuscated,
+      },
+      {
+        field: 'last_used_at',
+        headerName: 'Last Used',
+        flex: 1,
+        renderCell: (params: GridRenderCellParams) =>
+          params.row.last_used_at
+            ? formatDistanceToNow(new Date(params.row.last_used_at), {
+                addSuffix: true,
+              })
+            : 'Never',
+      },
+      {
+        field: 'expires_at',
+        headerName: 'Expires',
+        flex: 1,
+        renderCell: (params: GridRenderCellParams) => (
+          <GridBadge
+            label={
+              params.row.expires_at
+                ? formatDistanceToNow(new Date(params.row.expires_at), {
+                    addSuffix: true,
+                  })
+                : 'Never'
+            }
+          />
+        ),
+      },
+    ],
+    []
+  );
 
   return (
-    <>
-      <BaseDataGrid
-        columns={columns}
-        rows={tokens}
-        loading={loading}
-        getRowId={row => (row as Token).id}
-        density="standard"
-        paginationModel={paginationModel}
-        onPaginationModelChange={onPaginationModelChange}
-        serverSidePagination={false}
-        totalRows={totalCount}
-        pageSizeOptions={[10, 25, 50]}
-        disablePaperWrapper={true}
-        toolbarSlot={TokensUnifiedToolbar}
-        persistState
-        storageKey="tokens-grid"
-        sx={rowActionsHoverSx}
-        checkboxSelection={checkboxSelectionMode}
-        disableRowSelectionOnClick={checkboxSelectionMode || undefined}
-        rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
-        onRowSelectionModelChange={
-          checkboxSelectionMode ? onSelectionChange : undefined
-        }
-      />
-      <RefreshTokenModal
-        open={refreshModalOpen}
-        onClose={() => setRefreshModalOpen(false)}
-        onRefresh={async expiresInDays => {
-          if (selectedTokenId) {
-            await onRefreshToken(selectedTokenId, expiresInDays);
-            setRefreshModalOpen(false);
-          }
-        }}
-        tokenName={tokens.find(t => t.id === selectedTokenId)?.name || ''}
-      />
-    </>
+    <EntityGrid<Token, typeof tokensList.filters, TokenFilters>
+      descriptor={tokensList}
+      columns={columns}
+      toFilters={toFilters}
+      emptyState={
+        <EntityEmptyState
+          card
+          icon={VpnKeyIcon}
+          title="No API tokens yet"
+          description="Create your first API token to start interacting with the Rhesis API. Tokens allow you to authenticate your applications and build powerful integrations."
+          actionLabel={canCreate ? 'Create API token' : undefined}
+          onAction={canCreate ? onCreateClick : undefined}
+        />
+      }
+      refreshTrigger={refreshTrigger}
+      searchPlaceholder="Search tokens…"
+      pills={{ tabs: STATUS_PILL_TABS }}
+      drawer={drawerAdapter}
+      selectionLabel="Select tokens"
+      editAction={false}
+      extraRowActions={extraRowActions}
+      onBulkActionsChange={onBulkActionsChange}
+      density="standard"
+      storageKey="tokens-grid"
+      pageSizeOptions={[10, 25, 50]}
+      serverSort={false}
+      renderSelectionExtras={ctx => (
+        <RefreshTokenModal
+          open={refreshTarget !== null}
+          onClose={handleRefreshClose}
+          onRefresh={async expiresInDays => {
+            if (refreshTarget) {
+              await onRefreshToken(refreshTarget.id, expiresInDays);
+              setRefreshTarget(null);
+              ctx.refresh();
+            }
+          }}
+          tokenName={refreshTarget?.name || ''}
+        />
+      )}
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/tokens/components/TokensGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokensGrid.tsx
@@ -163,7 +163,6 @@ export default function TokensGrid({
       density="standard"
       storageKey="tokens-grid"
       pageSizeOptions={[10, 25, 50]}
-      serverSort={false}
       renderSelectionExtras={ctx => (
         <RefreshTokenModal
           open={refreshTarget !== null}

--- a/apps/frontend/src/app/(protected)/tokens/components/TokensPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokensPageClient.tsx
@@ -1,242 +1,69 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Paper, Alert } from '@mui/material';
+import { useState, useCallback, useRef } from 'react';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import TokensGrid, {
-  TokensToolbarContext,
-  type TokenStatusFilter,
-  type TokensToolbarState,
-} from './TokensGrid';
-import { useBulkDelete } from '@/hooks/useBulkDelete';
+import TokensGrid from './TokensGrid';
 import CreateTokenDrawer from './CreateTokenDrawer';
 import TokenDisplay from './TokenDisplay';
-import TokenFilterDrawer, {
-  type TokenFilters,
-  EMPTY_TOKEN_FILTERS,
-  hasActiveTokenFilters,
-  countActiveTokenFilters,
-} from './TokenFilterDrawer';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { Token, TokenResponse } from '@/utils/api-client/interfaces/token';
-import { DeleteModal } from '@/components/common/DeleteModal';
+import { TokenResponse } from '@/utils/api-client/interfaces/token';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
-import EntityEmptyState from '@/components/common/EntityEmptyState';
-import { VpnKeyIcon } from '@/components/icons';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import { Can, useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
+import { useBulkActionsBridge } from '@/hooks/useBulkActionsBridge';
 
 export default function TokensPageClient() {
   const { allowed: canManage, loading: permsLoading } = useCanWithStatus(
     Capability.Token.MANAGE
   );
 
-  // Data state
-  const [tokens, setTokens] = useState<Token[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  // Modal/dialog state
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [newToken, setNewToken] = useState<TokenResponse | null>(null);
   const [refreshedToken, setRefreshedToken] = useState<TokenResponse | null>(
     null
   );
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
 
-  // Search & filter state
-  const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<TokenStatusFilter>('all');
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [drawerFilters, setDrawerFilters] =
-    useState<TokenFilters>(EMPTY_TOKEN_FILTERS);
-
-  // Pagination state (client-side)
-  const [paginationModel, setPaginationModel] = useState({
-    page: 0,
-    pageSize: 10,
-  });
+  const { bulkActionsVisible, onBulkDelete, handleBulkActionsChange } =
+    useBulkActionsBridge();
 
   // Stable tokens client across renders
   const tokensClientRef = useRef(new ApiClientFactory().getTokensClient());
 
-  const loadTokens = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      // Pull a generous page so search/filter/pagination can work client-side.
-      // Tokens per user/org are typically far below 100.
-      const response = await tokensClientRef.current.listTokens({
-        skip: 0,
-        limit: 100,
-        sort_by: 'created_at',
-        sort_order: 'desc',
-      });
-      setTokens(response.data);
-    } catch (err) {
-      setError((err as Error).message || 'Failed to load tokens');
-      setTokens([]);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    loadTokens();
-  }, [loadTokens]);
-
-  // ── Handlers ────────────────────────────────────────────────────────────────
-
-  const handleOpenCreateModal = () => {
+  const handleOpenCreateModal = useCallback(() => {
     setNewToken(null);
     setIsCreateModalOpen(true);
-  };
+  }, []);
 
   const handleCreateToken = async (
     name: string,
     expiresInDays: number | null,
     scopes: string[] | null
   ) => {
-    try {
-      const response = await tokensClientRef.current.createToken(
-        name,
-        expiresInDays,
-        scopes
-      );
-      setNewToken({ ...response, name });
-      setIsCreateModalOpen(false);
-      await loadTokens();
-      return response;
-    } catch (err) {
-      setError((err as Error).message);
-      throw err;
-    }
+    const response = await tokensClientRef.current.createToken(
+      name,
+      expiresInDays,
+      scopes
+    );
+    setNewToken({ ...response, name });
+    setIsCreateModalOpen(false);
+    setRefreshTrigger(prev => prev + 1);
+    return response;
   };
 
-  const handleRefreshToken = async (
-    tokenId: string,
-    expiresInDays: number | null
-  ) => {
-    try {
+  const handleRefreshToken = useCallback(
+    async (tokenId: string, expiresInDays: number | null) => {
       const response = await tokensClientRef.current.refreshToken(
         tokenId,
         expiresInDays
       );
-      await loadTokens();
       setRefreshedToken(response);
-    } catch (err) {
-      setError((err as Error).message);
-    }
-  };
-
-  const {
-    checkboxSelectionMode,
-    setCheckboxSelectionMode,
-    selectedRows,
-    handleSelectionChange,
-    pendingDeleteId,
-    deleteModalOpen,
-    isDeleting,
-    requestDelete,
-    confirmDelete,
-    cancelDelete,
-  } = useBulkDelete({
-    bulkDeleteFn: (ids: string[]) =>
-      tokensClientRef.current.bulkDeleteTokens(ids),
-    onSuccess: loadTokens,
-    itemLabelSingular: 'token',
-    itemLabelPlural: 'tokens',
-  });
-
-  // No separate page here to bridge to -- the FabGroup below is already in
-  // the same component as useBulkDelete, so it reads this directly instead
-  // of going through useBulkActionsBridge/onBulkActionsChange.
-  const bulkActionsVisible = checkboxSelectionMode && selectedRows.length > 0;
-
-  // ── Derived data ────────────────────────────────────────────────────────────
-
-  const isExpired = (token: Token) =>
-    Boolean(token.expires_at) && new Date(token.expires_at) <= new Date();
-
-  const filteredTokens = useMemo(() => {
-    const query = search.trim().toLowerCase();
-
-    return tokens.filter(token => {
-      // Search by name or obfuscated token
-      if (query) {
-        const nameMatch = token.name?.toLowerCase().includes(query);
-        const tokenMatch = token.token_obfuscated
-          ?.toLowerCase()
-          .includes(query);
-        if (!nameMatch && !tokenMatch) return false;
-      }
-
-      // Center pill: status filter
-      if (statusFilter === 'active' && isExpired(token)) return false;
-      if (statusFilter === 'expired' && !isExpired(token)) return false;
-
-      // Drawer: status (mirrors center pill, narrower)
-      if (drawerFilters.status === 'active' && isExpired(token)) return false;
-      if (drawerFilters.status === 'expired' && !isExpired(token)) return false;
-
-      // Drawer: usage
-      if (drawerFilters.usage === 'used' && !token.last_used_at) return false;
-      if (drawerFilters.usage === 'never_used' && token.last_used_at)
-        return false;
-
-      return true;
-    });
-  }, [tokens, search, statusFilter, drawerFilters]);
-
-  const hasActiveFilters =
-    search.trim() !== '' ||
-    statusFilter !== 'all' ||
-    hasActiveTokenFilters(drawerFilters);
-
-  // Clamp pagination when the filtered list shrinks
-  useEffect(() => {
-    const lastPage = Math.max(
-      0,
-      Math.ceil(filteredTokens.length / paginationModel.pageSize) - 1
-    );
-    if (paginationModel.page > lastPage) {
-      setPaginationModel(prev => ({ ...prev, page: lastPage }));
-    }
-  }, [filteredTokens.length, paginationModel.page, paginationModel.pageSize]);
-
-  // ── Toolbar context value ────────────────────────────────────────────────────
-
-  const toolbarContextValue: TokensToolbarState = useMemo(
-    () => ({
-      searchQuery: search,
-      setSearchQuery: (v: string) => {
-        setSearch(v);
-        setPaginationModel(prev => ({ ...prev, page: 0 }));
-      },
-      statusFilter,
-      setStatusFilter: (v: TokenStatusFilter) => {
-        setStatusFilter(v);
-        setPaginationModel(prev => ({ ...prev, page: 0 }));
-      },
-      openFilterDrawer: () => setFilterDrawerOpen(true),
-      hasActiveDrawerFilters: hasActiveTokenFilters(drawerFilters),
-      activeFilterCount: countActiveTokenFilters(drawerFilters),
-      checkboxSelectionMode,
-      setCheckboxSelectionMode,
-    }),
-    [
-      search,
-      statusFilter,
-      drawerFilters,
-      checkboxSelectionMode,
-      setCheckboxSelectionMode,
-    ]
+    },
+    []
   );
-
-  // ── Render ──────────────────────────────────────────────────────────────────
 
   if (permsLoading) return <PageLoadingState />;
   if (!canManage) return <AccessDenied resource="API tokens" />;
@@ -254,7 +81,7 @@ export default function TokensPageClient() {
                 icon={<DeleteOutlineIcon sx={{ fontSize: 28 }} />}
                 tooltip="Delete Tokens"
                 aria-label="Delete Tokens"
-                onClick={() => requestDelete()}
+                onClick={onBulkDelete}
                 sx={{
                   bgcolor: 'error.main',
                   '&:hover': { bgcolor: 'error.dark' },
@@ -273,66 +100,14 @@ export default function TokensPageClient() {
         </FabGroup>
       }
     >
-      {/* Error state */}
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
+      <TokensGrid
+        canCreate={canManage}
+        onCreateClick={handleOpenCreateModal}
+        onRefreshToken={handleRefreshToken}
+        onBulkActionsChange={handleBulkActionsChange}
+        refreshTrigger={refreshTrigger}
+      />
 
-      {/* Empty state vs grid */}
-      {!loading && tokens.length === 0 ? (
-        <EntityEmptyState
-          card
-          icon={VpnKeyIcon}
-          title="No API tokens yet"
-          description="Create your first API token to start interacting with the Rhesis API. Tokens allow you to authenticate your applications and build powerful integrations."
-          actionLabel={canManage ? 'Create API token' : undefined}
-          onAction={canManage ? handleOpenCreateModal : undefined}
-        />
-      ) : !loading && filteredTokens.length === 0 && hasActiveFilters ? (
-        <EntityEmptyState
-          card
-          showAddIcon={false}
-          icon={VpnKeyIcon}
-          title="No tokens match your filters"
-          description="Try adjusting your search or filters to find the tokens you're looking for."
-          actionLabel="Reset filters"
-          onAction={() => {
-            setSearch('');
-            setStatusFilter('all');
-            setDrawerFilters(EMPTY_TOKEN_FILTERS);
-          }}
-        />
-      ) : (
-        <Paper
-          elevation={0}
-          sx={{
-            width: '100%',
-            borderRadius: BORDER_RADIUS.md,
-            boxShadow: ELEVATION.xs,
-            border: theme => `1px solid ${theme.palette.greyscale.border}`,
-            overflow: 'hidden',
-          }}
-        >
-          <TokensToolbarContext.Provider value={toolbarContextValue}>
-            <TokensGrid
-              tokens={filteredTokens}
-              onRefreshToken={handleRefreshToken}
-              onDeleteToken={requestDelete}
-              loading={loading}
-              totalCount={filteredTokens.length}
-              paginationModel={paginationModel}
-              onPaginationModelChange={setPaginationModel}
-              checkboxSelectionMode={checkboxSelectionMode}
-              selectedRows={selectedRows}
-              onSelectionChange={handleSelectionChange}
-            />
-          </TokensToolbarContext.Provider>
-        </Paper>
-      )}
-
-      {/* Modals & dialogs */}
       <CreateTokenDrawer
         open={isCreateModalOpen}
         onClose={() => setIsCreateModalOpen(false)}
@@ -350,37 +125,6 @@ export default function TokensPageClient() {
         open={refreshedToken !== null}
         onClose={() => setRefreshedToken(null)}
         token={refreshedToken}
-      />
-
-      <DeleteModal
-        open={deleteModalOpen}
-        onClose={cancelDelete}
-        onConfirm={confirmDelete}
-        isLoading={isDeleting}
-        title={pendingDeleteId ? 'Delete Token' : 'Delete Tokens'}
-        itemType="tokens"
-        itemName={
-          pendingDeleteId
-            ? tokens.find(t => t.id === pendingDeleteId)?.name
-            : undefined
-        }
-        message={
-          pendingDeleteId
-            ? tokens.find(t => t.id === pendingDeleteId)?.name
-              ? `Are you sure you want to delete the token "${tokens.find(t => t.id === pendingDeleteId)?.name}"? This action cannot be undone, and any applications using this token will no longer be able to authenticate.`
-              : `Are you sure you want to delete this token? This action cannot be undone, and any applications using this token will no longer be able to authenticate.`
-            : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'token' : 'tokens'}? This action cannot be undone, and any applications using ${selectedRows.length === 1 ? 'this token' : 'these tokens'} will no longer be able to authenticate.`
-        }
-      />
-
-      <TokenFilterDrawer
-        open={filterDrawerOpen}
-        onClose={() => setFilterDrawerOpen(false)}
-        filters={drawerFilters}
-        onApply={f => {
-          setDrawerFilters(f);
-          setPaginationModel(prev => ({ ...prev, page: 0 }));
-        }}
       />
     </PageLayout>
   );

--- a/apps/frontend/src/app/(protected)/tokens/components/__tests__/TokensGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/__tests__/TokensGrid.test.tsx
@@ -1,75 +1,116 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@/test-utils';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import TokensGrid from '../TokensGrid';
 
-// Stub out BaseDataGrid to avoid full MUI DataGrid setup
-jest.mock('@/components/common/BaseDataGrid', () => ({
-  __esModule: true,
-  default: ({
-    rows,
-    columns,
-  }: {
-    rows: { id: string; name: string }[];
-    columns: {
-      field: string;
-      renderCell?: (p: {
-        row: { id: string; name: string };
-      }) => React.ReactNode;
-    }[];
-  }) => (
-    <table>
-      <thead>
-        <tr>
-          {columns.map((c: { field: string }) => (
-            <th key={c.field}>{c.field}</th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row: { id: string; name: string }) => (
-          <tr key={row.id}>
-            {columns.map(
-              (c: {
-                field: string;
-                renderCell?: (p: {
-                  row: { id: string; name: string };
-                }) => React.ReactNode;
-              }) => (
-                <td key={c.field}>
-                  {c.renderCell
-                    ? c.renderCell({ row })
-                    : ((row as Record<string, unknown>)[
-                        c.field
-                      ] as React.ReactNode)}
-                </td>
-              )
-            )}
-          </tr>
-        ))}
-      </tbody>
-    </table>
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+  usePathname: () => '/tokens',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { user: { id: 'u1', name: 'Alice' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('@/components/common/NotificationContext', () => ({
+  useNotifications: () => ({ show: jest.fn(), close: jest.fn() }),
+  NotificationProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
   ),
 }));
 
-jest.mock('@/components/common/GridBadge', () => ({
-  __esModule: true,
-  default: ({ label }: { label: string }) => <span>{label}</span>,
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
+
+const mockListTokens = jest.fn();
+const mockBulkDeleteTokens = jest.fn();
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getTokensClient: () => ({
+      listTokens: mockListTokens,
+      bulkDeleteTokens: mockBulkDeleteTokens,
+    }),
+  })),
+}));
+
+interface MockGridProps {
+  rows: Array<Record<string, unknown>>;
+  loading?: boolean;
+  columns?: Array<{
+    field: string;
+    renderCell?: (params: {
+      id: unknown;
+      row: Record<string, unknown>;
+    }) => React.ReactNode;
+  }>;
+}
+
+jest.mock('@/components/common/BaseDataGrid', () => {
+  const MockBaseDataGrid = ({ rows, loading, columns }: MockGridProps) => {
+    if (loading) return <div data-testid="grid-loading">Loading…</div>;
+    const actionsCol = columns?.find(c => c.field === 'actions');
+    return (
+      <div data-testid="base-data-grid">
+        {rows.map(row => (
+          <div key={String(row.id)} data-testid={`row-${row.id}`}>
+            <span>{String(row.name)}</span>
+            {actionsCol?.renderCell?.({ id: row.id, row })}
+          </div>
+        ))}
+      </div>
+    );
+  };
+  return {
+    __esModule: true,
+    default: MockBaseDataGrid,
+    GRID_PAPER_SX: {},
+  };
+});
 
 jest.mock('../RefreshTokenModal', () => ({
   __esModule: true,
-  default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+  default: ({
+    open,
+    onClose,
+    onRefresh,
+    tokenName,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onRefresh: (days: number | null) => Promise<void>;
+    tokenName: string;
+  }) =>
     open ? (
       <div data-testid="refresh-modal">
+        <span data-testid="refresh-token-name">{tokenName}</span>
+        <button onClick={() => onRefresh(30)}>confirm-refresh</button>
         <button onClick={onClose}>close-refresh</button>
       </div>
     ) : null,
 }));
 
 const onRefreshToken = jest.fn().mockResolvedValue(undefined);
-const onDeleteToken = jest.fn();
-const onSelectionChange = jest.fn();
+
+const makeResponse = (data: Array<Record<string, unknown>>) => ({
+  data,
+  pagination: {
+    totalCount: data.length,
+    skip: 0,
+    limit: 10,
+    currentPage: 0,
+    pageSize: 10,
+    totalPages: 1,
+  },
+});
 
 function makeToken(id: string) {
   return {
@@ -88,40 +129,52 @@ function makeToken(id: string) {
 describe('TokensGrid', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockListTokens.mockResolvedValue(makeResponse([makeToken('t1')]));
   });
 
-  it('renders the grid (via BaseDataGrid) even when loading=true and no tokens', () => {
-    render(
-      <TokensGrid
-        tokens={[]}
-        loading={true}
-        onRefreshToken={onRefreshToken}
-        onDeleteToken={onDeleteToken}
-        totalCount={0}
-        checkboxSelectionMode={false}
-        selectedRows={[]}
-        onSelectionChange={onSelectionChange}
-      />
-    );
-    // BaseDataGrid is mocked to render a <table>; loading state is handled
-    // internally by BaseDataGrid (not by a standalone spinner in TokensGrid).
-    expect(document.querySelector('table')).toBeInTheDocument();
+  it('shows the empty state when there are no tokens', async () => {
+    mockListTokens.mockResolvedValue(makeResponse([]));
+    render(<TokensGrid onRefreshToken={onRefreshToken} />);
+    expect(await screen.findByText('No API tokens yet')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
   });
 
-  it('renders token names in the data grid', () => {
-    render(
-      <TokensGrid
-        tokens={[makeToken('t1'), makeToken('t2')]}
-        loading={false}
-        onRefreshToken={onRefreshToken}
-        onDeleteToken={onDeleteToken}
-        totalCount={2}
-        checkboxSelectionMode={false}
-        selectedRows={[]}
-        onSelectionChange={onSelectionChange}
-      />
+  it('renders token rows fetched through the descriptor', async () => {
+    mockListTokens.mockResolvedValue(
+      makeResponse([makeToken('t1'), makeToken('t2')])
     );
-    expect(screen.getByText('Token t1')).toBeInTheDocument();
+    render(<TokensGrid onRefreshToken={onRefreshToken} />);
+    expect(await screen.findByText('Token t1')).toBeInTheDocument();
     expect(screen.getByText('Token t2')).toBeInTheDocument();
+  });
+
+  it('opens the refresh modal from the row action and calls onRefreshToken', async () => {
+    render(<TokensGrid onRefreshToken={onRefreshToken} />);
+    await screen.findByText('Token t1');
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole('button', { name: /invalidate and refresh/i })
+    );
+    expect(screen.getByTestId('refresh-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('refresh-token-name')).toHaveTextContent(
+      'Token t1'
+    );
+
+    await user.click(screen.getByRole('button', { name: 'confirm-refresh' }));
+    await waitFor(() => expect(onRefreshToken).toHaveBeenCalledWith('t1', 30));
+  });
+
+  it('deletes a token through the row delete action', async () => {
+    mockBulkDeleteTokens.mockResolvedValue({ deleted_ids: ['t1'] });
+    render(<TokensGrid onRefreshToken={onRefreshToken} />);
+    await screen.findByText('Token t1');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+    await user.click(await screen.findByRole('button', { name: /^delete$/i }));
+    await waitFor(() =>
+      expect(mockBulkDeleteTokens).toHaveBeenCalledWith(['t1'])
+    );
   });
 });

--- a/apps/frontend/src/app/(protected)/tokens/components/list.ts
+++ b/apps/frontend/src/app/(protected)/tokens/components/list.ts
@@ -1,0 +1,52 @@
+import type { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { Capability } from '@/constants/capabilities';
+import { defineList } from '@/utils/list';
+
+/** OData datetime literal for "now" -- unquoted ISO, matching the jobs date filters. */
+function nowLiteral(): string {
+  return new Date().toISOString();
+}
+
+const TOKENS_FILTERS = {
+  search: { kind: 'search', columns: ['name', 'token_obfuscated'] },
+  // A token without expires_at never expires.
+  status: {
+    kind: 'raw',
+    toOData: (value: string) => {
+      if (value === 'active')
+        return `(expires_at eq null or expires_at gt ${nowLiteral()})`;
+      if (value === 'expired') return `expires_at le ${nowLiteral()}`;
+      return undefined;
+    },
+  },
+  usage: {
+    kind: 'raw',
+    toOData: (value: string) => {
+      if (value === 'used') return 'last_used_at ne null';
+      if (value === 'never_used') return 'last_used_at eq null';
+      return undefined;
+    },
+  },
+} as const;
+
+export const tokensList = defineList({
+  title: 'API Tokens',
+  resource: 'API tokens',
+  capability: Capability.Token.MANAGE,
+  defaultPageSize: 10,
+  filters: TOKENS_FILTERS,
+  list: (factory: ApiClientFactory, params) =>
+    factory.getTokensClient().listTokens(params),
+  delete: {
+    bulk: (factory: ApiClientFactory, ids: string[]) =>
+      factory.getTokensClient().bulkDeleteTokens(ids),
+    capability: Capability.Token.MANAGE,
+    capabilityMode: 'ambient',
+    labelSingular: 'token',
+    labelPlural: 'tokens',
+    confirmMessage: count =>
+      count === 1
+        ? 'Are you sure you want to delete this token? This action cannot be undone, and any applications using this token will no longer be able to authenticate.'
+        : `Are you sure you want to delete ${count} tokens? This action cannot be undone, and any applications using these tokens will no longer be able to authenticate.`,
+  },
+});

--- a/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
@@ -419,7 +419,6 @@ export default function TracesTable({
         }}
         pageSizeOptions={[25, 50, 100]}
         disablePaperWrapper
-        showToolbar
         toolbarSlot={() => (
           <TracesUnifiedToolbar hideTypeFilter={Boolean(fixedTestRunId)} />
         )}

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -3,65 +3,43 @@ import React, {
   useEffect,
   useLayoutEffect,
   useCallback,
-  ReactNode,
   useRef,
 } from 'react';
 import {
   Box,
   Typography,
-  Button,
   Paper,
   styled,
   useTheme,
-  FormControl,
-  InputLabel,
   Select,
   MenuItem,
-  SelectChangeEvent,
-  ButtonGroup,
-  Popper,
-  Grow,
-  ClickAwayListener,
-  MenuList,
   CircularProgress,
-  TextField,
-  InputAdornment,
   Menu,
   alpha,
 } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import SearchIcon from '@mui/icons-material/Search';
-import ClearIcon from '@mui/icons-material/Clear';
 import IconButton from '@mui/material/IconButton';
 import {
   DataGrid,
   GridColDef,
   GridPaginationModel,
   GridRowModel,
-  GridEditMode,
   GridDensity,
   GridRowSelectionModel,
-  GridToolbar,
-  GridToolbarQuickFilter,
   useGridApiRef,
   useGridApiContext,
   useGridSelector,
   gridPaginationModelSelector,
   gridRowCountSelector,
-  GridFilterModel,
   GridSortModel,
   GridInitialState,
   GridRowParams,
-  GridCellParams,
   GridColumnMenu,
   type GridColumnGroupingModel,
   type GridColumnMenuProps,
-  type GridToolbarProps,
 } from '@mui/x-data-grid';
 import type { SxProps, Theme } from '@mui/material/styles';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import { useGridStateStorage } from '@/hooks/useGridStateStorage';
@@ -87,67 +65,19 @@ export const GRID_PAPER_SX = {
   overflow: 'hidden',
 } as const;
 
-interface FilterOption {
-  value: string;
-  label: string;
-}
-
-interface FilterConfig {
-  name: string;
-  label: string;
-  filterField: string;
-  options: FilterOption[];
-  defaultValue: string;
-}
-
 interface BaseDataGridProps {
   columns: GridColDef[];
   /** Header groups spanning several columns, e.g. to separate a case from a run. */
   columnGroupingModel?: GridColumnGroupingModel;
   rows: GridRowModel[];
-  title?: string;
   loading?: boolean;
   getRowId?: (row: GridRowModel) => string | number;
-  showToolbar?: boolean;
   onRowClick?: (params: GridRowParams) => void;
   /** Per-row extra CSS class, e.g. to gently highlight a row with an unseen notification. */
   getRowClassName?: (params: GridRowParams) => string;
   density?: GridDensity;
   sx?: SxProps<Theme>;
   disableMultipleRowSelection?: boolean;
-  actionButtons?: {
-    href?: string;
-    label: string;
-    onClick?: () => void;
-    icon?: React.ReactNode;
-    variant?: 'text' | 'outlined' | 'contained';
-    color?:
-      | 'inherit'
-      | 'primary'
-      | 'secondary'
-      | 'success'
-      | 'error'
-      | 'info'
-      | 'warning';
-    disabled?: boolean;
-    splitButton?: {
-      options: {
-        label: string;
-        onClick: () => void;
-        disabled?: boolean;
-      }[];
-    };
-    dataTour?: string;
-  }[];
-  // CRUD related props
-  enableEditing?: boolean;
-  editMode?: GridEditMode;
-  processRowUpdate?: (
-    newRow: GridRowModel,
-    oldRow: GridRowModel
-  ) => Promise<GridRowModel> | GridRowModel;
-  onProcessRowUpdateError?: (error: unknown) => void;
-  isCellEditable?: (params: GridCellParams) => boolean;
   // Selection related props
   checkboxSelection?: boolean;
   disableRowSelectionOnClick?: boolean;
@@ -161,22 +91,6 @@ interface BaseDataGridProps {
    * default.
    */
   isRowSelectable?: (params: GridRowParams) => boolean;
-  // Filter related props
-  filters?: FilterConfig[];
-  filterHandler?: (filteredRows: GridRowModel[]) => void;
-  customToolbarContent?: ReactNode;
-  /**
-   * Extra content rendered inside the DataGrid's built-in toolbar, immediately
-   * to the right of the standard Columns / Filters / Density / Export buttons
-   * (and to the left of the search input). Use this for filter toggles that
-   * conceptually belong next to the grid's existing filter UI rather than
-   * alongside the page-level action buttons.
-   */
-  gridToolbarExtra?: ReactNode;
-  // Server-side filtering props
-  serverSideFiltering?: boolean;
-  filterModel?: GridFilterModel;
-  onFilterModelChange?: (model: GridFilterModel) => void;
   // Server-side sorting props
   sortingMode?: 'client' | 'server';
   sortModel?: GridSortModel;
@@ -198,9 +112,7 @@ interface BaseDataGridProps {
   paginationModel?: GridPaginationModel;
   onPaginationModelChange?: (model: GridPaginationModel) => void;
   pageSizeOptions?: number[];
-  // Quick filter props
-  enableQuickFilter?: boolean;
-  // Custom toolbar slot (overrides default CustomToolbarWithFilters when serverSideFiltering=true)
+  // Custom toolbar slot rendered inside the DataGrid (receives no props — read context)
   toolbarSlot?: React.ComponentType;
   // Styling props
   disablePaperWrapper?: boolean;
@@ -443,21 +355,6 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
   },
 }));
 
-function QuickFilterToolbar() {
-  return (
-    <Box
-      sx={{
-        px: '30px',
-        py: '16px',
-        display: 'flex',
-        justifyContent: 'flex-end',
-      }}
-    >
-      <GridToolbarQuickFilter debounceMs={300} />
-    </Box>
-  );
-}
-
 // Column menu that only shows sort actions (no Filter, no Hide/Manage columns).
 function SortOnlyColumnMenu(props: GridColumnMenuProps) {
   if (props.colDef?.sortable === false) {
@@ -613,33 +510,18 @@ export default function BaseDataGrid({
   columns,
   columnGroupingModel,
   rows,
-  title,
   loading = false,
   getRowId,
-  showToolbar: _showToolbar = false,
   onRowClick,
   getRowClassName,
   density,
   sx: _sx,
   disableMultipleRowSelection,
-  actionButtons,
-  enableEditing = false,
-  editMode = 'row',
-  processRowUpdate,
-  onProcessRowUpdateError,
-  isCellEditable,
   checkboxSelection = false,
   disableRowSelectionOnClick,
   onRowSelectionModelChange,
   rowSelectionModel,
   isRowSelectable,
-  filters,
-  filterHandler,
-  customToolbarContent,
-  gridToolbarExtra,
-  serverSideFiltering = false,
-  filterModel,
-  onFilterModelChange,
   sortingMode = 'client',
   sortModel,
   onSortModelChange,
@@ -651,7 +533,6 @@ export default function BaseDataGrid({
   paginationModel,
   onPaginationModelChange,
   pageSizeOptions = [10, 25, 50],
-  enableQuickFilter = false,
   toolbarSlot,
   disablePaperWrapper = false,
   disableColumnResize = false,
@@ -809,79 +690,6 @@ export default function BaseDataGrid({
     };
   }, [persistState, isInitialized, apiRef, handleStateChange]);
 
-  const [filterValues, setFilterValues] = useState<Record<string, string>>({});
-  const [filteredRows, setFilteredRows] = useState<GridRowModel[]>(rows);
-
-  // Create refs and state for action buttons
-  const buttonRefs = React.useRef<
-    Array<React.RefObject<HTMLDivElement | null>>
-  >(
-    Array(actionButtons?.length || 0)
-      .fill(null)
-      .map(() => React.createRef<HTMLDivElement | null>())
-  );
-  const [openStates, setOpenStates] = React.useState<boolean[]>(
-    Array(actionButtons?.length || 0).fill(false)
-  );
-
-  // Initialize filter values on component mount
-  useEffect(() => {
-    if (filters && filters.length > 0) {
-      const initialValues: Record<string, string> = {};
-      filters.forEach(filter => {
-        initialValues[filter.name] = filter.defaultValue;
-      });
-      setFilterValues(initialValues);
-    }
-  }, [filters]);
-
-  // Update filtered rows when rows change
-  useEffect(() => {
-    if (!serverSidePagination) {
-      setFilteredRows(rows);
-    }
-  }, [rows, serverSidePagination]);
-
-  // Apply filters when rows or filter values change
-  useEffect(() => {
-    if (serverSidePagination || !filters || filters.length === 0) {
-      return;
-    }
-
-    const result = rows.filter(row => {
-      return filters.every(filter => {
-        const currentValue = filterValues[filter.name];
-        if (currentValue === 'all') return true;
-
-        const rowValue = filter.filterField
-          .split('.')
-          .reduce(
-            (obj: unknown, key: string) =>
-              obj && typeof obj === 'object' && key in obj
-                ? (obj as Record<string, unknown>)[key]
-                : undefined,
-            row
-          );
-
-        return rowValue === currentValue;
-      });
-    });
-
-    setFilteredRows(result);
-
-    if (filterHandler) {
-      filterHandler(result);
-    }
-  }, [rows, filterValues, filters, filterHandler, serverSidePagination]);
-
-  const handleFilterChange =
-    (filterName: string) => (event: SelectChangeEvent<string>) => {
-      setFilterValues(prev => ({
-        ...prev,
-        [filterName]: event.target.value,
-      }));
-    };
-
   const [contextMenu, setContextMenu] = useState<{
     mouseX: number;
     mouseY: number;
@@ -966,189 +774,6 @@ export default function BaseDataGrid({
     [resolveRowUrl, apiRef]
   );
 
-  const handleToggle = (index: number) => {
-    setOpenStates(prev => {
-      const newStates = [...prev];
-      newStates[index] = !newStates[index];
-      return newStates;
-    });
-  };
-
-  const handleClose = (event: Event, index: number) => {
-    if (
-      buttonRefs.current[index]?.current &&
-      buttonRefs.current[index].current?.contains(event.target as HTMLElement)
-    ) {
-      return;
-    }
-    setOpenStates(prev => {
-      const newStates = [...prev];
-      newStates[index] = false;
-      return newStates;
-    });
-  };
-
-  const handleMenuItemClick = (onClick: () => void, index: number) => {
-    onClick();
-    setOpenStates(prev => {
-      const newStates = [...prev];
-      newStates[index] = false;
-      return newStates;
-    });
-  };
-
-  // Refs for server-side filtering with stable toolbar
-  // Using uncontrolled input to avoid re-render/focus issues
-  const quickFilterInputRef = useRef<HTMLInputElement | null>(null);
-  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
-  const onFilterModelChangeRef = useRef(onFilterModelChange);
-  const filterModelRef = useRef(filterModel);
-  const gridToolbarExtraRef = useRef(gridToolbarExtra);
-
-  // Keep callback refs up to date without causing re-renders
-  useEffect(() => {
-    onFilterModelChangeRef.current = onFilterModelChange;
-    filterModelRef.current = filterModel;
-    gridToolbarExtraRef.current = gridToolbarExtra;
-  });
-
-  // Sync input value with external filterModel changes (e.g., "Clear All Filters")
-  useEffect(() => {
-    if (!filterModel || !quickFilterInputRef.current) return;
-
-    const quickFilterItem = filterModel.items.find(
-      item => item.field === 'quickFilter' || item.field === '__quickFilter__'
-    );
-    const newValue = quickFilterItem?.value || '';
-
-    // Only update if different and not during active typing (debounce in progress)
-    if (
-      quickFilterInputRef.current.value !== newValue &&
-      !debounceTimerRef.current
-    ) {
-      quickFilterInputRef.current.value = newValue;
-    }
-  }, [filterModel]);
-
-  /**
-   * Handles quick filter input changes with debouncing.
-   * Updates the filter model after 300ms of inactivity.
-   */
-  const handleQuickFilterChange = useCallback(() => {
-    const value = quickFilterInputRef.current?.value || '';
-
-    // Clear existing debounce timer
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
-    }
-
-    // Debounced filter model update
-    debounceTimerRef.current = setTimeout(() => {
-      debounceTimerRef.current = null;
-
-      if (onFilterModelChangeRef.current && filterModelRef.current) {
-        const otherFilters = filterModelRef.current.items.filter(
-          item =>
-            item.field !== 'quickFilter' && item.field !== '__quickFilter__'
-        );
-
-        const newFilterModel = {
-          ...filterModelRef.current,
-          items: value
-            ? [
-                ...otherFilters,
-                { field: 'quickFilter', operator: 'contains', value },
-              ]
-            : otherFilters,
-        };
-
-        onFilterModelChangeRef.current(newFilterModel);
-      }
-    }, 300);
-  }, []);
-
-  /**
-   * Clears the quick filter input and updates the filter model immediately.
-   */
-  const handleQuickFilterClear = useCallback(() => {
-    if (quickFilterInputRef.current) {
-      quickFilterInputRef.current.value = '';
-    }
-
-    // Clear any pending debounce
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
-      debounceTimerRef.current = null;
-    }
-
-    // Immediately update filter model
-    if (onFilterModelChangeRef.current && filterModelRef.current) {
-      const otherFilters = filterModelRef.current.items.filter(
-        item => item.field !== 'quickFilter' && item.field !== '__quickFilter__'
-      );
-      onFilterModelChangeRef.current({
-        ...filterModelRef.current,
-        items: otherFilters,
-      });
-    }
-  }, []);
-
-  /**
-   * Stable toolbar component using uncontrolled input.
-   * Created once and stored in ref to prevent remounting and focus loss.
-   * The input manages its own value via DOM, avoiding React state/re-render complexity.
-   */
-  const CustomToolbarWithFiltersRef =
-    useRef<React.JSXElementConstructor<GridToolbarProps> | null>(null);
-  if (!CustomToolbarWithFiltersRef.current) {
-    CustomToolbarWithFiltersRef.current = function CustomToolbar() {
-      return (
-        <Box
-          sx={{
-            px: '30px',
-            py: '16px',
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            gap: 2,
-          }}
-        >
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-            <GridToolbar />
-            {gridToolbarExtraRef.current}
-          </Box>
-          <TextField
-            inputRef={quickFilterInputRef}
-            size="small"
-            placeholder="Search..."
-            defaultValue=""
-            onChange={handleQuickFilterChange}
-            sx={{ minWidth: 250 }}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon fontSize="small" />
-                </InputAdornment>
-              ),
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    size="small"
-                    onClick={handleQuickFilterClear}
-                    aria-label="Clear search"
-                  >
-                    <ClearIcon fontSize="small" />
-                  </IconButton>
-                </InputAdornment>
-              ),
-            }}
-          />
-        </Box>
-      );
-    };
-  }
-  const CustomToolbarWithFilters = CustomToolbarWithFiltersRef.current;
-
   // Wait for initialization and persisted state to be loaded before rendering DataGrid
   // This ensures initialState is correctly set before the grid mounts
   const isReady = isInitialized && (!persistState || isPersistedStateLoaded);
@@ -1173,10 +798,6 @@ export default function BaseDataGrid({
   }
   if (toolbarSlot) {
     resolvedSlots.toolbar = toolbarSlot;
-  } else if (serverSideFiltering) {
-    resolvedSlots.toolbar = CustomToolbarWithFilters;
-  } else if (enableQuickFilter) {
-    resolvedSlots.toolbar = QuickFilterToolbar;
   }
 
   const dataGridSx: SxProps<Theme> = [
@@ -1197,341 +818,85 @@ export default function BaseDataGrid({
     ...(Array.isArray(_sx) ? _sx : _sx ? [_sx] : []),
   ].filter(Boolean) as SxProps<Theme>;
 
-  const hasHeaderContent = !!(
-    title ||
-    (filters && filters.length > 0) ||
-    (actionButtons && actionButtons.length > 0) ||
-    customToolbarContent
-  );
-
   const hasRowUrl = !!(getRowUrl || linkPath);
 
   return (
     <>
-      {hasHeaderContent && (
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'flex-start',
-            alignItems: 'center',
-            mb: 2,
-            gap: 2,
-          }}
-        >
-          {title && (
-            <Typography variant="h6" component="h1">
-              {title}
-            </Typography>
-          )}
-
-          {filters && filters.length > 0 && (
-            <Box sx={{ display: 'flex', gap: 2 }}>
-              {filters.map(filter => (
-                <FormControl
-                  key={filter.name}
-                  variant="outlined"
-                  size="small"
-                  sx={{ minWidth: 150 }}
-                >
-                  <InputLabel id={`${filter.name}-label`}>
-                    {filter.label}
-                  </InputLabel>
-                  <Select
-                    labelId={`${filter.name}-label`}
-                    id={filter.name}
-                    value={filterValues[filter.name] || filter.defaultValue}
-                    onChange={handleFilterChange(filter.name)}
-                    label={filter.label}
-                  >
-                    {filter.options.map(option => (
-                      <MenuItem key={option.value} value={option.value}>
-                        {option.label}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              ))}
-            </Box>
-          )}
-
-          {actionButtons && actionButtons.length > 0 && (
-            <Box sx={{ display: 'flex', gap: 1 }}>
-              {actionButtons.map((button, index) => {
-                if (button.splitButton) {
-                  const options = button.splitButton.options; // Extract options to satisfy TypeScript
-                  return (
-                    <React.Fragment key={button.label}>
-                      <ButtonGroup
-                        variant={button.variant || 'contained'}
-                        color={button.color || 'primary'}
-                        ref={buttonRefs.current[index]}
-                        aria-label="split button"
-                        disabled={button.disabled}
-                      >
-                        <Button
-                          onClick={button.onClick}
-                          startIcon={button.icon}
-                          disabled={button.disabled}
-                        >
-                          {button.label}
-                        </Button>
-                        <Button
-                          size="small"
-                          aria-controls={
-                            openStates[index] ? 'split-button-menu' : undefined
-                          }
-                          aria-expanded={openStates[index] ? 'true' : undefined}
-                          aria-label="select option"
-                          aria-haspopup="menu"
-                          onClick={() => handleToggle(index)}
-                          disabled={button.disabled}
-                        >
-                          <ArrowDropDownIcon />
-                        </Button>
-                      </ButtonGroup>
-                      <Popper
-                        sx={{
-                          zIndex: 1,
-                        }}
-                        open={openStates[index]}
-                        anchorEl={buttonRefs.current[index].current}
-                        role={undefined}
-                        transition
-                        disablePortal
-                      >
-                        {({ TransitionProps, placement }) => (
-                          <Grow
-                            {...TransitionProps}
-                            style={{
-                              transformOrigin:
-                                placement === 'bottom'
-                                  ? 'center top'
-                                  : 'center bottom',
-                            }}
-                          >
-                            <Paper>
-                              <ClickAwayListener
-                                onClickAway={event => handleClose(event, index)}
-                              >
-                                <MenuList id="split-button-menu" autoFocusItem>
-                                  {options.map(option => (
-                                    <MenuItem
-                                      key={option.label}
-                                      disabled={option.disabled}
-                                      onClick={() =>
-                                        handleMenuItemClick(
-                                          option.onClick,
-                                          index
-                                        )
-                                      }
-                                    >
-                                      {option.label}
-                                    </MenuItem>
-                                  ))}
-                                </MenuList>
-                              </ClickAwayListener>
-                            </Paper>
-                          </Grow>
-                        )}
-                      </Popper>
-                    </React.Fragment>
-                  );
-                }
-
-                return button.href ? (
-                  <Link
-                    key={button.label}
-                    href={button.href}
-                    style={{ textDecoration: 'none' }}
-                  >
-                    <Button
-                      variant={button.variant || 'contained'}
-                      color={button.color || 'primary'}
-                      startIcon={button.icon}
-                      data-tour={button.dataTour}
-                      disabled={button.disabled}
-                    >
-                      {button.label}
-                    </Button>
-                  </Link>
-                ) : (
-                  <Button
-                    key={button.label}
-                    variant={button.variant || 'contained'}
-                    color={button.color || 'primary'}
-                    onClick={button.onClick}
-                    startIcon={button.icon}
-                    data-tour={button.dataTour}
-                    disabled={button.disabled}
-                  >
-                    {button.label}
-                  </Button>
-                );
-              })}
-            </Box>
-          )}
-          {customToolbarContent}
-        </Box>
-      )}
-
       <RowActionsHoverGrid enabled={hasActionsColumn}>
-        {rowActionsRootProps => (
-          <Box
-            onContextMenu={hasRowUrl ? handleContainerContextMenu : undefined}
-            onAuxClick={hasRowUrl ? handleContainerAuxClick : undefined}
-            {...rowActionsRootProps}
-          >
-            {disablePaperWrapper ? (
-              <HideRowsPerPageBelowContext.Provider
-                value={hideRowsPerPageBelow}
-              >
-                <PaginationSizeContext.Provider value={pageSizeOptions}>
-                  <StyledDataGrid
-                    apiRef={apiRef}
-                    rows={serverSidePagination ? rows : filteredRows}
-                    columns={gridColumns}
-                    {...(columnGroupingModel && { columnGroupingModel })}
-                    getRowId={getRowId}
-                    {...(autoHeight && { autoHeight: true })}
-                    pagination
-                    hideFooter={hideFooter}
-                    paginationMode={serverSidePagination ? 'server' : 'client'}
-                    rowCount={serverSidePagination ? totalRows : undefined}
-                    paginationModel={paginationModel}
-                    onPaginationModelChange={onPaginationModelChange}
-                    pageSizeOptions={pageSizeOptions}
-                    checkboxSelection={checkboxSelection}
-                    {...(checkboxSelection && {
-                      slotProps: {
-                        baseCheckbox: { color: 'primary' as const },
-                      },
-                    })}
-                    disableVirtualization={false}
-                    {...(hasActionsColumn && { columnBufferPx: 500 })}
-                    loading={loading}
-                    slots={resolvedSlots}
-                    sx={dataGridSx}
-                    onRowClick={
-                      enableEditing
-                        ? undefined
-                        : hasRowUrl || onRowClick
-                          ? handleRowClickWithLink
-                          : undefined
-                    }
-                    disableMultipleRowSelection={disableMultipleRowSelection}
-                    {...(density && { density })}
-                    {...(mergedInitialState && {
-                      initialState: mergedInitialState,
-                    })}
-                    {...(serverSideFiltering && {
-                      filterMode: 'server',
-                      filterModel,
-                      onFilterModelChange,
-                    })}
-                    {...(sortingMode === 'server' && {
-                      sortingMode: 'server',
-                      sortModel,
-                      onSortModelChange,
-                    })}
-                    {...(enableEditing && {
-                      editMode,
-                      processRowUpdate,
-                      onProcessRowUpdateError,
-                      isCellEditable,
-                    })}
-                    {...(onRowSelectionModelChange && {
-                      onRowSelectionModelChange,
-                    })}
-                    {...(rowSelectionModel !== undefined && {
-                      rowSelectionModel,
-                    })}
-                    {...(isRowSelectable && { isRowSelectable })}
-                    {...(getRowClassName && { getRowClassName })}
-                    {...(disableRowSelectionOnClick && {
-                      disableRowSelectionOnClick,
-                    })}
-                  />
-                </PaginationSizeContext.Provider>
-              </HideRowsPerPageBelowContext.Provider>
-            ) : (
-              <Paper elevation={0} sx={GRID_PAPER_SX}>
-                <HideRowsPerPageBelowContext.Provider
-                  value={hideRowsPerPageBelow}
-                >
-                  <PaginationSizeContext.Provider value={pageSizeOptions}>
-                    <StyledDataGrid
-                      apiRef={apiRef}
-                      rows={serverSidePagination ? rows : filteredRows}
-                      columns={gridColumns}
-                      {...(columnGroupingModel && { columnGroupingModel })}
-                      getRowId={getRowId}
-                      {...(autoHeight && { autoHeight: true })}
-                      pagination
-                      hideFooter={hideFooter}
-                      paginationMode={
-                        serverSidePagination ? 'server' : 'client'
-                      }
-                      rowCount={serverSidePagination ? totalRows : undefined}
-                      paginationModel={paginationModel}
-                      onPaginationModelChange={onPaginationModelChange}
-                      pageSizeOptions={pageSizeOptions}
-                      checkboxSelection={checkboxSelection}
-                      {...(checkboxSelection && {
-                        slotProps: {
-                          baseCheckbox: { color: 'primary' as const },
-                        },
-                      })}
-                      disableVirtualization={false}
-                      {...(hasActionsColumn && { columnBufferPx: 500 })}
-                      loading={loading}
-                      slots={resolvedSlots}
-                      sx={dataGridSx}
-                      onRowClick={
-                        enableEditing
-                          ? undefined
-                          : hasRowUrl || onRowClick
-                            ? handleRowClickWithLink
-                            : undefined
-                      }
-                      disableMultipleRowSelection={disableMultipleRowSelection}
-                      {...(density && { density })}
-                      {...(mergedInitialState && {
-                        initialState: mergedInitialState,
-                      })}
-                      {...(serverSideFiltering && {
-                        filterMode: 'server',
-                        filterModel,
-                        onFilterModelChange,
-                      })}
-                      {...(sortingMode === 'server' && {
-                        sortingMode: 'server',
-                        sortModel,
-                        onSortModelChange,
-                      })}
-                      {...(enableEditing && {
-                        editMode,
-                        processRowUpdate,
-                        onProcessRowUpdateError,
-                        isCellEditable,
-                      })}
-                      {...(onRowSelectionModelChange && {
-                        onRowSelectionModelChange,
-                      })}
-                      {...(rowSelectionModel !== undefined && {
-                        rowSelectionModel,
-                      })}
-                      {...(isRowSelectable && { isRowSelectable })}
-                      {...(getRowClassName && { getRowClassName })}
-                      {...(disableRowSelectionOnClick && {
-                        disableRowSelectionOnClick,
-                      })}
-                    />
-                  </PaginationSizeContext.Provider>
-                </HideRowsPerPageBelowContext.Provider>
-              </Paper>
-            )}
-          </Box>
-        )}
+        {rowActionsRootProps => {
+          const grid = (
+            <HideRowsPerPageBelowContext.Provider value={hideRowsPerPageBelow}>
+              <PaginationSizeContext.Provider value={pageSizeOptions}>
+                <StyledDataGrid
+                  apiRef={apiRef}
+                  rows={rows}
+                  columns={gridColumns}
+                  {...(columnGroupingModel && { columnGroupingModel })}
+                  getRowId={getRowId}
+                  {...(autoHeight && { autoHeight: true })}
+                  pagination
+                  hideFooter={hideFooter}
+                  paginationMode={serverSidePagination ? 'server' : 'client'}
+                  rowCount={serverSidePagination ? totalRows : undefined}
+                  paginationModel={paginationModel}
+                  onPaginationModelChange={onPaginationModelChange}
+                  pageSizeOptions={pageSizeOptions}
+                  checkboxSelection={checkboxSelection}
+                  {...(checkboxSelection && {
+                    slotProps: {
+                      baseCheckbox: { color: 'primary' as const },
+                    },
+                  })}
+                  disableVirtualization={false}
+                  {...(hasActionsColumn && { columnBufferPx: 500 })}
+                  loading={loading}
+                  slots={resolvedSlots}
+                  sx={dataGridSx}
+                  onRowClick={
+                    hasRowUrl || onRowClick ? handleRowClickWithLink : undefined
+                  }
+                  disableMultipleRowSelection={disableMultipleRowSelection}
+                  {...(density && { density })}
+                  {...(mergedInitialState && {
+                    initialState: mergedInitialState,
+                  })}
+                  {...(sortingMode === 'server' && {
+                    sortingMode: 'server',
+                    sortModel,
+                    onSortModelChange,
+                  })}
+                  {...(onRowSelectionModelChange && {
+                    onRowSelectionModelChange,
+                  })}
+                  {...(rowSelectionModel !== undefined && {
+                    rowSelectionModel,
+                  })}
+                  {...(isRowSelectable && { isRowSelectable })}
+                  {...(getRowClassName && { getRowClassName })}
+                  {...(disableRowSelectionOnClick && {
+                    disableRowSelectionOnClick,
+                  })}
+                />
+              </PaginationSizeContext.Provider>
+            </HideRowsPerPageBelowContext.Provider>
+          );
+
+          return (
+            <Box
+              onContextMenu={hasRowUrl ? handleContainerContextMenu : undefined}
+              onAuxClick={hasRowUrl ? handleContainerAuxClick : undefined}
+              {...rowActionsRootProps}
+            >
+              {disablePaperWrapper ? (
+                grid
+              ) : (
+                <Paper elevation={0} sx={GRID_PAPER_SX}>
+                  {grid}
+                </Paper>
+              )}
+            </Box>
+          );
+        }}
       </RowActionsHoverGrid>
 
       <Menu
@@ -1560,5 +925,3 @@ export default function BaseDataGrid({
     </>
   );
 }
-
-export type { FilterOption, FilterConfig };

--- a/apps/frontend/src/components/common/EntityGrid/EntityGrid.tsx
+++ b/apps/frontend/src/components/common/EntityGrid/EntityGrid.tsx
@@ -1,0 +1,538 @@
+'use client';
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useRouter } from 'next/navigation';
+import { Alert, Box, Paper } from '@mui/material';
+import type { GridColDef, GridRowModel, GridRowParams } from '@mui/x-data-grid';
+import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
+import GridStateGate from '@/components/common/GridStateGate';
+import { DeleteModal } from '@/components/common/DeleteModal';
+import { createRowActionsColumn } from '@/components/common/createRowActionsColumn';
+import {
+  EntityGridToolbarContext,
+  EntityGridToolbarSlot,
+  type EntityGridToolbarState,
+} from './EntityGridToolbar';
+import { useList } from '@/hooks/useList';
+import {
+  useBulkDelete,
+  type BulkDeleteActionsState,
+} from '@/hooks/useBulkDelete';
+import { useCan } from '@/components/common/Can';
+import { can } from '@/utils/affordances';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { useNotifications as useNotificationBadges } from '@/contexts/NotificationsContext';
+import { HIGHLIGHTED_ROW_CLASS } from '@/constants/notifications';
+import type { WithPermittedActions } from '@/types/affordances';
+import type { FilterSpecMap, FiltersOf } from '@/utils/list';
+import type { EntityGridProps, EntityGridSelectionContext } from './types';
+
+function capitalize(label: string): string {
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+const NO_HIGHLIGHTS: string[] = [];
+
+/**
+ * The standard list grid: descriptor-driven fetch, toolbar (search + pills +
+ * filter drawer), dismissible error, selection/bulk-delete, trailing actions
+ * column, confirm modal, empty state, and card chrome — composed once so a
+ * grid file is columns + a descriptor + its genuinely unique parts.
+ */
+export default function EntityGrid<
+  T,
+  S extends FilterSpecMap,
+  TDrawer = Record<string, never>,
+  TBulk extends BulkDeleteActionsState = BulkDeleteActionsState,
+>({
+  descriptor,
+  columns,
+  toFilters,
+  emptyState,
+  initialData,
+  initialTotalCount,
+  refreshTrigger,
+  extraFilters,
+  enabled,
+  pollMs,
+  onDataChange,
+  mapRows,
+  getRowId,
+  extraLoading = false,
+  searchPlaceholder,
+  pills,
+  drawer,
+  externalFilters,
+  toolbarRight,
+  showGridButtons = true,
+  showExport = true,
+  selectionLabel,
+  getRowUrl,
+  onRowClick,
+  highlightSection,
+  editAction,
+  extraRowActions,
+  rowActionsWidth,
+  onBulkActionsChange,
+  buildBulkActions,
+  renderSelectionExtras,
+  embedded = false,
+  banner,
+  persistState = true,
+  storageKey,
+  serverSort = true,
+  pageSizeOptions,
+  density,
+  initialState,
+  sx,
+}: EntityGridProps<T, S, TDrawer, TBulk>) {
+  const router = useRouter();
+  const deleteSpec = descriptor.delete;
+
+  // ── Toolbar-owned state ────────────────────────────────────────────────────
+  const allPillValue = pills?.allValue ?? 'all';
+  const [searchQuery, setSearchQuery] = useState('');
+  const [pillValue, setPillValue] = useState(allPillValue);
+  const emptyDrawer = drawer?.empty ?? ({} as TDrawer);
+  const [drawerFilters, setDrawerFilters] = useState<TDrawer>(emptyDrawer);
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
+  const [errorDismissed, setErrorDismissed] = useState(false);
+
+  const filters = useMemo(
+    () => ({
+      ...toFilters({
+        search: searchQuery,
+        pill: pillValue === allPillValue ? '' : pillValue,
+        drawer: drawerFilters,
+      }),
+      ...externalFilters,
+    }),
+    [
+      toFilters,
+      searchQuery,
+      pillValue,
+      allPillValue,
+      drawerFilters,
+      externalFilters,
+    ]
+  ) as FiltersOf<S>;
+
+  // ── Data ───────────────────────────────────────────────────────────────────
+  const {
+    data,
+    totalCount,
+    isLoading,
+    error: rawError,
+    refresh,
+    paginationModel,
+    onPaginationModelChange,
+    sortModel,
+    onSortModelChange,
+  } = useList(descriptor, {
+    filters,
+    extraFilters,
+    enabled,
+    initialData,
+    initialTotalCount,
+    pollMs,
+    onError: () => setErrorDismissed(false),
+  });
+
+  useEffect(() => {
+    setErrorDismissed(false);
+  }, [rawError]);
+  const error = rawError && !errorDismissed ? rawError : null;
+  const dismissError = useCallback(() => setErrorDismissed(true), []);
+
+  // Gate on "has the first load settled", not on isLoading: a refetch (search
+  // keystroke, pill change) must keep the grid mounted or the toolbar's search
+  // input unmounts mid-typing and loses focus. Refetches show the DataGrid's
+  // own loading overlay instead.
+  const hasLoadedOnce = useRef(initialData !== undefined);
+  if (!isLoading) hasLoadedOnce.current = true;
+
+  const isFirstRefreshTrigger = useRef(true);
+  useEffect(() => {
+    if (isFirstRefreshTrigger.current) {
+      isFirstRefreshTrigger.current = false;
+      return;
+    }
+    refresh();
+    // Only refreshTrigger (bumped by the page after a create) should re-run this.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refreshTrigger]);
+
+  const hasActiveDrawerFilters = drawer
+    ? drawer.countActive(drawerFilters) > 0
+    : false;
+  const activeFilterCount = drawer ? drawer.countActive(drawerFilters) : 0;
+  const filtersActive =
+    !!searchQuery || pillValue !== allPillValue || hasActiveDrawerFilters;
+
+  const onDataChangeRef = useRef(onDataChange);
+  onDataChangeRef.current = onDataChange;
+  useEffect(() => {
+    onDataChangeRef.current?.(data, totalCount, filtersActive);
+  }, [data, totalCount, filtersActive]);
+
+  // ── Delete / selection ─────────────────────────────────────────────────────
+  // Called unconditionally (rules of hooks); inert when there is no delete spec.
+  const ambientCanDelete = useCan(deleteSpec?.capability ?? '');
+  const canDeleteRow = useCallback(
+    (row: Record<string, unknown>): boolean => {
+      if (!deleteSpec) return false;
+      if (deleteSpec.capabilityMode === 'row') {
+        return can(
+          row as unknown as WithPermittedActions,
+          deleteSpec.capability
+        );
+      }
+      return ambientCanDelete;
+    },
+    [deleteSpec, ambientCanDelete]
+  );
+
+  const bulkDeleteFn = useMemo(
+    () =>
+      deleteSpec?.bulk
+        ? (ids: string[]) => deleteSpec.bulk!(new ApiClientFactory(), ids)
+        : undefined,
+    [deleteSpec]
+  );
+  const deleteOneFn = useMemo(
+    () =>
+      deleteSpec?.one
+        ? (id: string) => deleteSpec.one!(new ApiClientFactory(), id)
+        : undefined,
+    [deleteSpec]
+  );
+
+  const {
+    checkboxSelectionMode,
+    setCheckboxSelectionMode,
+    selectedRows,
+    setSelectedRows,
+    handleSelectionChange,
+    pendingDeleteId,
+    deleteModalOpen,
+    isDeleting,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+  } = useBulkDelete({
+    bulkDeleteFn,
+    deleteOneFn,
+    onSuccess: refresh,
+    itemLabelSingular: deleteSpec?.labelSingular ?? 'item',
+    itemLabelPlural: deleteSpec?.labelPlural ?? 'items',
+    getSkippedCount: deleteSpec?.getSkippedCount?.bind(deleteSpec),
+    skippedReason: deleteSpec?.skippedReason,
+  });
+
+  const rows: GridRowModel[] = useMemo(
+    () => (mapRows ? mapRows(data) : (data as GridRowModel[])),
+    [mapRows, data]
+  );
+
+  // ── Bulk-actions bridge ────────────────────────────────────────────────────
+  // Pushed from here (not useBulkDelete's own bridge) so extended states like
+  // Tests' assignDisabled re-evaluate when the selection itself changes, and
+  // refs keep the effect from re-firing on every new closure identity.
+  const clearSelection = useCallback(
+    () => setSelectedRows([]),
+    [setSelectedRows]
+  );
+  const selectionCtx: EntityGridSelectionContext<T> = useMemo(() => {
+    const selectedIds = selectedRows.map(String);
+    const idOf = (row: GridRowModel) =>
+      getRowId ? getRowId(row) : String((row as { id?: unknown }).id);
+    return {
+      selectedIds,
+      selectedRows: rows
+        .filter(row => selectedIds.includes(idOf(row)))
+        .map(row => row as T),
+      clearSelection,
+      refresh,
+    };
+  }, [selectedRows, rows, getRowId, clearSelection, refresh]);
+
+  const buildBulkActionsRef = useRef(buildBulkActions);
+  buildBulkActionsRef.current = buildBulkActions;
+  const onBulkActionsChangeRef = useRef(onBulkActionsChange);
+  onBulkActionsChangeRef.current = onBulkActionsChange;
+  const requestDeleteRef = useRef(requestDelete);
+  requestDeleteRef.current = requestDelete;
+  const selectionCtxRef = useRef(selectionCtx);
+  selectionCtxRef.current = selectionCtx;
+
+  const showBulkActions = checkboxSelectionMode && selectedRows.length > 0;
+  useEffect(() => {
+    const push = onBulkActionsChangeRef.current;
+    if (!push) return;
+    const base: BulkDeleteActionsState = {
+      visible: showBulkActions,
+      onDelete: () => requestDeleteRef.current(),
+    };
+    const build = buildBulkActionsRef.current;
+    push(build ? build(base, selectionCtxRef.current) : (base as TBulk));
+    // selectedRows (not just visibility) so extended bulk state re-evaluates.
+  }, [showBulkActions, selectedRows]);
+
+  useEffect(() => {
+    return () => {
+      const push = onBulkActionsChangeRef.current;
+      if (!push) return;
+      const base: BulkDeleteActionsState = {
+        visible: false,
+        onDelete: () => {},
+      };
+      const build = buildBulkActionsRef.current;
+      push(build ? build(base, selectionCtxRef.current) : (base as TBulk));
+    };
+  }, []);
+
+  // ── Row navigation / highlight ─────────────────────────────────────────────
+  const { highlightedIds, clearHighlight } = useNotificationBadges();
+  const highlights = highlightSection
+    ? highlightedIds(highlightSection)
+    : NO_HIGHLIGHTS;
+
+  const getRowClassName = useCallback(
+    (params: GridRowParams) =>
+      highlights.includes(String(params.id)) ? HIGHLIGHTED_ROW_CLASS : '',
+    [highlights]
+  );
+
+  const resolveRowUrl = useCallback(
+    (row: GridRowModel) => getRowUrl?.(row as T),
+    [getRowUrl]
+  );
+
+  const handleRowClick = useCallback(
+    (params: GridRowParams) => {
+      if (highlightSection) {
+        clearHighlight(highlightSection, String(params.id));
+      }
+      if (onRowClick) {
+        onRowClick(params);
+        return;
+      }
+      const url = resolveRowUrl(params.row);
+      if (url) router.push(url);
+    },
+    [highlightSection, clearHighlight, onRowClick, resolveRowUrl, router]
+  );
+
+  const wantsRowClick = !!onRowClick || !!getRowUrl;
+
+  // ── Actions column ─────────────────────────────────────────────────────────
+  const deleteEnabled = !!deleteSpec && !!(deleteSpec.bulk || deleteSpec.one);
+
+  const editActionRef = useRef(editAction);
+  editActionRef.current = editAction;
+  const gridColumns: GridColDef[] = useMemo(() => {
+    const edit = editAction === false ? undefined : editAction;
+    const showEditAction =
+      editAction !== false && !!(edit?.onClick || getRowUrl);
+    const hasAnyAction =
+      showEditAction || (extraRowActions?.length ?? 0) > 0 || deleteEnabled;
+    if (!hasAnyAction) return columns;
+
+    const actionsCol = createRowActionsColumn({
+      ...(showEditAction && {
+        onEdit: (id: string, row: Record<string, unknown>) => {
+          if (edit?.onClick) {
+            edit.onClick(id, row as T);
+            return;
+          }
+          const url = getRowUrl?.(row as T);
+          if (url) router.push(url);
+        },
+        canEdit: (row: Record<string, unknown>) =>
+          edit?.can ? edit.can(row as T) : true,
+      }),
+      extraActions: extraRowActions,
+      ...(deleteEnabled && {
+        onDelete: (id: string) => requestDelete(id),
+        canDelete: canDeleteRow,
+      }),
+      width: rowActionsWidth,
+    });
+    return [...columns, actionsCol];
+  }, [
+    columns,
+    editAction,
+    getRowUrl,
+    extraRowActions,
+    deleteEnabled,
+    requestDelete,
+    canDeleteRow,
+    rowActionsWidth,
+    router,
+  ]);
+
+  // ── Toolbar context ────────────────────────────────────────────────────────
+  const openFilterDrawer = useMemo(
+    () => (drawer ? () => setFilterDrawerOpen(true) : undefined),
+    [drawer]
+  );
+
+  const handleDrawerApply = useCallback(
+    (applied: TDrawer) => {
+      const newPill = drawer?.pillFromApply?.(applied, drawerFilters);
+      setDrawerFilters(applied);
+      if (newPill !== undefined) {
+        setPillValue(newPill === '' ? allPillValue : newPill);
+      }
+    },
+    [drawer, drawerFilters, allPillValue]
+  );
+
+  const toolbarContextValue: EntityGridToolbarState = useMemo(
+    () => ({
+      searchQuery,
+      setSearchQuery,
+      searchPlaceholder: searchPlaceholder ?? `Search ${descriptor.resource}…`,
+      pills: pills ? { tabs: pills.tabs } : undefined,
+      pillValue,
+      setPillValue,
+      openFilterDrawer,
+      hasActiveDrawerFilters,
+      activeFilterCount,
+      selection: deleteSpec?.bulk
+        ? {
+            checked: checkboxSelectionMode,
+            onChange: setCheckboxSelectionMode,
+            label: selectionLabel ?? `Select ${descriptor.resource}`,
+          }
+        : undefined,
+      toolbarRight,
+      showGridButtons,
+      showExport,
+    }),
+    [
+      searchQuery,
+      searchPlaceholder,
+      descriptor.resource,
+      pills,
+      pillValue,
+      openFilterDrawer,
+      hasActiveDrawerFilters,
+      activeFilterCount,
+      deleteSpec?.bulk,
+      checkboxSelectionMode,
+      setCheckboxSelectionMode,
+      selectionLabel,
+      toolbarRight,
+      showGridButtons,
+      showExport,
+    ]
+  );
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  const deleteCount = pendingDeleteId ? 1 : selectedRows.length;
+  const loading = isLoading || extraLoading;
+
+  const content = (
+    <EntityGridToolbarContext.Provider value={toolbarContextValue}>
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
+          {error}
+        </Alert>
+      )}
+      {banner}
+      <Box sx={{ position: 'relative' }}>
+        <BaseDataGrid
+          rows={rows}
+          columns={gridColumns}
+          loading={loading}
+          getRowId={getRowId}
+          serverSidePagination={true}
+          totalRows={totalCount}
+          paginationModel={paginationModel}
+          onPaginationModelChange={onPaginationModelChange}
+          pageSizeOptions={pageSizeOptions}
+          toolbarSlot={EntityGridToolbarSlot}
+          disablePaperWrapper={true}
+          persistState={persistState}
+          storageKey={storageKey}
+          density={density}
+          initialState={initialState}
+          sx={sx}
+          {...(serverSort && {
+            sortingMode: 'server' as const,
+            sortModel,
+            onSortModelChange,
+          })}
+          getRowUrl={
+            checkboxSelectionMode || !getRowUrl ? undefined : resolveRowUrl
+          }
+          onRowClick={
+            checkboxSelectionMode || !wantsRowClick ? undefined : handleRowClick
+          }
+          getRowClassName={highlightSection ? getRowClassName : undefined}
+          checkboxSelection={checkboxSelectionMode}
+          disableRowSelectionOnClick={checkboxSelectionMode || undefined}
+          rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
+          onRowSelectionModelChange={
+            checkboxSelectionMode ? handleSelectionChange : undefined
+          }
+          isRowSelectable={
+            checkboxSelectionMode && deleteSpec?.capabilityMode === 'row'
+              ? params => canDeleteRow(params.row)
+              : undefined
+          }
+        />
+
+        {deleteEnabled && (
+          <DeleteModal
+            open={deleteModalOpen}
+            onClose={cancelDelete}
+            onConfirm={confirmDelete}
+            isLoading={isDeleting}
+            title={
+              deleteCount === 1
+                ? `Delete ${capitalize(deleteSpec?.labelSingular ?? 'item')}`
+                : `Delete ${capitalize(deleteSpec?.labelPlural ?? 'items')}`
+            }
+            message={
+              deleteSpec?.confirmMessage
+                ? deleteSpec.confirmMessage(deleteCount)
+                : deleteCount === 1
+                  ? `Are you sure you want to delete this ${deleteSpec?.labelSingular}? This action cannot be undone.`
+                  : `Are you sure you want to delete ${deleteCount} ${deleteSpec?.labelPlural}? This action cannot be undone.`
+            }
+            itemType={deleteSpec?.labelPlural}
+          />
+        )}
+      </Box>
+
+      {drawer?.render({
+        open: filterDrawerOpen,
+        onClose: () => setFilterDrawerOpen(false),
+        filters: drawerFilters,
+        onApply: handleDrawerApply,
+      })}
+
+      {renderSelectionExtras?.(selectionCtx)}
+    </EntityGridToolbarContext.Provider>
+  );
+
+  return (
+    <GridStateGate
+      active={!embedded}
+      data={hasLoadedOnce.current ? {} : null}
+      error={error}
+      isEmpty={!loading && totalCount === 0 && !filtersActive}
+      emptyState={emptyState}
+    >
+      {embedded ? content : <Paper sx={GRID_PAPER_SX}>{content}</Paper>}
+    </GridStateGate>
+  );
+}

--- a/apps/frontend/src/components/common/EntityGrid/EntityGridToolbar.tsx
+++ b/apps/frontend/src/components/common/EntityGrid/EntityGridToolbar.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import React, { createContext, useContext } from 'react';
+import {
+  GridToolbarColumnsButton,
+  GridToolbarDensitySelector,
+  GridToolbarExport,
+} from '@mui/x-data-grid';
+import GridToolbar, {
+  ToolbarPillTabs,
+  type ToolbarPillTab,
+} from '@/components/common/GridToolbar';
+import SelectionModeToggle from '@/components/common/SelectionModeToggle';
+
+/**
+ * Everything the toolbar renders, provided by EntityGrid. A context is used
+ * because BaseDataGrid's `toolbarSlot` receives no props — and the slot
+ * component must be module-stable, or the DataGrid remounts the toolbar on
+ * every render and the search input loses focus while typing.
+ */
+export interface EntityGridToolbarState {
+  searchQuery: string;
+  setSearchQuery: (value: string) => void;
+  searchPlaceholder: string;
+  pills?: { tabs: ToolbarPillTab[] };
+  pillValue: string;
+  setPillValue: (value: string) => void;
+  /** Undefined ⇒ no filter button. */
+  openFilterDrawer?: () => void;
+  hasActiveDrawerFilters: boolean;
+  activeFilterCount: number;
+  /** Undefined ⇒ no selection toggle (read-only or single-delete grids). */
+  selection?: {
+    checked: boolean;
+    onChange: (checked: boolean) => void;
+    label: string;
+  };
+  toolbarRight?: React.ReactNode;
+  showGridButtons: boolean;
+  showExport: boolean;
+}
+
+export const EntityGridToolbarContext = createContext<EntityGridToolbarState>({
+  searchQuery: '',
+  setSearchQuery: () => {},
+  searchPlaceholder: 'Search…',
+  pillValue: '',
+  setPillValue: () => {},
+  hasActiveDrawerFilters: false,
+  activeFilterCount: 0,
+  showGridButtons: true,
+  showExport: true,
+});
+
+/** The single toolbar slot every EntityGrid instance shares. */
+export function EntityGridToolbarSlot() {
+  const {
+    searchQuery,
+    setSearchQuery,
+    searchPlaceholder,
+    pills,
+    pillValue,
+    setPillValue,
+    openFilterDrawer,
+    hasActiveDrawerFilters,
+    activeFilterCount,
+    selection,
+    toolbarRight,
+    showGridButtons,
+    showExport,
+  } = useContext(EntityGridToolbarContext);
+
+  return (
+    <GridToolbar
+      searchQuery={searchQuery}
+      onSearchChange={setSearchQuery}
+      searchPlaceholder={searchPlaceholder}
+      onFilterClick={openFilterDrawer}
+      hasActiveFilters={hasActiveDrawerFilters}
+      activeFilterCount={activeFilterCount}
+      middleContent={
+        pills ? (
+          <ToolbarPillTabs
+            tabs={pills.tabs}
+            activeValue={pillValue}
+            onChange={setPillValue}
+          />
+        ) : undefined
+      }
+      rightContent={
+        <>
+          {selection && (
+            <SelectionModeToggle
+              checked={selection.checked}
+              onChange={selection.onChange}
+              label={selection.label}
+            />
+          )}
+          {toolbarRight}
+          {showGridButtons && (
+            <>
+              <GridToolbarColumnsButton />
+              <GridToolbarDensitySelector />
+              {showExport && <GridToolbarExport />}
+            </>
+          )}
+        </>
+      }
+    />
+  );
+}

--- a/apps/frontend/src/components/common/EntityGrid/__tests__/EntityGrid.test.tsx
+++ b/apps/frontend/src/components/common/EntityGrid/__tests__/EntityGrid.test.tsx
@@ -1,0 +1,368 @@
+import React from 'react';
+import { render, screen, waitFor } from '@/test-utils';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import EntityGrid from '../EntityGrid';
+import { defineList } from '@/utils/list';
+import type { BulkDeleteActionsState } from '@/hooks/useBulkDelete';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush, refresh: jest.fn() }),
+  usePathname: () => '/widgets',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { user: { id: 'u1', name: 'Alice' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('@/components/common/NotificationContext', () => ({
+  useNotifications: () => ({ show: jest.fn(), close: jest.fn() }),
+  NotificationProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({})),
+}));
+
+// Toolbar buttons that require a live DataGrid api context.
+jest.mock('@mui/x-data-grid', () => {
+  const actual = jest.requireActual('@mui/x-data-grid');
+  return {
+    ...actual,
+    GridToolbarColumnsButton: () => null,
+    GridToolbarDensitySelector: () => null,
+    GridToolbarExport: () => <button data-testid="export-button" />,
+  };
+});
+
+const mockRouterPush = jest.fn();
+
+interface MockGridProps {
+  rows: Array<Record<string, unknown>>;
+  loading?: boolean;
+  columns?: Array<{
+    field: string;
+    renderCell?: (params: {
+      id: unknown;
+      row: Record<string, unknown>;
+    }) => React.ReactNode;
+  }>;
+  toolbarSlot?: React.ComponentType;
+  onRowClick?: (p: { id: unknown; row: Record<string, unknown> }) => void;
+  onRowSelectionModelChange?: (model: string[]) => void;
+  checkboxSelection?: boolean;
+}
+
+jest.mock('@/components/common/BaseDataGrid', () => {
+  const MockBaseDataGrid = ({
+    rows,
+    loading,
+    columns,
+    toolbarSlot: ToolbarSlot,
+    onRowClick,
+    onRowSelectionModelChange,
+    checkboxSelection,
+  }: MockGridProps) => {
+    // Like the real DataGrid: loading shows an overlay, the toolbar stays mounted.
+    const actionsCol = columns?.find(c => c.field === 'actions');
+    return (
+      <div data-testid="base-data-grid">
+        {loading && <div data-testid="grid-loading" />}
+        {ToolbarSlot && <ToolbarSlot />}
+        {checkboxSelection && (
+          <button
+            data-testid="select-all"
+            onClick={() =>
+              onRowSelectionModelChange?.(rows.map(r => String(r.id)))
+            }
+          />
+        )}
+        {rows.map(row => (
+          <div
+            key={String(row.id)}
+            role="row"
+            data-testid={`row-${row.id}`}
+            onClick={() => onRowClick?.({ id: row.id, row })}
+          >
+            <span>{String(row.name)}</span>
+            {actionsCol?.renderCell?.({ id: row.id, row })}
+          </div>
+        ))}
+      </div>
+    );
+  };
+  MockBaseDataGrid.GRID_PAPER_SX = {};
+  return {
+    __esModule: true,
+    default: MockBaseDataGrid,
+    GRID_PAPER_SX: {},
+  };
+});
+
+const mockList = jest.fn();
+const mockBulkDelete = jest.fn();
+const mockDeleteOne = jest.fn();
+
+const makeResponse = (
+  data: Array<Record<string, unknown>>,
+  total?: number
+) => ({
+  data,
+  pagination: {
+    totalCount: total ?? data.length,
+    skip: 0,
+    limit: 25,
+    currentPage: 0,
+    pageSize: 25,
+    totalPages: 1,
+  },
+});
+
+const makeWidget = (id: string, name = `Widget ${id}`) => ({ id, name });
+
+const widgetsList = defineList({
+  title: 'Widgets',
+  resource: 'widgets',
+  capability: 'widget:read',
+  defaultPageSize: 25,
+  filters: {
+    search: { kind: 'search', columns: ['name'] },
+    status: { kind: 'enum', column: 'status' },
+  },
+  list: (_factory, params) => mockList(params),
+  delete: {
+    bulk: (_factory, ids) => mockBulkDelete(ids),
+    capability: 'widget:delete',
+    capabilityMode: 'ambient',
+    labelSingular: 'widget',
+    labelPlural: 'widgets',
+  },
+});
+
+const readOnlyList = defineList({
+  title: 'Widgets',
+  resource: 'widgets',
+  capability: 'widget:read',
+  defaultPageSize: 25,
+  filters: { search: { kind: 'search', columns: ['name'] } },
+  list: (_factory, params) => mockList(params),
+});
+
+const singleDeleteList = defineList({
+  title: 'Widgets',
+  resource: 'widgets',
+  capability: 'widget:read',
+  defaultPageSize: 25,
+  filters: { search: { kind: 'search', columns: ['name'] } },
+  list: (_factory, params) => mockList(params),
+  delete: {
+    one: (_factory, id) => mockDeleteOne(id),
+    capability: 'widget:delete',
+    capabilityMode: 'ambient',
+    labelSingular: 'widget',
+    labelPlural: 'widgets',
+  },
+});
+
+const columns = [{ field: 'name', headerName: 'Name', flex: 1 }];
+
+const baseProps = {
+  columns,
+  toFilters: (state: { search: string; pill: string }) => ({
+    search: state.search,
+    status: state.pill,
+  }),
+  emptyState: <div data-testid="empty-state">No widgets yet</div>,
+};
+
+describe('EntityGrid', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockList.mockResolvedValue(makeResponse([makeWidget('w-1')]));
+  });
+
+  it('shows a loading state while the first fetch is in flight', () => {
+    mockList.mockReturnValue(new Promise(() => {}));
+    render(<EntityGrid descriptor={widgetsList} {...baseProps} />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state, never the grid, when there are zero rows', async () => {
+    mockList.mockResolvedValue(makeResponse([]));
+    render(<EntityGrid descriptor={widgetsList} {...baseProps} />);
+    expect(await screen.findByTestId('empty-state')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+  });
+
+  it('renders rows when data exists', async () => {
+    render(<EntityGrid descriptor={widgetsList} {...baseProps} />);
+    expect(await screen.findByTestId('row-w-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
+  });
+
+  it('bypasses the gate when embedded', async () => {
+    mockList.mockResolvedValue(makeResponse([]));
+    render(<EntityGrid descriptor={widgetsList} {...baseProps} embedded />);
+    expect(await screen.findByTestId('base-data-grid')).toBeInTheDocument();
+    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
+  });
+
+  it('shows a dismissible error alert when the fetch fails', async () => {
+    mockList.mockRejectedValue(new Error('Network error'));
+    render(<EntityGrid descriptor={widgetsList} {...baseProps} />);
+    const alert = await screen.findByText(/network error/i);
+    expect(alert).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /close/i }));
+    await waitFor(() =>
+      expect(screen.queryByText(/network error/i)).not.toBeInTheDocument()
+    );
+  });
+
+  it('sends the search box value into the descriptor filter', async () => {
+    render(<EntityGrid descriptor={widgetsList} {...baseProps} />);
+    await screen.findByTestId('row-w-1');
+
+    const user = userEvent.setup();
+    await user.type(screen.getByPlaceholderText('Search widgets…'), 'abc');
+
+    await waitFor(() => {
+      const lastCall = mockList.mock.calls.at(-1)?.[0];
+      expect(String(lastCall?.$filter ?? '')).toContain('abc');
+    });
+  });
+
+  it('maps an active pill into the descriptor filter and back to none on the all pill', async () => {
+    render(
+      <EntityGrid
+        descriptor={widgetsList}
+        {...baseProps}
+        pills={{
+          tabs: [
+            { label: 'All', value: 'all' },
+            { label: 'Active', value: 'active' },
+          ],
+        }}
+      />
+    );
+    await screen.findByTestId('row-w-1');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Active' }));
+    await waitFor(() => {
+      const lastCall = mockList.mock.calls.at(-1)?.[0];
+      expect(String(lastCall?.$filter ?? '')).toContain('active');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'All' }));
+    await waitFor(() => {
+      const lastCall = mockList.mock.calls.at(-1)?.[0];
+      expect(String(lastCall?.$filter ?? '')).not.toContain('active');
+    });
+  });
+
+  it('renders a delete action that opens the confirm modal and calls the bulk endpoint', async () => {
+    mockBulkDelete.mockResolvedValue(undefined);
+    render(<EntityGrid descriptor={widgetsList} {...baseProps} />);
+    await screen.findByTestId('row-w-1');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+    expect(await screen.findByText('Delete Widget')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+    await waitFor(() => expect(mockBulkDelete).toHaveBeenCalledWith(['w-1']));
+  });
+
+  it('uses the single-delete endpoint when the descriptor has no bulk delete', async () => {
+    mockDeleteOne.mockResolvedValue(undefined);
+    render(<EntityGrid descriptor={singleDeleteList} {...baseProps} />);
+    await screen.findByTestId('row-w-1');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+    await user.click(await screen.findByRole('button', { name: /^delete$/i }));
+    await waitFor(() => expect(mockDeleteOne).toHaveBeenCalledWith('w-1'));
+    expect(mockBulkDelete).not.toHaveBeenCalled();
+
+    // No bulk endpoint ⇒ no selection toggle either.
+    expect(screen.queryByText('Select widgets')).not.toBeInTheDocument();
+  });
+
+  it('renders no actions column and no selection toggle for a read-only descriptor', async () => {
+    render(<EntityGrid descriptor={readOnlyList} {...baseProps} />);
+    await screen.findByTestId('row-w-1');
+    expect(
+      screen.queryByRole('button', { name: /delete/i })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Select widgets')).not.toBeInTheDocument();
+  });
+
+  it('pushes extended bulk actions through buildBulkActions when the selection changes', async () => {
+    const onBulkActionsChange = jest.fn();
+    render(
+      <EntityGrid
+        descriptor={widgetsList}
+        {...baseProps}
+        onBulkActionsChange={onBulkActionsChange}
+        buildBulkActions={(base: BulkDeleteActionsState, ctx) => ({
+          ...base,
+          selectedCount: ctx.selectedIds.length,
+        })}
+      />
+    );
+    await screen.findByTestId('row-w-1');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByLabelText(/select widgets/i));
+    await user.click(await screen.findByTestId('select-all'));
+
+    await waitFor(() =>
+      expect(onBulkActionsChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ visible: true, selectedCount: 1 })
+      )
+    );
+  });
+
+  it('navigates to getRowUrl on row click', async () => {
+    render(
+      <EntityGrid
+        descriptor={widgetsList}
+        {...baseProps}
+        getRowUrl={row => `/widgets/${(row as { id: string }).id}`}
+      />
+    );
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId('row-w-1'));
+    expect(mockRouterPush).toHaveBeenCalledWith('/widgets/w-1');
+  });
+
+  it('refetches when refreshTrigger is bumped', async () => {
+    const { rerender } = render(
+      <EntityGrid descriptor={widgetsList} {...baseProps} refreshTrigger={0} />
+    );
+    await screen.findByTestId('row-w-1');
+    const callsBefore = mockList.mock.calls.length;
+
+    rerender(
+      <EntityGrid descriptor={widgetsList} {...baseProps} refreshTrigger={1} />
+    );
+    await waitFor(() =>
+      expect(mockList.mock.calls.length).toBeGreaterThan(callsBefore)
+    );
+  });
+});

--- a/apps/frontend/src/components/common/EntityGrid/index.ts
+++ b/apps/frontend/src/components/common/EntityGrid/index.ts
@@ -1,0 +1,8 @@
+export { default } from './EntityGrid';
+export { default as EntityGrid } from './EntityGrid';
+export type {
+  EntityGridProps,
+  EntityGridFilterState,
+  EntityGridDrawerAdapter,
+  EntityGridSelectionContext,
+} from './types';

--- a/apps/frontend/src/components/common/EntityGrid/types.ts
+++ b/apps/frontend/src/components/common/EntityGrid/types.ts
@@ -1,0 +1,147 @@
+import type React from 'react';
+import type {
+  GridColDef,
+  GridDensity,
+  GridInitialState,
+  GridRowModel,
+  GridRowParams,
+} from '@mui/x-data-grid';
+import type { SxProps, Theme } from '@mui/material/styles';
+import type { FilterSpecMap, FiltersOf, ListDescriptor } from '@/utils/list';
+import type { BulkDeleteActionsState } from '@/hooks/useBulkDelete';
+import type { ToolbarPillTab } from '@/components/common/GridToolbar';
+import type { RowExtraAction } from '@/components/common/createRowActionsColumn';
+import type { NotificationSection } from '@/constants/notifications';
+
+/** Toolbar-owned state handed to `toFilters`. `pill` is `''` when the "all" pill is active. */
+export interface EntityGridFilterState<TDrawer> {
+  search: string;
+  pill: string;
+  drawer: TDrawer;
+}
+
+/** Adapter connecting an entity's filter drawer to EntityGrid's toolbar state. */
+export interface EntityGridDrawerAdapter<TDrawer> {
+  empty: TDrawer;
+  /** Active-filter count shown as the filter button's badge. */
+  countActive: (filters: TDrawer) => number;
+  render: (props: {
+    open: boolean;
+    onClose: () => void;
+    filters: TDrawer;
+    onApply: (filters: TDrawer) => void;
+  }) => React.ReactNode;
+  /**
+   * Sync the pill from an applied drawer state (e.g. Tasks' status). Return the
+   * new pill value (`''` selects the "all" pill), or undefined to leave it.
+   */
+  pillFromApply?: (applied: TDrawer, previous: TDrawer) => string | undefined;
+}
+
+/** Live selection handed to `buildBulkActions` / `renderSelectionExtras`. */
+export interface EntityGridSelectionContext<T> {
+  selectedIds: string[];
+  /** Selected rows resolved from the current page's data. */
+  selectedRows: T[];
+  clearSelection: () => void;
+  refresh: () => void;
+}
+
+export interface EntityGridProps<
+  T,
+  S extends FilterSpecMap,
+  TDrawer = Record<string, never>,
+  TBulk extends BulkDeleteActionsState = BulkDeleteActionsState,
+> {
+  descriptor: ListDescriptor<T, S>;
+  /** Data columns only — the trailing actions column is assembled internally. */
+  columns: GridColDef[];
+  /** Map toolbar-owned state onto the descriptor's filter keys. */
+  toFilters: (state: EntityGridFilterState<TDrawer>) => FiltersOf<S>;
+  emptyState: React.ReactNode;
+
+  // ── data (pass-through to useList) ──
+  initialData?: T[];
+  initialTotalCount?: number;
+  /** Bumped by the page (e.g. after a create) to trigger a re-fetch. */
+  refreshTrigger?: number;
+  /** OData clauses the toolbar doesn't own — project scoping, insights ids. */
+  extraFilters?: (string | undefined)[];
+  /** Extra fetch gate AND'd with the auth gate. */
+  enabled?: boolean;
+  /** Live polling — see `usePaginatedList`. */
+  pollMs?: (data: T[]) => number | false;
+  /** Fires whenever the page data or total changes (Annotations' count callback). */
+  onDataChange?: (
+    data: T[],
+    totalCount: number,
+    filtersActive: boolean
+  ) => void;
+  /** Derive the grid rows from the fetched entities (TestSets' processed rows). */
+  mapRows?: (data: T[]) => GridRowModel[];
+  /** Row id override for synthesized ids (Annotations). */
+  getRowId?: (row: GridRowModel) => string;
+  /** OR'd into the grid's loading flag (Endpoints' side-fetched projects). */
+  extraLoading?: boolean;
+
+  // ── toolbar ──
+  searchPlaceholder?: string;
+  /** Pill tabs; `allValue` (default `'all'`) maps to "no pill filter". */
+  pills?: { tabs: ToolbarPillTab[]; allValue?: string };
+  drawer?: EntityGridDrawerAdapter<TDrawer>;
+  /** Descriptor-filter values owned by the caller, merged after `toFilters`. */
+  externalFilters?: Partial<FiltersOf<S>>;
+  /** Rendered before the Columns/Density/Export buttons (TestRuns' run-kind toggle). */
+  toolbarRight?: React.ReactNode;
+  /** Columns/Density/Export buttons. Default true; Jobs passes false. */
+  showGridButtons?: boolean;
+  /** CSV export button, gated separately (Tests: `useCan(TestSet.EXPORT)`). Default true. */
+  showExport?: boolean;
+  /** Selection toggle label. Default `Select ${descriptor.resource}`. */
+  selectionLabel?: string;
+
+  // ── rows / navigation ──
+  getRowUrl?: (row: T) => string | undefined;
+  /** Overrides URL navigation on left-click (Tests' drawer, Annotations' new tab). */
+  onRowClick?: (params: GridRowParams) => void;
+  /** Wire notification-badge row highlighting and clear-on-click. */
+  highlightSection?: NotificationSection;
+
+  // ── actions column ──
+  /**
+   * Edit icon. Defaults to navigating to `getRowUrl`; pass `false` to drop the
+   * icon, or an object for a custom handler and/or per-row gate (omitting
+   * `onClick` keeps the default navigation).
+   */
+  editAction?:
+    | { onClick?: (id: string, row: T) => void; can?: (row: T) => boolean }
+    | false;
+  extraRowActions?: RowExtraAction[];
+  rowActionsWidth?: number;
+
+  // ── selection / bulk (active only when descriptor.delete?.bulk is set) ──
+  onBulkActionsChange?: (state: TBulk) => void;
+  /** Extend the delete-only bulk state (TestSets' Run, Tests' Assign, Explorer's Save). */
+  buildBulkActions?: (
+    base: BulkDeleteActionsState,
+    ctx: EntityGridSelectionContext<T>
+  ) => TBulk;
+  /** Drawers/dialogs needing the live selection (RunDrawer, TestSetSelectionDrawer). */
+  renderSelectionExtras?: (
+    ctx: EntityGridSelectionContext<T>
+  ) => React.ReactNode;
+
+  // ── presentation ──
+  /** Skip the Paper wrapper and loading/empty gate (embedded tabs). */
+  embedded?: boolean;
+  /** Rendered between the error alert and the grid (Tests' insights banner). */
+  banner?: React.ReactNode;
+  persistState?: boolean;
+  storageKey?: string;
+  /** Server-side sorting. Default true. */
+  serverSort?: boolean;
+  pageSizeOptions?: number[];
+  density?: GridDensity;
+  initialState?: GridInitialState;
+  sx?: SxProps<Theme>;
+}

--- a/apps/frontend/src/components/common/__tests__/BaseDataGrid.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/BaseDataGrid.test.tsx
@@ -146,26 +146,6 @@ describe('BaseDataGrid', () => {
     return result;
   }
 
-  describe('title', () => {
-    it('renders title when provided', () => {
-      renderAndInit(
-        <BaseDataGrid
-          columns={sampleColumns}
-          rows={sampleRows}
-          title="My Grid"
-        />
-      );
-      expect(
-        screen.getByRole('heading', { name: 'My Grid' })
-      ).toBeInTheDocument();
-    });
-
-    it('does not render a heading when title is omitted', () => {
-      renderAndInit(<BaseDataGrid columns={sampleColumns} rows={sampleRows} />);
-      expect(screen.queryByRole('heading')).not.toBeInTheDocument();
-    });
-  });
-
   describe('data grid rendering', () => {
     it('renders the data grid', () => {
       renderAndInit(<BaseDataGrid columns={sampleColumns} rows={sampleRows} />);
@@ -198,75 +178,11 @@ describe('BaseDataGrid', () => {
     });
   });
 
-  describe('action buttons', () => {
-    it('renders a simple action button', () => {
-      const onClick = jest.fn();
-      renderAndInit(
-        <BaseDataGrid
-          columns={sampleColumns}
-          rows={sampleRows}
-          actionButtons={[{ label: 'Add Item', onClick }]}
-        />
-      );
-      expect(
-        screen.getByRole('button', { name: /add item/i })
-      ).toBeInTheDocument();
-    });
-
-    it('calls onClick when action button is clicked', async () => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      const onClick = jest.fn();
-      renderAndInit(
-        <BaseDataGrid
-          columns={sampleColumns}
-          rows={sampleRows}
-          actionButtons={[{ label: 'Add Item', onClick }]}
-        />
-      );
-      await user.click(screen.getByRole('button', { name: /add item/i }));
-      expect(onClick).toHaveBeenCalledTimes(1);
-    });
-
-    it('renders disabled action button when disabled=true', () => {
-      renderAndInit(
-        <BaseDataGrid
-          columns={sampleColumns}
-          rows={sampleRows}
-          actionButtons={[
-            { label: 'Locked', onClick: jest.fn(), disabled: true },
-          ]}
-        />
-      );
-      expect(screen.getByRole('button', { name: /locked/i })).toBeDisabled();
-    });
-
-    it('renders multiple action buttons', () => {
-      renderAndInit(
-        <BaseDataGrid
-          columns={sampleColumns}
-          rows={sampleRows}
-          actionButtons={[
-            { label: 'Add', onClick: jest.fn() },
-            { label: 'Export', onClick: jest.fn() },
-          ]}
-        />
-      );
-      expect(
-        screen.getByRole('button', { name: /^add$/i })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', { name: /export/i })
-      ).toBeInTheDocument();
-    });
-
-    it('does not inject action buttons when actionButtons prop is omitted', () => {
-      renderAndInit(<BaseDataGrid columns={sampleColumns} rows={sampleRows} />);
-      // BaseDataGrid only renders action-button elements when the actionButtons
-      // prop is supplied.  The DataGrid itself is mocked here (no built-in
-      // toolbar/quick-filter buttons), so we can assert that the component
-      // introduces no button elements of its own when no actions are requested.
-      expect(screen.queryByRole('button')).not.toBeInTheDocument();
-    });
+  it('introduces no button elements of its own', () => {
+    // The DataGrid itself is mocked here (no built-in toolbar buttons), so
+    // BaseDataGrid should render zero buttons around it.
+    renderAndInit(<BaseDataGrid columns={sampleColumns} rows={sampleRows} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
   describe('row click', () => {
@@ -284,59 +200,6 @@ describe('BaseDataGrid', () => {
       expect(onRowClick).toHaveBeenCalledWith(
         expect.objectContaining({ row: sampleRows[0] })
       );
-    });
-  });
-
-  describe('dropdown filters', () => {
-    const filters = [
-      {
-        name: 'status',
-        label: 'Status',
-        filterField: 'status',
-        defaultValue: 'all',
-        options: [
-          { value: 'all', label: 'All' },
-          { value: 'active', label: 'Active' },
-          { value: 'inactive', label: 'Inactive' },
-        ],
-      },
-    ];
-
-    it('renders a filter dropdown when filters are provided', () => {
-      renderAndInit(
-        <BaseDataGrid
-          columns={sampleColumns}
-          rows={sampleRows}
-          filters={filters}
-        />
-      );
-      expect(screen.getByLabelText(/status/i)).toBeInTheDocument();
-    });
-
-    it('shows all rows when filter default is "all"', () => {
-      renderAndInit(
-        <BaseDataGrid
-          columns={sampleColumns}
-          rows={sampleRows}
-          filters={filters}
-        />
-      );
-      expect(screen.getByText('Alice')).toBeInTheDocument();
-      expect(screen.getByText('Bob')).toBeInTheDocument();
-      expect(screen.getByText('Charlie')).toBeInTheDocument();
-    });
-  });
-
-  describe('custom toolbar content', () => {
-    it('renders custom toolbar content', () => {
-      renderAndInit(
-        <BaseDataGrid
-          columns={sampleColumns}
-          rows={sampleRows}
-          customToolbarContent={<div data-testid="custom-toolbar">Custom</div>}
-        />
-      );
-      expect(screen.getByTestId('custom-toolbar')).toBeInTheDocument();
     });
   });
 

--- a/apps/frontend/src/components/common/createRowActionsColumn.tsx
+++ b/apps/frontend/src/components/common/createRowActionsColumn.tsx
@@ -10,7 +10,6 @@ import React, {
 import { Box, IconButton, Tooltip } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
 import { gridClasses, type GridColDef, type GridRowId } from '@mui/x-data-grid';
-import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import type { SvgIconComponent } from '@mui/icons-material';
 import { EditIcon, DeleteIcon } from '@/components/icons';
 
@@ -131,37 +130,55 @@ function RowActionsCell({ rowId, children }: RowActionsCellProps) {
   );
 }
 
+/** An entity-specific action rendered between the edit and delete icons. */
+export interface RowExtraAction {
+  key: string;
+  icon: SvgIconComponent;
+  tooltip: string;
+  onClick: (id: string, row: Record<string, unknown>) => void;
+  /** Return false to hide the action for this row. Defaults to always visible. */
+  can?: (row: Record<string, unknown>) => boolean;
+  /** Icon hover color. Defaults to `warning.main`. */
+  hoverColor?: 'primary.main' | 'warning.main' | 'error.main';
+}
+
 interface RowActionsColumnOptions {
   onEdit?: (id: string, row: Record<string, unknown>) => void;
   onDelete?: (id: string, row: Record<string, unknown>) => void;
-  onCancel?: (id: string, row: Record<string, unknown>) => void;
   /** Return false to hide the edit button for this row. Defaults to always visible. */
   canEdit?: (row: Record<string, unknown>) => boolean;
-  canCancel?: (row: Record<string, unknown>) => boolean;
   canDelete?: (row: Record<string, unknown>) => boolean;
+  /** Entity-specific actions (cancel a run, refresh a token, …). */
+  extraActions?: RowExtraAction[];
   width?: number;
   editTooltip?: string;
   deleteTooltip?: string;
-  cancelTooltip?: string;
   deleteIcon?: SvgIconComponent;
 }
 
+const actionIconButtonSx = (hoverColor: string) => ({
+  p: 0.5,
+  color: 'text.secondary',
+  '&:hover': {
+    color: hoverColor,
+    bgcolor: 'action.hover',
+  },
+});
+
 /**
- * Creates a header-less trailing column showing edit / delete / cancel icons
- * revealed on row hover. Pass handlers as needed; `onCancel` is only rendered
- * when `canCancel(row)` returns true (defaults to always-true if omitted).
+ * Creates a header-less trailing column showing edit / extra / delete icons
+ * revealed on row hover. Pass handlers as needed; each entry only renders when
+ * its `can*` predicate returns true (defaults to always-true if omitted).
  */
 export function createRowActionsColumn({
   onEdit,
   onDelete,
-  onCancel,
   canEdit,
-  canCancel,
   canDelete,
+  extraActions,
   width = 88,
   editTooltip = 'Edit',
   deleteTooltip = 'Delete',
-  cancelTooltip = 'Cancel',
   deleteIcon: DeleteIconComponent = DeleteIcon,
 }: RowActionsColumnOptions): GridColDef {
   return {
@@ -176,9 +193,7 @@ export function createRowActionsColumn({
     renderCell: params => {
       const id = String(params.id);
       const row = params.row as Record<string, unknown>;
-      const cancelFn = onCancel;
       const showEdit = onEdit && (!canEdit || canEdit(row));
-      const showCancel = cancelFn && (!canCancel || canCancel(row));
       const showDelete = onDelete && (!canDelete || canDelete(row));
 
       return (
@@ -189,42 +204,32 @@ export function createRowActionsColumn({
                 size="small"
                 onClick={e => {
                   e.stopPropagation();
-                  onEdit!(id, row);
+                  onEdit(id, row);
                 }}
-                sx={{
-                  p: 0.5,
-                  color: 'text.secondary',
-                  '&:hover': {
-                    color: 'primary.main',
-                    bgcolor: 'action.hover',
-                  },
-                }}
+                sx={actionIconButtonSx('primary.main')}
               >
                 <EditIcon sx={{ fontSize: 18 }} />
               </IconButton>
             </Tooltip>
           )}
-          {showCancel && cancelFn && (
-            <Tooltip title={cancelTooltip}>
-              <IconButton
-                size="small"
-                onClick={e => {
-                  e.stopPropagation();
-                  cancelFn(id, row);
-                }}
-                sx={{
-                  p: 0.5,
-                  color: 'text.secondary',
-                  '&:hover': {
-                    color: 'warning.main',
-                    bgcolor: 'action.hover',
-                  },
-                }}
-              >
-                <StopCircleOutlinedIcon sx={{ fontSize: 18 }} />
-              </IconButton>
-            </Tooltip>
-          )}
+          {extraActions?.map(action => {
+            if (action.can && !action.can(row)) return null;
+            const ActionIcon = action.icon;
+            return (
+              <Tooltip key={action.key} title={action.tooltip}>
+                <IconButton
+                  size="small"
+                  onClick={e => {
+                    e.stopPropagation();
+                    action.onClick(id, row);
+                  }}
+                  sx={actionIconButtonSx(action.hoverColor ?? 'warning.main')}
+                >
+                  <ActionIcon sx={{ fontSize: 18 }} />
+                </IconButton>
+              </Tooltip>
+            );
+          })}
           {showDelete && (
             <Tooltip title={deleteTooltip}>
               <IconButton
@@ -233,14 +238,7 @@ export function createRowActionsColumn({
                   e.stopPropagation();
                   onDelete(id, row);
                 }}
-                sx={{
-                  p: 0.5,
-                  color: 'text.secondary',
-                  '&:hover': {
-                    color: 'error.main',
-                    bgcolor: 'action.hover',
-                  },
-                }}
+                sx={actionIconButtonSx('error.main')}
               >
                 <DeleteIconComponent sx={{ fontSize: 18 }} />
               </IconButton>

--- a/apps/frontend/src/components/tasks/TasksSection.tsx
+++ b/apps/frontend/src/components/tasks/TasksSection.tsx
@@ -298,7 +298,6 @@ export function TasksSection({
           paginationModel={paginationModel}
           onPaginationModelChange={handlePaginationModelChange}
           getRowId={row => row.id}
-          showToolbar={true}
           disablePaperWrapper={true}
           serverSidePagination={true}
           totalRows={totalCount}

--- a/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
+++ b/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
@@ -276,7 +276,6 @@ export default function LinkedTestSetsSection({
             paginationModel={paginationModel}
             onPaginationModelChange={setPaginationModel}
             getRowId={row => row.id}
-            showToolbar={true}
             disablePaperWrapper={true}
             serverSidePagination={true}
             totalRows={totalCount}

--- a/apps/frontend/src/components/tests/TestExecutionHistoryTable.tsx
+++ b/apps/frontend/src/components/tests/TestExecutionHistoryTable.tsx
@@ -139,7 +139,6 @@ export default function TestExecutionHistoryTable({
       columns={columns}
       getRowId={row => row.id}
       disableRowSelectionOnClick
-      showToolbar={false}
       disablePaperWrapper
       pageSizeOptions={[10, 25, 50]}
       initialState={{

--- a/apps/frontend/src/hooks/useBulkDelete.ts
+++ b/apps/frontend/src/hooks/useBulkDelete.ts
@@ -103,9 +103,9 @@ export function useBulkDelete<TResp = void>({
   }, []);
 
   const confirmDelete = useCallback(async () => {
-    const idsToDelete = pendingDeleteId
-      ? [pendingDeleteId]
-      : (selectedRows as string[]);
+    const idsToDelete = (
+      pendingDeleteId ? [pendingDeleteId] : selectedRows
+    ).map(String);
     if (idsToDelete.length === 0) return;
 
     try {

--- a/apps/frontend/src/hooks/useBulkDelete.ts
+++ b/apps/frontend/src/hooks/useBulkDelete.ts
@@ -10,8 +10,12 @@ export interface BulkDeleteActionsState {
 }
 
 interface UseBulkDeleteOptions<TResp> {
-  /** Calls the entity's `DELETE .../bulk` client method. */
-  bulkDeleteFn: (ids: string[]) => Promise<TResp>;
+  /** Calls the entity's `DELETE .../bulk` client method. Omit for entities
+   * with only a single-row delete endpoint (pass `deleteOneFn` instead). */
+  bulkDeleteFn?: (ids: string[]) => Promise<TResp>;
+  /** Single-row delete used when `requestDelete(id)` targeted one row and
+   * no bulk endpoint exists. */
+  deleteOneFn?: (id: string) => Promise<unknown>;
   /** Invalidated after a successful delete so the grid refetches. Omit for
    * grids that don't fetch through react-query (e.g. Tokens) and use
    * `onSuccess` instead. */
@@ -49,6 +53,7 @@ interface UseBulkDeleteOptions<TResp> {
  */
 export function useBulkDelete<TResp = void>({
   bulkDeleteFn,
+  deleteOneFn,
   queryKey,
   onSuccess,
   itemLabelSingular,
@@ -105,9 +110,16 @@ export function useBulkDelete<TResp = void>({
 
     try {
       setIsDeleting(true);
-      const response = await bulkDeleteFn(idsToDelete);
+      let skipped = 0;
+      if (bulkDeleteFn) {
+        const response = await bulkDeleteFn(idsToDelete);
+        skipped = getSkippedCount?.(response) ?? 0;
+      } else if (deleteOneFn && pendingDeleteId) {
+        await deleteOneFn(pendingDeleteId);
+      } else {
+        return;
+      }
 
-      const skipped = getSkippedCount?.(response) ?? 0;
       const deletedCount = idsToDelete.length - skipped;
       if (deletedCount > 0) {
         const deletedLabel =
@@ -152,6 +164,7 @@ export function useBulkDelete<TResp = void>({
     pendingDeleteId,
     selectedRows,
     bulkDeleteFn,
+    deleteOneFn,
     getSkippedCount,
     skippedReason,
     itemLabelSingular,

--- a/apps/frontend/src/utils/api-client/explorer-client.ts
+++ b/apps/frontend/src/utils/api-client/explorer-client.ts
@@ -1,6 +1,10 @@
 import { BaseApiClient } from './base-client';
 import { API_ENDPOINTS } from './config';
 import { joinUrl } from '@/utils/url';
+import type {
+  PaginatedResponse,
+  PaginationParams,
+} from './interfaces/pagination';
 import {
   EvaluateRequest,
   EvaluateResponse,
@@ -105,19 +109,15 @@ export class ExplorerClient extends BaseApiClient {
    * @param sortOrder Sort direction
    */
   async getExplorerTestSets(
-    skip: number = 0,
-    limit: number = 100,
-    sortBy: string = 'created_at',
-    sortOrder: string = 'desc'
-  ): Promise<ExplorerTestSetDetail[]> {
-    const params = new URLSearchParams({
-      skip: skip.toString(),
-      limit: limit.toString(),
-      sort_by: sortBy,
-      sort_order: sortOrder,
-    });
-    return this.fetch<ExplorerTestSetDetail[]>(
-      `${API_ENDPOINTS.explorer}/?${params.toString()}`,
+    params: PaginationParams & { $filter?: string } = { skip: 0, limit: 100 }
+  ): Promise<PaginatedResponse<ExplorerTestSetDetail>> {
+    return this.fetchPaginated<ExplorerTestSetDetail>(
+      API_ENDPOINTS.explorer,
+      {
+        sort_by: 'created_at',
+        sort_order: 'desc',
+        ...params,
+      },
       { cache: 'no-store' }
     );
   }

--- a/apps/frontend/src/utils/api-client/tokens-client.ts
+++ b/apps/frontend/src/utils/api-client/tokens-client.ts
@@ -30,28 +30,15 @@ export class TokensClient extends BaseApiClient {
   }
 
   async listTokens(
-    params?: PaginationParams
+    params?: PaginationParams & { $filter?: string }
   ): Promise<PaginatedResponse<Token>> {
-    try {
-      return this.fetchPaginated<Token>(API_ENDPOINTS.tokens, {
-        skip: params?.skip || 0,
-        limit: params?.limit || 10,
-        sort_by: params?.sort_by || 'created_at',
-        sort_order: params?.sort_order || 'desc',
-      });
-    } catch (_error) {
-      return {
-        data: [],
-        pagination: {
-          totalCount: 0,
-          skip: params?.skip || 0,
-          limit: params?.limit || 10,
-          currentPage: 0,
-          pageSize: params?.limit || 10,
-          totalPages: 0,
-        },
-      };
-    }
+    return this.fetchPaginated<Token>(API_ENDPOINTS.tokens, {
+      skip: params?.skip || 0,
+      limit: params?.limit || 10,
+      sort_by: params?.sort_by || 'created_at',
+      sort_order: params?.sort_order || 'desc',
+      ...(params?.$filter ? { $filter: params.$filter } : {}),
+    });
   }
 
   async deleteToken(tokenId: string): Promise<Token> {

--- a/apps/frontend/src/utils/list/define.ts
+++ b/apps/frontend/src/utils/list/define.ts
@@ -110,14 +110,48 @@ export interface ListState<S extends FilterSpecMap> {
 
 export type ListParams = PaginationParams & Record<string, unknown>;
 
-export interface ListDescriptor<T, S extends FilterSpecMap> {
+/**
+ * How rows of this list are deleted. Declaring it on the descriptor gives the
+ * grid its trailing delete action, the confirm modal, and (when `bulk` is set)
+ * the checkbox-selection bulk-delete mode — no per-grid wiring.
+ */
+export interface ListDeleteSpec<TResp = unknown> {
+  /** Calls the entity's `DELETE .../bulk` endpoint. Enables checkbox bulk mode. */
+  bulk?: (factory: ApiClientFactory, ids: string[]) => Promise<TResp>;
+  /** Single-row delete, for entities without a bulk endpoint. */
+  one?: (factory: ApiClientFactory, id: string) => Promise<unknown>;
+  /** e.g. `Capability.TestRun.DELETE`. */
+  capability: string;
+  /**
+   * `'row'`: the response rows carry `permitted_actions` — gate per row via
+   * `can(row, capability)` (also gates row selectability). `'ambient'`: gate
+   * once via `useCan(capability)`.
+   */
+  capabilityMode: 'row' | 'ambient';
+  labelSingular: string;
+  labelPlural: string;
+  // Method syntax on purpose: bivariant params keep a descriptor with a
+  // concrete TResp assignable to the `ListDescriptor<T, S>` (TDeleteResp =
+  // unknown) signatures the hooks use.
+  /** Owner-only delete rule: count of ids skipped by the bulk response. */
+  getSkippedCount?(response: TResp): number;
+  /** Reason shown alongside the skipped count, e.g. "not yours to delete". */
+  skippedReason?: string;
+  /** Confirm-modal body override; `count` is 1 for a single-row delete. */
+  confirmMessage?: (count: number) => string;
+}
+
+export interface ListDescriptor<
+  T,
+  S extends FilterSpecMap,
+  TDeleteResp = unknown,
+> {
   title: string;
   description?: string;
   /** Noun used in the `AccessDenied` message, e.g. `endpoints`. */
   resource: string;
   /** A single capability, or two OR'd together. */
   capability: string | readonly [string, string];
-  createCapability?: string;
   defaultPageSize: number;
   defaultSort: ListSort;
   filters: S;
@@ -130,19 +164,26 @@ export interface ListDescriptor<T, S extends FilterSpecMap> {
    * `has_experiment`/`has_reviews` are top-level params, not `$filter` clauses.
    */
   extraParams?: (filters: FiltersOf<S>) => Record<string, unknown>;
+  delete?: ListDeleteSpec<TDeleteResp>;
 }
 
-type DescriptorInput<T, S extends FilterSpecMap> = Omit<
-  ListDescriptor<T, S>,
+type DescriptorInput<T, S extends FilterSpecMap, TDeleteResp> = Omit<
+  ListDescriptor<T, S, TDeleteResp>,
   'defaultSort'
-> & { defaultSort?: ListSort };
+> & {
+  defaultSort?: ListSort;
+};
 
 /** Every list endpoint sorts newest-first unless the descriptor says otherwise. */
 const DEFAULT_SORT: ListSort = { by: 'created_at', order: 'desc' };
 
-export function defineList<T, const S extends FilterSpecMap>(
-  descriptor: DescriptorInput<T, S>
-): ListDescriptor<T, S> {
+export function defineList<
+  T,
+  const S extends FilterSpecMap,
+  TDeleteResp = unknown,
+>(
+  descriptor: DescriptorInput<T, S, TDeleteResp>
+): ListDescriptor<T, S, TDeleteResp> {
   return { defaultSort: DEFAULT_SORT, ...descriptor };
 }
 

--- a/apps/frontend/tests/e2e/pages/OrgTeamPage.ts
+++ b/apps/frontend/tests/e2e/pages/OrgTeamPage.ts
@@ -68,7 +68,7 @@ export class OrgTeamPage extends BasePage {
    */
   async expectMembersAreaVisible() {
     await this.page.waitForLoadState('networkidle');
-    await expect(this.page.getByRole('table').first()).toBeVisible({
+    await expect(this.page.locator('[role="grid"]').first()).toBeVisible({
       timeout: 15_000,
     });
   }

--- a/tests/backend/routes/test_explorer.py
+++ b/tests/backend/routes/test_explorer.py
@@ -489,6 +489,58 @@ class TestListExplorerTestSetsEndpoint:
             status.HTTP_403_FORBIDDEN,
         ]
 
+    def test_count_header_counts_only_explorer_rows(
+        self,
+        authenticated_client: TestClient,
+        explorer_and_regular_test_sets,
+    ):
+        """X-Total-Count must count explorer rows only, and ignore pagination."""
+        response = authenticated_client.get("/explorer", params={"limit": 1})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "X-Total-Count" in response.headers
+        total = int(response.headers["X-Total-Count"])
+        # Two explorer sets exist in the fixture; the regular ones must not count.
+        assert total >= 2
+        assert len(response.json()) == 1
+
+        unpaged = authenticated_client.get("/explorer")
+        assert int(unpaged.headers["X-Total-Count"]) == total
+        explorer_ids = {item["id"] for item in unpaged.json()}
+        assert total == len(explorer_ids)
+
+    def test_odata_filter_narrows_results(
+        self,
+        authenticated_client: TestClient,
+        explorer_and_regular_test_sets,
+    ):
+        """$filter should narrow both the page and the count header."""
+        target = explorer_and_regular_test_sets["explorer_1"]
+        response = authenticated_client.get(
+            "/explorer",
+            params={"$filter": f"name eq '{target.name}'"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert [item["id"] for item in data] == [str(target.id)]
+        assert response.headers["X-Total-Count"] == "1"
+
+    def test_odata_filter_no_match(
+        self,
+        authenticated_client: TestClient,
+        explorer_and_regular_test_sets,
+    ):
+        """A non-matching $filter returns an empty page and a zero count."""
+        response = authenticated_client.get(
+            "/explorer",
+            params={"$filter": "name eq 'no-such-session-name'"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+        assert response.headers["X-Total-Count"] == "0"
+
 
 @pytest.mark.integration
 @pytest.mark.routes


### PR DESCRIPTION
## Purpose

Every list grid hand-assembled the same ~10 pieces (fetch hook, toolbar context, filter drawer state, error alert, bulk delete, actions column, empty state), and Explorer fetched differently altogether. This PR centralizes all of it in one `EntityGrid` component so grids look and behave the same, every grid gets a trailing Actions column with delete, and the duplicated code is removed. Net −3,000 lines.

## What Changed

- New `EntityGrid` component composing fetch, toolbar, filters, selection/bulk delete, actions column, and empty state; `ListDescriptor` gains a `delete` spec.
- All 12 list grids migrated (tasks, endpoints, sources, jobs, annotations, experiments, test runs, test sets, tests, tokens, explorer, team members). Reviewable one commit per grid.
- Backend: explorer list endpoint gains `$filter` + `X-Total-Count`; explorer and tokens grids move to real server-side pagination/filtering (removes explorer's silent 100-row cap).
- Removed ~600 lines of dead BaseDataGrid props and the 12 bespoke per-grid toolbar contexts.

## Additional Context

- Visible changes: test runs' run-kind toggle reappears (was silently broken), explorer selection moves behind the standard toggle with export/delete as page actions, sources/experiments load errors become the standard dismissible alert, team members is now a DataGrid instead of a plain table.
- Grids no longer unmount during refetches, fixing search-box focus loss while typing.

## Testing

All 232 frontend suites pass (2,194 tests, incl. new EntityGrid suite), `tsc` and ESLint clean; backend explorer route tests pass (93, incl. new `$filter`/count-header cases). Smoke-test the explorer, tokens, and team members pages via `./rh dev`.
