### PR TITLE
fix(frontend): move run-kind toggle into test run filter drawer

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/crud/__init__.py
@@ -87,29 +87,27 @@ def get_test_sets(
         def has_runs_filter(query):
             logger.info(f"Applying has_runs filter: {has_runs}")
 
+            # Filter by an id subquery, not a direct join + .distinct() on `query` --
+            # that query eager-loads Organization.sso_config (plain `json`), which
+            # Postgres can't compare for DISTINCT.
+            subquery_builder = QueryBuilder(db, models.TestSet).with_organization_filter(
+                organization_id
+            )
+            subquery = (
+                subquery_builder.build()
+                .join(models.TestConfiguration)
+                .join(models.TestRun)
+                .distinct()
+                .with_entities(models.TestSet.id)
+                .subquery()
+            )
             if has_runs:
-                # Only test sets that have test runs
-                filtered_query = (
-                    query.join(models.TestConfiguration).join(models.TestRun).distinct()
-                )
+                filtered_query = query.filter(models.TestSet.id.in_(subquery))
                 logger.info("Applied filter for test sets WITH runs")
-                return filtered_query
             else:
-                # Only test sets that don't have test runs
-                subquery_builder = QueryBuilder(db, models.TestSet).with_organization_filter(
-                    organization_id
-                )
-                subquery = (
-                    subquery_builder.build()
-                    .join(models.TestConfiguration)
-                    .join(models.TestRun)
-                    .distinct()
-                    .with_entities(models.TestSet.id)
-                    .subquery()
-                )
                 filtered_query = query.filter(~models.TestSet.id.in_(subquery))
                 logger.info("Applied filter for test sets WITHOUT runs")
-                return filtered_query
+            return filtered_query
 
         query_builder = query_builder.with_custom_filter(has_runs_filter)
 

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunFilterDrawer.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import * as React from 'react';
-import { Box, TextField } from '@mui/material';
+import { Autocomplete, Box, TextField } from '@mui/material';
 import {
   FilterDrawerShell,
   FilterSection,
   filterChipSx,
   filterDrawerTextFieldSx,
 } from '@/components/common/FilterDrawer';
+import { useRunTestSets, useTags, useUsers } from '@/hooks/useLookups';
 import ActivityPresenceFiltersSection from '@/components/common/ActivityPresenceFilters';
 import {
   countActivePresenceFilters,
@@ -85,9 +86,63 @@ export default function TestRunFilterDrawer({
 }: TestRunFilterDrawerProps) {
   const [draft, setDraft] = React.useState<TestRunFilters>(filters);
 
+  // Suggestions, fetched only while the drawer is open. Typing still works
+  // for values that aren't listed (freeSolo).
+  const { data: rawTestSets, isLoading: loadingTestSets } =
+    useRunTestSets(open);
+  const { data: rawUsers, isLoading: loadingUsers } = useUsers(open);
+  const { data: rawTags, isLoading: loadingTags } = useTags(open);
+  const loadingOptions = loadingTestSets || loadingUsers || loadingTags;
+
+  const testSetOptions = React.useMemo(
+    () => (rawTestSets ?? []).map(ts => ts.name).filter(Boolean),
+    [rawTestSets]
+  );
+  const executorOptions = React.useMemo(
+    () =>
+      (rawUsers ?? [])
+        .map(
+          user =>
+            user.name ||
+            `${user.given_name || ''} ${user.family_name || ''}`.trim() ||
+            user.email
+        )
+        .filter(Boolean),
+    [rawUsers]
+  );
+  const tagOptions = React.useMemo(
+    () => (rawTags ?? []).map(tag => tag.name).filter(Boolean),
+    [rawTags]
+  );
+
   React.useEffect(() => {
     if (open) setDraft(filters);
   }, [open, filters]);
+
+  const renderAutocomplete = (
+    title: string,
+    field: keyof Pick<TestRunFilters, 'testSet' | 'executor' | 'tag'>,
+    options: string[],
+    placeholder: string
+  ) => (
+    <FilterSection title={title}>
+      <Autocomplete
+        freeSolo
+        options={options}
+        value={draft[field] || null}
+        loading={loadingOptions}
+        onChange={(_, value) =>
+          setDraft(prev => ({ ...prev, [field]: value || '' }))
+        }
+        onInputChange={(_, value) =>
+          setDraft(prev => ({ ...prev, [field]: value }))
+        }
+        renderInput={params => (
+          <TextField {...params} placeholder={placeholder} sx={textFieldSx} />
+        )}
+      />
+    </FilterSection>
+  );
 
   const handleReset = () => setDraft(EMPTY_TEST_RUN_FILTERS);
 
@@ -124,39 +179,19 @@ export default function TestRunFilterDrawer({
         </Box>
       </FilterSection>
 
-      <FilterSection title="Test Set">
-        <TextField
-          fullWidth
-          placeholder="Filter by test set name…"
-          value={draft.testSet}
-          onChange={e =>
-            setDraft(prev => ({ ...prev, testSet: e.target.value }))
-          }
-          sx={textFieldSx}
-        />
-      </FilterSection>
-
-      <FilterSection title="Executor">
-        <TextField
-          fullWidth
-          placeholder="Filter by executor name…"
-          value={draft.executor}
-          onChange={e =>
-            setDraft(prev => ({ ...prev, executor: e.target.value }))
-          }
-          sx={textFieldSx}
-        />
-      </FilterSection>
-
-      <FilterSection title="Tags">
-        <TextField
-          fullWidth
-          placeholder="Filter by tag name…"
-          value={draft.tag}
-          onChange={e => setDraft(prev => ({ ...prev, tag: e.target.value }))}
-          sx={textFieldSx}
-        />
-      </FilterSection>
+      {renderAutocomplete(
+        'Test Set',
+        'testSet',
+        testSetOptions,
+        'Select test set…'
+      )}
+      {renderAutocomplete(
+        'Executor',
+        'executor',
+        executorOptions,
+        'Select executor…'
+      )}
+      {renderAutocomplete('Tags', 'tag', tagOptions, 'Select tag…')}
 
       <ActivityPresenceFiltersSection
         showReviews

--- a/apps/frontend/src/hooks/useLookups.ts
+++ b/apps/frontend/src/hooks/useLookups.ts
@@ -9,6 +9,7 @@ import {
   tagKeys,
   userKeys,
   typeLookupKeys,
+  testSetKeys,
 } from '@/constants/query-keys';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { Status } from '@/utils/api-client/interfaces/status';
@@ -17,6 +18,7 @@ import { Category } from '@/utils/api-client/interfaces/category';
 import { Topic } from '@/utils/api-client/interfaces/topic';
 import { Tag } from '@/utils/api-client/interfaces/tag';
 import { User } from '@/utils/api-client/interfaces/user';
+import { TestSet } from '@/utils/api-client/interfaces/test-set';
 import { TypeLookup } from '@/utils/api-client/interfaces/type-lookup';
 import { getPriorities } from '@/utils/task-lookup';
 import type { Priority } from '@/utils/api-client/interfaces/task';
@@ -122,6 +124,28 @@ export function useTags(enabled = true) {
         .getTagsClient()
         .getTags({ sort_by: 'name', sort_order: 'asc' });
       return tags;
+    },
+    enabled: enabled && isAuthenticated,
+    staleTime: STALE_TIME,
+  });
+}
+
+/** Test sets that have been run at least once -- the only ones a test-run filter can match. */
+export function useRunTestSets(enabled = true) {
+  const isAuthenticated = useIsAuthenticated();
+  return useQuery<TestSet[]>({
+    queryKey: testSetKeys.list('has_runs', 0, 100, 'name', 'asc'),
+    queryFn: async () => {
+      const response = await new ApiClientFactory()
+        .getTestSetsClient()
+        .getTestSets({
+          has_runs: true,
+          skip: 0,
+          limit: 100,
+          sort_by: 'name',
+          sort_order: 'asc',
+        });
+      return response.data;
     },
     enabled: enabled && isAuthenticated,
     staleTime: STALE_TIME,


### PR DESCRIPTION
## Purpose

The "Tests"/"Experiments" quick filter for test runs lived in its own toolbar toggle outside the filter drawer, splitting run filtering across two separate UI locations. Separately, the Test Set, Executor, and Tag fields in the filter drawer were plain free-text inputs with no preview of valid values, making it easy to type a name that doesn't match anything and get an empty grid with no feedback.

## What Changed

- Moved the "Tests"/"Experiments" quick filter out of the `TestRunsGrid` toolbar and into a new "Run Type" section inside `TestRunFilterDrawer`, as a `runKind` field (`all` | `tests` | `experiments`) on `TestRunFilters`.
- Replaced the Test Set, Executor, and Tag free-text fields in the drawer with `Autocomplete` inputs (`freeSolo`, so typing an unlisted value still works) that show suggestions fetched while the drawer is open.
- Added `useRunTestSets` to `useLookups.ts`, fetching test sets that have at least one run (`has_runs: true`) — the only ones a test-run filter can actually match — reusing the existing `useUsers`/`useTags` hooks for the other two fields.
- Removed the now-unused `runKindFilter` state, `externalFilters`, and `runKindToolbar` from `TestRunsGrid`.

## Additional Context

None.

## Testing

Open the Test Runs page, open the filter drawer, and confirm: the "Run Type" section toggles between Tests/Experiments/All and filters the grid accordingly; the Test Set, Executor, and Tag fields show a dropdown of existing values when clicked/typed into, and typing a value not in the list still filters as free text.