### PR TITLE
fix(frontend): allow all metric types in custom execution metrics

### DIFF
--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectTraceMetrics.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectTraceMetrics.tsx
@@ -164,17 +164,17 @@ export default forwardRef<ProjectTraceMetricsHandle, ProjectTraceMetricsProps>(
       ? `Failed to load metrics: ${fetchError instanceof Error ? fetchError.message : 'Unknown error'}`
       : null;
 
-    const handleAddMetric = async (metricId: UUID) => {
+    const handleAddMetric = async (metric: { id: UUID }) => {
       try {
         const currentMetricIds = getTraceMetricIds(project);
-        if (currentMetricIds.includes(metricId)) {
+        if (currentMetricIds.includes(metric.id)) {
           notifications.show('Metric is already added to this project', {
             severity: 'warning',
           });
           return;
         }
 
-        const newMetricIds = [...currentMetricIds, metricId];
+        const newMetricIds = [...currentMetricIds, metric.id];
         const updatedAttributes = {
           ...(project.attributes || {}),
           trace_metrics: newMetricIds,

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetMetrics.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetMetrics.tsx
@@ -96,11 +96,11 @@ export default function TestSetMetrics({ testSetId }: TestSetMetricsProps) {
       : 'Failed to load metrics'
     : null;
 
-  const handleAddMetric = async (metricId: UUID) => {
+  const handleAddMetric = async (metric: { id: UUID }) => {
     try {
       await new ApiClientFactory()
         .getTestSetsClient()
-        .addMetricToTestSet(testSetId, metricId as string);
+        .addMetricToTestSet(testSetId, metric.id as string);
       queryClient.invalidateQueries({ queryKey: metricsQueryKey });
       notifications.show('Metric added to test set successfully', {
         severity: 'success',

--- a/apps/frontend/src/components/common/RunDrawer.tsx
+++ b/apps/frontend/src/components/common/RunDrawer.tsx
@@ -52,6 +52,7 @@ import ModelSelector from '@/components/common/ModelSelector';
 import { PreflightDialog } from '@/components/common/PreflightDialog';
 import SelectExperimentsDrawer from '@/components/common/SelectExperimentsDrawer';
 import SelectMetricsDialog from '@/components/common/SelectMetricsDialog';
+import type { MetricScope } from '@/utils/api-client/interfaces/metric';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { safeRandomUUID } from '@/utils/uuid';
 import { Project } from '@/utils/api-client/interfaces/project';
@@ -759,22 +760,11 @@ export default function RunDrawer(props: RunDrawerProps) {
   // Metric helpers
   // -----------------------------------------------------------------------
 
-  const handleAddMetric = async (metricId: UUID) => {
-    try {
-      const metric = await apiFactory.getMetricsClient().getMetric(metricId);
-      if (metric) {
-        setSelectedMetrics(prev => [
-          ...prev,
-          {
-            id: metric.id as UUID,
-            name: metric.name,
-            scope: metric.metric_scope,
-          },
-        ]);
-      }
-    } catch (err) {
-      console.error('Failed to fetch metric details:', err);
-    }
+  const handleAddMetric = (metric: { id: UUID; name: string; metric_scope?: MetricScope[] }) => {
+    setSelectedMetrics(prev => [
+      ...prev,
+      { id: metric.id, name: metric.name, scope: metric.metric_scope },
+    ]);
   };
 
   const handleRemoveMetric = (metricId: UUID) => {

--- a/apps/frontend/src/components/common/SelectMetricsDialog.tsx
+++ b/apps/frontend/src/components/common/SelectMetricsDialog.tsx
@@ -27,7 +27,7 @@ import CategoryIcon from '@mui/icons-material/Category';
 import ToggleOnIcon from '@mui/icons-material/ToggleOn';
 import { AutoGraphIcon } from '@/components/icons';
 import { MetricsClient } from '@/utils/api-client/metrics-client';
-import type { MetricDetail } from '@/utils/api-client/interfaces/metric';
+import type { MetricDetail, MetricScope } from '@/utils/api-client/interfaces/metric';
 import type { UUID } from 'crypto';
 import { getMetricScopeIcon } from '@/constants/metric-scopes';
 import BaseDrawer from '@/components/common/BaseDrawer';
@@ -86,7 +86,7 @@ const capitalize = (s: string) =>
 interface SelectMetricsDialogProps {
   open: boolean;
   onClose: () => void;
-  onSelect: (metricId: UUID) => void;
+  onSelect: (metric: { id: UUID; name: string; metric_scope?: MetricScope[] }) => void;
   excludeMetricIds?: UUID[];
   title?: string;
   subtitle?: string;
@@ -208,8 +208,8 @@ export default function SelectMetricsDialog({
     setFilteredMetrics(filtered);
   }, [searchQuery, backendFilter, metrics]);
 
-  const handleSelect = (metricId: UUID) => {
-    onSelect(metricId);
+  const handleSelect = (metric: MetricDetail) => {
+    onSelect({ id: metric.id as UUID, name: metric.name, metric_scope: metric.metric_scope });
     onClose();
   };
 
@@ -324,7 +324,7 @@ export default function SelectMetricsDialog({
                   boxShadow: 1,
                 },
               }}
-              onClick={() => handleSelect(metric.id as UUID)}
+              onClick={() => handleSelect(metric)}
             >
               <Box
                 sx={{

--- a/apps/frontend/src/components/common/__tests__/SelectMetricsDialog.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/SelectMetricsDialog.test.tsx
@@ -160,7 +160,11 @@ describe('SelectMetricsDialog', () => {
 
     await user.click(screen.getByText('Precision'));
 
-    expect(onSelect).toHaveBeenCalledWith('metric-abc');
+    expect(onSelect).toHaveBeenCalledWith({
+      id: 'metric-abc',
+      name: 'Precision',
+      metric_scope: ['Single-Turn'],
+    });
     expect(onClose).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- When adding custom metrics to a test execution, only Rhesis metrics could be added. Deepeval, Ragas, and Garak metrics silently failed.
- Root cause: `SelectMetricsDialog` passed only the metric ID to `onSelect`, so `RunDrawer.handleAddMetric` re-fetched via `GET /metrics/{id}`. That endpoint returns 403 for framework metrics (Deepeval/Ragas/Garak), and the error was silently swallowed.
- Fix: pass `{ id, name, metric_scope }` from the dialog directly, eliminating the redundant API call. Updated all three callers (`RunDrawer`, `TestSetMetrics`, `ProjectTraceMetrics`).

## Test plan

- [x] `SelectMetricsDialog` unit tests pass (16/16)
- [ ] Open a test set execution drawer, select "Custom Metrics", add a Deepeval or Ragas metric, confirm it appears in the selected list
- [ ] Verify Rhesis and custom metrics still add correctly
- [ ] Verify test set metrics page still adds/removes metrics correctly
- [ ] Verify project trace metrics still adds metrics correctly