### PR TITLE
Fix sidebar scrolling away on wide content

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailHeader.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailHeader.tsx
@@ -21,9 +21,95 @@ import {
   RUN_STATUS_ICON,
 } from '@/constants/test-runs';
 
-interface TestRunDetailHeaderProps {
+/**
+ * The three pieces of this page's header, shaped to fill `PageLayout`'s
+ * `title` / `metadata` / `actions` slots.
+ *
+ * They are not one component any more. Rendering a self-contained header
+ * inside the page body meant `PageLayout` drew its own header block for the
+ * breadcrumbs -- margin and all -- and this one drew a second below it, so
+ * the page paid for two headers where every other screen pays for one.
+ * Requirements is the reference: hand the parts to `PageLayout` and let it
+ * own the spacing.
+ */
+
+export function TestRunTitle({
+  testRun,
+  onRename,
+  canRename = true,
+}: {
   testRun: TestRunDetail;
   onRename: () => void;
+  /** Gate the rename button on server-driven affordances (default true). */
+  canRename?: boolean;
+}) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+      <Typography
+        variant="h4"
+        component="h1"
+        noWrap
+        sx={{
+          fontWeight: 700,
+          color: theme => theme.palette.greyscale.title,
+        }}
+      >
+        {testRun.name || 'Test Run'}
+      </Typography>
+      {canRename && (
+        <Tooltip title="Rename test run">
+          <IconButton size="small" onClick={onRename} aria-label="Rename">
+            <EditIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      )}
+    </Box>
+  );
+}
+
+export function TestRunMetadata({ testRun }: { testRun: TestRunDetail }) {
+  const creatorName =
+    testRun.user?.name || testRun.user?.email || 'Unknown user';
+  const createdOn = formatDate(getTestRunDisplayTimestamp(testRun));
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Typography
+          variant="body2"
+          sx={{ color: theme => theme.palette.greyscale.subtitle }}
+        >
+          created by: {creatorName}
+          <Box component="span" sx={{ mx: 2 }}>
+            |
+          </Box>
+          created on: {createdOn}
+        </Typography>
+        <RunStatusPill testRun={testRun} />
+      </Box>
+      <ExperimentLink testRun={testRun} />
+    </Box>
+  );
+}
+
+export function TestRunActions({
+  testRun,
+  onCompare,
+  onDownload,
+  onRerun,
+  isDownloading = false,
+  canRerun = true,
+  rerunTooltip = 'Re-run test',
+  canCompare = true,
+}: {
+  testRun: TestRunDetail;
   onCompare: () => void;
   onDownload: () => void;
   onRerun: () => void;
@@ -32,102 +118,36 @@ interface TestRunDetailHeaderProps {
   /** Tooltip for the re-run FAB (e.g. when disabled because the test set was deleted). */
   rerunTooltip?: string;
   canCompare?: boolean;
-  /** Gate the rename button on server-driven affordances (default true). */
-  canRename?: boolean;
-}
-
-export default function TestRunDetailHeader({
-  testRun,
-  onRename,
-  onCompare,
-  onDownload,
-  onRerun,
-  isDownloading = false,
-  canRerun = true,
-  rerunTooltip = 'Re-run test',
-  canCompare = true,
-  canRename = true,
-}: TestRunDetailHeaderProps) {
-  const creatorName =
-    testRun.user?.name || testRun.user?.email || 'Unknown user';
-  const createdOn = formatDate(getTestRunDisplayTimestamp(testRun));
-
+}) {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        alignItems: 'flex-start',
-        justifyContent: 'space-between',
-        gap: 2,
-        mb: 3,
-        flexWrap: 'wrap',
-      }}
-    >
-      <Box sx={{ minWidth: 0, flex: 1 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-          <Typography
-            variant="h4"
-            component="h1"
-            sx={{
-              fontWeight: 700,
-              color: theme => theme.palette.greyscale.title,
-            }}
-          >
-            {testRun.name || 'Test Run'}
-          </Typography>
-          {canRename && (
-            <Tooltip title="Rename test run">
-              <IconButton size="small" onClick={onRename} aria-label="Rename">
-                <EditIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-          )}
-        </Box>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mt: 0.5 }}>
-          <Typography
-            variant="body2"
-            sx={{ color: theme => theme.palette.greyscale.subtitle }}
-          >
-            created by: {creatorName}
-            <Box component="span" sx={{ mx: 2 }}>
-              |
-            </Box>
-            created on: {createdOn}
-          </Typography>
-          <RunStatusPill testRun={testRun} />
-        </Box>
-        <ExperimentLink testRun={testRun} />
-      </Box>
-
-      <FabGroup>
-        <TestRunSummarizeFab testRun={testRun} />
-        <Fab
-          icon={<CompareArrowsOutlinedIcon />}
-          tooltip={
-            canCompare
-              ? 'Compare runs'
-              : 'No other test runs on this test set to compare against'
-          }
-          onClick={onCompare}
-          disabled={!canCompare}
-          aria-label="Compare runs"
-        />
-        <Fab
-          icon={<DownloadIcon />}
-          tooltip="Download results"
-          onClick={onDownload}
-          loading={isDownloading}
-          aria-label="Download results"
-        />
-        <Fab
-          icon={<RestartAltOutlinedIcon />}
-          tooltip={rerunTooltip}
-          onClick={onRerun}
-          disabled={!canRerun}
-          aria-label="Re-run test"
-        />
-      </FabGroup>
-    </Box>
+    <FabGroup>
+      <TestRunSummarizeFab testRun={testRun} />
+      <Fab
+        icon={<CompareArrowsOutlinedIcon />}
+        tooltip={
+          canCompare
+            ? 'Compare runs'
+            : 'No other test runs on this test set to compare against'
+        }
+        onClick={onCompare}
+        disabled={!canCompare}
+        aria-label="Compare runs"
+      />
+      <Fab
+        icon={<DownloadIcon />}
+        tooltip="Download results"
+        onClick={onDownload}
+        loading={isDownloading}
+        aria-label="Download results"
+      />
+      <Fab
+        icon={<RestartAltOutlinedIcon />}
+        tooltip={rerunTooltip}
+        onClick={onRerun}
+        disabled={!canRerun}
+        aria-label="Re-run test"
+      />
+    </FabGroup>
   );
 }
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -12,7 +12,12 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { testRunKeys } from '@/constants/query-keys';
 import DetailTabNav from '@/components/common/DetailTabNav';
