### PR TITLE
Stop duplicating custom metrics per requirement

### DIFF
--- a/apps/backend/src/rhesis/backend/jobs/execution/metric_plan.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/metric_plan.py
@@ -166,6 +166,17 @@ def _build_metric_plan(
     cell_keys: Dict[str, Dict[str, str]] = {}
     sources: set = set()
 
+    # Execution-time and test-set metrics apply uniformly across the whole
+    # run -- resolving them per requirement group (below) still works, since
+    # every group's representative resolves the same config, but showing
+    # that identical result under every requirement's own header would
+    # duplicate each metric once per requirement instead of once for the
+    # run. Only a requirement-sourced result is actually specific to its
+    # requirement, so only those keep their own payload entry; everything
+    # else pools into one requirement-less section.
+    pooled_test_ids: List[str] = []
+    pooled_metrics: Dict[uuid.UUID, models.Metric] = {}
+
     for group in groups:
         group_test_ids = tests_by_group.get(group, [])
         representative = (
@@ -186,22 +197,29 @@ def _build_metric_plan(
         sources.add(source)
 
         keyed = _assign_metric_keys(metrics)
-        requirements_payload.append(
-            {
-                "id": group,
-                "name": requirement_names.get(group, "Unassigned") if group else "Unassigned",
-                "metrics": [
-                    {
-                        "key": key,
-                        "name": metric.name or metric.class_name,
-                        "id": str(metric.id) if metric.id else None,
-                        "ambiguous": ambiguous,
-                    }
-                    for key, metric, ambiguous in keyed
-                ],
-                "test_ids": group_test_ids,
-            }
-        )
+
+        if source == "requirement":
+            requirements_payload.append(
+                {
+                    "id": group,
+                    "name": requirement_names.get(group, "Unassigned") if group else "Unassigned",
+                    "metrics": [
+                        {
+                            "key": key,
+                            "name": metric.name or metric.class_name,
+                            "id": str(metric.id) if metric.id else None,
+                            "ambiguous": ambiguous,
+                        }
+                        for key, metric, ambiguous in keyed
+                    ],
+                    "test_ids": group_test_ids,
+                }
+            )
+        else:
+            pooled_test_ids.extend(group_test_ids)
+            for _, metric, _ in keyed:
+                if metric.id:
+                    pooled_metrics[metric.id] = metric
 
         for test_id in group_test_ids:
             scope = (
@@ -220,6 +238,25 @@ def _build_metric_plan(
             }
             if per_test:
                 cell_keys[test_id] = per_test
+
+    if pooled_test_ids:
+        pooled_keyed = _assign_metric_keys(list(pooled_metrics.values()))
+        requirements_payload.append(
+            {
+                "id": None,
+                "name": "Unassigned",
+                "metrics": [
+                    {
+                        "key": key,
+                        "name": metric.name or metric.class_name,
+                        "id": str(metric.id) if metric.id else None,
+                        "ambiguous": ambiguous,
+                    }
+                    for key, metric, ambiguous in pooled_keyed
+                ],
+                "test_ids": pooled_test_ids,
+            }
+        )
 
     return {
         "source": sources.pop() if len(sources) == 1 else "mixed",

--- a/apps/backend/src/rhesis/backend/jobs/execution/metric_plan.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/metric_plan.py
@@ -171,9 +171,10 @@ def _build_metric_plan(
     # every group's representative resolves the same config, but showing
     # that identical result under every requirement's own header would
     # duplicate each metric once per requirement instead of once for the
-    # run. Only a requirement-sourced result is actually specific to its
-    # requirement, so only those keep their own payload entry; everything
-    # else pools into one requirement-less section.
+    # run. Those two sources pool into one requirement-less section instead;
+    # "requirement" and "none" both keep their own entry, since neither is a
+    # metric shared across groups -- "requirement" is genuinely specific to
+    # its own requirement, and "none" is nothing resolved at all.
     pooled_test_ids: List[str] = []
     pooled_metrics: Dict[uuid.UUID, models.Metric] = {}
 
@@ -198,7 +199,14 @@ def _build_metric_plan(
 
         keyed = _assign_metric_keys(metrics)
 
-        if source == "requirement":
+        # "none" keeps its own entry too, not just "requirement" -- it isn't
+        # a metric that applies uniformly across the run, it is a group with
+        # nothing resolved at all (e.g. a requirement carrying no metric of
+        # its own). Pooling it would fold that requirement's name into the
+        # pooled bucket's "Unassigned" label, and if some other group's
+        # test_set/execution_time metric ends up in that same bucket, would
+        # wrongly attach it to this group's tests too.
+        if source in ("requirement", "none"):
             requirements_payload.append(
                 {
                     "id": group,

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/RequirementGroup.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/RequirementGroup.tsx
@@ -65,14 +65,91 @@ export default function RequirementGroup({
   onViewMetric,
   headerless = false,
 }: RequirementGroupProps) {
-  const theme = useTheme();
-  const reducedMotion = useReducedMotion();
   const [expanded, setExpanded] = useState(true);
 
   const groupRows = useMemo(
     () => rows.filter(r => requirement.metric_keys.includes(r.metric_key)),
     [rows, requirement.metric_keys]
   );
+
+  const metricNames = useMemo(
+    () => groupRows.map(r => r.metric_name),
+    [groupRows]
+  );
+  const trimmedNames = useMemo(
+    () => trimSharedPrefix(metricNames),
+    [metricNames]
+  );
+
+  const metricRows = groupRows.map((row, idx) => (
+    <MetricRow
+      key={row.metric_key}
+      row={row}
+      density={density}
+      testIds={testIds}
+      timings={timings}
+      metricIndex={idx}
+      metricCount={groupRows.length}
+      trimmedName={trimmedNames[idx]}
+      fullName={metricNames[idx]}
+      dataVersion={dataVersion}
+      onViewMetric={onViewMetric}
+    />
+  ));
+
+  if (headerless) {
+    return <Box sx={{ mb: 0.5 }}>{metricRows}</Box>;
+  }
+
+  return (
+    <Box sx={{ mb: 0.5 }}>
+      <RequirementGroupHeader
+        requirement={requirement}
+        groupRows={groupRows}
+        density={density}
+        testIds={testIds}
+        timings={timings}
+        dataVersion={dataVersion}
+        expanded={expanded}
+        onToggle={() => setExpanded(prev => !prev)}
+        onViewRequirement={onViewRequirement}
+      />
+
+      <Collapse in={expanded} timeout="auto">
+        {metricRows}
+      </Collapse>
+    </Box>
+  );
+}
+
+interface RequirementGroupHeaderProps {
+  requirement: VerdictRequirement;
+  groupRows: VerdictRow[];
+  density: DensityMode;
+  testIds: string[];
+  timings: TestTimingMap;
+  dataVersion: number;
+  expanded: boolean;
+  onToggle: () => void;
+  onViewRequirement?: (id: string) => void;
+}
+
+// Split out from RequirementGroup so the rollup/aggregate work below --
+// entirely for display in this header -- only runs when a header actually
+// renders. The pooled, headerless bucket never mounts this component.
+function RequirementGroupHeader({
+  requirement,
+  groupRows,
+  density,
+  testIds,
+  timings,
+  dataVersion,
+  expanded,
+  onToggle,
+  onViewRequirement,
+}: RequirementGroupHeaderProps) {
+  const theme = useTheme();
+  const reducedMotion = useReducedMotion();
 
   const rollupAt = useCallback(
     (t: number) => computeGroupRollup(groupRows, testIds, timings, t),
@@ -85,15 +162,6 @@ export default function RequirementGroup({
   const agg = useMemo(
     () => aggregateGroupByTest(groupRows, testIds, timings, Infinity),
     [groupRows, testIds, timings]
-  );
-
-  const metricNames = useMemo(
-    () => groupRows.map(r => r.metric_name),
-    [groupRows]
-  );
-  const trimmedNames = useMemo(
-    () => trimSharedPrefix(metricNames),
-    [metricNames]
   );
 
   const rate = useMemo(() => passRate(agg.passed, agg.failed), [agg]);
@@ -119,187 +187,145 @@ export default function RequirementGroup({
   // cells under it are the same shape. Numbers mode is 0 for both.
   const stripHeight = STRIP_HEIGHTS[density];
 
-  if (headerless) {
-    return (
-      <Box sx={{ mb: 0.5 }}>
-        {groupRows.map((row, idx) => (
-          <MetricRow
-            key={row.metric_key}
-            row={row}
-            density={density}
-            testIds={testIds}
-            timings={timings}
-            metricIndex={idx}
-            metricCount={groupRows.length}
-            trimmedName={trimmedNames[idx]}
-            fullName={metricNames[idx]}
-            dataVersion={dataVersion}
-            onViewMetric={onViewMetric}
-          />
-        ))}
-      </Box>
-    );
-  }
-
   return (
-    <Box sx={{ mb: 0.5 }}>
+    <Box
+      role="button"
+      tabIndex={0}
+      onClick={onToggle}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onToggle();
+        }
+      }}
+      aria-expanded={expanded}
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: COLUMN_TEMPLATES[density],
+        transition: gridMorphTransition(theme, reducedMotion),
+        columnGap: `${GRID_GAP}px`,
+        alignItems: 'center',
+        width: '100%',
+        py: 0.75,
+        minHeight: GEOMETRY.rowHeight,
+        px: `${GRID_PADDING_X}px`,
+        textAlign: 'left',
+        borderRadius: 1,
+        bgcolor: 'action.hover',
+        cursor: 'pointer',
+        '&:hover': {
+          bgcolor: 'action.selected',
+        },
+        '@media print': {
+          gridTemplateColumns: COLUMN_TEMPLATES.numbers,
+        },
+      }}
+    >
       <Box
-        role="button"
-        tabIndex={0}
-        onClick={() => setExpanded(prev => !prev)}
-        onKeyDown={e => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            setExpanded(prev => !prev);
-          }
-        }}
-        aria-expanded={expanded}
         sx={{
-          display: 'grid',
-          gridTemplateColumns: COLUMN_TEMPLATES[density],
-          transition: gridMorphTransition(theme, reducedMotion),
-          columnGap: `${GRID_GAP}px`,
+          display: 'flex',
           alignItems: 'center',
-          width: '100%',
-          py: 0.75,
-          minHeight: GEOMETRY.rowHeight,
-          px: `${GRID_PADDING_X}px`,
-          textAlign: 'left',
-          borderRadius: 1,
-          bgcolor: 'action.hover',
-          cursor: 'pointer',
-          '&:hover': {
-            bgcolor: 'action.selected',
-          },
-          '@media print': {
-            gridTemplateColumns: COLUMN_TEMPLATES.numbers,
-          },
+          gap: 0.5,
+          minWidth: 0,
+          overflow: 'hidden',
         }}
       >
-        <Box
+        <ExpandMoreIcon
           sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 0.5,
-            minWidth: 0,
-            overflow: 'hidden',
+            fontSize: 18,
+            transform: expanded ? 'rotate(0deg)' : 'rotate(-90deg)',
+            transition: 'transform 200ms',
+            flexShrink: 0,
           }}
-        >
-          <ExpandMoreIcon
-            sx={{
-              fontSize: 18,
-              transform: expanded ? 'rotate(0deg)' : 'rotate(-90deg)',
-              transition: 'transform 200ms',
-              flexShrink: 0,
-            }}
-          />
-          <Typography
-            variant="body2"
-            fontWeight={600}
-            noWrap
-            sx={{ display: 'block', maxWidth: '100%' }}
-            title={requirement.name}
-          >
-            {requirement.name}
-          </Typography>
-          {hasDrilldown && (
-            <Tooltip title="View failures in Tests" placement="top">
-              <IconButton
-                size="small"
-                onClick={handleDrilldown}
-                sx={{ ml: 0.5, p: 0.25 }}
-              >
-                <OpenInNewIcon sx={{ fontSize: INLINE_ICON_SIZE }} />
-              </IconButton>
-            </Tooltip>
-          )}
-        </Box>
-
-        {/* Total: 0-width outside Numbers mode -- kept mounted and in the
-            a11y tree deliberately (density is a visual affordance, not a
-            reason to hide numbers from screen reader users). */}
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          noWrap
-          sx={{
-            textAlign: 'right',
-            fontVariantNumeric: 'tabular-nums',
-            overflow: 'hidden',
-          }}
-        >
-          {agg.total}
-        </Typography>
-
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          noWrap
-          sx={{
-            textAlign: 'right',
-            fontVariantNumeric: 'tabular-nums',
-            overflow: 'hidden',
-          }}
-        >
-          {agg.passed}
-        </Typography>
-
+        />
         <Typography
           variant="body2"
           fontWeight={600}
           noWrap
-          sx={{
-            textAlign: 'right',
-            fontVariantNumeric: 'tabular-nums',
-            overflow: 'hidden',
-            color: agg.failed > 0 ? 'error.main' : 'text.secondary',
-          }}
+          sx={{ display: 'block', maxWidth: '100%' }}
+          title={requirement.name}
         >
-          {agg.failed}
+          {requirement.name}
         </Typography>
-
-        <Typography
-          variant="body2"
-          fontWeight={600}
-          noWrap
-          sx={{
-            textAlign: 'right',
-            fontVariantNumeric: 'tabular-nums',
-            overflow: 'hidden',
-          }}
-        >
-          {passRateStr}
-        </Typography>
-
-        <BandChip passRate={rate} />
-
-        <Box sx={{ overflow: 'hidden' }}>
-          <VerdictStrip
-            cellsAt={rollupAt}
-            dataVersion={dataVersion}
-            height={stripHeight}
-            ariaLabel={stripAriaLabel}
-          />
-        </Box>
+        {hasDrilldown && (
+          <Tooltip title="View failures in Tests" placement="top">
+            <IconButton
+              size="small"
+              onClick={handleDrilldown}
+              sx={{ ml: 0.5, p: 0.25 }}
+            >
+              <OpenInNewIcon sx={{ fontSize: INLINE_ICON_SIZE }} />
+            </IconButton>
+          </Tooltip>
+        )}
       </Box>
 
-      <Collapse in={expanded} timeout="auto">
-        {groupRows.map((row, idx) => (
-          <MetricRow
-            key={row.metric_key}
-            row={row}
-            density={density}
-            testIds={testIds}
-            timings={timings}
-            metricIndex={idx}
-            metricCount={groupRows.length}
-            trimmedName={trimmedNames[idx]}
-            fullName={metricNames[idx]}
-            dataVersion={dataVersion}
-            onViewMetric={onViewMetric}
-          />
-        ))}
-      </Collapse>
+      {/* Total: 0-width outside Numbers mode -- kept mounted and in the
+          a11y tree deliberately (density is a visual affordance, not a
+          reason to hide numbers from screen reader users). */}
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        noWrap
+        sx={{
+          textAlign: 'right',
+          fontVariantNumeric: 'tabular-nums',
+          overflow: 'hidden',
+        }}
+      >
+        {agg.total}
+      </Typography>
+
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        noWrap
+        sx={{
+          textAlign: 'right',
+          fontVariantNumeric: 'tabular-nums',
+          overflow: 'hidden',
+        }}
+      >
+        {agg.passed}
+      </Typography>
+
+      <Typography
+        variant="body2"
+        fontWeight={600}
+        noWrap
+        sx={{
+          textAlign: 'right',
+          fontVariantNumeric: 'tabular-nums',
+          overflow: 'hidden',
+          color: agg.failed > 0 ? 'error.main' : 'text.secondary',
+        }}
+      >
+        {agg.failed}
+      </Typography>
+
+      <Typography
+        variant="body2"
+        fontWeight={600}
+        noWrap
+        sx={{
+          textAlign: 'right',
+          fontVariantNumeric: 'tabular-nums',
+          overflow: 'hidden',
+        }}
+      >
+        {passRateStr}
+      </Typography>
+
+      <BandChip passRate={rate} />
+
+      <Box sx={{ overflow: 'hidden' }}>
+        <VerdictStrip
+          cellsAt={rollupAt}
+          dataVersion={dataVersion}
+          height={stripHeight}
+          ariaLabel={stripAriaLabel}
+        />
+      </Box>
     </Box>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/RequirementGroup.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/RequirementGroup.tsx
@@ -47,6 +47,11 @@ interface RequirementGroupProps {
   dataVersion: number;
   onViewRequirement?: (id: string) => void;
   onViewMetric?: (name: string, reqId?: string) => void;
+  /** Skip the collapsible requirement header and render the metric rows on
+   *  their own -- for the pooled bucket of metrics that never linked to a
+   *  requirement in the first place (execution-time and test-set metrics),
+   *  a "requirement" header has nothing real to say. */
+  headerless?: boolean;
 }
 
 export default function RequirementGroup({
@@ -58,6 +63,7 @@ export default function RequirementGroup({
   dataVersion,
   onViewRequirement,
   onViewMetric,
+  headerless = false,
 }: RequirementGroupProps) {
   const theme = useTheme();
   const reducedMotion = useReducedMotion();
@@ -112,6 +118,28 @@ export default function RequirementGroup({
   // Same height as the metric rows in this mode, so a rollup cell and the
   // cells under it are the same shape. Numbers mode is 0 for both.
   const stripHeight = STRIP_HEIGHTS[density];
+
+  if (headerless) {
+    return (
+      <Box sx={{ mb: 0.5 }}>
+        {groupRows.map((row, idx) => (
+          <MetricRow
+            key={row.metric_key}
+            row={row}
+            density={density}
+            testIds={testIds}
+            timings={timings}
+            metricIndex={idx}
+            metricCount={groupRows.length}
+            trimmedName={trimmedNames[idx]}
+            fullName={metricNames[idx]}
+            dataVersion={dataVersion}
+            onViewMetric={onViewMetric}
+          />
+        ))}
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ mb: 0.5 }}>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/RequirementTable.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/RequirementTable.tsx
@@ -223,6 +223,7 @@ export default function RequirementTable({
             dataVersion={matrix.version}
             onViewRequirement={onViewRequirement}
             onViewMetric={onViewMetric}
+            headerless={req.id === null}
           />
         ))}
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/RequirementTable.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/RequirementTable.test.tsx
@@ -210,6 +210,34 @@ describe('RequirementTable', () => {
     expect(screen.getByText('Safety')).toBeInTheDocument();
   });
 
+  it('renders a requirement-less group without a group header', () => {
+    // Execution-time/test-set metrics never linked to a requirement --
+    // "Unassigned" would misleadingly present them as a requirement.
+    renderWithClock(
+      <RequirementTable
+        matrix={makeMatrix({
+          requirements: [
+            { id: null, name: 'Unassigned', metric_keys: ['m1', 'm2'] },
+          ],
+        })}
+        density="shape"
+        onDensityChange={jest.fn()}
+        timings={EMPTY_TIMINGS}
+      />
+    );
+
+    // The metric rows themselves still render (shared-prefix trimmed, same
+    // as any other group)...
+    expect(screen.getByText('Toxicity Score')).toBeInTheDocument();
+    expect(screen.getByText('Bias Check')).toBeInTheDocument();
+    // ...but there is no clickable/collapsible group header for them, and
+    // no "Unassigned" label presented as if it were a requirement.
+    expect(
+      screen.queryByRole('button', { expanded: true })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Unassigned')).not.toBeInTheDocument();
+  });
+
   it('derives group header Total/Passed/Failed from the per-test rollup', () => {
     // m1 verdicts 'PF.', m2 verdicts 'PP.' across 3 tests:
     // t1: P,P -> passed. t2: F,P -> failed. t3: .,. -> pending (neither).

--- a/apps/frontend/src/components/common/RunDrawer.tsx
+++ b/apps/frontend/src/components/common/RunDrawer.tsx
@@ -760,7 +760,11 @@ export default function RunDrawer(props: RunDrawerProps) {
   // Metric helpers
   // -----------------------------------------------------------------------
 
-  const handleAddMetric = (metric: { id: UUID; name: string; metric_scope?: MetricScope[] }) => {
+  const handleAddMetric = (metric: {
+    id: UUID;
+    name: string;
+    metric_scope?: MetricScope[];
+  }) => {
     setSelectedMetrics(prev => [
       ...prev,
       { id: metric.id, name: metric.name, scope: metric.metric_scope },

--- a/apps/frontend/src/components/common/SelectMetricsDialog.tsx
+++ b/apps/frontend/src/components/common/SelectMetricsDialog.tsx
@@ -27,7 +27,10 @@ import CategoryIcon from '@mui/icons-material/Category';
 import ToggleOnIcon from '@mui/icons-material/ToggleOn';
 import { AutoGraphIcon } from '@/components/icons';
 import { MetricsClient } from '@/utils/api-client/metrics-client';
-import type { MetricDetail, MetricScope } from '@/utils/api-client/interfaces/metric';
+import type {
+  MetricDetail,
+  MetricScope,
+} from '@/utils/api-client/interfaces/metric';
 import type { UUID } from 'crypto';
 import { getMetricScopeIcon } from '@/constants/metric-scopes';
 import BaseDrawer from '@/components/common/BaseDrawer';
@@ -86,7 +89,11 @@ const capitalize = (s: string) =>
 interface SelectMetricsDialogProps {
   open: boolean;
   onClose: () => void;
-  onSelect: (metric: { id: UUID; name: string; metric_scope?: MetricScope[] }) => void;
+  onSelect: (metric: {
+    id: UUID;
+    name: string;
+    metric_scope?: MetricScope[];
+  }) => void;
   excludeMetricIds?: UUID[];
   title?: string;
   subtitle?: string;
@@ -209,7 +216,11 @@ export default function SelectMetricsDialog({
   }, [searchQuery, backendFilter, metrics]);
 
   const handleSelect = (metric: MetricDetail) => {
-    onSelect({ id: metric.id as UUID, name: metric.name, metric_scope: metric.metric_scope });
+    onSelect({
+      id: metric.id as UUID,
+      name: metric.name,
+      metric_scope: metric.metric_scope,
+    });
     onClose();
   };
 

--- a/tests/backend/services/test_verdict_matrix.py
+++ b/tests/backend/services/test_verdict_matrix.py
@@ -705,6 +705,84 @@ class TestCustomMetricPoolsAcrossRequirements:
         assert (row.passed, row.failed) == (1, 1)
 
 
+class TestMetriclessRequirementKeepsItsOwnEntry:
+    """A requirement with no metric of its own, and no test-set/execution-
+    time metric to fall through to, resolves "none" -- not a metric shared
+    across the run, just nothing resolved. It must keep its own (empty)
+    entry under its own name rather than being folded into the pooled
+    section, which would both rename it "Unassigned" and -- if some other
+    requirement's test-set metric were pooled too -- wrongly attach that
+    metric to its tests.
+    """
+
+    def test_metricless_requirement_is_not_pooled_or_renamed(
+        self, test_db: Session, test_organization, db_user, db_endpoint, db_status
+    ):
+        org_id = test_organization.id
+        user_id = db_user.id
+
+        test_config = models.TestConfiguration(
+            endpoint_id=db_endpoint.id, organization_id=org_id, user_id=user_id
+        )
+        test_db.add(test_config)
+        test_db.flush()
+
+        test_set = models.TestSet(
+            name="Metricless Requirement Test Set",
+            user_id=user_id,
+            organization_id=org_id,
+            status_id=db_status.id,
+        )
+        test_db.add(test_set)
+        test_db.flush()
+        test_config.test_set_id = test_set.id
+        test_db.flush()
+
+        # One requirement with its own metric, one with none at all -- and
+        # no test-set/execution-time metric for the metric-less one to fall
+        # through to.
+        requirement_with_metric = models.Requirement(
+            name="Has A Metric", organization_id=org_id, user_id=user_id
+        )
+        requirement_without_metric = models.Requirement(
+            name="Has No Metric", organization_id=org_id, user_id=user_id
+        )
+        test_db.add_all([requirement_with_metric, requirement_without_metric])
+        test_db.flush()
+        metric = _metric(test_db, org_id, user_id, name="Accuracy", scope=["Single-Turn"])
+        _link_metric(test_db, requirement_with_metric, metric, org_id, user_id)
+
+        test_with_metric = models.Test(
+            user_id=user_id, organization_id=org_id, requirement_id=requirement_with_metric.id
+        )
+        test_without_metric = models.Test(
+            user_id=user_id, organization_id=org_id, requirement_id=requirement_without_metric.id
+        )
+        test_db.add_all([test_with_metric, test_without_metric])
+        test_db.flush()
+        for test in (test_with_metric, test_without_metric):
+            _add_to_set(test_db, test, test_set, org_id, user_id)
+        test_db.commit()
+
+        plan = build_metric_plan(test_db, test_config, test_set, organization_id=str(org_id))
+
+        by_id = {g["id"]: g for g in plan["requirements"]}
+
+        assert [m["key"] for m in by_id[str(requirement_with_metric.id)]["metrics"]] == ["Accuracy"]
+
+        # The metric-less requirement keeps its own name and an empty
+        # metrics list -- it is not folded into a pooled "Unassigned" group.
+        metricless_id = str(requirement_without_metric.id)
+        assert metricless_id in by_id
+        assert by_id[metricless_id]["name"] == "Has No Metric"
+        assert by_id[metricless_id]["metrics"] == []
+        assert by_id[metricless_id]["test_ids"] == [str(test_without_metric.id)]
+
+        # No pooled "Unassigned" bucket exists here at all -- nothing in
+        # this run resolved from a test-set/execution-time source.
+        assert None not in by_id
+
+
 class TestScopeFilteredKeys:
     """cell_keys must carry the key the runtime will really write, not the
     plan's own row key. The runtime numbers duplicate names *after* scope

--- a/tests/backend/services/test_verdict_matrix.py
+++ b/tests/backend/services/test_verdict_matrix.py
@@ -583,6 +583,128 @@ class TestSourceResolutionPerGroup:
         assert by_id[None]["test_ids"] == [str(unassigned.id)]
 
 
+class TestCustomMetricPoolsAcrossRequirements:
+    """A metric that resolves from the test set, not a requirement, applies
+    the same way regardless of which requirement (if any) a test belongs to.
+    Grouping it under each requirement's own header would show the identical
+    metric once per requirement -- the same failures counted, and displayed,
+    over and over. It belongs in one requirement-less section instead.
+    """
+
+    def test_test_set_metric_gets_one_pooled_group_not_one_per_requirement(
+        self, test_db: Session, test_organization, db_user, db_endpoint, db_status
+    ):
+        org_id = test_organization.id
+        user_id = db_user.id
+
+        test_config = models.TestConfiguration(
+            endpoint_id=db_endpoint.id, organization_id=org_id, user_id=user_id
+        )
+        test_db.add(test_config)
+        test_db.flush()
+
+        test_set = models.TestSet(
+            name="Custom Metric Test Set",
+            user_id=user_id,
+            organization_id=org_id,
+            status_id=db_status.id,
+        )
+        test_db.add(test_set)
+        test_db.flush()
+        test_config.test_set_id = test_set.id
+        test_db.flush()
+
+        # Two requirements, neither with a requirement-level metric -- both
+        # fall through to the test set's own metric.
+        requirement_a = models.Requirement(
+            name="Reliability", organization_id=org_id, user_id=user_id
+        )
+        requirement_b = models.Requirement(
+            name="Compliance", organization_id=org_id, user_id=user_id
+        )
+        test_db.add_all([requirement_a, requirement_b])
+        test_db.flush()
+
+        metric = _metric(test_db, org_id, user_id, name="Custom Detector", scope=["Single-Turn"])
+        test_db.execute(
+            models.test_set_metric_association.insert().values(
+                test_set_id=test_set.id,
+                metric_id=metric.id,
+                organization_id=org_id,
+                user_id=user_id,
+            )
+        )
+
+        test_a = models.Test(
+            user_id=user_id, organization_id=org_id, requirement_id=requirement_a.id
+        )
+        test_b = models.Test(
+            user_id=user_id, organization_id=org_id, requirement_id=requirement_b.id
+        )
+        test_db.add_all([test_a, test_b])
+        test_db.flush()
+        for test in (test_a, test_b):
+            _add_to_set(test_db, test, test_set, org_id, user_id)
+
+        test_run = models.TestRun(
+            name="Custom Metric Run",
+            user_id=user_id,
+            organization_id=org_id,
+            status_id=db_status.id,
+            test_configuration_id=test_config.id,
+        )
+        test_db.add(test_run)
+        test_db.flush()
+
+        for test, is_successful in ((test_a, True), (test_b, False)):
+            status = get_or_create_status(
+                test_db,
+                TestResultStatus.PASS.value if is_successful else TestResultStatus.FAIL.value,
+                "TestResult",
+                organization_id=str(org_id),
+            )
+            metrics = {"Custom Detector": {"is_successful": is_successful}}
+            test_db.add(
+                models.TestResult(
+                    test_run_id=test_run.id,
+                    test_configuration_id=test_config.id,
+                    test_id=test.id,
+                    organization_id=org_id,
+                    user_id=user_id,
+                    status_id=status.id,
+                    test_metrics={"metrics": metrics},
+                    **_execution_verdict(metrics),
+                )
+            )
+        test_db.commit()
+
+        plan = build_metric_plan(test_db, test_config, test_set, organization_id=str(org_id))
+
+        # One pooled group, not one duplicated per requirement.
+        assert len(plan["requirements"]) == 1
+        group = plan["requirements"][0]
+        assert group["id"] is None
+        assert [m["key"] for m in group["metrics"]] == ["Custom Detector"]
+        assert set(group["test_ids"]) == {str(test_a.id), str(test_b.id)}
+
+        test_run.attributes = {"metric_plan": plan}
+        test_db.commit()
+        test_db.refresh(test_run)
+
+        matrix = get_verdict_matrix(test_db, test_run)
+
+        # One row for the metric, spanning both tests -- not one row per
+        # requirement repeating the same verdicts.
+        assert len(matrix.rows) == 1
+        row = matrix.rows[0]
+        test_order = plan["test_order"]
+        index_a = test_order.index(str(test_a.id))
+        index_b = test_order.index(str(test_b.id))
+        assert row.verdicts[index_a] == "P"
+        assert row.verdicts[index_b] == "F"
+        assert (row.passed, row.failed) == (1, 1)
+
+
 class TestScopeFilteredKeys:
     """cell_keys must carry the key the runtime will really write, not the
     plan's own row key. The runtime numbers duplicate names *after* scope


### PR DESCRIPTION
## Purpose

When a test run uses custom metrics (execution-time or test-set scoped, not tied to a requirement), the Requirements performance table showed the same metric duplicated once per requirement in the run -- e.g. the same "Polish Language Detection" metric and the same failures, repeated identically under "Reliability", "Compliance", and "Robustness" -- because those metrics aren't actually specific to any requirement.

## What Changed

- **Backend** (`metric_plan.py`): `build_metric_plan` resolves a run's metrics per requirement group and previously gave every group its own payload entry unconditionally. That's correct when a group's metrics genuinely come from its own requirement (two requirements can have different metrics), but execution-time and test-set metrics apply uniformly to the whole run regardless of requirement, so every group fell through to the identical metric set and got its own duplicate copy of it. Only a requirement-sourced group now keeps its own entry; everything else (test_set, execution_time, none) pools into one requirement-less section spanning the union of those tests.
- **Frontend** (`RequirementGroup.tsx` / `RequirementTable.tsx`): the pooled, requirement-less section no longer gets a fake "requirement" header (name, drilldown icon, rollup strip labeled "Unassigned") -- these metrics were never linked to a requirement, so presenting them as if they were one was misleading. `RequirementGroup` gains a `headerless` mode that renders just the metric rows; `RequirementTable` uses it whenever a group's `id` is `null`, which after the backend fix is exactly (and only) the requirement-less bucket.

## Additional Context

- `cell_keys` (how a row's verdicts are looked up) is unaffected by this change: a real metric's cell_keys entry is always keyed by the metric's own id, never a group-relative key, so pooling which payload entry a metric's row lives under doesn't change how its verdicts resolve.

## Testing

- Backend: `uv run pytest ../../tests/backend/services/test_verdict_matrix.py ../../tests/backend/jobs/test_metric_plan_dispatch.py -q` -- 22 passed, including a new test (`TestCustomMetricPoolsAcrossRequirements`) reproducing the exact bug: two requirements, neither with its own metric, both falling through to one test-set metric -- asserts one pooled group and one verdict row instead of two duplicated ones.
- Frontend: `npx tsc --noEmit`, `npx eslint`, `npm run format:check` all clean. `npx jest --testPathPatterns="test-runs"` -- 311 passed, including a new test asserting the pooled group renders its metric rows without a group header or an "Unassigned" label.
- `uvx ruff check` / `uvx ruff format --check` clean on the backend files.