### PR TITLE
Add user settings page with profile editing and password management

### DIFF
--- a/apps/backend/src/rhesis/backend/app/auth/public_routes.py
+++ b/apps/backend/src/rhesis/backend/app/auth/public_routes.py
@@ -95,6 +95,9 @@ AUTHZ_EXEMPT_ROUTES: frozenset[tuple[str, str]] = frozenset(
         # Onboarding: new users accept T&C before they have an organization.
         ("POST", "/auth/accept-terms"),
         ("GET", "/auth/terms-status"),
+        # Self-service password change/set: authenticated but not tied to any
+        # resource capability — the handler enforces identity via current_user.
+        ("POST", "/auth/change-password"),
         # Cross-project entity resolution: spans multiple resource types
         # (test, endpoint, metric, ...) so no single resource+verb capability
         # applies. Authorization is enforced in-handler: the lookup is always

--- a/apps/backend/src/rhesis/backend/app/auth/session_invalidation.py
+++ b/apps/backend/src/rhesis/backend/app/auth/session_invalidation.py
@@ -40,7 +40,10 @@ class SessionInvalidationStore:
             user_id: The user ID whose sessions should be invalidated
         """
         with self._lock:
-            self._logout_times[user_id] = datetime.now(timezone.utc)
+            # Truncate to second precision so the comparison with JWT iat
+            # (a Unix epoch integer) is on the same scale.
+            now = datetime.now(timezone.utc).replace(microsecond=0)
+            self._logout_times[user_id] = now
             logger.info(f"Invalidated all sessions for user {user_id}")
 
     def is_session_valid(self, user_id: str, issued_at: datetime) -> bool:
@@ -65,8 +68,10 @@ class SessionInvalidationStore:
             if issued_at.tzinfo is None:
                 issued_at = issued_at.replace(tzinfo=timezone.utc)
 
-            # Session is valid if it was issued AFTER the logout
-            is_valid = issued_at > logout_time
+            # Session is valid if it was issued AT or AFTER the logout.
+            # JWT iat and the stored logout time are both at second precision,
+            # so a token minted in the same second as invalidation is valid.
+            is_valid = issued_at >= logout_time
 
             if not is_valid:
                 logger.debug(

--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -946,7 +946,6 @@ async def change_password(
     token is returned so the current session survives.
     """
     from rhesis.backend.app.auth.session_invalidation import (
-        clear_user_logout,
         invalidate_user_sessions,
     )
     from rhesis.backend.app.utils.encryption import hash_password, verify_password
@@ -979,7 +978,6 @@ async def change_password(
     db.commit()
 
     invalidate_user_sessions(str(db_user.id))
-    clear_user_logout(str(db_user.id))
 
     logger.info("Password changed for user: %s", redact_email(db_user.email))
 

--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -976,10 +976,10 @@ async def change_password(
     if not db_user.provider_type:
         db_user.provider_type = AuthProviderType.EMAIL
 
+    db.commit()
+
     invalidate_user_sessions(str(db_user.id))
     clear_user_logout(str(db_user.id))
-
-    db.commit()
 
     logger.info("Password changed for user: %s", redact_email(db_user.email))
 

--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -68,6 +68,7 @@ from rhesis.backend.app.error_handlers import PublicHTTPException, internal_erro
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.utils.quick_start import is_quick_start_enabled
 from rhesis.backend.app.utils.rate_limit import (
+    AUTH_CHANGE_PASSWORD_LIMIT,
     AUTH_FORGOT_PASSWORD_LIMIT,
     AUTH_LOGIN_EMAIL_LIMIT,
     AUTH_MAGIC_LINK_LIMIT,
@@ -156,6 +157,15 @@ class ResetPasswordRequest(BaseModel):
     """Request body for password reset."""
 
     token: str
+    new_password: str = Field(..., min_length=1)
+
+
+class ChangePasswordRequest(BaseModel):
+    """Request body for authenticated password change/set."""
+
+    current_password: Optional[str] = Field(
+        None, description="Required when the user already has a password set."
+    )
     new_password: str = Field(..., min_length=1)
 
 
@@ -908,6 +918,75 @@ async def reset_password(
     return {
         "success": True,
         "message": "Password has been reset successfully",
+    }
+
+
+# =============================================================================
+# Change Password (Authenticated)
+# =============================================================================
+
+
+@router.post("/change-password")
+@limiter.limit(AUTH_CHANGE_PASSWORD_LIMIT)
+async def change_password(
+    request: Request,
+    body: ChangePasswordRequest,
+    db: Session = Depends(get_db_session),
+    current_user: User = Depends(require_current_user_or_token_without_context),
+):
+    """
+    Change or set a password for the currently authenticated user.
+
+    Users who already have a password must provide ``current_password``.
+    Users without a password (OAuth, magic-link, SSO) can set one by
+    omitting ``current_password``. Setting a password is additive -- it
+    does not change the user's primary authentication provider.
+
+    On success, all other sessions are invalidated and a fresh session
+    token is returned so the current session survives.
+    """
+    from rhesis.backend.app.auth.session_invalidation import (
+        clear_user_logout,
+        invalidate_user_sessions,
+    )
+    from rhesis.backend.app.utils.encryption import hash_password, verify_password
+
+    db_user = db.query(User).filter(User.id == current_user.id).first()
+    if db_user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    if db_user.password_hash is not None:
+        if not body.current_password:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Current password is required.",
+            )
+        if not verify_password(body.current_password, db_user.password_hash):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Current password is incorrect.",
+            )
+
+    await validate_password(
+        body.new_password,
+        context={"email": db_user.email, "name": db_user.name or ""},
+    )
+
+    db_user.password_hash = hash_password(body.new_password)
+    if not db_user.provider_type:
+        db_user.provider_type = AuthProviderType.EMAIL
+
+    invalidate_user_sessions(str(db_user.id))
+    clear_user_logout(str(db_user.id))
+
+    db.commit()
+
+    logger.info("Password changed for user: %s", redact_email(db_user.email))
+
+    return {
+        "success": True,
+        "message": "Password updated successfully.",
+        "session_token": create_session_token(db_user),
     }
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -108,6 +108,13 @@ def _user_settings_read_payload(
         **db_user.user_settings,
         "is_verified": db_user.is_verified,
         "permitted_actions": _user_settings_permitted_actions(request, current_user, db),
+        "has_password": db_user.password_hash is not None,
+        "provider_type": db_user.provider_type,
+        "email": db_user.email,
+        "name": db_user.name,
+        "given_name": db_user.given_name,
+        "family_name": db_user.family_name,
+        "picture": db_user.picture,
     }
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/user.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/user.py
@@ -173,13 +173,29 @@ class UserSettingsOutput(UserSettings):
 
 
 class UserSettingsRead(UserSettingsOutput):
-    """GET /users/settings — includes server-resolved affordances for self-service actions."""
+    """GET /users/settings — affordances, profile fields, and auth metadata."""
 
     permitted_actions: list[str] = Field(
         default_factory=list,
         description="Capabilities the caller may exercise on their own settings "
         "(e.g. polyphemus:request).",
     )
+    has_password: bool = Field(
+        False,
+        description="Whether the user has a password set (vs. OAuth/magic-link/SSO-only login).",
+    )
+    provider_type: Optional[str] = Field(
+        None,
+        description="Authentication provider type (google, github, email, oidc, etc.).",
+    )
+    email: str = Field(
+        ...,
+        description="User's email address.",
+    )
+    name: Optional[str] = Field(None, description="Full display name.")
+    given_name: Optional[str] = Field(None, description="First name.")
+    family_name: Optional[str] = Field(None, description="Last name.")
+    picture: Optional[str] = Field(None, description="Profile picture URL.")
 
 
 class UserSettingsUpdate(BaseModel):

--- a/apps/backend/src/rhesis/backend/app/utils/rate_limit.py
+++ b/apps/backend/src/rhesis/backend/app/utils/rate_limit.py
@@ -68,6 +68,7 @@ AUTH_MAGIC_LINK_LIMIT = "5/hour"
 AUTH_LOGIN_EMAIL_LIMIT = "20/hour"
 AUTH_REGISTER_LIMIT = "10/hour"
 AUTH_TERMS_STATUS_LIMIT = "30/hour"
+AUTH_CHANGE_PASSWORD_LIMIT = "5/hour"
 
 # EE features that need their own rate-limit constants define them
 # alongside their routers and decorate handlers with the shared

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rhesis-app",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rhesis-app",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "hasInstallScript": true,
       "dependencies": {
         "@emotion/react": "^11",

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointConnectionTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointConnectionTab.tsx
@@ -10,15 +10,15 @@ import {
   InputLabel,
   MenuItem,
   Select,
-  TextField,
 } from '@mui/material';
+import { SECTION_GRID } from '@/styles/theme-constants';
 import EditableSection from '@/components/common/EditableSection';
+import EditableField from '@/components/common/EditableField';
 import ViewField from '@/components/common/ViewField';
 import { normalizeUrl } from '@/utils/validation';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { useEndpointDetailContext } from './EndpointDetailContext';
 import { METHODS } from './endpoint-detail-shared';
-import { detailGridSpacing } from './endpoint-overview-utils';
 import EndpointSdkConnectionPanel from './EndpointSdkConnectionPanel';
 import EndpointHeadersFields from '../../components/EndpointHeadersFields';
 
@@ -103,24 +103,29 @@ export default function EndpointConnectionTab() {
         {({ draft, setDraft, isEditing }) => (
           <Grid
             container
-            columnSpacing={detailGridSpacing.columnSpacing(isEditing)}
-            rowSpacing={detailGridSpacing.rowSpacing(isEditing)}
+            columnSpacing={SECTION_GRID.columnSpacing}
+            rowSpacing={SECTION_GRID.rowSpacing}
           >
             <Grid size={{ xs: 12, md: 8 }}>
-              {isEditing ? (
-                <TextField
-                  fullWidth
-                  label="URL"
-                  placeholder="api.example.com or https://api.example.com"
-                  helperText="https:// will be added automatically if omitted"
-                  value={draft.url}
-                  onChange={e =>
-                    setDraft(prev => ({ ...prev, url: e.target.value }))
-                  }
-                />
-              ) : (
-                <ViewField label="URL" value={endpoint.url || '—'} />
-              )}
+              <EditableField
+                fullWidth
+                editing={isEditing}
+                label="URL"
+                placeholder={
+                  isEditing
+                    ? 'api.example.com or https://api.example.com'
+                    : undefined
+                }
+                helperText={
+                  isEditing
+                    ? 'https:// will be added automatically if omitted'
+                    : undefined
+                }
+                value={isEditing ? draft.url : endpoint.url || '—'}
+                onChange={e =>
+                  setDraft(prev => ({ ...prev, url: e.target.value }))
+                }
+              />
             </Grid>
             <Grid size={{ xs: 12, md: 4 }}>
               {isEditing ? (
@@ -189,9 +194,6 @@ export default function EndpointConnectionTab() {
               setDraft(prev => ({
                 ...prev,
                 auth_token: value,
-                // typing a real replacement cancels a pending removal;
-                // whitespace-only input is treated as empty on save, so it
-                // must not silently cancel the removal
                 clear_token: value.trim() !== '' ? false : prev.clear_token,
               }))
             }

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointOverviewTab.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { useMemo } from 'react';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
@@ -12,18 +11,18 @@ import {
   MenuItem,
   Select,
   Switch,
-  TextField,
   FormControl,
   InputLabel,
 } from '@mui/material';
+import { SECTION_GRID } from '@/styles/theme-constants';
 import GridBadge from '@/components/common/GridBadge';
 import EditableSection from '@/components/common/EditableSection';
+import EditableField from '@/components/common/EditableField';
 import ViewField from '@/components/common/ViewField';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import { useEndpointDetailContext } from './EndpointDetailContext';
 import { ENVIRONMENTS } from './endpoint-detail-shared';
 import {
-  detailGridSpacing,
   formatConfigSource,
   formatEnvironment,
 } from './endpoint-overview-utils';
@@ -82,62 +81,48 @@ export default function EndpointOverviewTab() {
         {({ draft, setDraft, isEditing }) => (
           <Grid
             container
-            columnSpacing={detailGridSpacing.columnSpacing(isEditing)}
-            rowSpacing={detailGridSpacing.rowSpacing(isEditing)}
+            columnSpacing={SECTION_GRID.columnSpacing}
+            rowSpacing={SECTION_GRID.rowSpacing}
           >
-            {/* Project is fixed once the endpoint exists — an endpoint cannot be
-                moved between projects, so this stays read-only even while editing. */}
             <Grid size={{ xs: 12, md: 6 }}>
-              <ViewField label="Project">
-                {endpoint.project_id ? (
-                  <Link
-                    href={`/projects/${endpoint.project_id}`}
-                    style={{ color: 'inherit', fontWeight: 500 }}
-                  >
-                    {projectName}
-                  </Link>
-                ) : (
-                  'No project assigned'
-                )}
-              </ViewField>
+              <EditableField
+                fullWidth
+                editing={isEditing}
+                label="Name"
+                value={isEditing ? draft.name : endpoint.name}
+                onChange={e =>
+                  setDraft(prev => ({ ...prev, name: e.target.value }))
+                }
+              />
             </Grid>
             <Grid size={{ xs: 12, md: 6 }}>
-              {isEditing ? (
-                <TextField
-                  fullWidth
-                  label="Name"
-                  value={draft.name}
-                  onChange={e =>
-                    setDraft(prev => ({ ...prev, name: e.target.value }))
-                  }
-                />
-              ) : (
-                <ViewField label="Name" value={endpoint.name} />
-              )}
+              <EditableField
+                fullWidth
+                editing={false}
+                label="Project"
+                value={projectName}
+              />
             </Grid>
 
             <Grid size={12}>
-              {isEditing ? (
-                <TextField
-                  fullWidth
-                  label="Description"
-                  value={draft.description}
-                  onChange={e =>
-                    setDraft(prev => ({
-                      ...prev,
-                      description: e.target.value,
-                    }))
-                  }
-                  multiline
-                  minRows={3}
-                />
-              ) : (
-                <ViewField
-                  label="Description"
-                  value={endpoint.description || 'No description provided'}
-                  multiline
-                />
-              )}
+              <EditableField
+                fullWidth
+                editing={isEditing}
+                label="Description"
+                value={
+                  isEditing
+                    ? draft.description
+                    : endpoint.description || 'No description provided'
+                }
+                onChange={e =>
+                  setDraft(prev => ({
+                    ...prev,
+                    description: e.target.value,
+                  }))
+                }
+                multiline
+                minRows={3}
+              />
             </Grid>
 
             <Grid size={{ xs: 12, md: 6 }}>

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/endpoint-overview-utils.ts
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/endpoint-overview-utils.ts
@@ -5,8 +5,3 @@ export function formatConfigSource(value: string): string {
 export function formatEnvironment(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
-
-export const detailGridSpacing = {
-  columnSpacing: (isEditing: boolean) => (isEditing ? 2 : '30px'),
-  rowSpacing: (isEditing: boolean) => (isEditing ? 2 : '50px'),
-} as const;

--- a/apps/frontend/src/app/(protected)/organizations/settings/components/ContactInformationForm.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/settings/components/ContactInformationForm.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import { Grid, TextField } from '@mui/material';
+import { Grid } from '@mui/material';
 import { Organization } from '@/utils/api-client/interfaces/organization';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { validateEmail, validatePhone } from '@/utils/validation';
+import { SECTION_GRID } from '@/styles/theme-constants';
 import EditableSection from '@/components/common/EditableSection';
-import ViewField from '@/components/common/ViewField';
+import EditableField from '@/components/common/EditableField';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 
@@ -144,75 +145,61 @@ function ContactFields({
     }
   };
 
-  const gridSpacing = isEditing ? 2 : '50px';
-  const columnSpacing = isEditing ? 2 : '30px';
-
   return (
-    <Grid container columnSpacing={columnSpacing} rowSpacing={gridSpacing}>
+    <Grid
+      container
+      columnSpacing={SECTION_GRID.columnSpacing}
+      rowSpacing={SECTION_GRID.rowSpacing}
+    >
       <Grid size={{ xs: 12, md: 6 }}>
-        {isEditing ? (
-          <TextField
-            fullWidth
-            label="Email"
-            value={draft.email}
-            onChange={handleChange('email')}
-            onBlur={handleBlur('email')}
-            placeholder="contact@example.com"
-            error={!!fieldErrors.email}
-            helperText={
-              fieldErrors.email || 'Primary contact email for your organization'
-            }
-          />
-        ) : (
-          <ViewField
-            label="Email"
-            value={draft.email}
-            helperText="Primary contact email for your organization"
-          />
-        )}
+        <EditableField
+          fullWidth
+          editing={isEditing}
+          label="Email"
+          value={draft.email}
+          onChange={handleChange('email')}
+          onBlur={handleBlur('email')}
+          placeholder={isEditing ? 'contact@example.com' : undefined}
+          error={isEditing && !!fieldErrors.email}
+          helperText={
+            isEditing
+              ? fieldErrors.email ||
+                'Primary contact email for your organization'
+              : 'Primary contact email for your organization'
+          }
+        />
       </Grid>
 
       <Grid size={{ xs: 12, md: 6 }}>
-        {isEditing ? (
-          <TextField
-            fullWidth
-            label="Phone"
-            value={draft.phone}
-            onChange={handleChange('phone')}
-            onBlur={handleBlur('phone')}
-            placeholder="+1 (555) 123-4567"
-            error={!!fieldErrors.phone}
-            helperText={fieldErrors.phone || 'Primary contact phone number'}
-          />
-        ) : (
-          <ViewField
-            label="Phone"
-            value={draft.phone}
-            helperText="Primary contact phone number"
-          />
-        )}
+        <EditableField
+          fullWidth
+          editing={isEditing}
+          label="Phone"
+          value={draft.phone}
+          onChange={handleChange('phone')}
+          onBlur={handleBlur('phone')}
+          placeholder={isEditing ? '+1 (555) 123-4567' : undefined}
+          error={isEditing && !!fieldErrors.phone}
+          helperText={
+            isEditing
+              ? fieldErrors.phone || 'Primary contact phone number'
+              : 'Primary contact phone number'
+          }
+        />
       </Grid>
 
       <Grid size={12}>
-        {isEditing ? (
-          <TextField
-            fullWidth
-            label="Address"
-            value={draft.address}
-            onChange={handleChange('address')}
-            multiline
-            rows={3}
-            placeholder="123 Main St, City, State, ZIP"
-            helperText="Physical address of your organization"
-          />
-        ) : (
-          <ViewField
-            label="Address"
-            value={draft.address}
-            helperText="Physical address of your organization"
-            multiline
-          />
-        )}
+        <EditableField
+          fullWidth
+          editing={isEditing}
+          label="Address"
+          value={draft.address}
+          onChange={handleChange('address')}
+          multiline
+          rows={3}
+          placeholder={isEditing ? '123 Main St, City, State, ZIP' : undefined}
+          helperText="Physical address of your organization"
+        />
       </Grid>
     </Grid>
   );

--- a/apps/frontend/src/app/(protected)/organizations/settings/components/OrganizationDetailsForm.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/settings/components/OrganizationDetailsForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useMemo, useState, useCallback } from 'react';
-import { Box, Grid, TextField, IconButton, Tooltip } from '@mui/material';
+import { Box, Grid, IconButton, Tooltip } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
 import { useRouter } from 'next/navigation';
@@ -9,7 +9,9 @@ import { Organization } from '@/utils/api-client/interfaces/organization';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { validateUrl, normalizeUrl } from '@/utils/validation';
+import { SECTION_GRID } from '@/styles/theme-constants';
 import EditableSection from '@/components/common/EditableSection';
+import EditableField from '@/components/common/EditableField';
 import ViewField from '@/components/common/ViewField';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
@@ -178,11 +180,12 @@ function DetailsFields({
     }
   };
 
-  const gridSpacing = isEditing ? 2 : '50px';
-  const columnSpacing = isEditing ? 2 : '30px';
-
   return (
-    <Grid container columnSpacing={columnSpacing} rowSpacing={gridSpacing}>
+    <Grid
+      container
+      columnSpacing={SECTION_GRID.columnSpacing}
+      rowSpacing={SECTION_GRID.rowSpacing}
+    >
       <Grid size={12}>
         <ViewField
           label="Organization ID"
@@ -220,105 +223,75 @@ function DetailsFields({
       </Grid>
 
       <Grid size={{ xs: 12, md: 6 }}>
-        {isEditing ? (
-          <TextField
-            fullWidth
-            label="Organization Name"
-            value={draft.name}
-            onChange={handleChange('name')}
-            required
-            helperText="The internal name for your organization"
-          />
-        ) : (
-          <ViewField
-            label="Organization Name"
-            value={draft.name}
-            helperText="The internal name for your organization"
-          />
-        )}
+        <EditableField
+          fullWidth
+          editing={isEditing}
+          label="Organization Name"
+          value={draft.name}
+          onChange={handleChange('name')}
+          required={isEditing}
+          helperText="The internal name for your organization"
+        />
       </Grid>
 
       <Grid size={{ xs: 12, md: 6 }}>
-        {isEditing ? (
-          <TextField
-            fullWidth
-            label="Display Name"
-            value={draft.display_name}
-            onChange={handleChange('display_name')}
-            helperText="Friendly name shown to users (optional)"
-          />
-        ) : (
-          <ViewField
-            label="Display Name"
-            value={draft.display_name}
-            helperText="Friendly name shown to users (optional)"
-          />
-        )}
+        <EditableField
+          fullWidth
+          editing={isEditing}
+          label="Display Name"
+          value={draft.display_name}
+          onChange={handleChange('display_name')}
+          helperText="Friendly name shown to users (optional)"
+        />
       </Grid>
 
       <Grid size={12}>
-        {isEditing ? (
-          <TextField
-            fullWidth
-            label="Description"
-            value={draft.description}
-            onChange={handleChange('description')}
-            multiline
-            rows={3}
-            helperText="A brief description of your organization"
-          />
-        ) : (
-          <ViewField
-            label="Description"
-            value={draft.description}
-            helperText="A brief description of your organization"
-            multiline
-          />
-        )}
+        <EditableField
+          fullWidth
+          editing={isEditing}
+          label="Description"
+          value={draft.description}
+          onChange={handleChange('description')}
+          multiline
+          rows={3}
+          helperText="A brief description of your organization"
+        />
       </Grid>
 
       <Grid size={{ xs: 12, md: 6 }}>
-        {isEditing ? (
-          <TextField
-            fullWidth
-            label="Website"
-            value={draft.website}
-            onChange={handleChange('website')}
-            onBlur={handleBlur('website')}
-            placeholder="https://example.com"
-            error={!!fieldErrors.website}
-            helperText={fieldErrors.website || "Your organization's website"}
-          />
-        ) : (
-          <ViewField
-            label="Website"
-            value={draft.website}
-            helperText="Your organization's website"
-          />
-        )}
+        <EditableField
+          fullWidth
+          editing={isEditing}
+          label="Website"
+          value={draft.website}
+          onChange={handleChange('website')}
+          onBlur={handleBlur('website')}
+          placeholder={isEditing ? 'https://example.com' : undefined}
+          error={isEditing && !!fieldErrors.website}
+          helperText={
+            isEditing
+              ? fieldErrors.website || "Your organization's website"
+              : "Your organization's website"
+          }
+        />
       </Grid>
 
       <Grid size={{ xs: 12, md: 6 }}>
-        {isEditing ? (
-          <TextField
-            fullWidth
-            label="Logo URL"
-            value={draft.logo_url}
-            onChange={handleChange('logo_url')}
-            onBlur={handleBlur('logo_url')}
-            placeholder="https://example.com/logo.png"
-            error={!!fieldErrors.logo_url}
-            helperText={
-              fieldErrors.logo_url || "URL to your organization's logo"
-            }
-          />
-        ) : (
-          <ViewField
-            label="Logo URL"
-            value={draft.logo_url}
-            helperText="URL to your organization's logo"
-          />
-        )}
+        <EditableField
+          fullWidth
+          editing={isEditing}
+          label="Logo URL"
+          value={draft.logo_url}
+          onChange={handleChange('logo_url')}
+          onBlur={handleBlur('logo_url')}
+          placeholder={isEditing ? 'https://example.com/logo.png' : undefined}
+          error={isEditing && !!fieldErrors.logo_url}
+          helperText={
+            isEditing
+              ? fieldErrors.logo_url || "URL to your organization's logo"
+              : "URL to your organization's logo"
+          }
+        />
       </Grid>
     </Grid>
   );

--- a/apps/frontend/src/app/(protected)/settings/components/ChangePasswordDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/settings/components/ChangePasswordDrawer.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { TextField, Alert, Box } from '@mui/material';
+import { useSession } from 'next-auth/react';
+import { useQueryClient } from '@tanstack/react-query';
+import { changePassword } from '@/utils/api-client/auth-client';
+import { useNotifications } from '@/components/common/NotificationContext';
+import { useUserScope } from '@/hooks/useIsAuthenticated';
+import { userSettingsKeys } from '@/constants/query-keys';
+import BaseDrawer from '@/components/common/BaseDrawer';
+import {
+  drawerFieldsSx,
+  drawerOutlinedFieldSx,
+} from '@/components/common/drawerFormFieldSx';
+
+const MIN_PASSWORD_LENGTH = 12;
+
+interface ChangePasswordDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  hasPassword: boolean;
+}
+
+export default function ChangePasswordDrawer({
+  open,
+  onClose,
+  hasPassword,
+}: ChangePasswordDrawerProps) {
+  const { update: updateSession } = useSession();
+  const queryClient = useQueryClient();
+  const userScope = useUserScope();
+  const notifications = useNotifications();
+
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const resetForm = useCallback(() => {
+    setCurrentPassword('');
+    setNewPassword('');
+    setConfirmPassword('');
+    setError(null);
+    setSaving(false);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    resetForm();
+    onClose();
+  }, [resetForm, onClose]);
+
+  const handleSave = useCallback(async () => {
+    setError(null);
+
+    if (hasPassword && !currentPassword) {
+      setError('Current password is required.');
+      return;
+    }
+
+    if (newPassword.length < MIN_PASSWORD_LENGTH) {
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError('New passwords do not match.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const result = await changePassword({
+        current_password: hasPassword ? currentPassword : undefined,
+        new_password: newPassword,
+      });
+
+      if (result.session_token) {
+        await updateSession({ session_token: result.session_token });
+      }
+
+      queryClient.invalidateQueries({
+        queryKey: userSettingsKeys.all(userScope),
+      });
+
+      notifications.show(
+        hasPassword
+          ? 'Password changed successfully.'
+          : 'Password set successfully.',
+        { severity: 'success' }
+      );
+
+      handleClose();
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to update password.';
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    hasPassword,
+    currentPassword,
+    newPassword,
+    confirmPassword,
+    updateSession,
+    queryClient,
+    userScope,
+    notifications,
+    handleClose,
+  ]);
+
+  const canSave =
+    newPassword.length > 0 &&
+    confirmPassword.length > 0 &&
+    (!hasPassword || currentPassword.length > 0);
+
+  return (
+    <BaseDrawer
+      open={open}
+      onClose={handleClose}
+      title={hasPassword ? 'Change Password' : 'Set Password'}
+      onSave={handleSave}
+      saveDisabled={!canSave}
+      loading={saving}
+      saveButtonText={hasPassword ? 'Change Password' : 'Set Password'}
+    >
+      <Box sx={drawerFieldsSx}>
+        {error && <Alert severity="error">{error}</Alert>}
+
+        {hasPassword && (
+          <TextField
+            fullWidth
+            type="password"
+            label="Current Password"
+            value={currentPassword}
+            onChange={e => setCurrentPassword(e.target.value)}
+            autoComplete="current-password"
+            autoFocus
+            sx={drawerOutlinedFieldSx}
+          />
+        )}
+
+        <TextField
+          fullWidth
+          type="password"
+          label="New Password"
+          value={newPassword}
+          onChange={e => setNewPassword(e.target.value)}
+          autoComplete="new-password"
+          helperText={`Minimum ${MIN_PASSWORD_LENGTH} characters`}
+          autoFocus={!hasPassword}
+          sx={drawerOutlinedFieldSx}
+        />
+
+        <TextField
+          fullWidth
+          type="password"
+          label="Confirm New Password"
+          value={confirmPassword}
+          onChange={e => setConfirmPassword(e.target.value)}
+          autoComplete="new-password"
+          sx={drawerOutlinedFieldSx}
+        />
+      </Box>
+    </BaseDrawer>
+  );
+}

--- a/apps/frontend/src/app/(protected)/settings/components/ChangePasswordDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/settings/components/ChangePasswordDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { TextField, Alert, Box } from '@mui/material';
 import { useSession } from 'next-auth/react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -8,13 +8,18 @@ import { changePassword } from '@/utils/api-client/auth-client';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { useUserScope } from '@/hooks/useIsAuthenticated';
 import { userSettingsKeys } from '@/constants/query-keys';
+import {
+  DEFAULT_PASSWORD_POLICY,
+  validatePassword,
+  validatePasswordConfirmation,
+  type PasswordPolicy,
+} from '@/utils/validation';
+import { getClientApiBaseUrl } from '@/utils/url-resolver';
 import BaseDrawer from '@/components/common/BaseDrawer';
 import {
   drawerFieldsSx,
   drawerOutlinedFieldSx,
 } from '@/components/common/drawerFormFieldSx';
-
-const MIN_PASSWORD_LENGTH = 12;
 
 interface ChangePasswordDrawerProps {
   open: boolean;
@@ -37,6 +42,26 @@ export default function ChangePasswordDrawer({
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [passwordPolicy, setPasswordPolicy] = useState<PasswordPolicy | null>(
+    null
+  );
+
+  useEffect(() => {
+    const fetchPolicy = async () => {
+      try {
+        const res = await fetch(`${getClientApiBaseUrl()}/auth/providers`);
+        if (res.ok) {
+          const data = await res.json();
+          setPasswordPolicy(data.password_policy || null);
+        }
+      } catch {
+        // Fall back to DEFAULT_PASSWORD_POLICY
+      }
+    };
+    fetchPolicy();
+  }, []);
+
+  const policy = passwordPolicy ?? DEFAULT_PASSWORD_POLICY;
 
   const resetForm = useCallback(() => {
     setCurrentPassword('');
@@ -59,13 +84,18 @@ export default function ChangePasswordDrawer({
       return;
     }
 
-    if (newPassword.length < MIN_PASSWORD_LENGTH) {
-      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+    const passwordResult = validatePassword(newPassword, policy);
+    if (!passwordResult.isValid) {
+      setError(passwordResult.message ?? 'Invalid password.');
       return;
     }
 
-    if (newPassword !== confirmPassword) {
-      setError('New passwords do not match.');
+    const confirmResult = validatePasswordConfirmation(
+      newPassword,
+      confirmPassword
+    );
+    if (!confirmResult.isValid) {
+      setError(confirmResult.message ?? 'Passwords do not match.');
       return;
     }
 
@@ -104,6 +134,7 @@ export default function ChangePasswordDrawer({
     currentPassword,
     newPassword,
     confirmPassword,
+    policy,
     updateSession,
     queryClient,
     userScope,
@@ -149,7 +180,7 @@ export default function ChangePasswordDrawer({
           value={newPassword}
           onChange={e => setNewPassword(e.target.value)}
           autoComplete="new-password"
-          helperText={`Minimum ${MIN_PASSWORD_LENGTH} characters`}
+          helperText={`Minimum ${policy.min_length} characters`}
           autoFocus={!hasPassword}
           sx={drawerOutlinedFieldSx}
         />

--- a/apps/frontend/src/app/(protected)/settings/components/ChangePasswordDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/settings/components/ChangePasswordDrawer.tsx
@@ -14,7 +14,6 @@ import {
   validatePasswordConfirmation,
   type PasswordPolicy,
 } from '@/utils/validation';
-import { getClientApiBaseUrl } from '@/utils/url-resolver';
 import BaseDrawer from '@/components/common/BaseDrawer';
 import {
   drawerFieldsSx,
@@ -49,7 +48,7 @@ export default function ChangePasswordDrawer({
   useEffect(() => {
     const fetchPolicy = async () => {
       try {
-        const res = await fetch(`${getClientApiBaseUrl()}/auth/providers`);
+        const res = await fetch('/api/auth-config');
         if (res.ok) {
           const data = await res.json();
           setPasswordPolicy(data.password_policy || null);

--- a/apps/frontend/src/app/(protected)/settings/components/ProfileForm.tsx
+++ b/apps/frontend/src/app/(protected)/settings/components/ProfileForm.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import React, { useMemo, useCallback } from 'react';
+import { Grid } from '@mui/material';
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useQueryClient } from '@tanstack/react-query';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { UserSettings, UserUpdate } from '@/utils/api-client/interfaces/user';
+import { useNotifications } from '@/components/common/NotificationContext';
+import { useUserScope } from '@/hooks/useIsAuthenticated';
+import { userSettingsKeys } from '@/constants/query-keys';
+import { validateUrl, normalizeUrl } from '@/utils/validation';
+import { SECTION_GRID } from '@/styles/theme-constants';
+import { SectionCard } from '@/components/common/SectionCard';
+import EditableSection from '@/components/common/EditableSection';
+import EditableField from '@/components/common/EditableField';
+import ViewField from '@/components/common/ViewField';
+
+interface ProfileFormProps {
+  userSettings?: UserSettings;
+}
+
+interface ProfileDraft {
+  given_name: string;
+  family_name: string;
+  name: string;
+  picture: string;
+}
+
+function formatProviderType(providerType?: string): string | null {
+  if (!providerType || providerType === 'email') return null;
+  const labels: Record<string, string> = {
+    google: 'Google',
+    github: 'GitHub',
+    oidc: 'SSO (OIDC)',
+    microsoft: 'Microsoft',
+  };
+  return labels[providerType] ?? providerType;
+}
+
+function draftFromSettings(settings?: UserSettings): ProfileDraft {
+  return {
+    given_name: settings?.given_name ?? '',
+    family_name: settings?.family_name ?? '',
+    name: settings?.name ?? '',
+    picture: settings?.picture ?? '',
+  };
+}
+
+export default function ProfileForm({ userSettings }: ProfileFormProps) {
+  const router = useRouter();
+  const { data: session, update: updateSession } = useSession();
+  const queryClient = useQueryClient();
+  const userScope = useUserScope();
+  const notifications = useNotifications();
+
+  const initialValue = useMemo(
+    () => draftFromSettings(userSettings),
+    [userSettings]
+  );
+
+  const userId = session?.user?.id;
+  const providerLabel = formatProviderType(userSettings?.provider_type);
+
+  const handleSave = useCallback(
+    async (draft: ProfileDraft) => {
+      if (!userId) return;
+
+      const errors: Record<string, string> = {};
+
+      if (draft.picture) {
+        const pictureValidation = validateUrl(draft.picture);
+        if (!pictureValidation.isValid) {
+          errors.picture = pictureValidation.message || '';
+        }
+      }
+
+      if (Object.keys(errors).length > 0) {
+        notifications.show(Object.values(errors)[0], { severity: 'error' });
+        throw new Error('validation');
+      }
+
+      try {
+        const apiFactory = new ApiClientFactory();
+        const usersClient = apiFactory.getUsersClient();
+
+        const payload: UserUpdate = {
+          given_name: draft.given_name || undefined,
+          family_name: draft.family_name || undefined,
+          name: draft.name || undefined,
+          picture: draft.picture ? normalizeUrl(draft.picture) : undefined,
+        };
+
+        const result = await usersClient.updateUser(userId, payload);
+
+        if ('session_token' in result && result.session_token) {
+          await updateSession({
+            session_token: result.session_token,
+          });
+        }
+
+        queryClient.invalidateQueries({
+          queryKey: userSettingsKeys.all(userScope),
+        });
+
+        notifications.show('Profile updated successfully', {
+          severity: 'success',
+        });
+
+        router.refresh();
+      } catch (err: unknown) {
+        if (err instanceof Error && err.message === 'validation') {
+          throw err;
+        }
+        notifications.show(
+          err instanceof Error ? err.message : 'Failed to update profile',
+          { severity: 'error' }
+        );
+        throw err;
+      }
+    },
+    [userId, notifications, updateSession, queryClient, userScope, router]
+  );
+
+  return (
+    <>
+      <SectionCard title="Account">
+        <Grid
+          container
+          columnSpacing={SECTION_GRID.columnSpacing}
+          rowSpacing={SECTION_GRID.rowSpacing}
+        >
+          <Grid size={{ xs: 12, md: 6 }}>
+            <ViewField
+              label="Email"
+              value={userSettings?.email}
+              helperText="Your login email address"
+            />
+          </Grid>
+
+          {providerLabel && (
+            <Grid size={{ xs: 12, md: 6 }}>
+              <ViewField
+                label="Identity provider"
+                value={providerLabel}
+                helperText="External authentication provider"
+              />
+            </Grid>
+          )}
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <ViewField
+              label="Password"
+              value={userSettings?.has_password ? 'Set' : 'Not set'}
+              helperText={
+                userSettings?.has_password
+                  ? 'You can sign in with email and password'
+                  : 'Set a password to also sign in with email'
+              }
+            />
+          </Grid>
+        </Grid>
+      </SectionCard>
+
+      <EditableSection
+        editable
+        title="Personal Information"
+        initialValue={initialValue}
+        onSave={handleSave}
+      >
+        {({ draft, setDraft, isEditing }) => (
+          <EditableFields
+            draft={draft}
+            setDraft={setDraft}
+            isEditing={isEditing}
+          />
+        )}
+      </EditableSection>
+    </>
+  );
+}
+
+function EditableFields({
+  draft,
+  setDraft,
+  isEditing,
+}: {
+  draft: ProfileDraft;
+  setDraft: (next: ProfileDraft | ((p: ProfileDraft) => ProfileDraft)) => void;
+  isEditing: boolean;
+}) {
+  const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>(
+    {}
+  );
+
+  const handleChange =
+    (field: keyof ProfileDraft) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      setDraft(prev => ({ ...prev, [field]: e.target.value }));
+      if (fieldErrors[field]) {
+        setFieldErrors(prev => ({ ...prev, [field]: '' }));
+      }
+    };
+
+  const handleBlur = (field: 'picture') => () => {
+    const value = draft[field];
+    if (value) {
+      const validation = validateUrl(value);
+      if (!validation.isValid) {
+        setFieldErrors(prev => ({
+          ...prev,
+          [field]: validation.message || '',
+        }));
+      }
+    }
+  };
+
+  return (
+    <Grid
+      container
+      columnSpacing={SECTION_GRID.columnSpacing}
+      rowSpacing={SECTION_GRID.rowSpacing}
+    >
+      <Grid size={{ xs: 12, md: 6 }}>
+        <EditableField
+          fullWidth
+          editing={isEditing}
+          label="First Name"
+          value={draft.given_name}
+          onChange={handleChange('given_name')}
+          helperText="Your first name"
+        />
+      </Grid>
+
+      <Grid size={{ xs: 12, md: 6 }}>
+        <EditableField
+          fullWidth
+          editing={isEditing}
+          label="Last Name"
+          value={draft.family_name}
+          onChange={handleChange('family_name')}
+          helperText="Your last name"
+        />
+      </Grid>
+
+      <Grid size={{ xs: 12, md: 6 }}>
+        <EditableField
+          fullWidth
+          editing={isEditing}
+          label="Display Name"
+          value={draft.name}
+          onChange={handleChange('name')}
+          helperText="How your name appears across the platform"
+        />
+      </Grid>
+
+      <Grid size={{ xs: 12, md: 6 }}>
+        <EditableField
+          fullWidth
+          editing={isEditing}
+          label="Picture URL"
+          value={draft.picture}
+          onChange={handleChange('picture')}
+          onBlur={handleBlur('picture')}
+          placeholder={isEditing ? 'https://example.com/photo.jpg' : undefined}
+          error={isEditing && !!fieldErrors.picture}
+          helperText={
+            isEditing
+              ? fieldErrors.picture || 'URL to your profile picture'
+              : 'URL to your profile picture'
+          }
+        />
+      </Grid>
+    </Grid>
+  );
+}

--- a/apps/frontend/src/app/(protected)/settings/components/SecuritySection.tsx
+++ b/apps/frontend/src/app/(protected)/settings/components/SecuritySection.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import { SectionCard } from '@/components/common/SectionCard';
+import { UserSettings } from '@/utils/api-client/interfaces/user';
+import ChangePasswordDrawer from './ChangePasswordDrawer';
+
+interface SecuritySectionProps {
+  userSettings?: UserSettings;
+}
+
+function formatProviderLabel(providerType?: string): string {
+  const labels: Record<string, string> = {
+    google: 'Google',
+    github: 'GitHub',
+    oidc: 'SSO',
+    microsoft: 'Microsoft',
+  };
+  if (!providerType) return 'an external provider';
+  return labels[providerType] ?? providerType;
+}
+
+export default function SecuritySection({
+  userSettings,
+}: SecuritySectionProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const hasPassword = userSettings?.has_password ?? false;
+  const providerType = userSettings?.provider_type;
+
+  return (
+    <>
+      <SectionCard title="Password">
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <Typography
+            variant="body2"
+            sx={{ color: theme => theme.palette.greyscale.body }}
+          >
+            {hasPassword
+              ? 'Change your password. You will need to enter your current password.'
+              : `You signed in with ${formatProviderLabel(providerType)}. You can set a password to also sign in with email.`}
+          </Typography>
+
+          <Box>
+            <Button
+              variant="outlined"
+              startIcon={<LockOutlinedIcon />}
+              onClick={() => setDialogOpen(true)}
+            >
+              {hasPassword ? 'Change Password' : 'Set Password'}
+            </Button>
+          </Box>
+        </Box>
+      </SectionCard>
+
+      <ChangePasswordDrawer
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        hasPassword={hasPassword}
+      />
+    </>
+  );
+}

--- a/apps/frontend/src/app/(protected)/settings/page.tsx
+++ b/apps/frontend/src/app/(protected)/settings/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React from 'react';
+import { Box } from '@mui/material';
+import { PAGE_SECTION_GAP } from '@/styles/theme-constants';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { useUserSettings } from '@/hooks/useUserSettings';
+import PageLoadingState from '@/components/common/PageLoadingState';
+import ProfileForm from './components/ProfileForm';
+import SecuritySection from './components/SecuritySection';
+
+export default function SettingsPage() {
+  const { data: userSettings, isLoading } = useUserSettings();
+
+  const breadcrumbs = [{ label: 'Settings', href: '/settings' }];
+
+  const pageHeader = {
+    title: 'Settings',
+    description: 'Manage your profile and account.',
+    breadcrumbs,
+  };
+
+  if (isLoading) return <PageLoadingState />;
+
+  return (
+    <PageLayout {...pageHeader}>
+      <Box
+        sx={{ display: 'flex', flexDirection: 'column', gap: PAGE_SECTION_GAP }}
+      >
+        <ProfileForm userSettings={userSettings} />
+        <SecuritySection userSettings={userSettings} />
+      </Box>
+    </PageLayout>
+  );
+}

--- a/apps/frontend/src/auth.ts
+++ b/apps/frontend/src/auth.ts
@@ -478,6 +478,9 @@ export const authConfig: NextAuthConfig = {
               organization_id:
                 claims.organization_id ?? token.user.organization_id,
               name: claims.name ?? token.user.name,
+              email: claims.email ?? token.user.email,
+              image: claims.picture ?? token.user.image,
+              picture: claims.picture ?? token.user.picture,
             };
           }
         }

--- a/apps/frontend/src/components/common/EditableField.tsx
+++ b/apps/frontend/src/components/common/EditableField.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React from 'react';
+import { TextField, type TextFieldProps } from '@mui/material';
+import { readOnlyOutlinedFieldSx } from '@/components/common/drawerFormFieldSx';
+
+export type EditableFieldProps = Omit<TextFieldProps, 'slotProps'> & {
+  editing: boolean;
+  slotProps?: TextFieldProps['slotProps'];
+};
+
+export default function EditableField({
+  editing,
+  sx,
+  slotProps,
+  ...rest
+}: EditableFieldProps) {
+  return (
+    <TextField
+      {...rest}
+      slotProps={{
+        ...slotProps,
+        input: {
+          ...slotProps?.input,
+          readOnly: !editing,
+        },
+      }}
+      sx={[
+        ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+        ...(!editing ? [readOnlyOutlinedFieldSx] : []),
+      ]}
+    />
+  );
+}

--- a/apps/frontend/src/components/common/drawerFormFieldSx.ts
+++ b/apps/frontend/src/components/common/drawerFormFieldSx.ts
@@ -78,6 +78,22 @@ export const drawerOutlinedFieldSx: SxProps<Theme> = {
   },
 };
 
+/** Read-only outlined field: filled background, no border. */
+export const readOnlyOutlinedFieldSx: SxProps<Theme> = {
+  '& .MuiOutlinedInput-notchedOutline': {
+    borderColor: 'transparent',
+  },
+  '& .MuiOutlinedInput-root': {
+    backgroundColor: theme => theme.palette.greyscale.fieldSurface,
+    '&:hover .MuiOutlinedInput-notchedOutline': {
+      borderColor: 'transparent',
+    },
+    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+      borderColor: 'transparent',
+    },
+  },
+};
+
 export const drawerDisabledFieldSx: SxProps<Theme> = {
   ...drawerOutlinedFieldSx,
   '& .MuiOutlinedInput-root.Mui-disabled': {

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -967,6 +967,18 @@ export function Sidebar() {
             },
           }}
         >
+          {/* Settings */}
+          <MenuItem
+            onClick={() => {
+              router.push('/settings');
+              setMenuAnchor(null);
+            }}
+            sx={MENU_ROW_SX}
+          >
+            <SettingsOutlinedIcon sx={MENU_ICON_SX} />
+            <Typography sx={MENU_LABEL_SX}>User Settings</Typography>
+          </MenuItem>
+
           {/* Notifications */}
           <MenuItem
             onClick={() => {

--- a/apps/frontend/src/styles/theme-constants.ts
+++ b/apps/frontend/src/styles/theme-constants.ts
@@ -46,6 +46,15 @@ export const BACKDROP_COLORS = {
 /** Horizontal gap between FAB buttons in a page-header action group (Figma) */
 export const FAB_GROUP_GAP = '20px';
 
+/** MUI spacing units for section-level Grid containers (EditableSection, SectionCard). */
+export const SECTION_GRID = {
+  columnSpacing: 4,
+  rowSpacing: 4,
+} as const;
+
+/** MUI spacing units for page-level section stacking. */
+export const PAGE_SECTION_GAP = 3;
+
 export const ELEVATION = {
   xs: '0px 2px 4px rgba(84, 90, 101, 0.25)',
   s: '0px 16px 32px -4px rgba(84, 90, 101, 0.10), 0px 4px 4px rgba(84, 90, 101, 0.04)',

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -586,9 +586,6 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
           root: {
             '& .MuiOutlinedInput-root': {
               borderRadius: 8,
-              ...(mode === 'dark' && {
-                backgroundColor: GREYSCALE.dark.fieldSurface,
-              }),
               '& fieldset': {
                 borderColor:
                   mode === 'light'
@@ -611,7 +608,6 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
           root: {
             borderRadius: 8,
             ...(mode === 'dark' && {
-              backgroundColor: GREYSCALE.dark.fieldSurface,
               color: '#ffffff',
             }),
           },

--- a/apps/frontend/src/utils/api-client/auth-client.ts
+++ b/apps/frontend/src/utils/api-client/auth-client.ts
@@ -30,3 +30,32 @@ export async function acceptTerms(): Promise<void> {
     throw new Error('Failed to record terms acceptance');
   }
 }
+
+export interface ChangePasswordParams {
+  current_password?: string;
+  new_password: string;
+}
+
+export interface ChangePasswordResponse {
+  success: boolean;
+  message: string;
+  session_token: string;
+}
+
+export async function changePassword(
+  params: ChangePasswordParams
+): Promise<ChangePasswordResponse> {
+  const response = await fetch('/api/backend/auth/change-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(params),
+  });
+
+  if (!response.ok) {
+    const data = await response.json();
+    throw new Error(data.detail || 'Password change failed');
+  }
+
+  return response.json();
+}

--- a/apps/frontend/src/utils/api-client/interfaces/user.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/user.ts
@@ -39,9 +39,9 @@ export interface UserSettings extends WithPermittedActions {
   polyphemus_access?: PolyphemusAccess;
   default_project?: DefaultProjectSetting;
   is_verified?: boolean;
-  has_password?: boolean;
+  has_password: boolean;
   provider_type?: string;
-  email?: string;
+  email: string;
   name?: string;
   given_name?: string;
   family_name?: string;

--- a/apps/frontend/src/utils/api-client/interfaces/user.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/user.ts
@@ -39,6 +39,13 @@ export interface UserSettings extends WithPermittedActions {
   polyphemus_access?: PolyphemusAccess;
   default_project?: DefaultProjectSetting;
   is_verified?: boolean;
+  has_password?: boolean;
+  provider_type?: string;
+  email?: string;
+  name?: string;
+  given_name?: string;
+  family_name?: string;
+  picture?: string;
 }
 
 export interface UserSettingsUpdate {

--- a/scripts/check-hardcoded-styles.js
+++ b/scripts/check-hardcoded-styles.js
@@ -114,6 +114,7 @@ const EXCLUDE_PATTERNS = [
   /coverage/,
   /\.next/,
   /theme\.ts$/, // Exclude the theme file itself
+  /theme-constants\.ts$/, // Exclude the design-token definitions file
   /authTokens\.ts$/, // Same reason as theme.ts: the auth pages' palette is defined here
   /brand-palette\.ts$/, // Same reason: holds the Rhesis literals a custom brand colour falls back to
   /globals\.css$/, // Exclude globals.css (contains theme definitions)


### PR DESCRIPTION
## Purpose

Users have no way to view or edit their profile (name, picture) or manage their password. The only self-service actions are in the sidebar popover (dark mode, notifications, sign out). This adds a dedicated settings page modeled after the existing organization settings pattern.

## What Changed

**Backend**
- New `POST /auth/change-password` endpoint for authenticated password change/set. Users with an existing password must provide it; OAuth-only users can set one without a current password. Invalidates other sessions on success.
- Extended `GET /users/settings` response with profile fields (`given_name`, `family_name`, `name`, `picture`, `email`) and auth metadata (`has_password`, `provider_type`).

**Frontend — user settings page**
- New `/settings` page with profile editing (first name, last name, display name, picture URL) and a read-only account section (email, identity provider, password status).
- Password change/set via `ChangePasswordDrawer` using the platform's `BaseDrawer` pattern. Conditionally shows the current password field when the user already has one.
- Session refreshes on save so the sidebar avatar and name update immediately.
- "User Settings" menu item added to the sidebar user popover.

**Frontend — EditableField component and layout constants**
- New `EditableField` component wrapping `TextField` with a read-only toggle and `readOnlyOutlinedFieldSx` styling. Eliminates layout jerk on edit/view transitions by keeping the same DOM structure in both modes.
- Added `SECTION_GRID` and `PAGE_SECTION_GAP` layout constants in `theme-constants.ts` to replace hardcoded spacing values.
- Removed the global dark mode `backgroundColor` override on `MuiTextField`/`MuiOutlinedInput` so editable and read-only fields are visually distinct.
- Migrated endpoint detail tabs and org settings forms to use `EditableField` and the new layout constants.

## Additional Context

- The endpoint overview Project field was converted from a `ViewField` with a link to an `EditableField` (always read-only) so it aligns with the Name field on the same row. The project link was dropped in favor of alignment consistency.
- Other `EditableSection` consumers (tests, test sets, experiments, etc.) still use the old `ViewField`/`TextField` toggle pattern and can be migrated incrementally.

## Testing

1. Navigate to the sidebar user menu, confirm "User Settings" item appears below "Org Settings".
2. Click it, confirm `/settings` loads with Account section and Personal Information section.
3. Verify read-only fields (email, identity provider, password status) display correctly.
4. Click Edit on Personal Information, change a field, save. Confirm sidebar name/avatar updates without page reload.
5. In the Security section, click "Change Password" (or "Set Password" for OAuth users). Verify the drawer requires the current password when one is set, enforces minimum length, and confirms match.
6. Check dark mode: read-only fields should have a filled background, editable fields should show a visible border against the card.
7. Visit an endpoint detail page and org settings. Confirm no layout jerk on edit toggle and consistent spacing.