### PR TITLE
Fix verdict rollup cells rendering a different shape to metric rows

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/RequirementGroup.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/RequirementGroup.tsx
@@ -27,7 +27,7 @@ import {
   GRID_GAP,
   GRID_PADDING_X,
   INLINE_ICON_SIZE,
-  ROLLUP_HEIGHT,
+  STRIP_HEIGHTS,
   gridMorphTransition,
   type DensityMode,
 } from './summary-tokens';
@@ -109,7 +109,9 @@ export default function RequirementGroup({
     [requirement.id, onViewRequirement]
   );
 
-  const stripHeight = density === 'numbers' ? 0 : ROLLUP_HEIGHT;
+  // Same height as the metric rows in this mode, so a rollup cell and the
+  // cells under it are the same shape. Numbers mode is 0 for both.
+  const stripHeight = STRIP_HEIGHTS[density];
 
   return (
     <Box sx={{ mb: 0.5 }}>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/RequirementTable.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/RequirementTable.test.tsx
@@ -592,6 +592,45 @@ describe('RequirementTable', () => {
     });
   });
 
+  describe('verdict cell shape', () => {
+    // Cells fill their strip's full height and share a cell width, so equal
+    // strip heights are what make a rollup cell and the cells under it the
+    // same shape. The rollup used to be pinned to its own 16px, which drew
+    // the requirement row as squares above rectangular metric rows.
+    function stripHeights(density: 'numbers' | 'shape' | 'detail'): string[] {
+      const { container } = renderWithClock(
+        <RequirementTable
+          matrix={makeMatrix()}
+          density={density}
+          onDensityChange={jest.fn()}
+          timings={EMPTY_TIMINGS}
+        />
+      );
+      return Array.from(container.querySelectorAll('canvas[role="img"]')).map(
+        c => (c.parentElement as HTMLElement).style.height
+      );
+    }
+
+    it.each(['numbers', 'shape', 'detail'] as const)(
+      'gives the requirement rollup and its metric rows one height in %s',
+      density => {
+        const heights = stripHeights(density);
+        // One rollup + two metric rows in the default matrix.
+        expect(heights).toHaveLength(3);
+        expect(new Set(heights).size).toBe(1);
+      }
+    );
+
+    it('still grows the cells from Shape to Detail', () => {
+      // Guards the fix from being "make everything 0" -- the modes must
+      // stay visually distinct.
+      const shape = parseFloat(stripHeights('shape')[0]);
+      const detail = parseFloat(stripHeights('detail')[0]);
+      expect(shape).toBeGreaterThan(0);
+      expect(detail).toBeGreaterThan(shape);
+    });
+  });
+
   it('renders a zero failed count in a muted color, not red', () => {
     renderWithClock(
       <RequirementTable

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/summary-tokens.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/summary-tokens.ts
@@ -19,13 +19,15 @@ export const COLUMN_TEMPLATES: Record<DensityMode, string> = {
   detail: '252px 0px 0px 52px 0px 0px 1fr',
 };
 
+// Cells fill their strip's full height, so this also sets their aspect
+// ratio. The requirement rollup and the metric rows below it share one
+// height per mode -- given a fixed cell width, two heights would draw the
+// same verdict as two different shapes in the same column.
 export const STRIP_HEIGHTS: Record<DensityMode, number> = {
   numbers: 0,
   shape: 13,
   detail: 21,
 };
-
-export const ROLLUP_HEIGHT = 16;
 
 export const LAST_COLUMN_LABEL: Record<DensityMode, string> = {
   numbers: '',


### PR DESCRIPTION
## Purpose

In the test run summary's verdict grid, the requirement row's cells are drawn as squares while the metric rows beneath it are taller rectangles. The same verdict reads as two different shapes in the same column, which makes the requirement row look like a different kind of thing rather than a rollup of the rows under it.

Verdict cells fill their strip's full height and share a fixed cell width, so strip height is what sets their aspect ratio. The requirement rollup was pinned to its own `ROLLUP_HEIGHT` of 16 while metric rows used `STRIP_HEIGHTS[density]`. In Detail that is 16 against 21, which is the visible mismatch. Shape was inconsistent too, just less obviously and in the other direction: the rollup was 16 against the rows' 13, so the top bar sat slightly taller.

## What Changed

- `RequirementGroup` now reads `STRIP_HEIGHTS[density]`, the same source the metric rows use, so a rollup cell and the cells under it are the same shape in every mode.
- `ROLLUP_HEIGHT` is removed. It had no other caller.
- The `density === 'numbers' ? 0 : ...` special case goes with it, since `STRIP_HEIGHTS.numbers` is already 0.
- `STRIP_HEIGHTS` gains a comment recording that it sets cell shape, not just strip size, so the next change to it does not reintroduce the split.

Three files, about 10 lines of source. No behaviour changes beyond cell height.

## Additional Context

- Branched from `release/v0.14.0` and targets it, since the verdict grid shipped in that release via #2619.
- Frontend only. No API, schema or migration changes.

## Testing

From `apps/frontend`:

```bash
npx tsc --noEmit && npx jest summary
```

248 summary tests pass.

The new tests were checked against the bug rather than just against the fix: reverting `stripHeight` to the old `16` makes three of them fail, while the `numbers` case correctly keeps passing because both strips were already 0 there. One test guards the degenerate fix of collapsing every mode to one height, asserting Detail stays taller than Shape.

Manual check: open a test run summary with at least one requirement group, switch to Detail, and confirm the requirement row's cells are the same shape as the metric rows below it. Then switch to Numbers + Shape and confirm they still match.
