### PR TITLE
Fix migration dropping a review status still used by tests

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/ff71b040aebf_add_test_result_execution_verdict.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/ff71b040aebf_add_test_result_execution_verdict.py
@@ -26,10 +26,13 @@ convention in the v_test_result_stats migrations -- an import here would
 silently change historical backfill behavior if constants.py is edited
 later.
 
-Also drops the seeded 'Review' TestResult status: never written by any code
-path, and read as an error by the backend and a Fail by the frontend where
-it did appear. Guarded to skip any row that (unexpectedly) still references
-it.
+Also drops the seeded 'Review' TestResult status, which no code path writes
+and which the backend read as an error and the frontend as a Fail where it
+did appear. initial_data.json used to seed two 'Review' rows per org, one
+against Test and a mis-scoped one against TestResult, and tests created
+through POST/PUT /tests (which take status_id straight from the client, with
+no entity-type check) could be pointed at either. So the drop is guarded on
+both test and test_result, and the row survives in orgs that still use it.
 
 Revision ID: ff71b040aebf
 Revises: f2b3c4d5e6a7
@@ -96,6 +99,9 @@ def upgrade() -> None:
         "(execution = 'ok') = (verdict IS NOT NULL)",
     )
 
+    # test as well as test_result: initial_data.json seeded two 'Review' rows per
+    # org, one against Test and a mis-scoped one against TestResult, and some
+    # tests were pointed at the TestResult row. Skipping keeps those tests valid.
     op.execute(
         """
         DELETE FROM status s
@@ -106,6 +112,9 @@ def upgrade() -> None:
           AND lower(s.name) = 'review'
           AND NOT EXISTS (
               SELECT 1 FROM test_result tr WHERE tr.status_id = s.id
+          )
+          AND NOT EXISTS (
+              SELECT 1 FROM test t WHERE t.status_id = s.id
           )
         """
     )


### PR DESCRIPTION
## Purpose

Deployment is failing on migration `ff71b040aebf`. The migration drops the seeded `Review` status scoped to `EntityType='TestResult'`, guarded only against references from `test_result`. Tests reference that same status row, so the delete hits a foreign key it did not check for:

```
psycopg2.errors.ForeignKeyViolation: update or delete on table "status" violates foreign key constraint "test_status_id_fkey" on table "test"
DETAIL: Key (id)=(18ba050c-6511-49cf-95e0-1efb2b9183d3) is still referenced from table "test".
```

Migrations run inside a single transaction (`alembic/env.py:211`, no `transaction_per_migration`), so the whole upgrade rolled back. Nothing is half-applied and this migration re-runs from scratch.

## What Changed

- Added a second `NOT EXISTS` guard on `test` alongside the existing one on `test_result`, so the delete skips any status row still in use.
- Corrected the migration docstring. Its stated premise, that the status is "never written by any code path", is what made the guard incomplete in the first place.

## Additional Context

`initial_data.json` used to seed **two** statuses named `Review` per organization:

```json
{ "name": "Review", "description": "This is a test status", "entity_type": "TestResult" },
{ "name": "Review", "description": "Test in review",       "entity_type": "Test" }
```

The `TestResult` one is a mis-scoped copy-paste, and its description gives it away. It was removed from the seed only recently, in `5be1dc03d`. Every organization seeded before that has both rows, same name, distinguishable only by `entity_type_id`.

`POST /tests/` and `PUT /tests/{id}` take `status_id` straight from the client. `resolve_test_entity_names` (`services/test.py:461`) resolves category, topic, requirement, prompt and test_type, but skips status entirely, and `crud.create_test` writes the value through unchecked. So a test could be pointed at either `Review`, and `UpdateTest.tsx:79` resubmits whatever it already has on every edit.

Scope of the risk: 20 tables have a foreign key to `status.id`, but only `test_result` (by design) and `test` (via the unvalidated endpoint above) can hold this particular row. Every bulk, import and onboarding path resolves through `get_or_create_status`, which filters on name **and** `entity_type_id` (`crud_utils.py:1101`), so it cannot return a cross-type row. Explorer and metric-tuning creation leave `status_id` NULL, and no migration writes `test.status_id`.

Skipping the delete introduces no inconsistency. The delete is opportunistic cleanup, not structural. The migration's real work is the `execution`/`verdict` columns, and their backfill reads the status *name*, mapping `review` to `execution='not_run'` whether or not the row is later deleted. The guard is per-row, so organizations where nothing references the status are still cleaned up and only the ones still using it are left alone.

Worth handling separately, none of it blocking this fix:

1. Repoint the mis-pointed tests at their organization's `EntityType='Test'` `Review` status, which the same seed guarantees exists, then drop the dead row. Same display name, correct scoping. Belongs in its own migration.
2. `POST`/`PUT /tests` accept any `status_id` with no entity-type validation. This is the hole that allowed it.
3. Same bug class in `services/connector/handlers/test_result.py:133` and `:191`, which look up statuses by name with an organization filter but no entity-type filter. The second assigns the result to `endpoint.status_id`.

## Testing

The deployment migration run is the real test, since the failure depends on production data that no fixture reproduces.

To verify against a database that has the mis-pointed test, confirm the row is referenced and that the migration now completes:

```sql
SELECT s.id, s.name, tl.type_value, s.organization_id
FROM status s
JOIN type_lookup tl ON s.entity_type_id = tl.id
WHERE tl.type_name = 'EntityType' AND tl.type_value = 'TestResult'
  AND lower(s.name) = 'review';

SELECT count(*) FROM test WHERE status_id = '18ba050c-6511-49cf-95e0-1efb2b9183d3';
```

Then run `alembic upgrade head`. It should complete, with the status row still present in organizations where a test or test result references it and removed everywhere else. Existing backend tests for the migration are unaffected, since the `execution`/`verdict` columns and their backfill are unchanged.
