### PR TITLE
Address AppShell review follow-ups from PR #2629

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailHeader.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailHeader.tsx
@@ -54,7 +54,7 @@ export function TestRunTitle({
           color: theme => theme.palette.greyscale.title,
         }}
       >
-        {testRun.name || 'Test Run'}
+        {testRun.name?.trim() || 'Test Run'}
       </Typography>
       {canRename && (
         <Tooltip title="Rename test run">

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -578,7 +578,7 @@ export default function TestRunMainView({
               ? 'Checking test set…'
               : 'Re-run test';
 
-  const title = testRun.name || `Test Run ${testRunId}`;
+  const title = testRun.name?.trim() || `Test Run ${testRunId}`;
 
   return (
     <PageLayout

--- a/apps/frontend/src/components/layout/AppShell.tsx
+++ b/apps/frontend/src/components/layout/AppShell.tsx
@@ -91,7 +91,6 @@ export function AppShell({ children, sidebar, topBar }: AppShellProps) {
             flexDirection: 'column',
             minHeight: scaledVh(),
             minWidth: 0,
-            overflowX: 'auto',
             bgcolor: 'background.default',
           }}
         >
@@ -114,6 +113,11 @@ export function AppShell({ children, sidebar, topBar }: AppShellProps) {
             sx={{
               flex: 1,
               minHeight: 0,
+              minWidth: 0,
+              // Contained here, not on `main`, so a page whose content is
+              // wider than the viewport scrolls only its body -- the
+              // header above (breadcrumbs, title, FABs) stays put.
+              overflowX: 'auto',
               ...(fullBleed
                 ? {
                     p: 0,


### PR DESCRIPTION
## Purpose

Two follow-up fixes from review comments on #2629 (already merged), which added `overflowX: 'auto'` containment to fix the sidebar scrolling away on wide content.

## What Changed

- `AppShell.tsx`: moved the horizontal overflow containment from the whole `main` column down to the content box below `topBar`. Previously, a page passing `topBar` (breadcrumbs, title, FABs) would have that header scroll away too whenever body content is wider than the viewport. No page currently uses the `topBar` prop, so this wasn't yet visible, but it's a real gap in the shell's contract that the review comment caught.
- `TestRunMainView.tsx` / `TestRunDetailHeader.tsx`: trim `testRun.name` before using it as a title/breadcrumb label. `testRun.name || fallback` treats a whitespace-only name as truthy, so the title would render blank and `PageLayout` would silently drop the breadcrumb entry (it filters on `label?.trim()`).

## Additional Context

- Both points were raised in review on #2629: https://github.com/rhesis-ai/rhesis/pull/2629

## Testing

- `npx tsc --noEmit` and `npx eslint` clean on all three changed files.