### PR TITLE
Fix verdict grid flickering when reloading a live test run

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/RunClockProvider.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/RunClockProvider.tsx
@@ -14,6 +14,7 @@ import {
   initialClock,
   isSettled,
   toFrame,
+  MAX_FRAME_DT,
   type ClockState,
   type ClockTargets,
   type RunClockFrame,
@@ -72,13 +73,20 @@ export default function RunClockProvider({
   // an old run is never replayed as if it were happening now.
   const state = useRef<ClockState | null>(null);
   if (state.current === null) {
-    state.current = { clock: initialClock(runDuration, isTerminal), rate: 1 };
+    state.current = {
+      clock: initialClock(runDuration, isTerminal, serverElapsed),
+      rate: 1,
+    };
   }
+
+  // Real seconds on screen. Kept apart from `clock`, which runs fast while
+  // catching up, so the pulses keep a steady rhythm through a replay.
+  const wall = useRef(0);
 
   const emit = useCallback((textToo: boolean) => {
     const { runDuration: dur, isTerminal: terminal } = targetsRef.current;
     const clock = state.current?.clock ?? 0;
-    const frame = toFrame(clock, dur, terminal);
+    const frame = toFrame(clock, dur, terminal, wall.current);
     for (const cb of frameSubscribers.current) cb(frame);
     if (textToo) {
       for (const cb of textSubscribers.current) cb(frame);
@@ -100,6 +108,10 @@ export default function RunClockProvider({
       const previous = lastTime.current;
       lastTime.current = now;
       const dt = previous === null ? 0 : (now - previous) / 1000;
+
+      // Same clamp advanceClock applies, minus the rate: a backgrounded tab
+      // resumes its pulse where it left off instead of jumping.
+      wall.current += Math.min(Math.max(dt, 0), MAX_FRAME_DT);
 
       if (state.current) {
         state.current = advanceClock(state.current, dt, targetsRef.current);

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/run-clock.test.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/run-clock.test.ts
@@ -9,6 +9,7 @@ import {
   LAG_SECONDS,
   REPLAY_RATE,
   MAX_FRAME_DT,
+  MAX_JOIN_REPLAY_SECONDS,
   SETTLE_TAIL,
   MIN_ANIMATION_SECONDS,
   TERMINAL_CATCHUP_RATE,
@@ -206,6 +207,38 @@ describe('initialClock', () => {
 
   it('starts a live run from the beginning, so it can replay', () => {
     expect(initialClock(null, false)).toBe(0);
+  });
+
+  it('still replays a short run from zero', () => {
+    // 12s elapsed is well inside the join window, so nothing is skipped.
+    expect(initialClock(null, false, 12)).toBe(0);
+  });
+
+  // A run that has been going a long time -- or one wedged in Running --
+  // would otherwise replay its whole history at REPLAY_RATE on every single
+  // page load.
+  it('joins near the present rather than replaying hours of history', () => {
+    const elapsed = 3600;
+    const clock = initialClock(null, false, elapsed);
+    const target = clockTarget({
+      serverElapsed: elapsed,
+      runDuration: null,
+      isTerminal: false,
+    });
+    expect(target).not.toBeNull();
+    expect(target === null ? 0 : target - clock).toBe(MAX_JOIN_REPLAY_SECONDS);
+  });
+
+  it('bounds the catch-up to a few seconds of real time', () => {
+    const elapsed = 3600;
+    const clock = initialClock(null, false, elapsed);
+    const target = clockTarget({
+      serverElapsed: elapsed,
+      runDuration: null,
+      isTerminal: false,
+    });
+    const realSeconds = ((target ?? 0) - clock) / REPLAY_RATE;
+    expect(realSeconds).toBeLessThanOrEqual(5);
   });
 });
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/verdict-strip-render.test.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/verdict-strip-render.test.ts
@@ -58,13 +58,24 @@ const palette: Record<CellState, { color: string; alpha: number }> = {
   evaluating: { color: '#fb0', alpha: 0.85 },
 };
 
-/** A run still in flight, so no completion transition is in play. */
-function runningFrame(clock = 0): RunClockFrame {
-  return { clock, t: clock, sinceComplete: -Infinity, isTerminal: false };
+/**
+ * A run still in flight, so no completion transition is in play.
+ *
+ * `wall` defaults to `clock`, which is the 1x case. Pass it separately to
+ * cover a catch-up, where run time outpaces real time.
+ */
+function runningFrame(clock = 0, wall = clock): RunClockFrame {
+  return { clock, t: clock, sinceComplete: -Infinity, isTerminal: false, wall };
 }
 
 function completedFrame(sinceComplete: number): RunClockFrame {
-  return { clock: 100, t: 100, sinceComplete, isTerminal: true };
+  return {
+    clock: 100,
+    t: 100,
+    sinceComplete,
+    isTerminal: true,
+    wall: 100,
+  };
 }
 
 describe('shouldBin', () => {
@@ -394,6 +405,29 @@ describe('alphaFor in-flight pulses', () => {
     const first = alphaFor('generating', 0, palette, frame, false);
     const later = alphaFor('generating', 5, palette, frame, false);
     expect(first).not.toBeCloseTo(later, 3);
+  });
+
+  // Catching up runs the clock at REPLAY_RATE. Driving the pulse from run
+  // time made it oscillate that many times faster, which is the flicker seen
+  // when reloading a long-running run.
+  it('keeps the pulse on real time while the clock is catching up', () => {
+    const realSeconds = 0.4;
+    // Same moment on screen, but run time has advanced 10x.
+    const normal = alphaFor(
+      'evaluating',
+      0,
+      palette,
+      runningFrame(realSeconds, realSeconds),
+      false
+    );
+    const replaying = alphaFor(
+      'evaluating',
+      0,
+      palette,
+      runningFrame(realSeconds * 10, realSeconds),
+      false
+    );
+    expect(replaying).toBeCloseTo(normal, 6);
   });
 
   it('never leaves the 0..1 alpha range', () => {

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/run-clock.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/run-clock.ts
@@ -25,6 +25,20 @@ export const LAG_SECONDS = 2;
 /** Catch-up rate when joining a run already in progress. */
 export const REPLAY_RATE = 10;
 
+/**
+ * How much history a mid-run join replays.
+ *
+ * Opening a live run replays it from the start so the fill reads as motion
+ * rather than a static grid. Replaying *everything* does not scale: a run
+ * that has been going an hour would spend six minutes at REPLAY_RATE
+ * re-animating work the viewer already missed, and every reload would start
+ * that over. Past this window the clock joins near the present instead.
+ *
+ * Short runs are unaffected -- the cap only bites once elapsed time exceeds
+ * it, so the common "launch it and watch" case still plays from zero.
+ */
+export const MAX_JOIN_REPLAY_SECONDS = 30;
+
 /** Rate used to close the lag gap once a run finishes, so the strip settles promptly. */
 export const TERMINAL_CATCHUP_RATE = 3;
 
@@ -134,12 +148,22 @@ export interface RunClockFrame {
   /** Seconds since the run finished; negative while it is still going. */
   sinceComplete: number;
   isTerminal: boolean;
+  /**
+   * Real seconds elapsed on screen, unaffected by playback rate.
+   *
+   * `clock` is run time, which speeds up to REPLAY_RATE while catching up.
+   * Anything that is a property of the *display* rather than of the run --
+   * the in-flight pulses -- must read this instead, or it oscillates at
+   * playback speed and reads as flicker rather than a breath.
+   */
+  wall: number;
 }
 
 export function toFrame(
   clock: number,
   runDuration: number | null,
-  isTerminal: boolean
+  isTerminal: boolean,
+  wall: number = clock
 ): RunClockFrame {
   const duration = runDuration ?? Infinity;
   return {
@@ -147,6 +171,7 @@ export function toFrame(
     t: Math.min(clock, duration),
     sinceComplete: runDuration === null ? -Infinity : clock - runDuration,
     isTerminal,
+    wall,
   };
 }
 
@@ -172,10 +197,17 @@ export function isSettled(
  */
 export function initialClock(
   runDuration: number | null,
-  isTerminal: boolean
+  isTerminal: boolean,
+  serverElapsed: number | null = null
 ): number {
-  if (!isTerminal) return 0;
-  return (runDuration ?? 0) + SETTLE_TAIL;
+  if (isTerminal) return (runDuration ?? 0) + SETTLE_TAIL;
+  if (serverElapsed === null) return 0;
+
+  // Join near the present rather than replaying hours of history. Negative
+  // for any run shorter than the window, which clamps to 0 -- so a run you
+  // just launched still plays from the very beginning.
+  const target = Math.max(0, serverElapsed - LAG_SECONDS);
+  return Math.max(0, target - MAX_JOIN_REPLAY_SECONDS);
 }
 
 /**

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/verdict-strip-render.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/verdict-strip-render.ts
@@ -112,7 +112,10 @@ export function alphaFor(
     }
     const freq = isGenerating ? GENERATING_FREQ : EVALUATING_FREQ;
     const depth = isGenerating ? GENERATING_DEPTH : EVALUATING_DEPTH;
-    const phase = freq * frame.clock - COLUMN_PHASE_LAG * columnIndex;
+    // Wall time, not run time: the pulse says "this is in flight", which is
+    // a property of the display. Driving it from `clock` made it oscillate
+    // at REPLAY_RATE during a catch-up, reading as flicker.
+    const phase = freq * frame.wall - COLUMN_PHASE_LAG * columnIndex;
     return clamp01(base * (1 + depth * Math.sin(phase)));
   }
 


### PR DESCRIPTION
## Purpose

Reloading the test run detail page while a run is still going makes the verdict grid replay itself in fast-forward, with cells strobing through colours. It was reported on a run that had wedged in Running, where it is worst, but it affects any run that has been going more than about half a minute. Cancelling the run stops it, because a terminal run renders settled and neither code path below is reached.

Two separate defects compound here.

**The whole run is replayed on every load.** `initialClock` returned 0 for any non-terminal run, so opening the page replays all elapsed history at `REPLAY_RATE` (10x). A run 40 minutes in spends four minutes re-animating work the viewer already missed, and every reload starts that over. A run stuck in Running never stops growing, so it never stops getting worse.

**The in-flight pulse ran at playback speed.** The amber generating/evaluating pulse was `phase = freq * frame.clock`, and `clock` advances at `REPLAY_RATE` during catch-up, so it oscillated ten times faster than designed. That is the strobing, as distinct from the replay itself.

## What Changed

- `initialClock` takes `serverElapsed` and joins at most `MAX_JOIN_REPLAY_SECONDS` (30s) behind the present. The value clamps at 0, so a run shorter than the window still plays from the very beginning and the "launch it and watch it fill" case is unchanged.
- `RunClockFrame` gains `wall`: real seconds on screen, unaffected by playback rate. `RunClockProvider` accumulates it from the same clamped frame delta `advanceClock` uses, minus the rate, so a backgrounded tab resumes its pulse rather than jumping.
- The pulse in `alphaFor` reads `frame.wall`. Cell state keeps using run time, which is correct: only the pulse is a property of the display rather than of the run.

Five files, no API or backend changes.

## Additional Context

- Branched from `release/v0.14.0` and targets it, since the verdict grid shipped in that release via #2619.
- This addresses the *symptom* the stuck run exposed. The run wedging in Running is a separate backend problem, tracked separately: a task killed after its results are persisted marks the job row failed but never the test run, so the run has no terminal state to reach.

## Testing

From `apps/frontend`:

```bash
npx tsc --noEmit && npx jest summary
```

248 summary tests pass.

Each new test was checked against the bug rather than only against the fix. Reverting `initialClock` to `return 0` fails the two join-window tests; reverting the pulse to `frame.clock` fails the real-time pulse test. One test deliberately guards the over-correction: a short run must still start at 0, so the fix cannot be "always skip the replay".

Manual check: start a run, leave the page open for a minute, then reload. The grid should pick up near the present with a short catch-up rather than replaying from the first test, and the amber cells should breathe at a steady rate throughout instead of strobing.