-import TestRunDetailHeader from './TestRunDetailHeader';
+import {
+  TestRunTitle,
+  TestRunMetadata,
+  TestRunActions,
+} from './TestRunDetailHeader';
+import { PageLayout } from '@/components/layout/PageLayout';
 import TestRunConfigurationTab from './TestRunConfigurationTab';
 import RunSummary from './summary/RunSummary';
 import TestRunTags from './TestRunTags';
@@ -573,26 +578,40 @@ export default function TestRunMainView({
               ? 'Checking test set…'
               : 'Re-run test';
 
+  const title = testRun.name || `Test Run ${testRunId}`;
+
   return (
-    <Box>
+    <PageLayout
+      breadcrumbs={[
+        { label: 'Test Runs', href: '/test-runs' },
+        { label: title, href: `/test-runs/${testRunId}` },
+      ]}
+      title={
+        <TestRunTitle
+          testRun={testRun}
+          onRename={handleRenameOpen}
+          canRename={can(testRun, Capability.TestRun.UPDATE)}
+        />
+      }
+      metadata={<TestRunMetadata testRun={testRun} />}
+      actions={
+        <TestRunActions
+          testRun={testRun}
+          onCompare={handleCompare}
+          onDownload={handleDownload}
+          onRerun={handleRerun}
+          isDownloading={isDownloading}
+          canRerun={canRerun}
+          rerunTooltip={rerunTooltip}
+          canCompare={hasComparisonRuns}
+        />
+      }
+    >
       {loadError && (
         <Typography color="error" sx={{ mb: 2 }}>
           {loadError}
         </Typography>
       )}
-
-      <TestRunDetailHeader
-        testRun={testRun}
-        onRename={handleRenameOpen}
-        onCompare={handleCompare}
-        onDownload={handleDownload}
-        onRerun={handleRerun}
-        isDownloading={isDownloading}
-        canRerun={canRerun}
-        rerunTooltip={rerunTooltip}
-        canCompare={hasComparisonRuns}
-        canRename={can(testRun, Capability.TestRun.UPDATE)}
-      />
 
       <BaseDrawer
         open={renameDialogOpen}
@@ -706,6 +725,6 @@ export default function TestRunMainView({
         onSuccess={handleRerunSuccess}
         onExecuted={handleRerunExecuted}
       />
-    </Box>
+    </PageLayout>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTags.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTags.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { Paper, Typography } from '@mui/material';
+import { Paper } from '@mui/material';
 import type { Theme } from '@mui/material/styles';
 import BaseTag from '@/components/common/BaseTag';
 import { drawerTagFieldSx } from '@/components/common/drawerFormFieldSx';
@@ -29,7 +29,6 @@ export default function TestRunTags({ testRun }: TestRunTagsProps) {
       elevation={0}
       sx={{
         p: '30px',
-        mt: 3,
         borderRadius: BORDER_RADIUS.md,
         boxShadow: (theme: Theme) =>
           theme.palette.mode === 'light' ? ELEVATION.xs : 'none',
@@ -43,18 +42,11 @@ export default function TestRunTags({ testRun }: TestRunTagsProps) {
         gap: '20px',
       }}
     >
-      <Typography
-        component="h2"
-        sx={{
-          fontSize: 20,
-          fontWeight: 600,
-          lineHeight: '24px',
-          color: 'primary.main',
-        }}
-      >
-        Tags
-      </Typography>
-
+      {/* No section heading: the field's own label already says "Tags", and
+          a card whose only content is one field does not need the word twice.
+          Matches TestResultTags, the sibling section on this page. Keeping the
+          label rather than the heading is deliberate -- it is what gives the
+          input its accessible name. */}
       <BaseTag
         value={tagNames}
         onChange={setTagNames}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
@@ -1,5 +1,4 @@
 import { Metadata } from 'next';
-import { PageLayout } from '@/components/layout/PageLayout';
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
@@ -76,38 +75,33 @@ export default async function TestRunPage({
       : Promise.resolve(false),
   ]);
 
-  const title = testRun.name || `Test Run ${identifier}`;
-  const breadcrumbs = [
-    { label: 'Test Runs', href: '/test-runs' },
-    { label: title, href: `/test-runs/${identifier}` },
-  ];
-
+  // PageLayout is rendered by TestRunMainView, not here: its title carries a
+  // rename control and its actions are FABs, both of which need the client
+  // component's handlers. Same shape as RequirementsClient.
   return (
-    <PageLayout title="" breadcrumbs={breadcrumbs}>
-      <TestRunMainView
-        testRunId={identifier}
-        testRunData={{
-          id: testRun.id,
-          name: testRun.name,
-          created_at:
-            (typeof testRun.attributes?.started_at === 'string'
-              ? testRun.attributes.started_at
-              : null) ||
-            testRun.created_at ||
-            '',
-          test_configuration_id: testRun.test_configuration_id,
-        }}
-        testRun={testRun}
-        currentUserId={session.user?.id || ''}
-        currentUserName={session.user?.name || ''}
-        currentUserPicture={session.user?.picture || undefined}
-        initialSelectedTestId={
-          typeof selectedResult === 'string' ? selectedResult : undefined
-        }
-        initialDetailTab={typeof detailTab === 'string' ? detailTab : undefined}
-        initialTestResults={testResults}
-        initialHasComparisonRuns={hasComparisonRuns}
-      />
-    </PageLayout>
+    <TestRunMainView
+      testRunId={identifier}
+      testRunData={{
+        id: testRun.id,
+        name: testRun.name,
+        created_at:
+          (typeof testRun.attributes?.started_at === 'string'
+            ? testRun.attributes.started_at
+            : null) ||
+          testRun.created_at ||
+          '',
+        test_configuration_id: testRun.test_configuration_id,
+      }}
+      testRun={testRun}
+      currentUserId={session.user?.id || ''}
+      currentUserName={session.user?.name || ''}
+      currentUserPicture={session.user?.picture || undefined}
+      initialSelectedTestId={
+        typeof selectedResult === 'string' ? selectedResult : undefined
+      }
+      initialDetailTab={typeof detailTab === 'string' ? detailTab : undefined}
+      initialTestResults={testResults}
+      initialHasComparisonRuns={hasComparisonRuns}
+    />
   );
 }

--- a/apps/frontend/src/components/layout/AppShell.tsx
+++ b/apps/frontend/src/components/layout/AppShell.tsx
@@ -91,6 +91,7 @@ export function AppShell({ children, sidebar, topBar }: AppShellProps) {
             flexDirection: 'column',
             minHeight: scaledVh(),
             minWidth: 0,
+            overflowX: 'auto',
             bgcolor: 'background.default',
           }}
         >


### PR DESCRIPTION
## Purpose

The test run detail page's sidebar scrolls away along with the content, unlike every other screen in the app, where the sidebar stays pinned and only the content scrolls.

## What Changed

- Root cause: `AppShell`'s sidebar is `position: sticky; top: 0`, which only pins it vertically. The shell's grid (sidebar | main) had no horizontal overflow containment, so on any page whose content is wider than the viewport, the whole grid -- sidebar included -- becomes one horizontally-scrollable unit. Scrolling right drags the sidebar off-screen with it. The test run detail page is the one that currently renders something wide enough to trigger it (the requirement/verdict table), but the gap is in the shared shell, not that page's own markup.
- Fix: added `overflowX: 'auto'` to the shell's main content column, so overly-wide content scrolls inside `main` instead of stretching the grid.
- Along the way, refactored `TestRunDetailHeader` into `PageLayout`'s title/metadata/actions slots (it was drawing its own header block below `PageLayout`'s, so the page paid for two headers where every other screen pays for one) and removed a duplicated "Tags" label on the test run detail page's Tags card.

## Additional Context

- A first attempt at the fix also added `overflowX: 'hidden'` to the outer grid box, which broke vertical stickiness -- setting `overflow-x` without `overflow-y` implicitly promotes `overflow-y` to `auto` too, making that box its own scroll container and severing the sidebar's sticky positioning from the real document scroll. That part was reverted; the fix only touches `main`.

## Testing

- `npx tsc --noEmit` and `npx eslint src/components/layout/AppShell.tsx` clean.
- Verified live against the running dev server with Playwright: injected an oversized element into a page's content area and checked the sidebar's screen position before/after a horizontal scroll. Before the fix the sidebar moved with the scroll (`navLeft` went from 0 to -1269); after the fix it stayed at 0. Re-verified vertical stickiness is unaffected (`navTop` stayed at 0 after a 1000px vertical scroll).
- To check manually: open the test run detail page for a run with a wide requirements table, and confirm the sidebar stays in place while scrolling both vertically and horizontally.