### PR TITLE
Fix stuck test-set tests spinner and server-render remaining detail tabs

### DIFF
--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentDetailClient.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentDetailClient.tsx
@@ -44,6 +44,7 @@ import PromoteEnvironmentDialog from './PromoteEnvironmentDialog';
 import ExperimentOverviewTab from './ExperimentOverviewTab';
 import ExperimentVersionsGrid from './ExperimentVersionsGrid';
 import ExperimentRunsTab from './ExperimentRunsTab';
+import type { ExperimentRunsData } from './experiment-data';
 import ExperimentParametersTab from './ExperimentParametersTab';
 import { formatDate } from '@/utils/date';
 import DetailEntityMissingState from '@/components/common/DetailEntityMissingState';
@@ -68,6 +69,8 @@ export interface ExperimentDetailData {
 interface ExperimentDetailClientProps {
   experimentId: string;
   initialExperiment: ExperimentDetailData;
+  /** Server-prefetched Runs tab; undefined falls back to a client fetch. */
+  initialRuns?: ExperimentRunsData;
 }
 
 function defaultsForSchema(
@@ -95,6 +98,7 @@ function valuesFromVersion(
 export default function ExperimentDetailClient({
   experimentId,
   initialExperiment,
+  initialRuns,
 }: ExperimentDetailClientProps) {
   const notifications = useNotifications();
   const { status } = useSession();
@@ -414,6 +418,7 @@ export default function ExperimentDetailClient({
         <DetailTabPanel value={activeTab} index={3} prefix="experiment">
           <ExperimentRunsTab
             experimentId={experiment.id}
+            initialRuns={initialRuns}
             onRunExperiment={() => setRunDrawerOpen(true)}
           />
         </DetailTabPanel>

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentRunsTab.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentRunsTab.tsx
@@ -29,6 +29,10 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useQuery } from '@tanstack/react-query';
 import { experimentKeys } from '@/constants/query-keys';
 import {
+  fetchExperimentRuns,
+  type ExperimentRunsData,
+} from './experiment-data';
+import {
   ExperimentResultsRunItem,
   shortVersion,
 } from '@/utils/api-client/interfaces/parameters';
@@ -40,11 +44,13 @@ import { passRate } from '@/constants/outcomes';
 interface ExperimentRunsTabProps {
   experimentId: string;
   onRunExperiment?: () => void;
+  initialRuns?: ExperimentRunsData;
 }
 
 export default function ExperimentRunsTab({
   experimentId,
   onRunExperiment,
+  initialRuns,
 }: ExperimentRunsTabProps) {
   const { status } = useSession();
   const [drawerRun, setDrawerRun] = useState<ExperimentResultsRunItem | null>(
@@ -60,9 +66,9 @@ export default function ExperimentRunsTab({
     error: fetchError,
   } = useQuery({
     queryKey: [...experimentKeys.detail(experimentId), 'runs'],
-    queryFn: () =>
-      apiFactory.getParametersClient().getExperimentResultsByRun(experimentId),
+    queryFn: () => fetchExperimentRuns(apiFactory, experimentId),
     enabled: isAuthenticated(status) && !!experimentId,
+    initialData: initialRuns,
   });
 
   const runs = data?.items ?? [];

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/components/experiment-data.ts
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/components/experiment-data.ts
@@ -1,0 +1,13 @@
+import type { ApiClientFactory } from '@/utils/api-client/client-factory';
+
+/** Results grouped by run (the Runs tab). Shared by server prefetch and client. */
+export function fetchExperimentRuns(
+  factory: ApiClientFactory,
+  experimentId: string
+) {
+  return factory.getParametersClient().getExperimentResultsByRun(experimentId);
+}
+
+export type ExperimentRunsData = Awaited<
+  ReturnType<typeof fetchExperimentRuns>
+>;

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/page.tsx
@@ -8,6 +8,9 @@ import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import ExperimentDetailClient, {
   type ExperimentDetailData,
 } from './components/ExperimentDetailClient';
+import { prefetch } from '@/utils/server-prefetch';
+import { Capability } from '@/constants/capabilities';
+import { fetchExperimentRuns } from './components/experiment-data';
 
 interface PageProps {
   params: Promise<{ identifier: string }>;
@@ -27,7 +30,8 @@ export default async function ExperimentDetailPage({ params }: PageProps) {
   }
 
   const { identifier } = await params;
-  const client = (await createServerApiFactory()).getParametersClient();
+  const apiFactory = await createServerApiFactory();
+  const client = apiFactory.getParametersClient();
 
   let initialExperiment: ExperimentDetailData;
   try {
@@ -42,10 +46,15 @@ export default async function ExperimentDetailPage({ params }: PageProps) {
     throw error;
   }
 
+  const runs = await prefetch(Capability.Experiment.READ, () =>
+    fetchExperimentRuns(apiFactory, identifier)
+  );
+
   return (
     <ExperimentDetailClient
       experimentId={identifier}
       initialExperiment={JSON.parse(JSON.stringify(initialExperiment))}
+      initialRuns={runs}
     />
   );
 }

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
@@ -1,6 +1,18 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import {
+  fetchMetricLinkedRequirements,
+  type LinkedRequirementRow,
+  type MetricTuningData,
+} from './metric-data';
 import { useRouter } from 'next/navigation';
 import { Box, Typography } from '@mui/material';
 import { useSession } from 'next-auth/react';
@@ -42,9 +54,6 @@ import type { Status } from '@/utils/api-client/interfaces/status';
 import type { UUID } from 'crypto';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 
-/** Linked requirements come back with the status relationship at runtime. */
-type LinkedRequirementRow = RequirementReference & { status?: Status | null };
-
 const TAB_KEYS = ['basic', 'linked-requirements', 'tuning'] as const;
 
 const NAV_LABELS: Record<(typeof TAB_KEYS)[number], string> = {
@@ -56,10 +65,15 @@ const NAV_LABELS: Record<(typeof TAB_KEYS)[number], string> = {
 export default function MetricDetailPageTabs({
   metricId,
   initialMetric,
+  initialRequirements,
+  initialTuning,
 }: {
   metricId: string;
   /** Fetched by the server page so the first paint already has content. */
   initialMetric: MetricDetail;
+  /** Same, for the other tabs; undefined falls back to a client fetch. */
+  initialRequirements?: LinkedRequirementRow[];
+  initialTuning?: MetricTuningData;
 }) {
   const { status } = useSession();
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
@@ -112,10 +126,12 @@ export default function MetricDetailPageTabs({
           <MetricLinkedRequirements
             metricId={metricId}
             sessionStatus={status}
+            initialRequirements={initialRequirements}
           />
         ) : activeTab === 2 && showTuning ? (
           <MetricTuningTab
             metricId={metricId}
+            initialData={initialTuning}
             onMetricChanged={() => setMetricRevision(revision => revision + 1)}
           />
         ) : undefined
@@ -127,15 +143,21 @@ export default function MetricDetailPageTabs({
 function MetricLinkedRequirements({
   metricId,
   sessionStatus,
+  initialRequirements,
 }: {
   metricId: string;
   sessionStatus: 'loading' | 'authenticated' | 'unauthenticated';
+  initialRequirements?: LinkedRequirementRow[];
 }) {
   const router = useRouter();
   const notifications = useNotifications();
   const canEditMetric = useCan(Capability.Metric.UPDATE);
-  const [requirements, setRequirements] = useState<LinkedRequirementRow[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [requirements, setRequirements] = useState<LinkedRequirementRow[]>(
+    initialRequirements ?? []
+  );
+  const [loading, setLoading] = useState(!initialRequirements);
+  // The metric id the server-rendered rows belong to: no mount fetch for it.
+  const seededMetricIdRef = useRef(initialRequirements ? metricId : null);
 
   // Assign drawer state
   const [assignOpen, setAssignOpen] = useState(false);
@@ -158,11 +180,9 @@ function MetricLinkedRequirements({
     if (!isAuthenticated(sessionStatus)) return;
     setLoading(true);
     try {
-      const client = new MetricsClient();
-      const result = await client.getMetricRequirements(metricId as UUID);
-      const data =
-        (result as unknown as { data: LinkedRequirementRow[] }).data ?? [];
-      setRequirements(data);
+      setRequirements(
+        await fetchMetricLinkedRequirements(new ApiClientFactory(), metricId)
+      );
     } catch {
       setRequirements([]);
     } finally {
@@ -171,6 +191,7 @@ function MetricLinkedRequirements({
   }, [metricId, sessionStatus]);
 
   useEffect(() => {
+    if (seededMetricIdRef.current === metricId) return;
     fetchLinked();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only on mount / id change
   }, [metricId]);

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/metric-data.ts
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/metric-data.ts
@@ -1,0 +1,49 @@
+import type { UUID } from 'crypto';
+import type { ApiClientFactory } from '@/utils/api-client/client-factory';
+import type { MetricDetail } from '@/utils/api-client/interfaces/metric';
+import type {
+  MetricTuningCase,
+  MetricTuningRun,
+} from '@/utils/api-client/interfaces/metric-tuning';
+import type { RequirementReference } from '@/utils/api-client/interfaces/requirement';
+import type { Status } from '@/utils/api-client/interfaces/status';
+
+/** Linked requirements come back with the status relationship at runtime. */
+export type LinkedRequirementRow = RequirementReference & {
+  status?: Status | null;
+};
+
+export interface MetricTuningData {
+  metric: MetricDetail;
+  cases: MetricTuningCase[];
+  run: MetricTuningRun;
+}
+
+/** Only custom metrics can be tuned; the tuning routes reject the rest. */
+export function isCustomMetric(metric: MetricDetail): boolean {
+  return metric.backend_type?.type_value?.toLowerCase() === 'custom';
+}
+
+export async function fetchMetricLinkedRequirements(
+  factory: ApiClientFactory,
+  metricId: string
+): Promise<LinkedRequirementRow[]> {
+  const result = await factory
+    .getMetricsClient()
+    .getMetricRequirements(metricId as UUID);
+  // The endpoint is typed as metrics but returns the linked requirements.
+  return (result as unknown as { data?: LinkedRequirementRow[] }).data ?? [];
+}
+
+/** The Tuning tab's whole state: the metric, its cases and the latest run. */
+export async function fetchMetricTuning(
+  factory: ApiClientFactory,
+  metricId: string
+): Promise<MetricTuningData> {
+  const [metric, cases, run] = await Promise.all([
+    factory.getMetricsClient().getMetric(metricId as UUID),
+    factory.getMetricTuningClient().getTuningCases(metricId),
+    factory.getMetricTuningClient().getTuningRun(metricId),
+  ]);
+  return { metric, cases, run };
+}

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/page.tsx
@@ -6,6 +6,13 @@ import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import MetricDetailPageTabs from './MetricDetailPageTabs';
 import type { MetricDetail } from '@/utils/api-client/interfaces/metric';
 import type { UUID } from 'crypto';
+import { prefetch } from '@/utils/server-prefetch';
+import { Capability } from '@/constants/capabilities';
+import {
+  fetchMetricLinkedRequirements,
+  fetchMetricTuning,
+  isCustomMetric,
+} from './metric-data';
 
 interface PageProps {
   params: Promise<{ identifier: string }>;
@@ -19,7 +26,8 @@ export default async function MetricDetailPage({ params }: PageProps) {
   }
 
   const { identifier } = await params;
-  const client = (await createServerApiFactory()).getMetricsClient();
+  const apiFactory = await createServerApiFactory();
+  const client = apiFactory.getMetricsClient();
 
   let metric: MetricDetail;
   try {
@@ -35,10 +43,24 @@ export default async function MetricDetailPage({ params }: PageProps) {
     redirect('/metrics');
   }
 
+  // The other tabs' data; the tuning routes reject non-custom metrics.
+  const [requirements, tuning] = await Promise.all([
+    prefetch(Capability.Requirement.READ, () =>
+      fetchMetricLinkedRequirements(apiFactory, identifier)
+    ),
+    isCustomMetric(metric)
+      ? prefetch(Capability.Metric.READ, () =>
+          fetchMetricTuning(apiFactory, identifier)
+        )
+      : Promise.resolve(undefined),
+  ]);
+
   return (
     <MetricDetailPageTabs
       metricId={identifier}
       initialMetric={JSON.parse(JSON.stringify(metric))}
+      initialRequirements={requirements}
+      initialTuning={tuning}
     />
   );
 }

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningTab.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { fetchMetricTuning, type MetricTuningData } from '../metric-data';
 import {
   Box,
   Button,
@@ -482,6 +489,8 @@ export interface MetricTuningTabProps {
    * metric. Applying writes the evaluation prompt every other tab is showing.
    */
   onMetricChanged?: () => void;
+  /** Server-prefetched metric, cases and run; skips the mount fetch. */
+  initialData?: MetricTuningData;
 }
 
 /**
@@ -500,19 +509,28 @@ export interface MetricTuningTabProps {
 export default function MetricTuningTab({
   metricId,
   onMetricChanged,
+  initialData,
 }: MetricTuningTabProps) {
   const notifications = useNotifications();
   const canEdit = useCan(Capability.Metric.UPDATE);
 
-  const [cases, setCases] = useState<MetricTuningCase[]>([]);
+  const [cases, setCases] = useState<MetricTuningCase[]>(
+    initialData?.cases ?? []
+  );
   // The whole metric, because the Improve dialog shows the current fields beside
   // the proposed ones and the grid needs the score type to render a verdict.
-  const [metric, setMetric] = useState<Metric | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [metric, setMetric] = useState<Metric | null>(
+    initialData?.metric ?? null
+  );
+  const [loading, setLoading] = useState(!initialData);
+  // The metric id the server-rendered data belongs to: no mount fetch for it.
+  const seededMetricIdRef = useRef(initialData ? metricId : null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editing, setEditing] = useState<MetricTuningCase | null>(null);
   const [rejecting, setRejecting] = useState<MetricTuningCase | null>(null);
-  const [run, setRun] = useState<MetricTuningRun | null>(null);
+  const [run, setRun] = useState<MetricTuningRun | null>(
+    initialData?.run ?? null
+  );
   const [starting, setStarting] = useState(false);
   const [acceptingRest, setAcceptingRest] = useState(false);
   const [improving, setImproving] = useState(false);
@@ -526,15 +544,10 @@ export default function MetricTuningTab({
   const fetchCases = useCallback(async () => {
     setLoading(true);
     try {
-      const factory = new ApiClientFactory();
-      const [tuningMetric, tuningCases, tuningRun] = await Promise.all([
-        factory.getMetricsClient().getMetric(metricId as UUID),
-        factory.getMetricTuningClient().getTuningCases(metricId),
-        factory.getMetricTuningClient().getTuningRun(metricId),
-      ]);
-      setMetric(tuningMetric);
-      setCases(tuningCases);
-      setRun(tuningRun);
+      const tuning = await fetchMetricTuning(new ApiClientFactory(), metricId);
+      setMetric(tuning.metric);
+      setCases(tuning.cases);
+      setRun(tuning.run);
     } catch (error) {
       notifications.show(
         error instanceof Error
@@ -549,6 +562,7 @@ export default function MetricTuningTab({
   }, [metricId, notifications]);
 
   useEffect(() => {
+    if (seededMetricIdRef.current === metricId) return;
     fetchCases();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- notifications identity changes each render
   }, [metricId]);

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
@@ -24,18 +24,22 @@ import {
   PROJECT_DELETE_WARNING,
 } from '../constants';
 import ProjectEditDrawer from './edit-drawer';
-import ProjectDetailTabs from './components/ProjectDetailTabs';
+import ProjectDetailTabs, {
+  type ProjectDetailInitialData,
+} from './components/ProjectDetailTabs';
 import { format } from 'date-fns';
 import { useDeleteProject } from '@/hooks/useEndpoints';
 
 interface ClientWrapperProps {
   project: Project;
+  initialData?: ProjectDetailInitialData;
   projectId: string;
 }
 
 export default function ClientWrapper({
   project,
   projectId,
+  initialData,
 }: ClientWrapperProps) {
   const router = useRouter();
   const params = useParams<{ identifier: string }>();
@@ -204,6 +208,7 @@ export default function ClientWrapper({
         project={currentProject}
         projectId={projectId}
         onProjectUpdate={handleUpdateProject}
+        initialData={initialData}
       />
 
       <ProjectEditDrawer

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectConfigurationTab.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectConfigurationTab.tsx
@@ -7,6 +7,8 @@ import { AddIcon } from '@/components/icons';
 import { SectionCard } from '@/components/common/SectionCard';
 import { sectionEditButtonSx } from '@/components/common/SectionCardActions';
 import { Project } from '@/utils/api-client/interfaces/project';
+import type { MetricDetail } from '@/utils/api-client/interfaces/metric';
+import type { ProjectEnvironmentsData } from './project-data';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import ProjectTraceMetrics, {
@@ -25,12 +27,16 @@ interface ProjectConfigurationTabProps {
   project: Project;
   projectId: string;
   onProjectUpdate: (updatedProject: Partial<Project>) => Promise<boolean>;
+  initialTraceMetrics?: MetricDetail[];
+  initialEnvironments?: ProjectEnvironmentsData;
 }
 
 export default function ProjectConfigurationTab({
   project,
   projectId,
   onProjectUpdate,
+  initialTraceMetrics,
+  initialEnvironments,
 }: ProjectConfigurationTabProps) {
   const canUpdateProject = useCan(Capability.Project.UPDATE);
   const traceMetricsRef = useRef<ProjectTraceMetricsHandle>(null);
@@ -62,6 +68,7 @@ export default function ProjectConfigurationTab({
           ref={traceMetricsRef}
           project={project}
           onProjectUpdate={onProjectUpdate}
+          initialMetrics={initialTraceMetrics}
         />
       </SectionCard>
 
@@ -87,6 +94,7 @@ export default function ProjectConfigurationTab({
           ref={environmentsRef}
           projectId={projectId}
           hideToolbarAddButton
+          initialData={initialEnvironments}
         />
       </SectionCard>
     </>

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectDetailTabs.tsx
@@ -6,7 +6,9 @@ import { Alert, Box } from '@mui/material';
 import { useRouter, useSearchParams } from 'next/navigation';
 import DetailTabNav from '@/components/common/DetailTabNav';
 import DetailTabPanel from '@/components/common/DetailTabPanel';
-import { Project } from '@/utils/api-client/interfaces/project';
+import { Project, ProjectMember } from '@/utils/api-client/interfaces/project';
+import type { MetricDetail } from '@/utils/api-client/interfaces/metric';
+import type { ProjectEnvironmentsData } from './project-data';
 import ProjectOverviewTab from './ProjectOverviewTab';
 import ProjectEndpoints from './ProjectEndpoints';
 import ProjectConfigurationTab from './ProjectConfigurationTab';
@@ -44,16 +46,25 @@ function normalizeTabParam(param: string | null): ProjectTabKey {
   return 'overview';
 }
 
+/** Server-prefetched tab data, threaded through from `page.tsx`. */
+export interface ProjectDetailInitialData {
+  members?: ProjectMember[];
+  environments?: ProjectEnvironmentsData;
+  traceMetrics?: MetricDetail[];
+}
+
 interface ProjectDetailTabsProps {
   project: Project;
   projectId: string;
   onProjectUpdate: (updatedProject: Partial<Project>) => Promise<boolean>;
+  initialData?: ProjectDetailInitialData;
 }
 
 export default function ProjectDetailTabs({
   project,
   projectId,
   onProjectUpdate,
+  initialData,
 }: ProjectDetailTabsProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -97,7 +108,11 @@ export default function ProjectDetailTabs({
       </DetailTabPanel>
 
       <DetailTabPanel value={activeTab} index={1} prefix="project-detail">
-        <ProjectMembersTab project={project} projectId={projectId} />
+        <ProjectMembersTab
+          project={project}
+          projectId={projectId}
+          initialMembers={initialData?.members}
+        />
       </DetailTabPanel>
 
       <DetailTabPanel value={activeTab} index={2} prefix="project-detail">
@@ -112,6 +127,8 @@ export default function ProjectDetailTabs({
           project={project}
           projectId={projectId}
           onProjectUpdate={onProjectUpdate}
+          initialTraceMetrics={initialData?.traceMetrics}
+          initialEnvironments={initialData?.environments}
         />
       </DetailTabPanel>
     </Box>

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectEnvironments.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectEnvironments.tsx
@@ -73,6 +73,10 @@ import { DeleteModal } from '@/components/common/DeleteModal';
 import ProjectAddEnvironmentDrawer from './ProjectAddEnvironmentDrawer';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { projectKeys } from '@/constants/query-keys';
+import {
+  fetchProjectEnvironments,
+  type ProjectEnvironmentsData,
+} from './project-data';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 
 const FIGMA_BODY_SX = {
@@ -86,6 +90,8 @@ interface ProjectEnvironmentsProps {
   projectId: string;
   /** When true, the add action lives in the section header instead of the grid toolbar. */
   hideToolbarAddButton?: boolean;
+  /** Server-prefetched bindings and experiments; seeds the query. */
+  initialData?: ProjectEnvironmentsData;
 }
 
 export interface ProjectEnvironmentsHandle {
@@ -150,7 +156,7 @@ function canRemoveEnvironment(row: EnvironmentRow): boolean {
  */
 export default forwardRef<ProjectEnvironmentsHandle, ProjectEnvironmentsProps>(
   function ProjectEnvironments(
-    { projectId, hideToolbarAddButton = false },
+    { projectId, hideToolbarAddButton = false, initialData },
     ref
   ) {
     const notifications = useNotifications();
@@ -185,15 +191,10 @@ export default forwardRef<ProjectEnvironmentsHandle, ProjectEnvironmentsProps>(
       error: fetchError,
     } = useQuery({
       queryKey: environmentsQueryKey,
-      queryFn: async () => {
-        const client = new ApiClientFactory().getParametersClient();
-        const [bindingsResp, expsResp] = await Promise.all([
-          client.getEnvironments(projectId),
-          client.listProjectExperiments(projectId, { limit: 200 }),
-        ]);
-        return { bindings: bindingsResp, experiments: expsResp };
-      },
+      queryFn: () =>
+        fetchProjectEnvironments(new ApiClientFactory(), projectId),
       enabled: isAuthenticated(status) && !!projectId,
+      initialData,
     });
 
     const bindings = envData?.bindings ?? null;

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMembers.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMembers.tsx
@@ -2,6 +2,8 @@
 
 import * as React from 'react';
 import { useCallback, useEffect, useState } from 'react';
+
+const EMPTY_MEMBERS: ProjectMember[] = [];
 import { Alert, Avatar, Box, IconButton, Typography } from '@mui/material';
 import { GridColDef, GridPaginationModel } from '@mui/x-data-grid';
 import PersonIcon from '@mui/icons-material/Person';
@@ -30,6 +32,8 @@ interface ProjectMembersProps {
   /** ID of the project owner — prevents removing them. */
   ownerId?: string;
   onMembersLoaded?: (members: ProjectMember[]) => void;
+  /** Server-prefetched members; seeds the query. */
+  initialMembers?: ProjectMember[];
 }
 
 function getMemberDisplayName(
@@ -45,6 +49,7 @@ export default function ProjectMembers({
   projectId,
   ownerId,
   onMembersLoaded,
+  initialMembers,
 }: ProjectMembersProps) {
   const notifications = useNotifications();
   const canManageMembers = useCan(Capability.ProjectMember.MANAGE);
@@ -67,20 +72,24 @@ export default function ProjectMembers({
   ] as const;
 
   const {
-    data: members = [],
+    data: members = EMPTY_MEMBERS,
     isLoading: membersLoading,
     error: membersQueryError,
   } = useQuery({
     queryKey: membersQueryKey,
-    queryFn: async () => {
-      const data = await new ApiClientFactory(undefined, projectId)
+    queryFn: () =>
+      new ApiClientFactory(undefined, projectId)
         .getProjectsClient()
-        .getProjectMembers(projectId);
-      onMembersLoaded?.(data);
-      return data;
-    },
+        .getProjectMembers(projectId),
     enabled: isAuthenticated(status) && !!projectId,
+    initialData: initialMembers,
   });
+
+  // An effect rather than a side effect of the fetch, so server-prefetched
+  // members reach the parent too.
+  useEffect(() => {
+    if (members !== EMPTY_MEMBERS) onMembersLoaded?.(members);
+  }, [members, onMembersLoaded]);
 
   const membersError = membersQueryError
     ? 'Failed to load project members.'

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMembersTab.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMembersTab.tsx
@@ -17,11 +17,13 @@ import { Capability } from '@/constants/capabilities';
 interface ProjectMembersTabProps {
   project: Project;
   projectId: string;
+  initialMembers?: ProjectMember[];
 }
 
 export default function ProjectMembersTab({
   project,
   projectId,
+  initialMembers,
 }: ProjectMembersTabProps) {
   const queryClient = useQueryClient();
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -59,6 +61,7 @@ export default function ProjectMembersTab({
           projectId={projectId}
           ownerId={project.owner_id ? String(project.owner_id) : undefined}
           onMembersLoaded={handleMembersLoaded}
+          initialMembers={initialMembers}
         />
       </SectionCard>
 

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectTraceMetrics.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectTraceMetrics.tsx
@@ -58,11 +58,17 @@ import { DeleteModal } from '@/components/common/DeleteModal';
 import type { UUID } from 'crypto';
 import { useQuery } from '@tanstack/react-query';
 import { projectKeys } from '@/constants/query-keys';
+import {
+  fetchProjectTraceMetrics,
+  projectTraceMetricIds,
+} from './project-data';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 
 interface ProjectTraceMetricsProps {
   project: Project;
   onProjectUpdate: (updatedProject: Partial<Project>) => Promise<boolean>;
+  /** Server-prefetched trace metrics; seeds the query. */
+  initialMetrics?: MetricDetail[];
 }
 
 export interface ProjectTraceMetricsHandle {
@@ -109,7 +115,10 @@ function getTraceMetricIds(project: Project): string[] {
 }
 
 export default forwardRef<ProjectTraceMetricsHandle, ProjectTraceMetricsProps>(
-  function ProjectTraceMetrics({ project, onProjectUpdate }, ref) {
+  function ProjectTraceMetrics(
+    { project, onProjectUpdate, initialMetrics },
+    ref
+  ) {
     const theme = useTheme();
     const { status } = useSession();
     const canUpdateProject = useCan(Capability.Project.UPDATE);
@@ -124,10 +133,11 @@ export default forwardRef<ProjectTraceMetricsHandle, ProjectTraceMetricsProps>(
       openAddDialog: () => setMetricsDialogOpen(true),
     }));
 
-    const metricIds: string[] = useMemo(() => {
-      const rawIds = project.attributes?.trace_metrics;
-      return Array.isArray(rawIds) ? rawIds.map(String) : [];
-    }, [project.attributes?.trace_metrics]);
+    const metricIds: string[] = useMemo(
+      () => projectTraceMetricIds(project),
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- only the stored ids matter
+      [project.attributes?.trace_metrics]
+    );
 
     const {
       data: metrics = [],
@@ -139,25 +149,10 @@ export default forwardRef<ProjectTraceMetricsHandle, ProjectTraceMetricsProps>(
         'trace-metrics',
         metricIds,
       ],
-      queryFn: async () => {
-        if (metricIds.length === 0) return [];
-        const metricsClient = new ApiClientFactory().getMetricsClient();
-        const results = await Promise.allSettled(
-          metricIds.map(id =>
-            metricsClient.getMetric(
-              id as `${string}-${string}-${string}-${string}-${string}`
-            )
-          )
-        );
-        return results
-          .filter(
-            (r): r is PromiseFulfilledResult<MetricDetail> =>
-              r.status === 'fulfilled'
-          )
-          .map(r => r.value)
-          .filter(m => m.metric_scope?.includes('Trace'));
-      },
+      queryFn: () =>
+        fetchProjectTraceMetrics(new ApiClientFactory(), metricIds),
       enabled: isAuthenticated(status),
+      initialData: initialMetrics,
     });
 
     const error = fetchError

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/project-data.ts
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/project-data.ts
@@ -1,0 +1,45 @@
+import type { UUID } from 'crypto';
+import type { ApiClientFactory } from '@/utils/api-client/client-factory';
+import type { MetricDetail } from '@/utils/api-client/interfaces/metric';
+import type { Project } from '@/utils/api-client/interfaces/project';
+
+/** Environment bindings plus the experiments they can point at (Configuration tab). */
+export async function fetchProjectEnvironments(
+  factory: ApiClientFactory,
+  projectId: string
+) {
+  const client = factory.getParametersClient();
+  const [bindings, experiments] = await Promise.all([
+    client.getEnvironments(projectId),
+    client.listProjectExperiments(projectId, { limit: 200 }),
+  ]);
+  return { bindings, experiments };
+}
+
+export type ProjectEnvironmentsData = Awaited<
+  ReturnType<typeof fetchProjectEnvironments>
+>;
+
+/** The metric ids a project evaluates traces with, as stored on its attributes. */
+export function projectTraceMetricIds(project: Project): string[] {
+  const raw = project.attributes?.trace_metrics;
+  return Array.isArray(raw) ? raw.map(String) : [];
+}
+
+/** The trace metrics behind `projectTraceMetricIds`, resolved to full records. */
+export async function fetchProjectTraceMetrics(
+  factory: ApiClientFactory,
+  metricIds: string[]
+): Promise<MetricDetail[]> {
+  if (metricIds.length === 0) return [];
+  const metricsClient = factory.getMetricsClient();
+  const results = await Promise.allSettled(
+    metricIds.map(id => metricsClient.getMetric(id as UUID))
+  );
+  return results
+    .filter(
+      (r): r is PromiseFulfilledResult<MetricDetail> => r.status === 'fulfilled'
+    )
+    .map(r => r.value)
+    .filter(m => m.metric_scope?.includes('Trace'));
+}

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/page.tsx
@@ -4,6 +4,13 @@ import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
 import type { Project } from '@/utils/api-client/interfaces/project';
 import ClientWrapper from './client-wrapper';
+import { prefetch } from '@/utils/server-prefetch';
+import { Capability } from '@/constants/capabilities';
+import {
+  fetchProjectEnvironments,
+  fetchProjectTraceMetrics,
+  projectTraceMetricIds,
+} from './components/project-data';
 
 interface PageProps {
   params: Promise<{ identifier: string }>;
@@ -34,5 +41,27 @@ export default async function ProjectDetailPage({ params }: PageProps) {
     throw error;
   }
 
-  return <ClientWrapper project={project} projectId={project.id} />;
+  // Members and Configuration tab data, so each tab opens with rows in place.
+  const [members, environments, traceMetrics] = await Promise.all([
+    prefetch(Capability.ProjectMember.READ, () =>
+      apiFactory
+        .forProject(project.id)
+        .getProjectsClient()
+        .getProjectMembers(project.id)
+    ),
+    prefetch(Capability.Experiment.READ, () =>
+      fetchProjectEnvironments(apiFactory, project.id)
+    ),
+    prefetch(Capability.Metric.READ, () =>
+      fetchProjectTraceMetrics(apiFactory, projectTraceMetricIds(project))
+    ),
+  ]);
+
+  return (
+    <ClientWrapper
+      project={project}
+      projectId={project.id}
+      initialData={{ members, environments, traceMetrics }}
+    />
+  );
 }

--- a/apps/frontend/src/app/(protected)/requirements/[identifier]/components/RequirementDetailClient.tsx
+++ b/apps/frontend/src/app/(protected)/requirements/[identifier]/components/RequirementDetailClient.tsx
@@ -6,6 +6,7 @@ import { format } from 'date-fns';
 import { PageLayout } from '@/components/layout/PageLayout';
 import DetailMetadataStrip from '@/components/common/DetailMetadataStrip';
 import type { RequirementWithMetrics } from '@/utils/api-client/interfaces/requirement';
+import type { TestDetail } from '@/utils/api-client/interfaces/tests';
 import { API_ENDPOINTS } from '@/utils/api-client/config';
 import RequirementDetailTabs from './RequirementDetailTabs';
 import AccessDenied from '@/components/common/AccessDenied';
@@ -16,11 +17,13 @@ import { Capability } from '@/constants/capabilities';
 interface RequirementDetailClientProps {
   requirement: RequirementWithMetrics;
   identifier: string;
+  initialLinkedTests?: TestDetail[];
 }
 
 export default function RequirementDetailClient({
   requirement: initialRequirement,
   identifier,
+  initialLinkedTests,
 }: RequirementDetailClientProps) {
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
     Capability.Requirement.READ
@@ -65,6 +68,7 @@ export default function RequirementDetailClient({
         <RequirementDetailTabs
           requirement={requirement}
           onUpdated={setRequirement}
+          initialLinkedTests={initialLinkedTests}
         />
       </Box>
     </PageLayout>

--- a/apps/frontend/src/app/(protected)/requirements/[identifier]/components/RequirementDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/requirements/[identifier]/components/RequirementDetailTabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Box, Stack, Typography } from '@mui/material';
 import {
   GridColDef,
@@ -34,6 +34,7 @@ import type {
   MetricWithRelationships,
 } from '@/utils/api-client/interfaces/requirement';
 import type { MetricDetail } from '@/utils/api-client/interfaces/metric';
+import type { TestDetail } from '@/utils/api-client/interfaces/tests';
 import type { Status } from '@/utils/api-client/interfaces/status';
 import { EntityType, type Tag } from '@/utils/api-client/interfaces/tag';
 import { RequirementClient } from '@/utils/api-client/requirement-client';
@@ -56,11 +57,13 @@ const NAV_LABELS: Record<(typeof TAB_KEYS)[number], string> = {
 interface RequirementDetailTabsProps {
   requirement: RequirementWithMetrics;
   onUpdated: (updated: RequirementWithMetrics) => void;
+  initialLinkedTests?: TestDetail[];
 }
 
 export default function RequirementDetailTabs({
   requirement,
   onUpdated,
+  initialLinkedTests,
 }: RequirementDetailTabsProps) {
   const { activeTab, handleTabChange } = useDetailTabNav(TAB_KEYS);
 
@@ -89,7 +92,10 @@ export default function RequirementDetailTabs({
       </DetailTabPanel>
 
       <DetailTabPanel value={activeTab} index={2} prefix="requirement-detail">
-        <RequirementLinkedTests requirement={requirement} />
+        <RequirementLinkedTests
+          requirement={requirement}
+          initialTests={initialLinkedTests}
+        />
       </DetailTabPanel>
     </Box>
   );
@@ -320,10 +326,8 @@ function RequirementLinkedMetrics({
     }
   }, [requirement.id]);
 
-  useEffect(() => {
-    fetchLinked();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- only on mount / id change
-  }, [requirement.id]);
+  // No mount fetch: `requirement.metrics` arrives with the server-rendered
+  // requirement, so `fetchLinked` only re-reads after an assignment.
 
   const handleUnassign = useCallback(
     async (metricId: string) => {

--- a/apps/frontend/src/app/(protected)/requirements/[identifier]/components/RequirementLinkedTests.tsx
+++ b/apps/frontend/src/app/(protected)/requirements/[identifier]/components/RequirementLinkedTests.tsx
@@ -15,7 +15,13 @@ import { DescriptionIcon, ErrorIcon } from '@/components/icons';
 import { useRouter } from 'next/navigation';
 import type { RequirementWithMetrics } from '@/utils/api-client/interfaces/requirement';
 import type { TestDetail } from '@/utils/api-client/interfaces/tests';
-import { TestsClient } from '@/utils/api-client/tests-client';
+import { useQuery } from '@tanstack/react-query';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { useIsAuthenticated } from '@/hooks/useIsAuthenticated';
+import { requirementKeys } from '@/constants/query-keys';
+import { fetchRequirementLinkedTests } from './linked-tests';
+
+const EMPTY_TESTS: TestDetail[] = [];
 import {
   getTestDisplayContent,
   renderTestContentCell,
@@ -24,50 +30,43 @@ import { TEST_TYPE_PILL_TABS } from '@/constants/test-types';
 
 interface RequirementLinkedTestsProps {
   requirement: RequirementWithMetrics;
-}
-
-function escapeODataValue(value: string): string {
-  return value.replace(/'/g, "''");
+  /** Server-prefetched rows; when present the grid renders without a fetch. */
+  initialTests?: TestDetail[];
 }
 
 export default function RequirementLinkedTests({
   requirement,
+  initialTests,
 }: RequirementLinkedTestsProps) {
   const router = useRouter();
   const notifications = useNotifications();
-  const [tests, setTests] = useState<TestDetail[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [loadError, setLoadError] = useState(false);
+  const isAuthenticated = useIsAuthenticated();
   const [typePill, setTypePill] = useState('all');
 
-  const fetchLinked = useCallback(async () => {
-    setLoading(true);
-    setLoadError(false);
-    try {
-      const client = new TestsClient();
-      const result = await client.getAllTests({
-        filter: `requirement_id eq '${escapeODataValue(String(requirement.id))}'`,
-        sort_by: 'created_at',
-        sort_order: 'desc',
-      });
-      setTests(result);
-    } catch (error) {
-      setLoadError(true);
-      setTests([]);
-      notifications.show(
-        error instanceof Error
-          ? `Failed to load linked tests: ${error.message}`
-          : 'Failed to load linked tests',
-        { severity: 'error', autoHideDuration: 6000 }
-      );
-    } finally {
-      setLoading(false);
-    }
-  }, [requirement.id, notifications]);
+  const requirementId = String(requirement.id);
+  const {
+    data,
+    isLoading: loading,
+    error,
+  } = useQuery({
+    queryKey: [...requirementKeys.detail(requirementId), 'linked-tests'],
+    queryFn: () =>
+      fetchRequirementLinkedTests(new ApiClientFactory(), requirementId),
+    enabled: isAuthenticated,
+    initialData: initialTests,
+  });
+  const tests = error ? EMPTY_TESTS : (data ?? EMPTY_TESTS);
+  const loadError = !!error;
 
   useEffect(() => {
-    fetchLinked();
-  }, [fetchLinked]);
+    if (!error) return;
+    notifications.show(
+      error instanceof Error
+        ? `Failed to load linked tests: ${error.message}`
+        : 'Failed to load linked tests',
+      { severity: 'error', autoHideDuration: 6000 }
+    );
+  }, [error, notifications]);
 
   const rows = useMemo<GridRowModel[]>(
     () =>

--- a/apps/frontend/src/app/(protected)/requirements/[identifier]/components/linked-tests.ts
+++ b/apps/frontend/src/app/(protected)/requirements/[identifier]/components/linked-tests.ts
@@ -1,0 +1,14 @@
+import type { ApiClientFactory } from '@/utils/api-client/client-factory';
+import type { TestDetail } from '@/utils/api-client/interfaces/tests';
+
+/** Every test linked to a requirement, newest first. Shared by server prefetch and client. */
+export function fetchRequirementLinkedTests(
+  factory: ApiClientFactory,
+  requirementId: string
+): Promise<TestDetail[]> {
+  return factory.getTestsClient().getAllTests({
+    filter: `requirement_id eq '${requirementId.replace(/'/g, "''")}'`,
+    sort_by: 'created_at',
+    sort_order: 'desc',
+  });
+}

--- a/apps/frontend/src/app/(protected)/requirements/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/requirements/[identifier]/page.tsx
@@ -4,6 +4,9 @@ import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import RequirementDetailClient from './components/RequirementDetailClient';
+import { prefetch } from '@/utils/server-prefetch';
+import { Capability } from '@/constants/capabilities';
+import { fetchRequirementLinkedTests } from './components/linked-tests';
 import type { UUID } from 'crypto';
 
 interface PageProps {
@@ -34,7 +37,8 @@ export default async function RequirementDetailPage({ params }: PageProps) {
   // object no longer exposes the access token (session.session_token is
   // always undefined post-BFF), and the factory also threads the active
   // project header.
-  const client = (await createServerApiFactory()).getRequirementClient();
+  const apiFactory = await createServerApiFactory();
+  const client = apiFactory.getRequirementClient();
 
   let requirement;
   try {
@@ -46,10 +50,16 @@ export default async function RequirementDetailPage({ params }: PageProps) {
 
   const serializedRequirement = JSON.parse(JSON.stringify(requirement));
 
+  // Linked Tests tab; Linked Metrics already arrive on the requirement.
+  const linkedTests = await prefetch(Capability.Test.READ, () =>
+    fetchRequirementLinkedTests(apiFactory, identifier)
+  );
+
   return (
     <RequirementDetailClient
       requirement={serializedRequirement}
       identifier={identifier}
+      initialLinkedTests={linkedTests}
     />
   );
 }

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailClient.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailClient.tsx
@@ -17,6 +17,7 @@ import { User } from '@/utils/api-client/interfaces/user';
 import { useNotifications } from '@/components/common/NotificationContext';
 import CreateJiraIssueButton from '../../components/CreateJiraIssueButton';
 import TaskDetailTabs from './TaskDetailTabs';
+import type { Comment } from '@/types/comments';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
 import DetailEntityMissingState from '@/components/common/DetailEntityMissingState';
@@ -27,11 +28,13 @@ import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 interface TaskDetailClientProps {
   identifier: string;
   initialTask: Task;
+  initialComments?: Comment[];
 }
 
 export default function TaskDetailClient({
   identifier: taskId,
   initialTask,
+  initialComments,
 }: TaskDetailClientProps) {
   const router = useRouter();
   const { data: session, status } = useSession();
@@ -199,6 +202,7 @@ export default function TaskDetailClient({
         currentUserId={session?.user?.id || ''}
         currentUserName={session?.user?.name || 'Unknown User'}
         currentUserPicture={session?.user?.picture || undefined}
+        initialComments={initialComments}
         onTaskUpdated={setTask}
         updateTask={handleUpdateTask}
       />

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailTabs.tsx
@@ -5,6 +5,7 @@ import { Box } from '@mui/material';
 import DetailTabNav from '@/components/common/DetailTabNav';
 import DetailTabPanel from '@/components/common/DetailTabPanel';
 import CommentsWrapper from '@/components/comments/CommentsWrapper';
+import type { Comment } from '@/types/comments';
 import { useDetailTabNav } from '@/hooks/useDetailTabNav';
 import { Priority, Status, Task, TaskUpdate } from '@/types/tasks';
 import type { User } from '@/utils/api-client/interfaces/user';
@@ -27,6 +28,7 @@ interface TaskDetailTabsProps {
   currentUserId: string;
   currentUserName: string;
   currentUserPicture?: string;
+  initialComments?: Comment[];
   onTaskUpdated: (task: Task) => void;
   updateTask: (
     id: string,
@@ -42,6 +44,7 @@ export default function TaskDetailTabs({
   currentUserId,
   currentUserName,
   currentUserPicture,
+  initialComments,
   onTaskUpdated,
   updateTask,
 }: TaskDetailTabsProps) {
@@ -87,6 +90,7 @@ export default function TaskDetailTabs({
           currentUserId={currentUserId}
           currentUserName={currentUserName}
           currentUserPicture={currentUserPicture}
+          initialComments={initialComments}
         />
       </DetailTabPanel>
     </Box>

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
@@ -3,6 +3,8 @@ import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import TaskDetailClient from './components/TaskDetailClient';
+import { prefetch } from '@/utils/server-prefetch';
+import { Capability } from '@/constants/capabilities';
 
 interface PageProps {
   params: Promise<{ identifier: string }>;
@@ -16,7 +18,8 @@ export default async function TaskDetailPage({ params }: PageProps) {
   }
 
   const { identifier } = await params;
-  const client = (await createServerApiFactory()).getTasksClient();
+  const apiFactory = await createServerApiFactory();
+  const client = apiFactory.getTasksClient();
 
   let task;
   try {
@@ -26,10 +29,16 @@ export default async function TaskDetailPage({ params }: PageProps) {
     throw error;
   }
 
+  // Comments tab, so it opens with content in place.
+  const comments = await prefetch(Capability.Comment.READ, () =>
+    apiFactory.getCommentsClient().getComments('Task', identifier)
+  );
+
   return (
     <TaskDetailClient
       identifier={identifier}
       initialTask={JSON.parse(JSON.stringify(task))}
+      initialComments={comments}
     />
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -35,6 +35,7 @@ import {
   type BatchRunOutcome,
 } from '@/utils/test-run-batch';
 import { useTestRunDetailData } from '../hooks/useTestRunDetailData';
+import { hasOtherRunsForTestSet } from './comparison-runs';
 import { useLiveTestRun } from '../hooks/useLiveTestRun';
 import {
   getTestEvaluationSummary,
@@ -108,6 +109,10 @@ interface TestRunMainViewProps {
   initialSelectedTestId?: string;
   /** Drawer tab to open when deep-linking via selectedresult (e.g. "reviews"). */
   initialDetailTab?: string;
+  /** Server-prefetched results (small runs only); see `useTestRunDetailData`. */
+  initialTestResults?: TestResultDetail[];
+  /** Whether the test set has other runs to compare with, when the server already checked. */
+  initialHasComparisonRuns?: boolean;
 }
 
 export default function TestRunMainView({
@@ -119,6 +124,8 @@ export default function TestRunMainView({
   currentUserPicture,
   initialSelectedTestId,
   initialDetailTab,
+  initialTestResults,
+  initialHasComparisonRuns,
 }: TestRunMainViewProps) {
   const testRun = useLiveTestRun(testRunId, initialTestRun);
   // Already watching this run live on screen -- a completion notification
@@ -155,6 +162,7 @@ export default function TestRunMainView({
   } = useTestRunDetailData({
     testRunId,
     enabled: needsTestResults.current,
+    initialTestResults,
   });
 
   const handleTabChange = useCallback(
@@ -172,7 +180,10 @@ export default function TestRunMainView({
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [renameValue, setRenameValue] = useState('');
   // Whether another test run exists on the same test set to compare against.
-  const [hasComparisonRuns, setHasComparisonRuns] = useState(false);
+  const [hasComparisonRuns, setHasComparisonRuns] = useState(
+    initialHasComparisonRuns ?? false
+  );
+  const comparisonSeededRef = useRef(initialHasComparisonRuns !== undefined);
   const [testSetExists, setTestSetExists] = useState<boolean | null>(null);
   const [testSetCheckError, setTestSetCheckError] = useState(false);
 
@@ -438,6 +449,8 @@ export default function TestRunMainView({
   }, [testSetId]);
 
   useEffect(() => {
+    // Already answered by the server for this run's test set.
+    if (comparisonSeededRef.current) return;
     if (!testSetId) {
       setHasComparisonRuns(false);
       return;
@@ -445,18 +458,12 @@ export default function TestRunMainView({
     let cancelled = false;
     (async () => {
       try {
-        const testRunsClient = new ApiClientFactory().getTestRunsClient();
-        const response = await testRunsClient.getTestRuns({
-          limit: 2,
-          skip: 0,
-          sort_by: 'created_at',
-          sort_order: 'desc',
-          filter: `test_configuration/test_set/id eq '${testSetId}'`,
-        });
-        if (!cancelled) {
-          const others = response.data.filter(run => run.id !== testRunId);
-          setHasComparisonRuns(others.length > 0);
-        }
+        const has = await hasOtherRunsForTestSet(
+          new ApiClientFactory(),
+          testSetId,
+          testRunId
+        );
+        if (!cancelled) setHasComparisonRuns(has);
       } catch {
         if (!cancelled) setHasComparisonRuns(false);
       }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/comparison-runs.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/comparison-runs.ts
@@ -1,0 +1,17 @@
+import type { ApiClientFactory } from '@/utils/api-client/client-factory';
+
+/** Whether the test set has at least one other run to compare `testRunId` with. */
+export async function hasOtherRunsForTestSet(
+  factory: ApiClientFactory,
+  testSetId: string,
+  testRunId: string
+): Promise<boolean> {
+  const response = await factory.getTestRunsClient().getTestRuns({
+    limit: 2,
+    skip: 0,
+    sort_by: 'created_at',
+    sort_order: 'desc',
+    filter: `test_configuration/test_set/id eq '${testSetId}'`,
+  });
+  return response.data.some(run => run.id !== testRunId);
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunDetailData.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunDetailData.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { Prompt } from '@/utils/api-client/interfaces/prompt';
@@ -14,6 +14,8 @@ export interface RequirementWithMetrics {
 interface UseTestRunDetailDataOptions {
   testRunId: string;
   enabled?: boolean;
+  /** Server-prefetched results (whole run); when present the mount fetch is skipped. */
+  initialTestResults?: TestResultDetail[];
 }
 
 interface UseTestRunDetailDataReturn {
@@ -54,6 +56,26 @@ export async function fetchAllTestResults(
   }
 
   return testResults;
+}
+
+/**
+ * Server-side prefetch: the run's results when one page holds them all,
+ * otherwise `undefined`. Rendering the page shouldn't wait on tens of
+ * sequential requests for a big run; the client loads those as before.
+ */
+export async function fetchSmallTestRunResults(
+  factory: ApiClientFactory,
+  testRunId: string
+): Promise<TestResultDetail[] | undefined> {
+  const response = await factory.getTestResultsClient().getTestResults({
+    filter: `test_run_id eq '${testRunId}'`,
+    limit: 100,
+    skip: 0,
+    sort_by: 'created_at',
+    sort_order: 'desc',
+  });
+  const totalCount = response.pagination?.totalCount || 0;
+  return response.data.length < totalCount ? undefined : response.data;
 }
 
 function buildPromptsMap(
@@ -128,15 +150,32 @@ function extractRequirementsWithMetrics(results: TestResultDetail[]): {
 export function useTestRunDetailData({
   testRunId,
   enabled = true,
+  initialTestResults,
 }: UseTestRunDetailDataOptions): UseTestRunDetailDataReturn {
   const isAuthenticated = useIsAuthenticated();
-  const [testResults, setTestResults] = useState<TestResultDetail[]>([]);
-  const [prompts, setPrompts] = useState<Record<string, Prompt>>({});
-  const [requirements, setRequirements] = useState<RequirementWithMetrics[]>(
-    []
+  const [seed] = useState(() =>
+    initialTestResults
+      ? {
+          ...extractRequirementsWithMetrics(initialTestResults),
+          prompts: buildPromptsMap(initialTestResults),
+        }
+      : null
   );
-  const [availableMetrics, setAvailableMetrics] = useState<string[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [testResults, setTestResults] = useState<TestResultDetail[]>(
+    initialTestResults ?? []
+  );
+  const [prompts, setPrompts] = useState<Record<string, Prompt>>(
+    seed?.prompts ?? {}
+  );
+  const [requirements, setRequirements] = useState<RequirementWithMetrics[]>(
+    seed?.requirements ?? []
+  );
+  const [availableMetrics, setAvailableMetrics] = useState<string[]>(
+    seed?.availableMetrics ?? []
+  );
+  const [loading, setLoading] = useState(!initialTestResults);
+  // The run the server-rendered results belong to: no mount fetch for it.
+  const seededRunIdRef = useRef(initialTestResults ? testRunId : null);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
 
@@ -147,6 +186,9 @@ export function useTestRunDetailData({
   useEffect(() => {
     if (!enabled || !isAuthenticated || !testRunId) {
       setLoading(false);
+      return;
+    }
+    if (seededRunIdRef.current === testRunId && reloadToken === 0) {
       return;
     }
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
@@ -4,6 +4,10 @@ import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import TestRunMainView from './components/TestRunMainViewClient';
+import { prefetch } from '@/utils/server-prefetch';
+import { Capability } from '@/constants/capabilities';
+import { fetchSmallTestRunResults } from './hooks/useTestRunDetailData';
+import { hasOtherRunsForTestSet } from './components/comparison-runs';
 
 interface _PageProps {
   params: Promise<{ identifier: string }>;
@@ -58,6 +62,20 @@ export default async function TestRunPage({
     throw error;
   }
 
+  // Results for the Summary/Test Cases tabs (small runs only) and the
+  // "can compare" check, so both tabs open without a client round trip.
+  const testSetId = testRun.test_configuration?.test_set?.id;
+  const [testResults, hasComparisonRuns] = await Promise.all([
+    prefetch(Capability.TestResult.READ, () =>
+      fetchSmallTestRunResults(apiFactory, identifier)
+    ),
+    testSetId
+      ? prefetch(Capability.TestRun.READ, () =>
+          hasOtherRunsForTestSet(apiFactory, testSetId, identifier)
+        )
+      : Promise.resolve(false),
+  ]);
+
   const title = testRun.name || `Test Run ${identifier}`;
   const breadcrumbs = [
     { label: 'Test Runs', href: '/test-runs' },
@@ -87,6 +105,8 @@ export default async function TestRunPage({
           typeof selectedResult === 'string' ? selectedResult : undefined
         }
         initialDetailTab={typeof detailTab === 'string' ? detailTab : undefined}
+        initialTestResults={testResults}
+        initialHasComparisonRuns={hasComparisonRuns}
       />
     </PageLayout>
   );

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunFilterDrawer.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import * as React from 'react';
-import { TextField } from '@mui/material';
+import { Box, TextField } from '@mui/material';
 import {
   FilterDrawerShell,
   FilterSection,
+  filterChipSx,
   filterDrawerTextFieldSx,
 } from '@/components/common/FilterDrawer';
 import ActivityPresenceFiltersSection from '@/components/common/ActivityPresenceFilters';
@@ -14,6 +15,8 @@ import {
   type ActivityPresenceFilters,
 } from '@/components/common/presence-filter';
 
+export type RunKindFilter = 'all' | 'tests' | 'experiments';
+
 export interface TestRunFilters {
   /** test_configuration/test_set/name contains */
   testSet: string;
@@ -21,6 +24,8 @@ export interface TestRunFilters {
   executor: string;
   /** tags contains */
   tag: string;
+  /** surfaced as `has_experiment` via `extraParams`, see list.ts */
+  runKind: RunKindFilter;
   tags: ActivityPresenceFilters['tags'];
   reviews: ActivityPresenceFilters['reviews'];
   comments: ActivityPresenceFilters['comments'];
@@ -31,6 +36,7 @@ export const EMPTY_TEST_RUN_FILTERS: TestRunFilters = {
   testSet: '',
   executor: '',
   tag: '',
+  runKind: 'all',
   tags: 'all',
   reviews: 'all',
   comments: 'all',
@@ -42,6 +48,7 @@ export function hasActiveTestRunFilters(f: TestRunFilters): boolean {
     f.testSet !== '' ||
     f.executor !== '' ||
     f.tag !== '' ||
+    f.runKind !== 'all' ||
     hasActivePresenceFilters(f)
   );
 }
@@ -51,9 +58,15 @@ export function countActiveTestRunFilters(f: TestRunFilters): number {
     (f.testSet !== '' ? 1 : 0) +
     (f.executor !== '' ? 1 : 0) +
     (f.tag !== '' ? 1 : 0) +
+    (f.runKind !== 'all' ? 1 : 0) +
     countActivePresenceFilters(f)
   );
 }
+
+const RUN_KIND_OPTIONS: { label: string; value: RunKindFilter }[] = [
+  { label: 'Tests', value: 'tests' },
+  { label: 'Experiments', value: 'experiments' },
+];
 
 const textFieldSx = filterDrawerTextFieldSx;
 
@@ -90,6 +103,27 @@ export default function TestRunFilterDrawer({
       onReset={handleReset}
       onApply={handleApply}
     >
+      <FilterSection title="Run Type">
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          {RUN_KIND_OPTIONS.map(opt => (
+            <Box
+              key={opt.value}
+              component="button"
+              type="button"
+              onClick={() =>
+                setDraft(prev => ({
+                  ...prev,
+                  runKind: prev.runKind === opt.value ? 'all' : opt.value,
+                }))
+              }
+              sx={filterChipSx(draft.runKind === opt.value)}
+            >
+              {opt.label}
+            </Box>
+          ))}
+        </Box>
+      </FilterSection>
+
       <FilterSection title="Test Set">
         <TextField
           fullWidth

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -2,16 +2,7 @@
 
 import React, { useState, useCallback, useMemo } from 'react';
 import { GridColDef } from '@mui/x-data-grid';
-import {
-  Typography,
-  Box,
-  Avatar,
-  Chip,
-  Button,
-  ButtonGroup,
-  Tooltip,
-} from '@mui/material';
-import ListIcon from '@mui/icons-material/List';
+import { Typography, Box, Avatar, Chip, Tooltip } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
 import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import RateReviewOutlinedIcon from '@mui/icons-material/RateReviewOutlined';
@@ -24,13 +15,7 @@ import TagLabel from '@/components/common/Tag';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
-import {
-  ChatIcon,
-  DescriptionIcon,
-  ScienceIcon,
-  BiotechIcon,
-  PlayArrowIcon,
-} from '@/components/icons';
+import { ChatIcon, DescriptionIcon, PlayArrowIcon } from '@/components/icons';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { NotificationSection } from '@/constants/notifications';
@@ -46,8 +31,6 @@ import TestRunFilterDrawer, {
   countActiveTestRunFilters,
 } from './TestRunFilterDrawer';
 import { passRate } from '@/constants/outcomes';
-
-type RunKindFilter = 'all' | 'tests' | 'experiments';
 
 interface TestRunsGridProps {
   canCreate?: boolean;
@@ -86,8 +69,7 @@ function toFilters(state: EntityGridFilterState<TestRunFilters>) {
     tagsPresence: state.drawer.tags,
     commentsPresence: state.drawer.comments,
     tasksPresence: state.drawer.tasks,
-    // Owned by the toolbar's run-kind toggle, merged in via externalFilters.
-    runKind: 'all',
+    runKind: state.drawer.runKind,
     reviews: state.drawer.reviews ?? 'all',
   };
 }
@@ -122,43 +104,8 @@ export default function TestRunsGrid({
 }: TestRunsGridProps) {
   const notifications = useNotifications();
 
-  const [runKindFilter, setRunKindFilter] = useState<RunKindFilter>('all');
   const [pendingCancelId, setPendingCancelId] = useState<string | null>(null);
   const [isCancelling, setIsCancelling] = useState(false);
-
-  const externalFilters = useMemo(
-    () => ({ runKind: runKindFilter }),
-    [runKindFilter]
-  );
-
-  const runKindToolbar = useMemo(
-    () => (
-      <ButtonGroup size="small" variant="outlined">
-        <Button
-          onClick={() => setRunKindFilter('all')}
-          variant={runKindFilter === 'all' ? 'contained' : 'outlined'}
-          startIcon={<ListIcon fontSize="small" />}
-        >
-          All
-        </Button>
-        <Button
-          onClick={() => setRunKindFilter('tests')}
-          variant={runKindFilter === 'tests' ? 'contained' : 'outlined'}
-          startIcon={<ScienceIcon fontSize="small" />}
-        >
-          Tests
-        </Button>
-        <Button
-          onClick={() => setRunKindFilter('experiments')}
-          variant={runKindFilter === 'experiments' ? 'contained' : 'outlined'}
-          startIcon={<BiotechIcon fontSize="small" />}
-        >
-          Experiments
-        </Button>
-      </ButtonGroup>
-    ),
-    [runKindFilter]
-  );
 
   const handleCancelClose = useCallback(() => {
     setPendingCancelId(null);
@@ -509,7 +456,6 @@ export default function TestRunsGrid({
       descriptor={testRunsList}
       columns={columns}
       toFilters={toFilters}
-      externalFilters={externalFilters}
       emptyState={
         <EntityEmptyState
           card
@@ -527,7 +473,6 @@ export default function TestRunsGrid({
       searchPlaceholder="Search test runs…"
       pills={{ tabs: STATUS_TABS }}
       drawer={drawerAdapter}
-      toolbarRight={runKindToolbar}
       selectionLabel="Select test runs"
       getRowUrl={row => `/test-runs/${row.id}`}
       highlightSection={NotificationSection.TEST_RUNS}

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
@@ -73,12 +73,16 @@ const CLUSTER_VIEW_ENABLED = false;
 interface EmbeddingTestsPanelProps {
   testSetId: string;
   testSetType?: string;
+  initialTests?: TestDetail[];
+  initialTotalCount?: number;
   onTotalCountChange?: (count: number) => void;
 }
 
 export default function EmbeddingTestsPanel({
   testSetId,
   testSetType,
+  initialTests,
+  initialTotalCount,
   onTotalCountChange,
 }: EmbeddingTestsPanelProps) {
   const theme = useTheme();
@@ -306,6 +310,8 @@ export default function EmbeddingTestsPanel({
           <TestSetTestsGrid
             testSetId={testSetId}
             testSetType={testSetType}
+            initialTests={initialTests}
+            initialTotalCount={initialTotalCount}
             embedded
             onTotalCountChange={onTotalCountChange}
           />

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetDetailTabs.tsx
@@ -7,6 +7,9 @@ import DetailTabPanel from '@/components/common/DetailTabPanel';
 import { useDetailTabNav } from '@/hooks/useDetailTabNav';
 import { useRouter } from 'next/navigation';
 import { TestSet } from '@/utils/api-client/interfaces/test-set';
+import type { TestDetail } from '@/utils/api-client/interfaces/tests';
+import type { Task } from '@/types/tasks';
+import type { Comment } from '@/types/comments';
 import { TasksAndCommentsWrapper } from '@/components/tasks/TasksAndCommentsWrapper';
 import TestSetDetailsCard from './TestSetDetailsCard';
 import TestSetTagsMetricsCard from './TestSetTagsMetricsCard';
@@ -17,6 +20,12 @@ const TAB_KEYS = ['basic', 'linked', 'tasks'] as const;
 interface TestSetDetailTabsProps {
   testSet: TestSet;
   testCount: number;
+  /** Server-prefetched first page of the Tests tab; undefined falls back to a client fetch. */
+  initialTests?: TestDetail[];
+  /** Server-prefetched first page of the Tasks tab. */
+  initialTasks?: Task[];
+  initialTasksTotalCount?: number;
+  initialComments?: Comment[];
   isGenerating?: boolean;
   currentUserId: string;
   currentUserName: string;
@@ -26,6 +35,10 @@ interface TestSetDetailTabsProps {
 export default function TestSetDetailTabs({
   testSet,
   testCount,
+  initialTests,
+  initialTasks,
+  initialTasksTotalCount,
+  initialComments,
   isGenerating = false,
   currentUserId,
   currentUserName,
@@ -69,6 +82,7 @@ export default function TestSetDetailTabs({
           testSetId={testSet.id as string}
           testSetType={testSet.test_set_type?.type_value}
           testCount={testCount}
+          initialTests={initialTests}
           isGenerating={isGenerating}
         />
       </DetailTabPanel>
@@ -77,6 +91,9 @@ export default function TestSetDetailTabs({
         <TasksAndCommentsWrapper
           entityType="TestSet"
           entityId={testSet.id as string}
+          initialTasks={initialTasks}
+          initialTasksTotalCount={initialTasksTotalCount}
+          initialComments={initialComments}
           currentUserId={currentUserId}
           currentUserName={currentUserName}
           currentUserPicture={currentUserPicture}

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetLinkedTestsSection.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetLinkedTestsSection.tsx
@@ -36,6 +36,7 @@ interface TestSetLinkedTestsSectionProps {
   testSetId: string;
   testSetType?: string;
   testCount: number;
+  initialTests?: TestDetail[];
   isGenerating?: boolean;
 }
 
@@ -43,6 +44,7 @@ export default function TestSetLinkedTestsSection({
   testSetId,
   testSetType,
   testCount: initialTestCount,
+  initialTests,
   isGenerating: initialIsGenerating = false,
 }: TestSetLinkedTestsSectionProps) {
   const { show: showNotification } = useNotifications();
@@ -256,6 +258,8 @@ export default function TestSetLinkedTestsSection({
           <EmbeddingTestsPanel
             testSetId={testSetId}
             testSetType={testSetType}
+            initialTests={initialTests}
+            initialTotalCount={initialTestCount}
             onTotalCountChange={setTotalCount}
           />
         </>

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
@@ -22,6 +22,7 @@ import { useList } from '@/hooks/useList';
 import { testSetTestsList } from './list';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
+import type { TestDetail } from '@/utils/api-client/interfaces/tests';
 
 interface LinkedTestsToolbarState {
   searchQuery: string;
@@ -71,12 +72,17 @@ interface TestSetTestsGridProps {
   testSetType?: string;
   /** When true, grid is rendered inside embedding atlas (spacing only). */
   embedded?: boolean;
+  /** Server-prefetched first page (default sort, no filters); skips the mount fetch. */
+  initialTests?: TestDetail[];
+  initialTotalCount?: number;
   onTotalCountChange?: (count: number) => void;
 }
 
 export default function TestSetTestsGrid({
   testSetId,
   testSetType,
+  initialTests,
+  initialTotalCount,
   onTotalCountChange,
 }: TestSetTestsGridProps) {
   const router = useRouter();
@@ -114,6 +120,8 @@ export default function TestSetTestsGrid({
   } = useList(descriptor, {
     filters,
     enabled: !!testSetId,
+    initialData: initialTests,
+    initialTotalCount,
     onError: () => setErrorDismissed(false),
   });
 

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/page.tsx
@@ -4,6 +4,10 @@ import { Metadata } from 'next';
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
+import { prefetch, prefetchList } from '@/utils/server-prefetch';
+import { Capability } from '@/constants/capabilities';
+import { firstPageParams } from '@/utils/list';
+import { entityTasksList } from '@/components/tasks/list';
 import { format } from 'date-fns';
 
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -11,6 +15,7 @@ import DetailMetadataStrip from '@/components/common/DetailMetadataStrip';
 
 import TestSetHeaderActions from './components/TestSetHeaderActions';
 import TestSetDetailTabs from './components/TestSetDetailTabs';
+import { testSetTestsList } from './components/list';
 
 interface PageProps {
   params: Promise<{ identifier: string }>;
@@ -61,15 +66,26 @@ export default async function TestSetPage({ params }: PageProps) {
     }
   }
 
-  let testCount = testSet.attributes?.metadata?.total_tests ?? 0;
-  try {
-    const testsResponse = await testSetsClient.getTestSetTests(identifier, {
-      limit: 1,
-    });
-    testCount = testsResponse.pagination.totalCount;
-  } catch {
-    // fall back to cached count
-  }
+  // First pages of the Tests and Tasks tabs, so they render with rows in
+  // place instead of a client-side spinner. The tests total doubles as the
+  // header count.
+  const linkedTests = testSetTestsList(identifier);
+  const tasks = entityTasksList('TestSet', identifier);
+  const [testsPage, tasksPage, comments] = await Promise.all([
+    prefetchList(linkedTests.capability, () =>
+      linkedTests.list(apiFactory, firstPageParams(linkedTests))
+    ),
+    prefetchList(tasks.capability, () =>
+      tasks.list(apiFactory, firstPageParams(tasks))
+    ),
+    prefetch(Capability.Comment.READ, () =>
+      apiFactory.getCommentsClient().getComments('TestSet', identifier)
+    ),
+  ]);
+  const testCount =
+    testsPage.initialData !== undefined
+      ? testsPage.initialTotalCount
+      : (testSet.attributes?.metadata?.total_tests ?? 0);
 
   const serializedTestSet = JSON.parse(JSON.stringify(testSet));
 
@@ -127,6 +143,10 @@ export default async function TestSetPage({ params }: PageProps) {
           <TestSetDetailTabs
             testSet={serializedTestSet}
             testCount={testCount}
+            initialTests={testsPage.initialData}
+            initialTasks={tasksPage.initialData}
+            initialTasksTotalCount={tasksPage.initialTotalCount}
+            initialComments={comments}
             isGenerating={isGenerating}
             currentUserId={session.user?.id || ''}
             currentUserName={session.user?.name || ''}

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestDetailTabs.tsx
@@ -7,6 +7,10 @@ import DetailTabPanel from '@/components/common/DetailTabPanel';
 import { useDetailTabNav } from '@/hooks/useDetailTabNav';
 import { useRouter } from 'next/navigation';
 import { TestDetail } from '@/utils/api-client/interfaces/tests';
+import type { TestSet } from '@/utils/api-client/interfaces/test-set';
+import type { Task } from '@/types/tasks';
+import type { Comment } from '@/types/comments';
+import type { TestExecutionHistoryRow } from '@/components/tests/test-execution-history';
 import { TasksAndCommentsWrapper } from '@/components/tasks/TasksAndCommentsWrapper';
 import LinkedTestSetsSection from '@/components/tests/LinkedTestSetsSection';
 import TestExecutionHistorySection from '@/components/tests/TestExecutionHistorySection';
@@ -19,6 +23,13 @@ const TAB_KEYS = ['basic', 'linked', 'history', 'tasks'] as const;
 
 interface TestDetailTabsProps {
   test: TestDetail;
+  /** Server-prefetched first pages for the Linked Test Sets and Tasks tabs. */
+  initialLinkedTestSets?: TestSet[];
+  initialLinkedTestSetsTotalCount?: number;
+  initialTasks?: Task[];
+  initialTasksTotalCount?: number;
+  initialComments?: Comment[];
+  initialExecutionHistory?: TestExecutionHistoryRow[];
   currentUserId: string;
   currentUserName: string;
   currentUserPicture?: string;
@@ -26,6 +37,12 @@ interface TestDetailTabsProps {
 
 export default function TestDetailTabs({
   test,
+  initialLinkedTestSets,
+  initialLinkedTestSetsTotalCount,
+  initialTasks,
+  initialTasksTotalCount,
+  initialComments,
+  initialExecutionHistory,
   currentUserId,
   currentUserName,
   currentUserPicture,
@@ -68,17 +85,27 @@ export default function TestDetailTabs({
       </DetailTabPanel>
 
       <DetailTabPanel value={activeTab} index={1} prefix="test-detail">
-        <LinkedTestSetsSection testId={test.id} />
+        <LinkedTestSetsSection
+          testId={test.id}
+          initialTestSets={initialLinkedTestSets}
+          initialTotalCount={initialLinkedTestSetsTotalCount}
+        />
       </DetailTabPanel>
 
       <DetailTabPanel value={activeTab} index={2} prefix="test-detail">
-        <TestExecutionHistorySection testId={test.id} />
+        <TestExecutionHistorySection
+          testId={test.id}
+          initialRows={initialExecutionHistory}
+        />
       </DetailTabPanel>
 
       <DetailTabPanel value={activeTab} index={3} prefix="test-detail">
         <TasksAndCommentsWrapper
           entityType="Test"
           entityId={test.id}
+          initialTasks={initialTasks}
+          initialTasksTotalCount={initialTasksTotalCount}
+          initialComments={initialComments}
           currentUserId={currentUserId}
           currentUserName={currentUserName}
           currentUserPicture={currentUserPicture}

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/page.tsx
@@ -4,6 +4,12 @@ import { Metadata } from 'next';
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
+import { prefetch, prefetchList } from '@/utils/server-prefetch';
+import { Capability } from '@/constants/capabilities';
+import { fetchTestExecutionHistory } from '@/components/tests/test-execution-history';
+import { firstPageParams } from '@/utils/list';
+import { linkedTestSetsList } from '@/components/tests/list';
+import { entityTasksList } from '@/components/tasks/list';
 import Link from 'next/link';
 import { format } from 'date-fns';
 
@@ -69,6 +75,26 @@ export default async function TestDetailPage({ params }: PageProps) {
     content = test.prompt?.content || '';
   }
 
+  // First pages of the Linked Test Sets and Tasks tabs, so they open with
+  // rows in place instead of a spinner.
+  const linkedTestSets = linkedTestSetsList(identifier);
+  const tasks = entityTasksList('Test', identifier);
+  const [linkedTestSetsPage, tasksPage, comments, executionHistory] =
+    await Promise.all([
+      prefetchList(linkedTestSets.capability, () =>
+        linkedTestSets.list(apiFactory, firstPageParams(linkedTestSets))
+      ),
+      prefetchList(tasks.capability, () =>
+        tasks.list(apiFactory, firstPageParams(tasks))
+      ),
+      prefetch(Capability.Comment.READ, () =>
+        apiFactory.getCommentsClient().getComments('Test', identifier)
+      ),
+      prefetch(Capability.TestResult.READ, () =>
+        fetchTestExecutionHistory(apiFactory, identifier)
+      ),
+    ]);
+
   const title = content
     ? content.length > 45
       ? `${content.substring(0, 45)}...`
@@ -131,6 +157,14 @@ export default async function TestDetailPage({ params }: PageProps) {
         >
           <TestDetailTabs
             test={test}
+            initialLinkedTestSets={linkedTestSetsPage.initialData}
+            initialLinkedTestSetsTotalCount={
+              linkedTestSetsPage.initialTotalCount
+            }
+            initialTasks={tasksPage.initialData}
+            initialTasksTotalCount={tasksPage.initialTotalCount}
+            initialComments={comments}
+            initialExecutionHistory={executionHistory}
             currentUserId={session.user?.id || ''}
             currentUserName={session.user?.name || ''}
             currentUserPicture={session.user?.picture || undefined}

--- a/apps/frontend/src/components/comments/CommentsWrapper.tsx
+++ b/apps/frontend/src/components/comments/CommentsWrapper.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { CommentsSection } from './CommentsSection';
 import { useComments } from '@/hooks/useComments';
-import { EntityType } from '@/types/comments';
+import { Comment, EntityType } from '@/types/comments';
 
 interface CommentsWrapperProps {
   entityType: EntityType;
@@ -14,6 +14,7 @@ interface CommentsWrapperProps {
   onCreateTask?: (commentId: string) => void;
   onCreateTaskFromEntity?: () => void;
   onCountsChange?: () => void;
+  initialComments?: Comment[];
 }
 
 export default function CommentsWrapper({
@@ -25,6 +26,7 @@ export default function CommentsWrapper({
   onCreateTask,
   onCreateTaskFromEntity,
   onCountsChange,
+  initialComments,
 }: CommentsWrapperProps) {
   const {
     comments,
@@ -41,6 +43,7 @@ export default function CommentsWrapper({
     currentUserId,
     currentUserName,
     currentUserPicture,
+    initialComments,
   });
 
   // Wrap the functions to match the expected Promise<void> return type

--- a/apps/frontend/src/components/tasks/TasksAndCommentsWrapper.tsx
+++ b/apps/frontend/src/components/tasks/TasksAndCommentsWrapper.tsx
@@ -2,11 +2,10 @@
 
 import React, { useCallback, useState } from 'react';
 import { Box } from '@mui/material';
-import { useQueryClient } from '@tanstack/react-query';
-import { EntityType } from '@/types/tasks';
+import { EntityType, type Task } from '@/types/tasks';
+import type { Comment } from '@/types/comments';
 import type { TaskCreate } from '@/utils/api-client/interfaces/task';
 import { useTasks } from '@/hooks/useTasks';
-import { taskKeys } from '@/constants/query-keys';
 import { TasksSection } from './TasksSection';
 import CommentsWrapper from '@/components/comments/CommentsWrapper';
 import { TaskCreationDrawer } from './TaskCreationDrawer';
@@ -19,6 +18,10 @@ interface TasksAndCommentsWrapperProps {
   currentUserPicture?: string;
   onCountsChange?: () => void;
   additionalMetadata?: Record<string, unknown>;
+  /** Server-prefetched first page of tasks; see `TasksSection`. */
+  initialTasks?: Task[];
+  initialTasksTotalCount?: number;
+  initialComments?: Comment[];
 }
 
 export function TasksAndCommentsWrapper({
@@ -29,8 +32,16 @@ export function TasksAndCommentsWrapper({
   currentUserPicture,
   onCountsChange,
   additionalMetadata,
+  initialTasks,
+  initialTasksTotalCount,
+  initialComments,
 }: TasksAndCommentsWrapperProps) {
-  const queryClient = useQueryClient();
+  // Bumped after a create/delete so the tasks grid re-reads its page.
+  const [tasksRefreshToken, setTasksRefreshToken] = useState(0);
+  const refreshTasks = useCallback(
+    () => setTasksRefreshToken(token => token + 1),
+    []
+  );
   const [createDrawerOpen, setCreateDrawerOpen] = useState(false);
   const [pendingCommentId, setPendingCommentId] = useState<
     string | undefined
@@ -58,7 +69,7 @@ export function TasksAndCommentsWrapper({
         await createTask(enrichedTaskData);
         setCreateDrawerOpen(false);
         setPendingCommentId(undefined);
-        queryClient.invalidateQueries({ queryKey: taskKeys.all() });
+        refreshTasks();
         await onCountsChange?.();
       } catch {
         // Errors surfaced by useTasks
@@ -66,7 +77,7 @@ export function TasksAndCommentsWrapper({
         setIsCreating(false);
       }
     },
-    [createTask, onCountsChange, additionalMetadata, queryClient]
+    [createTask, onCountsChange, additionalMetadata, refreshTasks]
   );
 
   const handleEditTask = useCallback((taskId: string) => {
@@ -77,13 +88,13 @@ export function TasksAndCommentsWrapper({
     async (taskId: string) => {
       try {
         await deleteTask(taskId);
-        queryClient.invalidateQueries({ queryKey: taskKeys.all() });
+        refreshTasks();
         await onCountsChange?.();
       } catch {
         // Errors surfaced by useTasks
       }
     },
-    [deleteTask, onCountsChange, queryClient]
+    [deleteTask, onCountsChange, refreshTasks]
   );
 
   const handleOpenCreateDrawer = useCallback((commentId?: string) => {
@@ -115,6 +126,9 @@ export function TasksAndCommentsWrapper({
           onEditTask={handleEditTask}
           onDeleteTask={handleDeleteTask}
           onOpenCreateDrawer={handleOpenCreateDrawer}
+          initialTasks={initialTasks}
+          initialTotalCount={initialTasksTotalCount}
+          refreshToken={tasksRefreshToken}
         />
 
         <CommentsWrapper
@@ -126,6 +140,7 @@ export function TasksAndCommentsWrapper({
           onCreateTask={commentId => handleOpenCreateDrawer(commentId)}
           onCreateTaskFromEntity={() => handleOpenCreateDrawer()}
           onCountsChange={onCountsChange}
+          initialComments={initialComments}
         />
       </Box>
 

--- a/apps/frontend/src/components/tasks/TasksSection.tsx
+++ b/apps/frontend/src/components/tasks/TasksSection.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Box, Typography, Button, Chip, Avatar } from '@mui/material';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useSession } from 'next-auth/react';
 import { AddIcon } from '@/components/icons';
 import TasksIcon from '@/components/TasksIcon';
 import { Task, EntityType } from '@/types/tasks';
@@ -12,17 +10,14 @@ import { Can } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import BaseDataGrid from '@/components/common/BaseDataGrid';
 import { SectionCard } from '@/components/common/SectionCard';
-import {
-  GridColDef,
-  GridPaginationModel,
-  GridRowParams,
-} from '@mui/x-data-grid';
+import { GridColDef, GridRowParams } from '@mui/x-data-grid';
 import { useRouter } from 'next/navigation';
 import { TaskErrorBoundary } from './TaskErrorBoundary';
 import { AVATAR_SIZES } from '@/constants/avatar-sizes';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { taskKeys } from '@/constants/query-keys';
-import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { useList } from '@/hooks/useList';
+import { entityTasksList } from './list';
+
+const NO_FILTERS = {};
 
 interface TasksSectionProps {
   entityType: EntityType;
@@ -32,6 +27,11 @@ interface TasksSectionProps {
   onDeleteTask?: (taskId: string) => Promise<void>;
   /** Opens the in-context task creation drawer */
   onOpenCreateDrawer?: (commentId?: string) => void;
+  /** Server-prefetched first page; undefined falls back to a client fetch. */
+  initialTasks?: Task[];
+  initialTotalCount?: number;
+  /** Bump to re-read the list after a task is created or deleted elsewhere. */
+  refreshToken?: number;
 }
 
 export function TasksSection({
@@ -41,63 +41,41 @@ export function TasksSection({
   onEditTask: _onEditTask,
   onDeleteTask,
   onOpenCreateDrawer,
+  initialTasks,
+  initialTotalCount,
+  refreshToken = 0,
 }: TasksSectionProps) {
   const router = useRouter();
-  const queryClient = useQueryClient();
-  const { status } = useSession();
-  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
-    page: 0,
-    pageSize: 10,
-  });
 
-  const currentPage = paginationModel.page;
-  const currentPageSize = paginationModel.pageSize;
-  const filter = `entity_type eq '${entityType}' and entity_id eq ${entityId}`;
-
-  const queryKey = taskKeys.list(
-    `${entityType}:${entityId}`,
-    currentPage,
-    currentPageSize,
-    'created_at',
-    'desc'
+  const descriptor = useMemo(
+    () => entityTasksList(entityType, entityId),
+    [entityType, entityId]
   );
 
   const {
-    data,
+    data: tasks,
+    totalCount,
     isLoading: loading,
     error,
-  } = useQuery({
-    queryKey,
-    queryFn: async () => {
-      const clientFactory = new ApiClientFactory();
-      const tasksClient = clientFactory.getTasksClient();
-      return tasksClient.getTasks({
-        skip: currentPage * currentPageSize,
-        limit: currentPageSize,
-        sort_by: 'created_at',
-        sort_order: 'desc',
-        $filter: filter,
-      });
-    },
-    enabled: isAuthenticated(status) && !!entityType && !!entityId,
-    placeholderData: prev => prev,
+    refresh,
+    paginationModel,
+    onPaginationModelChange: handlePaginationModelChange,
+  } = useList(descriptor, {
+    filters: NO_FILTERS,
+    enabled: !!entityType && !!entityId,
+    initialData: initialTasks,
+    initialTotalCount,
   });
 
-  const tasks: Task[] = data?.data ?? [];
-  const totalCount: number = data?.pagination.totalCount ?? 0;
-
-  const handlePaginationModelChange = useCallback(
-    (newModel: GridPaginationModel) => {
-      setPaginationModel(newModel);
-    },
-    []
-  );
+  useEffect(() => {
+    if (refreshToken > 0) refresh();
+  }, [refreshToken, refresh]);
 
   const _handleDeleteTask = async (taskId: string) => {
     if (onDeleteTask) {
       try {
         await onDeleteTask(taskId);
-        queryClient.invalidateQueries({ queryKey: taskKeys.all() });
+        refresh();
       } catch (err) {
         console.error('Failed to delete task:', err);
       }

--- a/apps/frontend/src/components/tasks/__tests__/TasksAndCommentsWrapper.test.tsx
+++ b/apps/frontend/src/components/tasks/__tests__/TasksAndCommentsWrapper.test.tsx
@@ -2,17 +2,10 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { taskKeys } from '@/constants/query-keys';
 import { TasksAndCommentsWrapper } from '../TasksAndCommentsWrapper';
 
 const mockCreateTask = jest.fn();
 const mockDeleteTask = jest.fn();
-const mockInvalidateQueries = jest.fn();
-
-jest.mock('@tanstack/react-query', () => ({
-  ...jest.requireActual('@tanstack/react-query'),
-  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
-}));
 
 jest.mock('@/hooks/useTasks', () => ({
   useTasks: jest.fn(() => ({
@@ -42,11 +35,13 @@ jest.mock('../TasksSection', () => ({
   TasksSection: ({
     onCreateTask,
     onDeleteTask,
+    refreshToken,
   }: {
     onCreateTask: (data: Record<string, unknown>) => Promise<void>;
     onDeleteTask: (id: string) => Promise<void>;
+    refreshToken?: number;
   }) => (
-    <div data-testid="tasks-section">
+    <div data-testid="tasks-section" data-refresh-token={refreshToken}>
       <button type="button" onClick={() => onCreateTask({ title: 'New Task' })}>
         create
       </button>
@@ -86,20 +81,25 @@ describe('TasksAndCommentsWrapper', () => {
     expect(screen.getByTestId('comments-wrapper')).toBeInTheDocument();
   });
 
-  it('invalidates the task cache after creating a task', async () => {
+  it('asks the tasks grid to refresh after creating a task', async () => {
     const user = userEvent.setup();
     mockCreateTask.mockResolvedValue({ id: 'task-1' });
 
     render(<TasksAndCommentsWrapper {...DEFAULT_PROPS} />);
+    expect(screen.getByTestId('tasks-section')).toHaveAttribute(
+      'data-refresh-token',
+      '0'
+    );
     await user.click(screen.getByRole('button', { name: 'create' }));
 
     expect(mockCreateTask).toHaveBeenCalledWith({ title: 'New Task' });
-    expect(mockInvalidateQueries).toHaveBeenCalledWith({
-      queryKey: taskKeys.all(),
-    });
+    expect(screen.getByTestId('tasks-section')).toHaveAttribute(
+      'data-refresh-token',
+      '1'
+    );
   });
 
-  it('invalidates the task cache after deleting a task', async () => {
+  it('asks the tasks grid to refresh after deleting a task', async () => {
     const user = userEvent.setup();
     mockDeleteTask.mockResolvedValue(true);
 
@@ -107,9 +107,10 @@ describe('TasksAndCommentsWrapper', () => {
     await user.click(screen.getByRole('button', { name: 'delete' }));
 
     expect(mockDeleteTask).toHaveBeenCalledWith('task-1');
-    expect(mockInvalidateQueries).toHaveBeenCalledWith({
-      queryKey: taskKeys.all(),
-    });
+    expect(screen.getByTestId('tasks-section')).toHaveAttribute(
+      'data-refresh-token',
+      '1'
+    );
   });
 
   it('calls parent onCountsChange when CommentsWrapper triggers it', async () => {

--- a/apps/frontend/src/components/tasks/__tests__/TasksSection.test.tsx
+++ b/apps/frontend/src/components/tasks/__tests__/TasksSection.test.tsx
@@ -8,6 +8,7 @@ import { ApiClientFactory } from '../../../utils/api-client/client-factory';
 
 jest.mock('../../../components/common/Can', () => ({
   useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
   Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   can: (_subject: unknown, _capability: string) => true,
 }));
@@ -59,6 +60,10 @@ describe('TasksSection - Infinite Loading Fix', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseSession.mockImplementation(() => ({
+      data: { session_token: 'tok' },
+      status: 'authenticated',
+    }));
 
     mockApiClientFactory.mockImplementation(
       () =>
@@ -112,10 +117,15 @@ describe('TasksSection - Infinite Loading Fix', () => {
   });
 
   it('should set loading to false when required props are missing', async () => {
-    mockUseSession.mockReturnValueOnce({
-      data: null,
-      status: 'unauthenticated',
-    } as unknown as ReturnType<typeof mockUseSession>);
+    // Every useSession() call in the tree must see the signed-out state, not
+    // just the first one.
+    mockUseSession.mockImplementation(
+      () =>
+        ({
+          data: null,
+          status: 'unauthenticated',
+        }) as unknown as ReturnType<typeof mockUseSession>
+    );
     wrap(<TasksSection {...defaultProps} />);
 
     // Should show empty state, not loading spinner

--- a/apps/frontend/src/components/tasks/list.ts
+++ b/apps/frontend/src/components/tasks/list.ts
@@ -1,0 +1,26 @@
+import type { ApiClientFactory } from '@/utils/api-client/client-factory';
+import type { Task } from '@/types/tasks';
+import { Capability } from '@/constants/capabilities';
+import { defineList } from '@/utils/list';
+
+export const ENTITY_TASKS_FILTERS = {} as const;
+
+/**
+ * The tasks attached to one entity (a detail page's Tasks tab), newest first.
+ * The entity scope is part of the descriptor rather than a filter so the
+ * server prefetch and the client grid can't disagree on it.
+ */
+export function entityTasksList(entityType: string, entityId: string) {
+  return defineList<Task, typeof ENTITY_TASKS_FILTERS>({
+    title: 'Tasks',
+    resource: 'tasks',
+    capability: Capability.Task.READ,
+    defaultPageSize: 10,
+    filters: ENTITY_TASKS_FILTERS,
+    list: (factory: ApiClientFactory, params) =>
+      factory.getTasksClient().getTasks({
+        ...params,
+        $filter: `entity_type eq '${entityType}' and entity_id eq ${entityId}`,
+      }),
+  });
+}

--- a/apps/frontend/src/components/tasks/list.ts
+++ b/apps/frontend/src/components/tasks/list.ts
@@ -2,6 +2,7 @@ import type { ApiClientFactory } from '@/utils/api-client/client-factory';
 import type { Task } from '@/types/tasks';
 import { Capability } from '@/constants/capabilities';
 import { defineList } from '@/utils/list';
+import { escapeODataValue } from '@/utils/odata-filter';
 
 export const ENTITY_TASKS_FILTERS = {} as const;
 
@@ -20,7 +21,7 @@ export function entityTasksList(entityType: string, entityId: string) {
     list: (factory: ApiClientFactory, params) =>
       factory.getTasksClient().getTasks({
         ...params,
-        $filter: `entity_type eq '${entityType}' and entity_id eq ${entityId}`,
+        $filter: `entity_type eq '${escapeODataValue(entityType)}' and entity_id eq '${escapeODataValue(entityId)}'`,
       }),
   });
 }

--- a/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
+++ b/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
@@ -1,83 +1,62 @@
 'use client';
 
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { Box, Button, Paper, Typography } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import RouteOutlinedIcon from '@mui/icons-material/RouteOutlined';
 import Link from 'next/link';
-import { useSession } from 'next-auth/react';
 import BaseDataGrid from '@/components/common/BaseDataGrid';
 import AssignEntityDrawer from '@/components/common/AssignEntityDrawer';
-import {
-  GridColDef,
-  GridPaginationModel,
-  GridRowModel,
-} from '@mui/x-data-grid';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { GridColDef, GridRowModel } from '@mui/x-data-grid';
 import { TestSetsClient } from '@/utils/api-client/test-sets-client';
 import { TestSet } from '@/utils/api-client/interfaces/test-set';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { formatDate } from '@/utils/date';
-import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { useList } from '@/hooks/useList';
+import { linkedTestSetsList } from './list';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 
+const NO_FILTERS = {};
+
 interface LinkedTestSetsSectionProps {
   testId: string;
+  /** Server-prefetched first page; undefined falls back to a client fetch. */
+  initialTestSets?: TestSet[];
+  initialTotalCount?: number;
 }
 
 export default function LinkedTestSetsSection({
   testId,
+  initialTestSets,
+  initialTotalCount,
 }: LinkedTestSetsSectionProps) {
   const { show: showNotification } = useNotifications();
-  const { status } = useSession();
   const canEditTest = useCan(Capability.TestSet.UPDATE);
-
-  const [testSets, setTestSets] = useState<TestSet[]>([]);
-  const [totalCount, setTotalCount] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
-    page: 0,
-    pageSize: 10,
-  });
 
   // Assign drawer state
   const [assignOpen, setAssignOpen] = useState(false);
   const [available, setAvailable] = useState<TestSet[]>([]);
   const [loadingAvailable, setLoadingAvailable] = useState(false);
 
-  const fetchLinkedTestSets = useCallback(async () => {
-    if (!testId || !isAuthenticated(status)) return;
-    setLoading(true);
-    try {
-      const apiFactory = new ApiClientFactory();
-      const testsClient = apiFactory.getTestsClient();
-      const response = await testsClient.getLinkedTestSets(testId, {
-        skip: paginationModel.page * paginationModel.pageSize,
-        limit: paginationModel.pageSize,
-        sort_by: 'created_at',
-        sort_order: 'desc',
-      });
-      setTestSets(response.data);
-      setTotalCount(response.pagination.totalCount);
-    } catch {
+  const descriptor = useMemo(() => linkedTestSetsList(testId), [testId]);
+  const {
+    data: testSets,
+    totalCount,
+    isLoading: loading,
+    refresh: fetchLinkedTestSets,
+    paginationModel,
+    onPaginationModelChange: setPaginationModel,
+  } = useList(descriptor, {
+    filters: NO_FILTERS,
+    enabled: !!testId,
+    initialData: initialTestSets,
+    initialTotalCount,
+    onError: () =>
       showNotification('Failed to load linked test sets', {
         severity: 'error',
-      });
-    } finally {
-      setLoading(false);
-    }
-  }, [
-    testId,
-    paginationModel.page,
-    paginationModel.pageSize,
-    showNotification,
-    status,
-  ]);
-
-  useEffect(() => {
-    fetchLinkedTestSets();
-  }, [fetchLinkedTestSets]);
+      }),
+  });
 
   const handleAssignClick = useCallback(async () => {
     setLoadingAvailable(true);
@@ -134,7 +113,7 @@ export default function LinkedTestSetsSection({
         );
       }
       setAssignOpen(false);
-      await fetchLinkedTestSets();
+      fetchLinkedTestSets();
     },
     [testId, showNotification, fetchLinkedTestSets]
   );

--- a/apps/frontend/src/components/tests/TestExecutionHistorySection.tsx
+++ b/apps/frontend/src/components/tests/TestExecutionHistorySection.tsx
@@ -6,16 +6,20 @@ import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import TestExecutionHistoryTable from './TestExecutionHistoryTable';
 import { useTestExecutionHistory } from './useTestExecutionHistory';
+import type { TestExecutionHistoryRow } from './test-execution-history';
 
 interface TestExecutionHistorySectionProps {
   testId: string;
+  initialRows?: TestExecutionHistoryRow[];
 }
 
 export default function TestExecutionHistorySection({
   testId,
+  initialRows,
 }: TestExecutionHistorySectionProps) {
   const { rows, loading, error } = useTestExecutionHistory({
     testId,
+    initialRows,
   });
 
   if (loading) {

--- a/apps/frontend/src/components/tests/__tests__/LinkedTestSetsSection.test.tsx
+++ b/apps/frontend/src/components/tests/__tests__/LinkedTestSetsSection.test.tsx
@@ -7,6 +7,7 @@ let mockCanEdit = true;
 
 jest.mock('@/components/common/Can', () => ({
   useCan: () => mockCanEdit,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
   Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   can: () => mockCanEdit,
 }));

--- a/apps/frontend/src/components/tests/list.ts
+++ b/apps/frontend/src/components/tests/list.ts
@@ -1,0 +1,19 @@
+import type { ApiClientFactory } from '@/utils/api-client/client-factory';
+import type { TestSet } from '@/utils/api-client/interfaces/test-set';
+import { Capability } from '@/constants/capabilities';
+import { defineList } from '@/utils/list';
+
+export const LINKED_TEST_SETS_FILTERS = {} as const;
+
+/** The test sets one test belongs to (the test detail page's Linked Test Sets tab). */
+export function linkedTestSetsList(testId: string) {
+  return defineList<TestSet, typeof LINKED_TEST_SETS_FILTERS>({
+    title: 'Linked Test Sets',
+    resource: 'test sets',
+    capability: Capability.TestSet.READ,
+    defaultPageSize: 10,
+    filters: LINKED_TEST_SETS_FILTERS,
+    list: (factory: ApiClientFactory, params) =>
+      factory.getTestsClient().getLinkedTestSets(testId, params),
+  });
+}

--- a/apps/frontend/src/components/tests/test-execution-history.ts
+++ b/apps/frontend/src/components/tests/test-execution-history.ts
@@ -2,6 +2,8 @@ import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { getEffectiveTestResultStatus } from '@/utils/test-result-status';
 import type { TestResultStatus } from '@/constants/outcomes';
 
+import type { ApiClientFactory } from '@/utils/api-client/client-factory';
+
 export interface TestExecutionHistoryRow {
   id: string;
   testRunId: string;
@@ -61,5 +63,61 @@ export function dedupeHistoryByTestRun(
   return Array.from(uniqueByTestRun.values()).sort(
     (a, b) =>
       new Date(b.executedAt).getTime() - new Date(a.executedAt).getTime()
+  );
+}
+
+const MAX_RESULTS = 100;
+
+/**
+ * The test's most recent results, one row per test run. Runs the results
+ * endpoint doesn't embed a name for are looked up individually so every row
+ * has one. Shared by the server prefetch and the client hook.
+ */
+export async function fetchTestExecutionHistory(
+  factory: ApiClientFactory,
+  testId: string
+): Promise<TestExecutionHistoryRow[]> {
+  const results = await factory.getTestResultsClient().getTestResults({
+    filter: `test_id eq '${testId}'`,
+    limit: MAX_RESULTS,
+    skip: 0,
+    sort_by: 'created_at',
+    sort_order: 'desc',
+  });
+
+  const testRunNames = new Map<string, string>();
+  for (const result of results.data) {
+    if (result.test_run_id && result.test_run?.name) {
+      testRunNames.set(result.test_run_id, result.test_run.name);
+    }
+  }
+
+  const missingTestRunIds = [
+    ...new Set(
+      results.data
+        .filter(
+          (r): r is typeof r & { test_run_id: string } =>
+            !!r.test_run_id && !testRunNames.has(r.test_run_id)
+        )
+        .map(r => r.test_run_id)
+    ),
+  ];
+
+  if (missingTestRunIds.length > 0) {
+    const testRunsClient = factory.getTestRunsClient();
+    const testRuns = await Promise.allSettled(
+      missingTestRunIds.map(id => testRunsClient.getTestRun(id))
+    );
+    testRuns.forEach((result, index) => {
+      const id = missingTestRunIds[index];
+      testRunNames.set(
+        id,
+        result.status === 'fulfilled' ? result.value.name || id : id
+      );
+    });
+  }
+
+  return dedupeHistoryByTestRun(
+    results.data.map(result => mapTestResultToHistoryRow(result, testRunNames))
   );
 }

--- a/apps/frontend/src/components/tests/useTestExecutionHistory.ts
+++ b/apps/frontend/src/components/tests/useTestExecutionHistory.ts
@@ -1,18 +1,19 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { useIsAuthenticated } from '@/hooks/useIsAuthenticated';
+import { testKeys } from '@/constants/query-keys';
 import {
-  dedupeHistoryByTestRun,
-  mapTestResultToHistoryRow,
-  TestExecutionHistoryRow,
+  fetchTestExecutionHistory,
+  type TestExecutionHistoryRow,
 } from './test-execution-history';
-
-const MAX_RESULTS = 100;
 
 interface UseTestExecutionHistoryOptions {
   testId: string | undefined;
   enabled?: boolean;
+  /** Server-prefetched rows; when present the hook skips its mount fetch. */
+  initialRows?: TestExecutionHistoryRow[];
 }
 
 interface UseTestExecutionHistoryResult {
@@ -22,116 +23,36 @@ interface UseTestExecutionHistoryResult {
   refetch: () => void;
 }
 
+const EMPTY_ROWS: TestExecutionHistoryRow[] = [];
+
 export function useTestExecutionHistory({
   testId,
   enabled = true,
+  initialRows,
 }: UseTestExecutionHistoryOptions): UseTestExecutionHistoryResult {
-  const [rows, setRows] = useState<TestExecutionHistoryRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [fetchKey, setFetchKey] = useState(0);
+  const isAuthenticated = useIsAuthenticated();
 
-  const refetch = useCallback(() => {
-    setFetchKey(key => key + 1);
-  }, []);
+  const { data, isPending, error, refetch } = useQuery({
+    queryKey: [...testKeys.detail(testId ?? ''), 'execution-history'],
+    queryFn: () =>
+      fetchTestExecutionHistory(new ApiClientFactory(), testId as string),
+    enabled: enabled && isAuthenticated && !!testId,
+    initialData: initialRows,
+  });
 
-  useEffect(() => {
-    if (!enabled) {
-      setLoading(false);
-      return;
-    }
-
-    if (!testId) {
-      setError('No test ID available');
-      setRows([]);
-      setLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-
-    async function fetchHistory() {
-      try {
-        setLoading(true);
-        const clientFactory = new ApiClientFactory();
-        const testResultsClient = clientFactory.getTestResultsClient();
-
-        const results = await testResultsClient.getTestResults({
-          filter: `test_id eq '${testId}'`,
-          limit: MAX_RESULTS,
-          skip: 0,
-          sort_by: 'created_at',
-          sort_order: 'desc',
-        });
-
-        if (cancelled) return;
-
-        const testRunNamesMap = new Map<string, string>();
-        for (const result of results.data) {
-          if (result.test_run_id && result.test_run?.name) {
-            testRunNamesMap.set(result.test_run_id, result.test_run.name);
-          }
-        }
-
-        const missingTestRunIds = [
-          ...new Set(
-            results.data
-              .filter(
-                (r): r is typeof r & { test_run_id: string } =>
-                  !!r.test_run_id && !testRunNamesMap.has(r.test_run_id)
-              )
-              .map(r => r.test_run_id)
-          ),
-        ];
-
-        if (missingTestRunIds.length > 0) {
-          const testRunsClient = clientFactory.getTestRunsClient();
-          const testRunsData = await Promise.allSettled(
-            missingTestRunIds.map(id => testRunsClient.getTestRun(id))
-          );
-
-          if (cancelled) return;
-
-          testRunsData.forEach((result, index) => {
-            if (result.status === 'fulfilled') {
-              const testRun = result.value;
-              testRunNamesMap.set(
-                testRun.id,
-                testRun.name || missingTestRunIds[index]
-              );
-            } else {
-              testRunNamesMap.set(
-                missingTestRunIds[index],
-                missingTestRunIds[index]
-              );
-            }
-          });
-        }
-
-        const historicalData = results.data.map(result =>
-          mapTestResultToHistoryRow(result, testRunNamesMap)
-        );
-
-        setRows(dedupeHistoryByTestRun(historicalData));
-        setError(null);
-      } catch {
-        if (!cancelled) {
-          setError('Failed to load execution history');
-          setRows([]);
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    }
-
-    fetchHistory();
-
-    return () => {
-      cancelled = true;
+  if (!testId) {
+    return {
+      rows: EMPTY_ROWS,
+      loading: false,
+      error: 'No test ID available',
+      refetch: () => {},
     };
-  }, [testId, enabled, fetchKey]);
+  }
 
-  return { rows, loading, error, refetch };
+  return {
+    rows: data ?? EMPTY_ROWS,
+    loading: enabled && isPending,
+    error: error ? 'Failed to load execution history' : null,
+    refetch: () => void refetch(),
+  };
 }

--- a/apps/frontend/src/hooks/useComments.ts
+++ b/apps/frontend/src/hooks/useComments.ts
@@ -12,6 +12,8 @@ interface UseCommentsProps {
   currentUserId: string;
   currentUserName: string;
   currentUserPicture?: string;
+  /** Server-prefetched comments; seeds the cache so the first render has them. */
+  initialComments?: Comment[];
 }
 
 export function useComments({
@@ -20,6 +22,7 @@ export function useComments({
   currentUserId,
   currentUserName,
   currentUserPicture,
+  initialComments,
 }: UseCommentsProps) {
   const queryClient = useQueryClient();
   const notifications = useNotifications();
@@ -43,6 +46,7 @@ export function useComments({
         .getComments(entityType, entityId);
     },
     enabled: isAuthenticated && !!entityType && !!entityId,
+    initialData: initialComments,
   });
 
   const createComment = useCallback(

--- a/apps/frontend/src/hooks/useEndpoints.ts
+++ b/apps/frontend/src/hooks/useEndpoints.ts
@@ -64,8 +64,8 @@ export function useEndpoint(
     queryFn: () =>
       new ApiClientFactory().getEndpointsClient().getEndpoint(identifier),
     enabled: enabled && isAuthenticated && !!identifier,
-    staleTime: STALE_TIME,
     initialData,
+    staleTime: STALE_TIME,
   });
 }
 
@@ -75,8 +75,8 @@ export function useProject(id: string, enabled = true, initialData?: Project) {
     queryKey: projectKeys.detail(id),
     queryFn: () => new ApiClientFactory().getProjectsClient().getProject(id),
     enabled: enabled && isAuthenticated && !!id,
-    staleTime: STALE_TIME,
     initialData,
+    staleTime: STALE_TIME,
   });
 }
 

--- a/apps/frontend/src/hooks/useList.ts
+++ b/apps/frontend/src/hooks/useList.ts
@@ -13,6 +13,21 @@ import {
 import { useListAuthGate } from './useListAuthGate';
 import { usePaginatedList } from './usePaginatedList';
 
+// A descriptor built per parent entity (e.g. `entityTasksList(type, id)`) is a
+// new object when that entity changes, and the list must refetch then. Number
+// each identity so it can be part of the request fingerprint; callers memoize
+// descriptors, so a stable list keeps a stable number.
+const descriptorIds = new WeakMap<object, number>();
+let nextDescriptorId = 0;
+function descriptorId(descriptor: object): number {
+  let id = descriptorIds.get(descriptor);
+  if (id === undefined) {
+    id = nextDescriptorId++;
+    descriptorIds.set(descriptor, id);
+  }
+  return id;
+}
+
 interface UseListOptions<T, S extends FilterSpecMap> {
   filters: FiltersOf<S>;
   /**
@@ -79,7 +94,12 @@ export function useList<T, S extends FilterSpecMap>(
           extraFilters ?? []
         )
       ),
-    filterFingerprint: JSON.stringify({ filters, sort, extraFilters }),
+    filterFingerprint: JSON.stringify({
+      descriptor: descriptorId(descriptor),
+      filters,
+      sort,
+      extraFilters,
+    }),
     defaultPageSize: descriptor.defaultPageSize,
     initialData,
     initialTotalCount,

--- a/apps/frontend/src/hooks/usePaginatedList.ts
+++ b/apps/frontend/src/hooks/usePaginatedList.ts
@@ -68,12 +68,13 @@ export interface UsePaginatedListResult<T> {
  *
  * Fetches are keyed by a request signature (page, rowsPerPage,
  * filterFingerprint, refreshKey, sessionStatus, enabled) rather than a
- * one-shot "skip the first fetch" flag, so it stays correct under React 18
- * Strict Mode's dev-only double-invoke of mount effects: both invocations
- * compute the same signature and both no-op, instead of the second slipping
- * through a "consumed" ref. `sessionStatus` is part of the key so a run that
- * lands while the session is still `loading` doesn't "claim" the same key a
- * later `authenticated` run would use.
+ * one-shot "skip the first fetch" flag. With `initialData` the key is
+ * pre-filled so the SSR'd page isn't refetched on mount. A fetch cancelled
+ * by effect cleanup releases its key again, so React 18 Strict Mode's
+ * dev-only double-invoke of mount effects refetches instead of getting
+ * stuck behind a cancelled request. `sessionStatus` is part of the key so a
+ * run that lands while the session is still `loading` doesn't "claim" the
+ * same key a later `authenticated` run would use.
  */
 export function usePaginatedList<T>({
   fetchPage,
@@ -131,6 +132,7 @@ export function usePaginatedList<T>({
     loadedRequestKeyRef.current = requestKey;
 
     let cancelled = false;
+    let settled = false;
     const silent = silentRef.current;
     silentRef.current = false;
 
@@ -169,9 +171,18 @@ export function usePaginatedList<T>({
       }
     };
 
-    run();
+    run().finally(() => {
+      settled = true;
+    });
     return () => {
       cancelled = true;
+      // A cancelled in-flight fetch never writes its result, so it must not
+      // "claim" this key: otherwise a remount with the same signature (Strict
+      // Mode's dev double-invoke, when the gate is already open) would skip
+      // the fetch and leave the grid spinning forever.
+      if (!settled && loadedRequestKeyRef.current === requestKey) {
+        loadedRequestKeyRef.current = null;
+      }
     };
     // fetchPage/onData/onError are recreated every render; the request-key
     // check above (not this array) is what governs whether a fetch actually

--- a/apps/frontend/src/utils/api-client/client-factory.ts
+++ b/apps/frontend/src/utils/api-client/client-factory.ts
@@ -87,6 +87,11 @@ export class ApiClientFactory {
     this.projectId = projectId;
   }
 
+  /** Same credentials, requests scoped to `projectId` instead of the active project. */
+  forProject(projectId: string): ApiClientFactory {
+    return new ApiClientFactory(this.sessionToken, projectId);
+  }
+
   getExplorerClient(): ExplorerClient {
     if (!this.explorerClient) {
       this.explorerClient = new ExplorerClient(

--- a/apps/frontend/src/utils/list/params.ts
+++ b/apps/frontend/src/utils/list/params.ts
@@ -1,11 +1,12 @@
 import { gridSortToApiParams } from '@/utils/grid-sort';
 import { buildListFilter } from './odata';
-import type {
-  ListDescriptor,
-  ListParams,
-  ListState,
-  FilterSpecMap,
-  FiltersOf,
+import {
+  emptyFilters,
+  type ListDescriptor,
+  type ListParams,
+  type ListState,
+  type FilterSpecMap,
+  type FiltersOf,
 } from './define';
 
 function isActive(value: string | string[] | undefined): boolean {
@@ -60,4 +61,19 @@ export function listParams<T, S extends FilterSpecMap>(
     ...(descriptor.extraParams?.(state.filters) ?? {}),
     ...($filter ? { $filter } : {}),
   };
+}
+
+/**
+ * The params for a descriptor's first page in its default state -- what a
+ * server prefetch fetches, and what the client grid asks for on mount.
+ */
+export function firstPageParams<T, S extends FilterSpecMap>(
+  descriptor: ListDescriptor<T, S>
+): ListParams {
+  return listParams(descriptor, {
+    page: 1,
+    pageSize: descriptor.defaultPageSize,
+    sort: descriptor.defaultSort,
+    filters: emptyFilters(descriptor),
+  });
 }

--- a/apps/frontend/src/utils/server-prefetch.ts
+++ b/apps/frontend/src/utils/server-prefetch.ts
@@ -48,3 +48,24 @@ export async function prefetchList<T>(
     return { initialData: undefined, initialTotalCount: 0 };
   }
 }
+
+/**
+ * `prefetchList` for a single value: a detail record, an unpaginated list, a
+ * lookup. Same contract -- capability-gated (a tuple is OR'd), never throws,
+ * `undefined` means "let the client fetch it" -- and the result is passed to
+ * the client component as an `initial*` prop that seeds its existing hook.
+ */
+export async function prefetch<T>(
+  capability: string | readonly string[],
+  fetch: () => Promise<T>
+): Promise<T | undefined> {
+  const capabilities: readonly string[] =
+    typeof capability === 'string' ? [capability] : capability;
+  const checks = await Promise.all(capabilities.map(hasServerCapability));
+  if (!checks.some(Boolean)) return undefined;
+  try {
+    return JSON.parse(JSON.stringify(await fetch()));
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Purpose

Opening a test set's **Tests** tab (`/test-sets/<id>?tab=linked`) for the first time showed a spinner that never resolved; only a hard reload brought the rows up. The cause was in `usePaginatedList`: a fetch cancelled by effect cleanup never released its request key, so under React Strict Mode's double mount (which happens whenever the auth gate is already open, i.e. on client-side navigation) the second run skipped the fetch and the grid stayed loading forever.

The fix is twofold: repair the hook so a cancelled fetch can run again, and render that tab server-side so there is no client-side first fetch to get stuck in the first place. While there, the same server-prefetch treatment is applied to every remaining detail-page tab and list page that still loaded its data after mount, so they open with content in place instead of a spinner.

## What Changed

- `usePaginatedList`: a fetch cancelled by effect cleanup now releases its request key, so a remount with the same signature refetches instead of leaving `isLoading` stuck.
- `useList`: the descriptor identity is now part of the request fingerprint, so a grid whose descriptor is built per entity (e.g. `entityTasksList(type, id)`) refetches when the entity changes.
- New `prefetch()` helper in `server-prefetch.ts`, the single-value counterpart of `prefetchList`: capability-gated, never throws, `undefined` means "let the client fetch it". Pages fetch on the server and pass the result down as `initial*` props that seed the existing client hooks.
- New list descriptors `entityTasksList` and `linkedTestSetsList`; `TasksSection` and `LinkedTestSetsSection` moved onto `useList`; `firstPageParams()` helper for descriptor prefetches.
- Server-prefetched now: `/test-sets/<id>` (Tests grid, Tasks, Comments), `/tests/<id>` (Linked Test Sets, Execution History, Tasks, Comments), `/tasks/<id>` (Comments), `/requirements/<id>` (Linked Tests; Linked Metrics no longer refetches what the server already sent), `/metrics/<id>` (Linked Requirements, Tuning), `/experiments/<id>` (Runs), `/test-runs/<id>` (results for runs that fit one page, plus the "can compare" check), `/projects/<id>` (Members, Environments, Trace Metrics).
- Fetch logic that both server and client need lives in small plain modules next to the page (`metric-data.ts`, `project-data.ts`, `experiment-data.ts`, `test-execution-history.ts`, `linked-tests.ts`, `comparison-runs.ts`) — a `'use client'` file can't be imported by a server component.

## Additional Context

- Builds on #2614 / #2615 on this release branch, which already covered the tasks, jobs, models, tokens, endpoints and organization-settings pages; this PR only adds what those didn't.
- Test-run results are prefetched only when the whole run fits in one page of 100; bigger runs keep loading client-side so rendering isn't blocked on dozens of sequential requests.
- `/explorer/<id>` is left client-side: its settings load depends on client state and needs a separate restructure.
- The diff is wide (55 files) but mostly plumbing: each `initial*` value crosses 2–4 component layers.

## Testing

- `tsc`, ESLint and the affected Jest suites (90 suites / 854 tests) pass.
- Manual: navigate from `/test-sets` into a test set and open the Tests tab via client-side navigation (no reload) — rows appear immediately with no spinner. Repeat for the Tasks tab and for the other pages listed above; each tab should render with data on first paint, and create/assign/delete actions should still refresh their grid.
- Worth a `next build` before merging: several pages changed their server/client component split.
