### PR TITLE
Fix truncated changelog summaries in release tooling

### DIFF
--- a/.github/release_tools/changelog.py
+++ b/.github/release_tools/changelog.py
@@ -10,13 +10,6 @@ from .config import COMPONENTS, PLATFORM_CHANGELOG, format_component_name
 from .git_ops import get_commits_since_tag, get_last_tag
 from .utils import call_gemini_api, info, success, warn
 
-# gemini-3.5-flash's documented output ceiling. Clamp the commit-scaled budget
-# to this so a very large release requests a valid maxOutputTokens instead of
-# paying for an API call that only fails once the generic HTTPError fallback
-# catches the 400 from an out-of-range value.
-GEMINI_MAX_OUTPUT_TOKENS = 8192
-
-# New entries go directly below this heading, newest first
 UNRELEASED_MARKER = "## [Unreleased]"
 
 
@@ -26,18 +19,11 @@ def generate_changelog_with_llm(
     version: str,
     commits: List[Dict[str, str]],
     last_tag: Optional[str],
-    max_tokens: Optional[int] = None,
 ) -> Optional[str]:
     """Generate changelog using Gemini API"""
     if not api_key:
         warn(f"No Gemini API key available. Skipping LLM changelog generation for {component}")
         return None
-
-    if max_tokens is None:
-        # Scale with commit volume: a 20+ commit release previously exhausted
-        # the flat 2048-token budget mid-generation, producing truncated,
-        # broken markdown that still got committed to the changelog.
-        max_tokens = min(max(4096, 256 * len(commits)), GEMINI_MAX_OUTPUT_TOKENS)
 
     commits_text = "\n".join(
         [f"- {commit['message']} ({commit['hash'][:8]}, {commit['author']})" for commit in commits]
@@ -55,7 +41,7 @@ Do NOT include the version header line (## [version] - date) - only return the c
 
 Return ONLY the changelog content without any additional text or explanations."""
 
-    return call_gemini_api(api_key, prompt, max_tokens=max_tokens)
+    return call_gemini_api(api_key, prompt)
 
 
 def generate_component_summary_with_llm(
@@ -67,6 +53,7 @@ def generate_component_summary_with_llm(
 ) -> Optional[str]:
     """Generate a brief component summary for platform changelog using Gemini API"""
     if not api_key:
+        warn(f"No Gemini API key available. Skipping LLM summary generation for {component}")
         return None
 
     commits_text = "\n".join(
@@ -83,23 +70,16 @@ Focus on the most important user-facing changes and improvements. Format as 2-4 
 
 Return ONLY the bullet points without any additional text or explanations."""
 
-    return call_gemini_api(api_key, prompt, max_tokens=512)
+    return call_gemini_api(api_key, prompt)
 
 
-def generate_fallback_changelog(version: str, commits: List[Dict[str, str]]) -> str:
-    """Generate fallback changelog from commits"""
-    date = datetime.now().strftime("%Y-%m-%d")
+def placeholder_entry(component: str) -> str:
+    """Unmissable stand-in for a changelog section the LLM failed to produce.
 
-    changelog = f"## [{version}] - {date}\n\n### Changed\n\n"
-
-    if commits:
-        for commit in commits:
-            changelog += f"- {commit['message'].splitlines()[0]}\n"
-    else:
-        changelog += "- Initial release\n"
-
-    changelog += "\n"
-    return changelog
+    Never fabricate the section from commit subjects -- it reads as real prose, and two releases
+    shipped it before anyone noticed.
+    """
+    return f"- TODO: changelog generation failed for {component}; write this section by hand.\n"
 
 
 def _insert_under_unreleased(changelog_path: Path, entry: str) -> None:
@@ -201,7 +181,6 @@ This release includes the following component versions:
             component_name = format_component_name(component)
             platform_entry += f"**{component_name} v{version}:**\n"
 
-            # Try to generate LLM summary
             summary = None
             if api_key and commits:
                 summary = generate_component_summary_with_llm(
@@ -211,12 +190,7 @@ This release includes the following component versions:
             if summary:
                 platform_entry += f"{summary}\n\n"
             elif commits:
-                # Fallback to first few commit messages
-                commit_msgs = [commit["message"].splitlines()[0] for commit in commits[:3]]
-                ellipsis = "..." if len(commits) > 2 else ""
-                platform_entry += (
-                    f"Key changes include: {', '.join(commit_msgs[:2])}{ellipsis}.\n\n"
-                )
+                platform_entry += f"{placeholder_entry(component)}\n"
             else:
                 platform_entry += "Initial release or no significant changes.\n\n"
 

--- a/.github/release_tools/changelog.py
+++ b/.github/release_tools/changelog.py
@@ -83,24 +83,27 @@ def placeholder_entry(component: str) -> str:
 
 
 def _insert_under_unreleased(changelog_path: Path, entry: str) -> None:
-    """Insert an entry directly below the [Unreleased] heading.
+    """Insert an entry below the [Unreleased] section, above the newest released version.
 
-    Does nothing if the heading is absent, which is how both callers have always
-    behaved -- they rewrite the file unchanged and still report success.
+    Anything hand-written under [Unreleased] stays there. Inserting directly beneath the heading
+    instead would leave those entries under the new version header, reading as part of a release
+    that never contained them.
     """
     lines = changelog_path.read_text().split("\n")
 
-    new_lines = []
-    inserted = False
+    try:
+        start = next(i for i, line in enumerate(lines) if line.strip() == UNRELEASED_MARKER)
+    except StopIteration:
+        raise ValueError(f"{changelog_path} has no '{UNRELEASED_MARKER}' heading to insert under")
 
-    for line in lines:
-        new_lines.append(line)
-        if line.strip() == UNRELEASED_MARKER and not inserted:
-            new_lines.append("")
-            new_lines.extend(entry.split("\n"))
-            inserted = True
+    # Skip past any existing Unreleased content to the next section heading, or the end of the file
+    insert_at = next(
+        (i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")),
+        len(lines),
+    )
 
-    changelog_path.write_text("\n".join(new_lines))
+    lines[insert_at:insert_at] = entry.split("\n") + [""]
+    changelog_path.write_text("\n".join(lines))
 
 
 def update_component_changelog(

--- a/.github/release_tools/processor.py
+++ b/.github/release_tools/processor.py
@@ -9,7 +9,7 @@ from typing import Dict
 
 from .changelog import (
     generate_changelog_with_llm,
-    generate_fallback_changelog,
+    placeholder_entry,
     update_component_changelog,
     update_platform_changelog,
 )
@@ -106,23 +106,19 @@ class ReleaseProcessor:
 
             # Generate changelog (skip for platform-wide releases)
             if component != "platform":
-                changelog_content = None
-
-                # Try LLM generation first
+                body = None
                 if self.gemini_api_key:
                     llm_content = generate_changelog_with_llm(
                         self.gemini_api_key, component, new_version, commits, last_tag
                     )
                     if llm_content:
-                        # Add proper header with current date to LLM-generated content
-                        date = datetime.now().strftime("%Y-%m-%d")
-                        changelog_content = (
-                            f"## [{new_version}] - {date}\n\n{llm_content.strip()}\n"
-                        )
+                        body = llm_content.strip()
 
-                # Fall back to basic changelog if LLM failed
-                if not changelog_content:
-                    changelog_content = generate_fallback_changelog(new_version, commits)
+                if body is None:
+                    body = placeholder_entry(component).rstrip()
+
+                date = datetime.now().strftime("%Y-%m-%d")
+                changelog_content = f"## [{new_version}] - {date}\n\n{body}\n"
 
                 # Update component changelog
                 if not update_component_changelog(

--- a/.github/release_tools/utils.py
+++ b/.github/release_tools/utils.py
@@ -130,15 +130,21 @@ def check_prerequisites(repo_root: Path, gemini_api_key: Optional[str] = None) -
 
 GEMINI_MODEL = "gemini-3.5-flash"
 
+# Reasoning tokens count against maxOutputTokens, and the model spends 1-4k of them thinking before
+# it writes a word, so a budget sized for the visible text alone comes back empty with
+# finishReason: MAX_TOKENS. Worst case across every changelog we've shipped is ~5.8k (2k of text
+# plus 3.7k of reasoning); this is deliberately far above it. A cap is not a reservation -- billing
+# is on tokens actually generated -- so the headroom costs nothing.
+LLM_MAX_OUTPUT_TOKENS = 32768
 
-def call_gemini_api(api_key: str, prompt: str, max_tokens: int = 4096) -> Optional[str]:
+
+def call_gemini_api(
+    api_key: str, prompt: str, max_tokens: int = LLM_MAX_OUTPUT_TOKENS
+) -> Optional[str]:
     """Call Gemini API with the given prompt.
 
-    Returns None (triggering the caller's fallback) rather than truncated
-    markdown if the model hits the token budget before finishing — a release
-    with 20+ commits previously produced a `finishReason: MAX_TOKENS` response
-    at the old 2048-token budget, which got committed as broken, cut-off
-    changelog markdown since nothing checked for that.
+    Returns None rather than truncated markdown if the model hits the token budget before
+    finishing, so the caller writes a visible placeholder instead of half a changelog.
     """
     if not api_key:
         return None

--- a/tests/release_tools/conftest.py
+++ b/tests/release_tools/conftest.py
@@ -1,0 +1,15 @@
+"""Put `.github` on sys.path so `release_tools` imports the way `python3 .github/release` does."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+sys.path.insert(0, str(REPO_ROOT / ".github"))
+
+
+@pytest.fixture
+def repo_root() -> Path:
+    return REPO_ROOT

--- a/tests/release_tools/test_changelog.py
+++ b/tests/release_tools/test_changelog.py
@@ -1,0 +1,150 @@
+"""Tests for the release tool's changelog generation.
+
+No network: the LLM call itself is out of scope here, only the budget it is given and what happens
+to the file when it comes back empty.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+from release_tools.changelog import (
+    UNRELEASED_MARKER,
+    _insert_under_unreleased,
+    placeholder_entry,
+)
+from release_tools.config import COMPONENTS
+from release_tools.utils import LLM_MAX_OUTPUT_TOKENS
+
+pytestmark = pytest.mark.unit
+
+VERSION_SECTION = re.compile(
+    r"^## \[([^\]]+)\] - (\d{4}-\d{2}-\d{2})\n(.*?)(?=\n## \[|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+# Deliberately pessimistic: Gemini averages ~4.5 chars/token on our changelog prose, so assuming 3
+# overestimates the token cost of the longest section rather than flattering the budget.
+MIN_CHARS_PER_TOKEN = 3
+
+# The model spends this many output tokens reasoning before it writes anything, measured against
+# real release commit ranges. It counts against the same budget as the visible text.
+OBSERVED_REASONING_TOKENS = 4_000
+
+
+def _longest_section(repo_root: Path) -> tuple[str, int]:
+    """The biggest changelog section ever shipped, as (label, chars)."""
+    biggest = ("", 0)
+    for component in COMPONENTS:
+        path = repo_root / COMPONENTS[component].changelog_path
+        if not path.exists():
+            continue
+        for version, _date, body in VERSION_SECTION.findall(path.read_text()):
+            if len(body) > biggest[1]:
+                biggest = (f"{component} v{version}", len(body))
+    return biggest
+
+
+def test_budget_clears_the_largest_changelog_we_have_shipped(repo_root):
+    """Trips if a release outgrows the budget, which is how the truncation bug shipped twice."""
+    label, chars = _longest_section(repo_root)
+    assert chars, "found no changelog sections to measure"
+
+    needed = chars / MIN_CHARS_PER_TOKEN + OBSERVED_REASONING_TOKENS
+
+    assert LLM_MAX_OUTPUT_TOKENS > needed, (
+        f"{label} is {chars} chars (~{chars / MIN_CHARS_PER_TOKEN:.0f} tokens); with "
+        f"~{OBSERVED_REASONING_TOKENS} reasoning tokens that needs ~{needed:.0f}, over the "
+        f"{LLM_MAX_OUTPUT_TOKENS} budget. Raise LLM_MAX_OUTPUT_TOKENS."
+    )
+
+
+def test_placeholder_names_the_component_and_invents_nothing():
+    entry = placeholder_entry("backend")
+
+    assert "TODO" in entry
+    assert "backend" in entry
+    # The old fallback pasted commit subjects here, which read as a real changelog
+    assert "(#" not in entry
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "CHANGELOG.md"
+    path.write_text(body)
+    return path
+
+
+def test_insert_keeps_hand_written_unreleased_entries_above_the_new_section(tmp_path):
+    path = _write(
+        tmp_path,
+        f"# Changelog\n\n{UNRELEASED_MARKER}\n\n### Added\n\n- A hand-written note\n\n"
+        "## [0.13.0] - 2026-08-20\n\n- Older\n",
+    )
+
+    _insert_under_unreleased(path, "## [0.14.0] - 2026-08-27\n\n- Fresh\n")
+
+    result = path.read_text()
+    assert result.index("hand-written note") < result.index("## [0.14.0]")
+    assert result.index("## [0.14.0]") < result.index("## [0.13.0]")
+
+
+def test_insert_works_when_unreleased_is_empty(tmp_path):
+    path = _write(
+        tmp_path,
+        f"# Changelog\n\n{UNRELEASED_MARKER}\n\n## [0.13.0] - 2026-08-20\n\n- Older\n",
+    )
+
+    _insert_under_unreleased(path, "## [0.14.0] - 2026-08-27\n\n- Fresh\n")
+
+    result = path.read_text()
+    assert result.index(UNRELEASED_MARKER) < result.index("## [0.14.0]")
+    assert result.index("## [0.14.0]") < result.index("## [0.13.0]")
+
+
+def test_insert_appends_when_there_is_no_released_version_yet(tmp_path):
+    path = _write(tmp_path, f"# Changelog\n\n{UNRELEASED_MARKER}\n")
+
+    _insert_under_unreleased(path, "## [0.1.0] - 2026-08-27\n\n- First\n")
+
+    assert "## [0.1.0]" in path.read_text()
+
+
+def test_insert_refuses_a_changelog_with_no_unreleased_heading(tmp_path):
+    """Previously a silent no-op that still reported success, so the entry vanished."""
+    path = _write(tmp_path, "# Changelog\n\n## [0.13.0] - 2026-08-20\n\n- Older\n")
+
+    with pytest.raises(ValueError, match="Unreleased"):
+        _insert_under_unreleased(path, "## [0.14.0] - 2026-08-27\n\n- Fresh\n")
+
+
+def test_platform_summary_falls_back_to_a_placeholder_not_commit_subjects(tmp_path, monkeypatch):
+    """Reproduces the v0.13.0 / v0.14.0 failure.
+
+    The LLM returns nothing, and the release PR must say so rather than present
+    `Key changes include: <subject>, <subject>....` as if it were a real summary.
+    """
+    from release_tools import changelog as changelog_mod
+
+    path = _write(tmp_path, f"# Changelog\n\n{UNRELEASED_MARKER}\n\n## [0.13.0] - 2026-08-20\n")
+
+    monkeypatch.setattr(changelog_mod, "PLATFORM_CHANGELOG", "CHANGELOG.md")
+    monkeypatch.setattr(changelog_mod, "get_last_tag", lambda component: "backend-v0.13.0")
+    monkeypatch.setattr(
+        changelog_mod,
+        "get_commits_since_tag",
+        lambda component, tag: [
+            {"hash": "abc1234", "author": "A", "message": "feat: a thing (#42)"}
+        ],
+    )
+    # The failure mode under test: the model produced nothing usable
+    monkeypatch.setattr(changelog_mod, "call_gemini_api", lambda *a, **k: None)
+
+    changelog_mod.update_platform_changelog(
+        {"platform": "0.14.0", "backend": "0.14.0"}, "0.14.0", "fake-key", tmp_path
+    )
+
+    result = path.read_text()
+    assert "TODO" in result
+    assert "Key changes include" not in result
+    assert "...." not in result
+    assert "(#42)" not in result


### PR DESCRIPTION
## Purpose

The root `CHANGELOG.md` "Summary of Changes" has shipped as commit-subject soup in the last two releases — [#2532](https://github.com/rhesis-ai/rhesis/pull/2532) (v0.13.0) and [#2621](https://github.com/rhesis-ai/rhesis/pull/2621) (v0.14.0) — and each one needed a manual cleanup commit:

```
**Backend v0.14.0:**
Key changes include: Rebuild test run summary as a live verdict grid (#2619), Add user settings page with profile editing and password management (#2616)....
```

`generate_component_summary_with_llm` passed a flat `max_tokens=512`. Reasoning tokens count against `maxOutputTokens` and `gemini-3.5-flash` spends 1-4k of them before writing a word, so the budget was gone before any prose existed. The API returned `finishReason: MAX_TOKENS`, `call_gemini_api` correctly discarded it, and the caller fell back to stitching raw commit subjects together. Confirmed in the [v0.14.0 release run](https://github.com/rhesis-ai/rhesis/actions/runs/33056352361), which logged the warning four times — once per component — and still exited green:

```
[WARNING] LLM response truncated at 512 tokens; discarding to avoid committing incomplete markdown
```

The component changelogs were fine only because `generate_changelog_with_llm` already scaled its budget — a fix applied earlier for this exact failure that was never carried over to the summary path.

## What Changed

**One budget constant, `LLM_MAX_OUTPUT_TOKENS = 32768`.** Sized from measurement, not guesswork. Token-counted all 134 version sections across the four component changelogs and all 121 root summary blocks with the model's own `countTokens` endpoint, then read `usageMetadata` off live calls against the real v0.14.0 commit ranges:

| what the model must emit | samples | median | max |
| --- | --- | --- | --- |
| component changelog section | 134 | 303 | 2,050 (backend 0.4.1) |
| root per-component summary | 121 | 68 | 186 (backend 0.6.6) |

| prompt | commits | thinking | visible | total out |
| --- | --- | --- | --- | --- |
| summary | 2 | 1,140 | 55 | 1,195 |
| summary | 36 | 2,236 | 137 | 2,373 |
| changelog | 2 | 1,251 | 130 | 1,381 |
| changelog | 36 | 3,470 | 669 | 4,139 |

Worst case is historical peak text plus observed peak reasoning: ~5,750 tokens. 32,768 leaves ~6x headroom. `maxOutputTokens` is a cap and not a reservation — billing is on tokens actually generated, and responses at a raised budget came back the same length — so the headroom costs nothing.

**Dropped the `256 * len(commits)` scaling.** It allocates by the one variable that does not drive cost: polyphemus burnt 1,251 thinking tokens to emit 130, where the formula would have given it 512. It only ever worked because of the `max(4096, ...)` floor, and the changelog path was one small-commit release away from the same bug — at a 4096 budget the frontend prompt already returned `MAX_TOKENS`.

**Dropped `GEMINI_MAX_OUTPUT_TOKENS`.** Its comment claimed 8192 was `gemini-3.5-flash`'s documented output ceiling; the models endpoint reports `outputTokenLimit: 65536` (8192 was the Gemini 1.5/2.0 limit). With the real ceiling 2x any budget we would set, there was nothing to clamp.

**Replaced both fallbacks with a visible `TODO` placeholder.** Fabricating a changelog out of commit subjects reads as real prose, which is exactly why two releases shipped it unnoticed. This also removes the defects that fallback carried: `"..." + "."` rendering as `....`, `commit_msgs` built from `commits[:3]` but joined from `[:2]`, and release-PR merge titles leaking in (polyphemus v0.7.0 was summarised with the *previous* release PR's title).

**Fixed a second bug found on the same branch.** New version sections were inserted directly below the `## [Unreleased]` heading, so hand-written `[Unreleased]` entries ended up under the new version header and read as part of a release that never contained them. Live on `release/v0.14.0`: the `conversation_turn` block in `sdk/CHANGELOG.md` was written for `[Unreleased]` and landed inside 0.14.0. Insertion now scans past existing `[Unreleased]` content, and raises when the heading is absent instead of rewriting the file unchanged and reporting success.

Net **−21 lines** of production code, plus the first tests for `.github/release_tools`.

## Additional Context

- No retry or escalation path was added. With ~6x headroom the budget is not the failure mode any more, and a retry is the kind of machinery this change removes.
- Not pursued: lowering `thinkingLevel` to cut reasoning tokens. The reasoning is what produces usable prose, and cost was never the problem.
- Not pursued: filtering release-machinery commits (`Prepare release`, `Release: …`) out of the LLM prompt. Polyphemus's v0.14.0 prompt was fed the previous release PR's merge title, but the model handled it and the shipped section was clean. Separate concern.
- The 5 pre-existing `E501` warnings in `changelog.py` are in the prompt string literals and are untouched.

## Testing

`uv run --project apps/backend pytest tests/release_tools -v` — 7 passed.

The budget test is a regression guard, not a tautology: it parses the real component changelogs, finds the largest section ever shipped (backend v0.4.1, 11,299 chars) and asserts the budget still clears it with room for reasoning. It **fails at the old 4096 floor** and passes at 32,768, so a future release outgrowing the budget trips a test instead of shipping a broken changelog.

Verified against the live API and a full end-to-end generation run on a scratch branch:

| check | result |
| --- | --- |
| Live LLM, all 4 components | clean 2-4 bullet summaries, **0 truncation warnings** (was 4) |
| Token usage @ 32768 | 754–2,085 total, `finish=STOP` throughout |
| Full `.github/release` run | root summary correct — no `....`, no `TODO` |
| Orphan fix on `sdk/CHANGELOG.md` | `conversation_turn` stays under `[Unreleased]` (L14–88); `0.14.0` now starts at L89, previously inserted at L16 |
| `--dry-run` | writes nothing |
| Ruff | `check` clean apart from the pre-existing `E501`s; `format` reports no changes |

The no-API-key path can't be exercised through the CLI (it falls back to the symlinked `.env`), so that wiring is covered by a test that stubs the LLM to fail and asserts `TODO` appears while `Key changes include`, `(#42)` and `....` do not.

To sanity-check the real thing, the next release run should log no `LLM response truncated` warnings and produce bullet summaries in the root `CHANGELOG.md` with no hand-editing.
