### PR TITLE
Fix test runs wedging in Running when their task dies

### DIFF
--- a/apps/backend/src/rhesis/backend/celery/config.py
+++ b/apps/backend/src/rhesis/backend/celery/config.py
@@ -30,6 +30,16 @@ CELERY_CONFIG = {
     # slow operations under Redis contention don't cause unbounded growth.
     "broker_transport_options": {
         "retry_on_timeout": True,
+        # Must exceed the longest task_annotations time_limit below, or Redis
+        # redelivers a still-running task to a second worker: with
+        # task_acks_late the message is only acked on completion, and kombu's
+        # default here is 3600s -- shorter than the 3900s hard limit on
+        # execute_test_configuration. Nothing guards against the duplicate
+        # (a run already in Progress is re-executed from the first test), and
+        # progress is written as an absolute value keyed by celery_task_id,
+        # which a redelivery reuses -- so the second pass drags the counter
+        # backwards over the first.
+        "visibility_timeout": 7200,
         "connection_pool_kwargs": {
             "max_connections": 10,
             "retry_on_timeout": True,

--- a/apps/backend/src/rhesis/backend/jobs/base.py
+++ b/apps/backend/src/rhesis/backend/jobs/base.py
@@ -321,6 +321,10 @@ class BaseJob(Task):
             # notifications above: those already guard themselves, and the row
             # should record the outcome even if one of them misbehaved.
             self._advance_job_row("failed", error=exc)
+            # The job row is not the only record: a run whose task died has no
+            # other path to a terminal status. No-op for job types that carry
+            # no test_run_id.
+            self._fail_linked_test_run(exc)
         else:
             self.log_with_context(
                 "warning",
@@ -406,6 +410,63 @@ class BaseJob(Task):
             self._emit_lifecycle_event(transition, error=error)
         except Exception as exc:
             logger.warning(f"Lifecycle event '{transition}' failed: {exc}", exc_info=True)
+
+    def _fail_linked_test_run(self, exc: BaseException) -> None:
+        """Mark this task's test run failed, if it has one and is still open.
+
+        The ``job`` row and the ``test_run`` are separate records, and until
+        this existed only the job row was written here. A task killed outside
+        its own ``except`` -- an OOM kill, a pod eviction, a hard time limit,
+        or a status write that could not get a connection -- never reached the
+        handler that fails the run, so the run sat in Progress with nothing
+        left alive to move it, and no sweeper to notice.
+
+        Terminal states are left alone. Cancelled matters most: the user asked
+        for that, and a task torn down mid-cancel must not relabel it Failed.
+        """
+        from uuid import UUID
+
+        from rhesis.backend.app.crud.test_run import get_test_run
+        from rhesis.backend.app.database import get_db_with_tenant_variables
+        from rhesis.backend.jobs.enums import RunStatus
+        from rhesis.backend.jobs.utils import update_test_run_with_error
+
+        terminal = {
+            RunStatus.COMPLETED.value,
+            RunStatus.FAILED.value,
+            RunStatus.CANCELLED.value,
+            RunStatus.PARTIAL.value,
+        }
+
+        try:
+            headers = getattr(self.request, "headers", {}) or {}
+            test_run_id = headers.get("test_run_id")
+            if not test_run_id:
+                return
+
+            org_id, user_id, project_id = self.get_tenant_context()
+            with get_db_with_tenant_variables(org_id or "", user_id or "", project_id or "") as db:
+                test_run = get_test_run(
+                    db, UUID(str(test_run_id)), organization_id=org_id, user_id=user_id
+                )
+                if test_run is None:
+                    return
+
+                current = test_run.status.name if test_run.status else None
+                if current in terminal:
+                    return
+
+                update_test_run_with_error(db, test_run, str(exc))
+                db.commit()
+                self.log_with_context(
+                    "info",
+                    f"Test run {test_run_id} marked failed after the task died",
+                    previous_status=current,
+                )
+        except Exception as inner:
+            # Same rule as every other hook here: bookkeeping must not turn
+            # into a second failure on top of the one being handled.
+            logger.warning(f"Could not fail test run for {self.request.id}: {inner}", exc_info=True)
 
     def _emit_lifecycle_event(self, transition: str, error: Optional[BaseException] = None) -> None:
         """The activity-log side of a job-row transition. See _advance_job_row."""

--- a/apps/backend/src/rhesis/backend/jobs/execution/results.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/results.py
@@ -131,6 +131,14 @@ def collect_results(self, *args, **kwargs) -> Dict[str, Any]:
             if exec_time:
                 summary_line += f" in {exec_time}"
             self.emit(summary_line)
+            # Progress is written per test on a best-effort basis, each on its
+            # own short-lived session -- under connection pressure some of
+            # those writes are dropped and the counter freezes below the real
+            # figure for good. This is the one place that knows the true
+            # total, so restate it rather than leave a run reading 14/20 next
+            # to 20 persisted results.
+            if total > 0:
+                self.set_progress(total, total)
             _emit_terminal_tick(self, test_run, org_id, user_id, project_id, total)
             self.log_with_context("info", f"Test run update completed for: {test_run_id}")
 

--- a/tests/backend/jobs/test_celery_timeouts.py
+++ b/tests/backend/jobs/test_celery_timeouts.py
@@ -1,0 +1,52 @@
+"""The broker's visibility timeout must outlast the longest task.
+
+With ``task_acks_late`` the message is only acknowledged once the task
+finishes. If a task can still be running when Redis decides the message was
+never picked up, Redis hands the *same* message to a second worker while the
+first is mid-run. Nothing guards against that duplicate -- a run already in
+Progress is re-executed from the first test -- and progress is stored as an
+absolute value keyed by ``celery_task_id``, which a redelivery reuses, so the
+second pass drags the counter backwards over the first.
+
+kombu's default is 3600s, which was shorter than the 3900s hard limit on
+execute_test_configuration. This pins the ordering so the two cannot drift
+apart again.
+
+Run with:
+    cd apps/backend
+    uv run pytest ../../tests/backend/jobs/test_celery_timeouts.py -v
+"""
+
+from rhesis.backend.celery.config import CELERY_CONFIG
+
+
+def _longest_hard_limit() -> int:
+    limits = [
+        opts["time_limit"]
+        for opts in CELERY_CONFIG.get("task_annotations", {}).values()
+        if "time_limit" in opts
+    ]
+    assert limits, "expected at least one annotated time_limit"
+    return max(limits)
+
+
+def test_visibility_timeout_is_set_explicitly():
+    """Relying on kombu's default is what caused the inversion."""
+    assert "visibility_timeout" in CELERY_CONFIG["broker_transport_options"]
+
+
+def test_visibility_timeout_outlasts_the_longest_task():
+    visibility = CELERY_CONFIG["broker_transport_options"]["visibility_timeout"]
+    assert visibility > _longest_hard_limit()
+
+
+def test_acks_late_is_on():
+    """The invariant above only matters because of this; if it ever goes
+    off, the reasoning in this file needs revisiting rather than deleting."""
+    assert CELERY_CONFIG["task_acks_late"] is True
+
+
+def test_soft_limits_stay_below_their_hard_limits():
+    for name, opts in CELERY_CONFIG.get("task_annotations", {}).items():
+        if "soft_time_limit" in opts and "time_limit" in opts:
+            assert opts["soft_time_limit"] < opts["time_limit"], name

--- a/tests/backend/jobs/test_fail_linked_test_run.py
+++ b/tests/backend/jobs/test_fail_linked_test_run.py
@@ -1,0 +1,188 @@
+"""A task that dies must leave its test run in a terminal state.
+
+The ``job`` row and the ``test_run`` are separate records. Before this hook,
+``on_failure`` wrote only the job row, so a task killed outside its own
+``except`` -- an OOM kill, a pod eviction, a hard time limit, or a status
+write that could not get a connection -- left the run in Progress with
+nothing alive to move it and no sweeper to notice. The Summary tab then shows
+a run as still executing forever.
+
+Run with:
+    cd apps/backend
+    uv run pytest ../../tests/backend/jobs/test_fail_linked_test_run.py -v
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+
+from rhesis.backend.jobs.base import BaseJob
+from rhesis.backend.jobs.enums import RunStatus
+
+
+class _Task(BaseJob):
+    """Celery's ``request`` is a read-only property, so override it here."""
+
+    def __init__(self, test_run_id=None):
+        self._request = Mock()
+        self._request.id = "task-1"
+        self._request.headers = {"test_run_id": str(test_run_id)} if test_run_id else {}
+        self.get_tenant_context = Mock(return_value=("org-1", "user-1", "proj-1"))
+        self.log_with_context = Mock()
+
+    @property
+    def request(self):
+        return self._request
+
+
+def _make_task(test_run_id=None):
+    """A BaseJob wired with just enough request context for the hook."""
+    return _Task(test_run_id)
+
+
+def _make_run(status_name):
+    run = Mock()
+    run.status = Mock()
+    run.status.name = status_name
+    return run
+
+
+@pytest.fixture
+def db_session():
+    """A session whose context manager yields a MagicMock."""
+    session = MagicMock()
+    ctx = MagicMock()
+    ctx.__enter__ = Mock(return_value=session)
+    ctx.__exit__ = Mock(return_value=False)
+    return session, ctx
+
+
+class TestFailsAnOpenRun:
+    def test_marks_a_running_run_failed(self, db_session):
+        session, ctx = db_session
+        run = _make_run(RunStatus.PROGRESS.value)
+        task = _make_task(uuid4())
+
+        with (
+            patch("rhesis.backend.app.database.get_db_with_tenant_variables", return_value=ctx),
+            patch("rhesis.backend.app.crud.test_run.get_test_run", return_value=run),
+            patch("rhesis.backend.jobs.utils.update_test_run_with_error") as update,
+        ):
+            task._fail_linked_test_run(RuntimeError("worker lost"))
+
+        update.assert_called_once()
+        assert "worker lost" in update.call_args[0][2]
+        session.commit.assert_called_once()
+
+    def test_also_covers_a_queued_run(self, db_session):
+        """Killed before it ever started is still a run that must not hang."""
+        session, ctx = db_session
+        run = _make_run(RunStatus.QUEUED.value)
+        task = _make_task(uuid4())
+
+        with (
+            patch("rhesis.backend.app.database.get_db_with_tenant_variables", return_value=ctx),
+            patch("rhesis.backend.app.crud.test_run.get_test_run", return_value=run),
+            patch("rhesis.backend.jobs.utils.update_test_run_with_error") as update,
+        ):
+            task._fail_linked_test_run(RuntimeError("evicted"))
+
+        update.assert_called_once()
+
+
+class TestLeavesTerminalRunsAlone:
+    @pytest.mark.parametrize(
+        "status",
+        [
+            RunStatus.CANCELLED.value,
+            RunStatus.COMPLETED.value,
+            RunStatus.FAILED.value,
+            RunStatus.PARTIAL.value,
+        ],
+    )
+    def test_does_not_overwrite(self, db_session, status):
+        """Cancelled matters most: the user asked for it, and a task torn
+        down mid-cancel must not relabel it Failed."""
+        session, ctx = db_session
+        run = _make_run(status)
+        task = _make_task(uuid4())
+
+        with (
+            patch("rhesis.backend.app.database.get_db_with_tenant_variables", return_value=ctx),
+            patch("rhesis.backend.app.crud.test_run.get_test_run", return_value=run),
+            patch("rhesis.backend.jobs.utils.update_test_run_with_error") as update,
+        ):
+            task._fail_linked_test_run(RuntimeError("boom"))
+
+        update.assert_not_called()
+        session.commit.assert_not_called()
+
+
+class TestNoLinkedRun:
+    def test_skips_entirely_without_a_test_run_id(self):
+        """Most job types have no run; the hook must not touch the database."""
+        task = _make_task(None)
+
+        with patch("rhesis.backend.app.database.get_db_with_tenant_variables") as get_db:
+            task._fail_linked_test_run(RuntimeError("boom"))
+
+        get_db.assert_not_called()
+
+    def test_tolerates_a_deleted_run(self, db_session):
+        session, ctx = db_session
+        task = _make_task(uuid4())
+
+        with (
+            patch("rhesis.backend.app.database.get_db_with_tenant_variables", return_value=ctx),
+            patch("rhesis.backend.app.crud.test_run.get_test_run", return_value=None),
+            patch("rhesis.backend.jobs.utils.update_test_run_with_error") as update,
+        ):
+            task._fail_linked_test_run(RuntimeError("boom"))
+
+        update.assert_not_called()
+
+
+class TestOnFailureWiring:
+    def test_permanent_failure_reaches_the_hook(self):
+        """The hook is only useful if on_failure actually calls it."""
+        task = _make_task(uuid4())
+        task._advance_job_row = Mock()
+        task._fail_linked_test_run = Mock()
+        task._get_execution_time = Mock(return_value="1s")
+        task.send_email_notification_flag = False
+        task._request.retries = task.max_retries  # out of retries -> permanent
+
+        # Call the real implementation, stubbing only Celery's own super().
+        with patch("celery.Task.on_failure", return_value=None):
+            BaseJob.on_failure(task, RuntimeError("boom"), "task-1", (), {}, None)
+
+        task._advance_job_row.assert_called_once()
+        task._fail_linked_test_run.assert_called_once()
+
+    def test_a_retry_leaves_the_run_alone(self):
+        """Still going to run again -- failing the run now would be wrong."""
+        task = _make_task(uuid4())
+        task._advance_job_row = Mock()
+        task._fail_linked_test_run = Mock()
+        task._get_execution_time = Mock(return_value="1s")
+        task._request.retries = 0
+
+        with patch("celery.Task.on_failure", return_value=None):
+            BaseJob.on_failure(task, RuntimeError("boom"), "task-1", (), {}, None)
+
+        task._fail_linked_test_run.assert_not_called()
+
+
+class TestNeverRaises:
+    def test_swallows_its_own_failure(self):
+        """This runs inside on_failure. Raising here would replace the real
+        error with a bookkeeping one -- the pool being exhausted is exactly
+        when this hook is most likely to fail and least allowed to."""
+        task = _make_task(uuid4())
+
+        with patch(
+            "rhesis.backend.app.database.get_db_with_tenant_variables",
+            side_effect=TimeoutError("QueuePool limit reached"),
+        ):
+            task._fail_linked_test_run(RuntimeError("original"))


### PR DESCRIPTION
## Purpose

A test run wedged in Running while the cluster was under load. Its Summary tab read 20/20 tests executed with 200/200 verdicts, the Jobs page read 14/20 for the same run, and the status never advanced. Cancelling it by hand was the only way out.

Both numbers and the stuck status come from the same place: writes that are best-effort, on their own short-lived sessions, with nothing that reconciles them afterwards.

**Why the status never advanced.** `on_failure` wrote the `job` row and stopped there. The job and the test run are separate records, and a task killed outside its own `except` never reaches the handler that fails the run: an OOM kill, a pod eviction, a hard time limit, or a status write that could not get a database connection. There is no sweeper to notice afterwards, so the run sat in Progress with nothing alive to move it.

**Why the two progress numbers disagreed.** `tests_executed` counts persisted `TestResult` rows. The Jobs figure is a separate counter written per test by `set_progress`, each call opening its own session, with failures swallowed in three places (`tracking.py`, `base.py`, and a bare `except Exception: pass` in the batch runner). The value written is absolute and never reconciled, so once acquisition starts timing out the counter freezes at the last write that got through while the tests themselves keep completing and persisting.

## What Changed

- **`_fail_linked_test_run`** in `jobs/base.py`, called from `on_failure`'s permanent-failure branch. It no-ops for job types carrying no `test_run_id`, leaves terminal states alone, and swallows its own errors — an exhausted pool is exactly when this hook is most likely to fail and least allowed to raise a second exception over the real one. Cancelled is guarded above all: a task torn down mid-cancel must not relabel a user's cancellation as Failed. A task that is about to retry is left alone.
- **`collect_results` restates progress** as `total/total` once it has the real figure, so a counter frozen by dropped writes self-corrects instead of staying wrong for the life of the job.
- **`visibility_timeout: 7200`** in `broker_transport_options`. kombu's default is 3600s, shorter than the 3900s hard limit on `execute_test_configuration`; with `task_acks_late` any run crossing an hour was handed to a second worker while the first was still going. Nothing guards the duplicate (a run already in Progress is re-executed from the first test), and since progress is keyed by `celery_task_id` — which a redelivery reuses — the second pass drags the counter backwards over the first. A test pins the ordering so the two cannot drift apart again.

79 lines of source, all additive. No existing behaviour is rewritten, no migration, no API change.

## Additional Context

- Branched from `release/v0.14.0` and targets it, alongside #2623 and #2624.
- **Behaviour change worth knowing about:** runs that previously hung in Running will now surface as Failed. That is the honest state, but the Summary tab will start showing failures it used to show as in-progress.
- The visibility-timeout inversion did **not** cause this incident — the run in question lasted minutes, not an hour. It is a separate latent bug found while investigating, fixed here because it is one line and the same class of problem.

### Deliberately not included

- **No stuck-run sweeper.** It needs `celery beat`, which the config's own comment says is not deployed anywhere, so it would be dead code. This PR covers a task that *dies*; a task that hangs without dying still has nothing to catch it.
- **No pool or `pool_timeout` change.** `pool_size=10, max_overflow=20, pool_timeout=10` is plausibly too tight for the load that triggered this, but tuning it needs real load characteristics rather than a guess, and it is the riskiest knob in the set.

## Testing

From `apps/backend`:

```bash
uv run pytest ../../tests/backend/jobs/ -q
```

582 existing job tests pass, plus 15 new ones. `uvx ruff check` clean.

The terminal-state guard was checked against the bug rather than only against the fix: removing it makes exactly the four guard tests fail, and they pass again once restored.

Manual check, if you want to reproduce the original: start a run and kill the worker pod mid-execution. The run should land on Failed rather than sitting in Running, and the Jobs progress bar should agree with the executed count on a run that completes normally.
