### PR TITLE
Add edit/delete actions to annotations grid

### DIFF
--- a/apps/frontend/src/app/(protected)/annotations/components/AnnotationsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/annotations/components/AnnotationsGrid.tsx
@@ -1,8 +1,18 @@
 'use client';
 
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { GridColDef, GridRowParams } from '@mui/x-data-grid';
-import { Typography } from '@mui/material';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  FormControlLabel,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import EntityGrid, {
   type EntityGridDrawerAdapter,
@@ -10,6 +20,12 @@ import EntityGrid, {
 } from '@/components/common/EntityGrid';
 import GridBadge from '@/components/common/GridBadge';
 import { MentionText } from '@/components/common/MentionTextInput';
+import { DeleteModal } from '@/components/common/DeleteModal';
+import { useNotifications } from '@/components/common/NotificationContext';
+import { useCan } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { DeleteIcon } from '@/components/icons';
 import {
   AnnotationListItem,
   AnnotationSource,
@@ -23,6 +39,46 @@ import AnnotationFilterDrawer, {
   EMPTY_ANNOTATION_FILTERS,
   countActiveAnnotationFilters,
 } from './AnnotationFilterDrawer';
+
+/**
+ * Annotations are flattened reviews from test results and traces, not their
+ * own entity -- edit/delete route to the review sub-resource on whichever
+ * parent the row came from.
+ */
+function updateAnnotationReview(
+  factory: ApiClientFactory,
+  row: AnnotationListItem,
+  updates: { comments?: string; resolved?: boolean }
+) {
+  if (row.source === 'test_result' && row.test_result_id) {
+    return factory
+      .getTestResultsClient()
+      .updateReview(row.test_result_id, row.review_id, updates);
+  }
+  if (row.source === 'trace' && row.trace_db_id) {
+    return factory
+      .getTelemetryClient()
+      .updateReview(row.trace_db_id, row.review_id, updates);
+  }
+  return Promise.reject(new Error('Annotation is missing its parent id.'));
+}
+
+function deleteAnnotationReview(
+  factory: ApiClientFactory,
+  row: AnnotationListItem
+) {
+  if (row.source === 'test_result' && row.test_result_id) {
+    return factory
+      .getTestResultsClient()
+      .deleteReview(row.test_result_id, row.review_id);
+  }
+  if (row.source === 'trace' && row.trace_db_id) {
+    return factory
+      .getTelemetryClient()
+      .deleteReview(row.trace_db_id, row.review_id);
+  }
+  return Promise.reject(new Error('Annotation is missing its parent id.'));
+}
 
 interface AnnotationsGridProps {
   onTotalCountChange?: (count: number) => void;
@@ -84,6 +140,112 @@ export default function AnnotationsGrid({
   initialTotalCount,
 }: AnnotationsGridProps) {
   const theme = useTheme();
+  const notifications = useNotifications();
+
+  const canUpdateTestResult = useCan(Capability.TestResult.UPDATE);
+  const canDeleteTestResult = useCan(Capability.TestResult.DELETE);
+  const canUpdateTrace = useCan(Capability.Telemetry.UPDATE);
+  const canDeleteTrace = useCan(Capability.Telemetry.DELETE);
+
+  const canEditRow = useCallback(
+    (row: AnnotationListItem) =>
+      row.source === 'test_result' ? canUpdateTestResult : canUpdateTrace,
+    [canUpdateTestResult, canUpdateTrace]
+  );
+  const canDeleteRow = useCallback(
+    (row: AnnotationListItem) =>
+      row.source === 'test_result' ? canDeleteTestResult : canDeleteTrace,
+    [canDeleteTestResult, canDeleteTrace]
+  );
+
+  const [editTarget, setEditTarget] = useState<AnnotationListItem | null>(null);
+  const [editComments, setEditComments] = useState('');
+  const [editResolved, setEditResolved] = useState(false);
+  const [editSaving, setEditSaving] = useState(false);
+
+  const handleEditClick = useCallback((row: AnnotationListItem) => {
+    setEditTarget(row);
+    setEditComments(row.comments);
+    setEditResolved(Boolean(row.resolved));
+  }, []);
+
+  const handleCancelEdit = useCallback(() => setEditTarget(null), []);
+
+  const makeConfirmEdit = useCallback(
+    (refresh: () => void) => async () => {
+      if (!editTarget) return;
+      try {
+        setEditSaving(true);
+        const factory = new ApiClientFactory();
+        await updateAnnotationReview(factory, editTarget, {
+          comments: editComments,
+          resolved: editResolved,
+        });
+        notifications.show('Annotation updated.', { severity: 'success' });
+        setEditTarget(null);
+        refresh();
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Failed to update annotation. Please try again.';
+        notifications.show(message, { severity: 'error' });
+      } finally {
+        setEditSaving(false);
+      }
+    },
+    [editTarget, editComments, editResolved, notifications]
+  );
+
+  const [deleteTarget, setDeleteTarget] = useState<AnnotationListItem | null>(
+    null
+  );
+  const [deleting, setDeleting] = useState(false);
+
+  const handleDeleteClick = useCallback((row: AnnotationListItem) => {
+    setDeleteTarget(row);
+  }, []);
+
+  const handleCancelDelete = useCallback(() => setDeleteTarget(null), []);
+
+  const makeConfirmDelete = useCallback(
+    (refresh: () => void) => async () => {
+      if (!deleteTarget) return;
+      try {
+        setDeleting(true);
+        const factory = new ApiClientFactory();
+        await deleteAnnotationReview(factory, deleteTarget);
+        notifications.show('Annotation deleted.', { severity: 'success' });
+        setDeleteTarget(null);
+        refresh();
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Failed to delete annotation. Please try again.';
+        notifications.show(message, { severity: 'error' });
+      } finally {
+        setDeleting(false);
+      }
+    },
+    [deleteTarget, notifications]
+  );
+
+  const extraRowActions = useMemo(
+    () => [
+      {
+        key: 'delete',
+        icon: DeleteIcon,
+        tooltip: 'Delete annotation',
+        onClick: (_id: string, row: Record<string, unknown>) =>
+          handleDeleteClick(row as unknown as AnnotationListItem),
+        can: (row: Record<string, unknown>) =>
+          canDeleteRow(row as unknown as AnnotationListItem),
+        hoverColor: 'error.main' as const,
+      },
+    ],
+    [handleDeleteClick, canDeleteRow]
+  );
 
   const onTotalCountChangeRef = useRef(onTotalCountChange);
   onTotalCountChangeRef.current = onTotalCountChange;
@@ -271,11 +433,71 @@ export default function AnnotationsGrid({
       pills={{ tabs: STATUS_PILL_TABS }}
       drawer={drawerAdapter}
       onRowClick={handleRowClick}
-      editAction={false}
+      editAction={{
+        onClick: (_id, row) => handleEditClick(row),
+        can: canEditRow,
+      }}
+      extraRowActions={extraRowActions}
       persistState={false}
       serverSort={false}
       pageSizeOptions={[10, 25, 50]}
       sx={{ '& .MuiDataGrid-row': { cursor: 'pointer' } }}
+      renderSelectionExtras={ctx => (
+        <>
+          <Dialog
+            open={editTarget !== null}
+            onClose={handleCancelEdit}
+            maxWidth="sm"
+            fullWidth
+          >
+            <DialogTitle>Edit Annotation</DialogTitle>
+            <DialogContent>
+              <TextField
+                autoFocus
+                margin="dense"
+                label="Comment"
+                fullWidth
+                multiline
+                rows={4}
+                value={editComments}
+                onChange={e => setEditComments(e.target.value)}
+              />
+              <FormControlLabel
+                sx={{ mt: 1 }}
+                control={
+                  <Switch
+                    checked={editResolved}
+                    onChange={e => setEditResolved(e.target.checked)}
+                  />
+                }
+                label="Resolved"
+              />
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleCancelEdit} disabled={editSaving}>
+                Cancel
+              </Button>
+              <Button
+                variant="contained"
+                onClick={makeConfirmEdit(ctx.refresh)}
+                disabled={editSaving}
+              >
+                {editSaving ? 'Saving…' : 'Save'}
+              </Button>
+            </DialogActions>
+          </Dialog>
+          <DeleteModal
+            open={deleteTarget !== null}
+            onClose={handleCancelDelete}
+            onConfirm={makeConfirmDelete(ctx.refresh)}
+            isLoading={deleting}
+            title="Delete Annotation"
+            itemType="annotation"
+            message="Are you sure you want to delete this annotation? This action cannot be undone."
+            confirmButtonText={deleting ? 'Deleting…' : 'Delete Annotation'}
+          />
+        </>
+      )}
     />
   );
 }

--- a/apps/frontend/src/components/common/createRowActionsColumn.tsx
+++ b/apps/frontend/src/components/common/createRowActionsColumn.tsx
@@ -183,7 +183,7 @@ export function createRowActionsColumn({
 }: RowActionsColumnOptions): GridColDef {
   return {
     field: 'actions',
-    headerName: '',
+    headerName: 'Actions',
     width,
     sortable: false,
     hideable: false,

--- a/apps/frontend/src/utils/api-client/interfaces/annotation.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/annotation.ts
@@ -24,6 +24,8 @@ export interface AnnotationListItem {
   test_result_id?: string | null;
   test_run_id?: string | null;
   trace_id?: string | null;
+  /** Internal DB id of the trace span row -- required by the review edit/delete endpoints. */
+  trace_db_id?: string | null;
   project_id?: string | null;
   requirement_id?: string | null;
   requirement_name?: string | null;


### PR DESCRIPTION
## Purpose

Every top-level list grid in the app already had an Actions column (edit/delete), wired through the shared `EntityGrid` component. Annotations was the one exception: it has no per-row edit/delete because it isn't its own entity — each row is a human review flattened out of JSON stored on a test result or a trace. Separately, the shared actions column had no visible "Actions" header anywhere in the app, just hover-revealed icons.

## What Changed

- Added an Actions column to the Annotations grid: Edit opens a small dialog to change the comment and toggle Resolved/Open; Delete opens the standard confirm modal.
- Both actions route to the correct backend endpoint (`test_results/{id}/reviews/{review_id}` or `telemetry/traces/{trace_db_id}/reviews/{review_id}`) depending on the row's `source`, reusing the existing `updateReview`/`deleteReview` client methodslready used by the test-result and trace review tabs.
- Gated on `Capability.TestResult.UPDATE`/`DELETE` or `Capability.Telemetry.UPDATE`/`DELETE` per row, matching how the equivalent actions are gated elsewhere.
- Added the missing `trace_db_id` field to the `AnnotationListItem` frontend interface — the backend already returned it, but it wasn't typed, and it's the id the trace review endpoints need (distinct from `trace_id`, the OTel trace id used for the "open in new tab" link).
- Labeled the shared row-actions column "Actions" in `createRowActionsColumn.tsx`, so every grid using it (Tasks, Endpoints, Test Sets, Experiments, Tests, Explorer, Sources, Tokens, Test Runs, Team Members, and now Annotations) shows a visible header instead of blank text.

## Additional Context

Team Members already had a working delete action (via `extraRowActions`, not the generic descriptor), so it needed no functional changes beyond the header label. Jobs has no delete/update API at all (only cancel) and was intentionallyeft out. A handful of embedded/detail-page grids (Test Run's Tests table, Project Environments, Project Trace Metrics, Project Members, Explorer suggestions/detail) build their own actions column separately and were left unlabeled — out of scope for this change.

## Testing

- `npx tsc --noEmit` and `npx eslint` pass clean on all changed files.
- Not yet exercised in a running browser session — before merging, click through: the "Actions" header now shows on Test Runs and the other list grids, and on Annotations, edit/delete on a test-result-sourced row and a trace-sourced row, confirming the underlying review updates on the Test Run's Reviews tab / Trace's Reviews tab.