### PR TITLE
Fix verdict grid clustering and a build-breaking import

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/verdict-strip-render.test.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/verdict-strip-render.test.ts
@@ -136,7 +136,7 @@ describe('paintStrip', () => {
     }
   });
 
-  it('caps cell width at 24px', () => {
+  it('fills the full width when there are few cells', () => {
     const { ctx, calls } = fakeContext();
     paintStrip(ctx, {
       width: 200,
@@ -151,8 +151,34 @@ describe('paintStrip', () => {
 
     const roundRectCalls = calls.filter(c => c.method === 'roundRect');
     expect(roundRectCalls).toHaveLength(1);
-    // drawWidth = min(24, 200/1) = 24; cellWidth = max(1, 24-0) = 24
-    expect(roundRectCalls[0].args[2]).toBe(24);
+    // A single cell has no gap, so it draws at the strip's full width --
+    // no fixed cap left to clamp it and cluster it at the left edge.
+    expect(roundRectCalls[0].args[2]).toBe(200);
+  });
+
+  it('divides the width evenly, with a 1px gap, across a handful of cells', () => {
+    const { ctx, calls } = fakeContext();
+    const cells: CellState[] = ['passed', 'passed', 'failed', 'passed', 'failed'];
+    paintStrip(ctx, {
+      width: 200,
+      height: 20,
+      dpr: 1,
+      cells,
+      palette,
+      binned: false,
+      frame: runningFrame(),
+      reducedMotion: false,
+    });
+
+    const roundRectCalls = calls.filter(c => c.method === 'roundRect');
+    expect(roundRectCalls).toHaveLength(5);
+    // drawWidth = 200 / 5 = 40; cellWidth = 40 - 1 (gap) = 39.
+    for (const call of roundRectCalls) {
+      expect(call.args[2]).toBe(39);
+    }
+    // Cells are evenly spaced across the full width, not clustered at the start.
+    const xs = roundRectCalls.map(c => c.args[0]);
+    expect(xs).toEqual([0, 40, 80, 120, 160]);
   });
 
   it('clamps the corner radius to half the smaller dimension for a thin cell', () => {

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/verdict-strip-render.test.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/verdict-strip-render.test.ts
@@ -158,7 +158,13 @@ describe('paintStrip', () => {
 
   it('divides the width evenly, with a 1px gap, across a handful of cells', () => {
     const { ctx, calls } = fakeContext();
-    const cells: CellState[] = ['passed', 'passed', 'failed', 'passed', 'failed'];
+    const cells: CellState[] = [
+      'passed',
+      'passed',
+      'failed',
+      'passed',
+      'failed',
+    ];
     paintStrip(ctx, {
       width: 200,
       height: 20,

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/verdict-strip-render.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/verdict-strip-render.ts
@@ -17,7 +17,6 @@ export interface StripPaintOptions {
   reducedMotion: boolean;
 }
 
-const CELL_MAX_WIDTH = 24;
 const CELL_BORDER_RADIUS = 2;
 const MIN_CELL_WIDTH = 3;
 
@@ -203,7 +202,9 @@ function paintPerCell(
   opts: StripPaintOptions
 ): void {
   const { width, height, cells, palette, frame, reducedMotion } = opts;
-  const drawWidth = Math.min(CELL_MAX_WIDTH, width / cells.length);
+  // No max: a strip with few tests fills the full width rather than
+  // clustering a handful of fixed-size cells at the left edge.
+  const drawWidth = width / cells.length;
   const gap = cells.length > 1 ? 1 : 0;
   const cellWidth = Math.max(1, drawWidth - gap);
   const ringAlpha = failRingAlpha(frame, reducedMotion);

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/test-run-results.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/test-run-results.ts
@@ -1,0 +1,59 @@
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+
+/**
+ * Server-safe fetchers for a run's test results -- no React import, so
+ * `page.tsx` (a Server Component) can call `fetchSmallTestRunResults`
+ * directly without pulling the client-only `useTestRunDetailData` hook
+ * into its module graph.
+ */
+
+export async function fetchAllTestResults(
+  testRunId: string
+): Promise<TestResultDetail[]> {
+  const testResultsClient = new ApiClientFactory().getTestResultsClient();
+
+  let testResults: TestResultDetail[] = [];
+  let skip = 0;
+  const batchSize = 100;
+  let hasMore = true;
+
+  while (hasMore) {
+    const response = await testResultsClient.getTestResults({
+      filter: `test_run_id eq '${testRunId}'`,
+      limit: batchSize,
+      skip,
+      sort_by: 'created_at',
+      sort_order: 'desc',
+    });
+
+    testResults = [...testResults, ...response.data];
+    const totalCount = response.pagination?.totalCount || 0;
+    hasMore = testResults.length < totalCount;
+    skip += batchSize;
+
+    if (skip > 10000) break;
+  }
+
+  return testResults;
+}
+
+/**
+ * Server-side prefetch: the run's results when one page holds them all,
+ * otherwise `undefined`. Rendering the page shouldn't wait on tens of
+ * sequential requests for a big run; the client loads those as before.
+ */
+export async function fetchSmallTestRunResults(
+  factory: ApiClientFactory,
+  testRunId: string
+): Promise<TestResultDetail[] | undefined> {
+  const response = await factory.getTestResultsClient().getTestResults({
+    filter: `test_run_id eq '${testRunId}'`,
+    limit: 100,
+    skip: 0,
+    sort_by: 'created_at',
+    sort_order: 'desc',
+  });
+  const totalCount = response.pagination?.totalCount || 0;
+  return response.data.length < totalCount ? undefined : response.data;
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunDetailData.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunDetailData.ts
@@ -1,8 +1,10 @@
+'use client';
+
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { Prompt } from '@/utils/api-client/interfaces/prompt';
 import { useIsAuthenticated } from '@/hooks/useIsAuthenticated';
+import { fetchAllTestResults } from './test-run-results';
 
 export interface RequirementWithMetrics {
   id: string;
@@ -26,56 +28,6 @@ interface UseTestRunDetailDataReturn {
   loading: boolean;
   error: string | null;
   refetch: () => Promise<void>;
-}
-
-export async function fetchAllTestResults(
-  testRunId: string
-): Promise<TestResultDetail[]> {
-  const testResultsClient = new ApiClientFactory().getTestResultsClient();
-
-  let testResults: TestResultDetail[] = [];
-  let skip = 0;
-  const batchSize = 100;
-  let hasMore = true;
-
-  while (hasMore) {
-    const response = await testResultsClient.getTestResults({
-      filter: `test_run_id eq '${testRunId}'`,
-      limit: batchSize,
-      skip,
-      sort_by: 'created_at',
-      sort_order: 'desc',
-    });
-
-    testResults = [...testResults, ...response.data];
-    const totalCount = response.pagination?.totalCount || 0;
-    hasMore = testResults.length < totalCount;
-    skip += batchSize;
-
-    if (skip > 10000) break;
-  }
-
-  return testResults;
-}
-
-/**
- * Server-side prefetch: the run's results when one page holds them all,
- * otherwise `undefined`. Rendering the page shouldn't wait on tens of
- * sequential requests for a big run; the client loads those as before.
- */
-export async function fetchSmallTestRunResults(
-  factory: ApiClientFactory,
-  testRunId: string
-): Promise<TestResultDetail[] | undefined> {
-  const response = await factory.getTestResultsClient().getTestResults({
-    filter: `test_run_id eq '${testRunId}'`,
-    limit: 100,
-    skip: 0,
-    sort_by: 'created_at',
-    sort_order: 'desc',
-  });
-  const totalCount = response.pagination?.totalCount || 0;
-  return response.data.length < totalCount ? undefined : response.data;
 }
 
 function buildPromptsMap(

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
@@ -5,7 +5,7 @@ import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import TestRunMainView from './components/TestRunMainViewClient';
 import { prefetch } from '@/utils/server-prefetch';
 import { Capability } from '@/constants/capabilities';
-import { fetchSmallTestRunResults } from './hooks/useTestRunDetailData';
+import { fetchSmallTestRunResults } from './hooks/test-run-results';
 import { hasOtherRunsForTestSet } from './components/comparison-runs';
 
 interface _PageProps {


### PR DESCRIPTION
## Purpose

Two fixes on the test run detail page:

1. In Detail density, a run with few tests (5, 10) shows its per-test verdict squares clustered at the left edge of the row instead of filling the available width.
2. The page currently fails to build: `page.tsx` (a Server Component) imports a function from the same file as a client-only hook, and Next.js rejects pulling that hook's React imports into the server bundle.

## What Changed

- `verdict-strip-render.ts`: `paintPerCell` capped each cell at a fixed 24px regardless of the strip's actual width. With few tests in the Detail density's wide `1fr` column, that left a handful of fixed-size squares bunched at the left edge. Now the available width divides evenly across the cells, so the strip always fills its container -- one test draws a single cell at the full width, a handful spread evenly with the usual 1px gaps.
- Split the server-safe fetchers (`fetchAllTestResults`, `fetchSmallTestRunResults` -- no React import) out of `useTestRunDetailData.ts` into their own module, `test-run-results.ts`, matching the existing `comparison-runs.ts` pattern already used by the same page for its other prefetch call. `page.tsx` now imports from there; `useTestRunDetailData.ts` keeps only the hook and gains an explicit `'use client'`, matching every other hook file in that directory.

## Additional Context

- The build error: `You're importing a module that depends on useEffect into a React Server Component module.` -- pre-existing on `release/v0.14.0`, not introduced by either of these two changes; it surfaced while testing the verdict-strip fix.

## Testing

- `npx tsc --noEmit` and `npx eslint` clean.
- `npx jest --testPathPatterns="test-runs"`: 22 suites, 311 tests, all passing (added two tests covering the new fill behaviour, updated the one that asserted the old 24px cap).
- Confirmed the dev server serves the test-runs route with `200` again after the import fix (previously `500`).