### PR TITLE
Fix Tests tab refresh/sort and add remove-from-test-set

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -510,8 +510,8 @@ def get_test_set_tests(
     response: Response,
     skip: int = 0,
     limit: int = 10,
-    order_by: str = "created_at",
-    order: str = "desc",
+    sort_by: str = "created_at",
+    sort_order: str = "desc",
     filter: str | None = Query(None, alias="$filter", description="OData filter expression"),
     db: Session = Depends(get_tenant_db_session),
     current_user: User = Depends(require_current_user_or_token),
@@ -525,8 +525,8 @@ def get_test_set_tests(
         test_set_id=db_test_set.id,
         skip=skip,
         limit=limit,
-        sort_by=order_by,
-        sort_order=order,
+        sort_by=sort_by,
+        sort_order=sort_order,
         filter=filter,
     )
 

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
@@ -76,6 +76,8 @@ interface EmbeddingTestsPanelProps {
   initialTests?: TestDetail[];
   initialTotalCount?: number;
   onTotalCountChange?: (count: number) => void;
+  /** Bumped by the page (e.g. after an assign) to trigger a re-fetch. */
+  refreshTrigger?: number;
 }
 
 export default function EmbeddingTestsPanel({
@@ -84,6 +86,7 @@ export default function EmbeddingTestsPanel({
   initialTests,
   initialTotalCount,
   onTotalCountChange,
+  refreshTrigger,
 }: EmbeddingTestsPanelProps) {
   const theme = useTheme();
   const router = useRouter();
@@ -312,8 +315,8 @@ export default function EmbeddingTestsPanel({
             testSetType={testSetType}
             initialTests={initialTests}
             initialTotalCount={initialTotalCount}
-            embedded
             onTotalCountChange={onTotalCountChange}
+            refreshTrigger={refreshTrigger}
           />
         </Box>
       )}

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetLinkedTestsSection.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetLinkedTestsSection.tsx
@@ -11,7 +11,6 @@ import {
 import AddIcon from '@mui/icons-material/Add';
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
 import { useRouter } from 'next/navigation';
-import { useQueryClient } from '@tanstack/react-query';
 import AssignTestsDrawer from './AssignTestsDrawer';
 import EmbeddingTestsPanel from './EmbeddingTestsPanel';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -19,7 +18,6 @@ import { TestDetail } from '@/utils/api-client/interfaces/tests';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
-import { testSetKeys } from '@/constants/query-keys';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import type { Theme } from '@mui/material/styles';
 
@@ -50,10 +48,10 @@ export default function TestSetLinkedTestsSection({
   const { show: showNotification } = useNotifications();
   const canEditTestSet = useCan(Capability.TestSet.UPDATE);
   const router = useRouter();
-  const queryClient = useQueryClient();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [totalCount, setTotalCount] = useState(initialTestCount);
   const [isGenerating, setIsGenerating] = useState(initialIsGenerating);
+  const [testsRefreshTrigger, setTestsRefreshTrigger] = useState(0);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
@@ -136,11 +134,9 @@ export default function TestSetLinkedTestsSection({
       // Optimistically grow the count so the empty state gives way to the grid
       // immediately after the first assignment.
       setTotalCount(prev => prev + tests.length);
-      // Drop cached test-list pages so the grid refetches with the new rows
-      // (React Query keeps them fresh for 5 min otherwise).
-      await queryClient.invalidateQueries({
-        queryKey: [...testSetKeys.detail(testSetId), 'tests'],
-      });
+      // Bump so the grid (mounted throughout this flow -- the tab doesn't
+      // switch) actually refetches and shows the newly assigned rows.
+      setTestsRefreshTrigger(prev => prev + 1);
       // Sync the server-rendered testCount prop for this page.
       router.refresh();
     } catch (error) {
@@ -261,6 +257,7 @@ export default function TestSetLinkedTestsSection({
             initialTests={initialTests}
             initialTotalCount={initialTestCount}
             onTotalCountChange={setTotalCount}
+            refreshTrigger={testsRefreshTrigger}
           />
         </>
       )}

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
@@ -1,82 +1,63 @@
 'use client';
 
-import React, { useCallback, useContext, useMemo, useState } from 'react';
-import {
-  GridColDef,
-  GridRowParams,
-  GridToolbarColumnsButton,
-  GridToolbarDensitySelector,
-  GridToolbarExport,
-} from '@mui/x-data-grid';
-import BaseDataGrid from '@/components/common/BaseDataGrid';
-import { Alert } from '@mui/material';
-import GridToolbar from '@/components/common/GridToolbar';
-import { useRouter } from 'next/navigation';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import type { GridColDef } from '@mui/x-data-grid';
+import EntityGrid, {
+  type EntityGridDrawerAdapter,
+  type EntityGridFilterState,
+} from '@/components/common/EntityGrid';
+import { DeleteModal } from '@/components/common/DeleteModal';
 import { getTestSetTestColumns } from './testSetTestColumns';
 import TestFilterDrawer, {
   type TestFilters,
   EMPTY_TEST_FILTERS,
-  hasActiveTestFilters,
+  countActiveTestFilters,
 } from '@/app/(protected)/tests/components/TestFilterDrawer';
-import { useList } from '@/hooks/useList';
 import { testSetTestsList } from './list';
+import { useNotifications } from '@/components/common/NotificationContext';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { LinkOffIcon } from '@/components/icons';
+import type { RowExtraAction } from '@/components/common/createRowActionsColumn';
 import type { TestDetail } from '@/utils/api-client/interfaces/tests';
-
-interface LinkedTestsToolbarState {
-  searchQuery: string;
-  setSearchQuery: (v: string) => void;
-  openFilterDrawer: () => void;
-  hasActiveDrawerFilters: boolean;
-}
-
-const LinkedTestsToolbarContext = React.createContext<LinkedTestsToolbarState>({
-  searchQuery: '',
-  setSearchQuery: () => {},
-  openFilterDrawer: () => {},
-  hasActiveDrawerFilters: false,
-});
-
-function LinkedTestsUnifiedToolbar() {
-  const canExport = useCan(Capability.TestSet.EXPORT);
-  const {
-    searchQuery,
-    setSearchQuery,
-    openFilterDrawer,
-    hasActiveDrawerFilters,
-  } = useContext(LinkedTestsToolbarContext);
-
-  return (
-    <GridToolbar
-      searchQuery={searchQuery}
-      onSearchChange={setSearchQuery}
-      searchPlaceholder="Search tests…"
-      searchWidth={288}
-      onFilterClick={openFilterDrawer}
-      hasActiveFilters={hasActiveDrawerFilters}
-      sx={{ px: '30px', pt: 0, pb: '30px', minHeight: 'auto' }}
-      rightContent={
-        <>
-          <GridToolbarColumnsButton />
-          <GridToolbarDensitySelector />
-          {canExport && <GridToolbarExport />}
-        </>
-      }
-    />
-  );
-}
 
 interface TestSetTestsGridProps {
   testSetId: string;
   testSetType?: string;
-  /** When true, grid is rendered inside embedding atlas (spacing only). */
-  embedded?: boolean;
   /** Server-prefetched first page (default sort, no filters); skips the mount fetch. */
   initialTests?: TestDetail[];
   initialTotalCount?: number;
   onTotalCountChange?: (count: number) => void;
+  /** Bumped by the page (e.g. after an assign) to trigger a re-fetch. */
+  refreshTrigger?: number;
 }
+
+function toFilters(state: EntityGridFilterState<TestFilters>) {
+  return {
+    search: state.search,
+    testType: state.drawer.testType,
+    requirement: state.drawer.requirement,
+    category: state.drawer.category,
+    topic: state.drawer.topic,
+    tagsPresence: state.drawer.tags,
+    commentsPresence: state.drawer.comments,
+    tasksPresence: state.drawer.tasks,
+  };
+}
+
+const drawerAdapter: EntityGridDrawerAdapter<TestFilters> = {
+  empty: EMPTY_TEST_FILTERS,
+  countActive: countActiveTestFilters,
+  render: props => (
+    <TestFilterDrawer
+      open={props.open}
+      onClose={props.onClose}
+      filters={props.filters}
+      onApply={props.onApply}
+    />
+  ),
+};
 
 export default function TestSetTestsGrid({
   testSetId,
@@ -84,110 +65,110 @@ export default function TestSetTestsGrid({
   initialTests,
   initialTotalCount,
   onTotalCountChange,
+  refreshTrigger,
 }: TestSetTestsGridProps) {
-  const router = useRouter();
-  const [searchQuery, setSearchQuery] = useState('');
-  const [drawerFilters, setDrawerFilters] =
-    useState<TestFilters>(EMPTY_TEST_FILTERS);
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [errorDismissed, setErrorDismissed] = useState(false);
+  const notifications = useNotifications();
+  const canEditTestSet = useCan(Capability.TestSet.UPDATE);
+  const canExport = useCan(Capability.TestSet.EXPORT);
 
   const descriptor = useMemo(() => testSetTestsList(testSetId), [testSetId]);
-
-  const filters = useMemo(
-    () => ({
-      search: searchQuery,
-      testType: drawerFilters.testType,
-      requirement: drawerFilters.requirement,
-      category: drawerFilters.category,
-      topic: drawerFilters.topic,
-      tagsPresence: drawerFilters.tags,
-      commentsPresence: drawerFilters.comments,
-      tasksPresence: drawerFilters.tasks,
-    }),
-    [searchQuery, drawerFilters]
-  );
-
-  const filtersActive = !!searchQuery || hasActiveTestFilters(drawerFilters);
-
-  const {
-    data: tests,
-    totalCount,
-    isLoading: loading,
-    error: rawError,
-    paginationModel,
-    onPaginationModelChange: handlePaginationModelChange,
-  } = useList(descriptor, {
-    filters,
-    enabled: !!testSetId,
-    initialData: initialTests,
-    initialTotalCount,
-    onError: () => setErrorDismissed(false),
-  });
-
-  React.useEffect(() => {
-    setErrorDismissed(false);
-  }, [rawError]);
-
-  const error = rawError && !errorDismissed ? rawError : null;
-  const dismissError = useCallback(() => setErrorDismissed(true), []);
-
-  React.useEffect(() => {
-    if (!loading && !filtersActive) onTotalCountChange?.(totalCount);
-  }, [loading, filtersActive, totalCount, onTotalCountChange]);
-
-  const columns: GridColDef[] = React.useMemo(
+  const columns: GridColDef[] = useMemo(
     () => getTestSetTestColumns(testSetType),
     [testSetType]
   );
 
-  const handleRowClick = useCallback(
-    (params: GridRowParams) => {
-      const testId = params.id;
-      router.push(`/tests/${testId}`);
+  const onTotalCountChangeRef = useRef(onTotalCountChange);
+  onTotalCountChangeRef.current = onTotalCountChange;
+  const handleDataChange = useCallback(
+    (_data: TestDetail[], totalCount: number, filtersActive: boolean) => {
+      if (!filtersActive) {
+        onTotalCountChangeRef.current?.(totalCount);
+      }
     },
-    [router]
+    []
   );
 
-  const toolbarContextValue = useMemo(
-    () => ({
-      searchQuery,
-      setSearchQuery,
-      openFilterDrawer: () => setFilterDrawerOpen(true),
-      hasActiveDrawerFilters: hasActiveTestFilters(drawerFilters),
-    }),
-    [searchQuery, drawerFilters]
+  const [removeTarget, setRemoveTarget] = useState<TestDetail | null>(null);
+  const [removing, setRemoving] = useState(false);
+
+  const handleRemoveClick = useCallback((row: TestDetail) => {
+    setRemoveTarget(row);
+  }, []);
+
+  const handleCancelRemove = useCallback(() => setRemoveTarget(null), []);
+
+  const makeConfirmRemove = useCallback(
+    (refresh: () => void) => async () => {
+      if (!removeTarget) return;
+      try {
+        setRemoving(true);
+        const factory = new ApiClientFactory();
+        await factory
+          .getTestSetsClient()
+          .disassociateTestsFromTestSet(testSetId, [String(removeTarget.id)]);
+        notifications.show('Test removed from test set', {
+          severity: 'success',
+          autoHideDuration: 4000,
+        });
+        setRemoveTarget(null);
+        refresh();
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Failed to remove test from test set. Please try again.';
+        notifications.show(message, { severity: 'error' });
+      } finally {
+        setRemoving(false);
+      }
+    },
+    [removeTarget, testSetId, notifications]
+  );
+
+  const extraRowActions: RowExtraAction[] = useMemo(
+    () => [
+      {
+        key: 'remove',
+        icon: LinkOffIcon,
+        tooltip: 'Remove from test set',
+        onClick: (_id: string, row: Record<string, unknown>) =>
+          handleRemoveClick(row as unknown as TestDetail),
+        can: () => canEditTestSet,
+        hoverColor: 'error.main' as const,
+      },
+    ],
+    [handleRemoveClick, canEditTestSet]
   );
 
   return (
-    <LinkedTestsToolbarContext.Provider value={toolbarContextValue}>
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
-          {error}
-        </Alert>
+    <EntityGrid<TestDetail, typeof descriptor.filters, TestFilters>
+      descriptor={descriptor}
+      columns={columns}
+      toFilters={toFilters}
+      emptyState={null}
+      embedded
+      initialData={initialTests}
+      initialTotalCount={initialTotalCount}
+      refreshTrigger={refreshTrigger}
+      onDataChange={handleDataChange}
+      searchPlaceholder="Search tests…"
+      drawer={drawerAdapter}
+      showExport={canExport}
+      getRowUrl={row => `/tests/${row.id}`}
+      editAction={false}
+      extraRowActions={extraRowActions}
+      pageSizeOptions={[10, 25, 50]}
+      renderSelectionExtras={ctx => (
+        <DeleteModal
+          open={removeTarget !== null}
+          onClose={handleCancelRemove}
+          onConfirm={makeConfirmRemove(ctx.refresh)}
+          isLoading={removing}
+          title="Remove from Test Set"
+          message="Remove this test from the test set? The test itself will not be deleted."
+          confirmButtonText={removing ? 'Removing…' : 'Remove'}
+        />
       )}
-
-      <BaseDataGrid
-        rows={tests}
-        columns={columns}
-        loading={loading}
-        getRowId={row => row.id}
-        paginationModel={paginationModel}
-        onPaginationModelChange={handlePaginationModelChange}
-        onRowClick={handleRowClick}
-        serverSidePagination={true}
-        totalRows={totalCount}
-        pageSizeOptions={[10, 25, 50]}
-        disablePaperWrapper={true}
-        toolbarSlot={LinkedTestsUnifiedToolbar}
-      />
-
-      <TestFilterDrawer
-        open={filterDrawerOpen}
-        onClose={() => setFilterDrawerOpen(false)}
-        filters={drawerFilters}
-        onApply={setDrawerFilters}
-      />
-    </LinkedTestsToolbarContext.Provider>
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/list.ts
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/list.ts
@@ -6,8 +6,9 @@ import { TESTS_FILTERS } from '@/app/(protected)/tests/components/list';
 
 /**
  * The embedded "tests in this test set" grid: same filter surface as the main
- * tests list, but scoped to one test set's nested endpoint and fixed to the
- * topic ordering the detail page has always shown.
+ * tests list, but scoped to one test set's nested endpoint. Defaults to the
+ * topic ordering the detail page has always shown; sortable interactively
+ * from there like any other EntityGrid-backed list.
  */
 export function testSetTestsList(testSetId: string) {
   return defineList<TestDetail, typeof TESTS_FILTERS>({
@@ -15,7 +16,7 @@ export function testSetTestsList(testSetId: string) {
     resource: 'tests',
     capability: Capability.Test.READ,
     defaultPageSize: 25,
-    defaultSort: { by: 'topic', order: 'asc' },
+    defaultSort: { by: 'topic.name', order: 'asc' },
     filters: TESTS_FILTERS,
     list: (factory: ApiClientFactory, params) =>
       factory.getTestSetsClient().getTestSetTests(testSetId, params),

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/testSetTestColumns.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/testSetTestColumns.tsx
@@ -20,10 +20,11 @@ export function getTestSetTestColumns(testSetType?: string): GridColDef[] {
       renderCell: renderTestContentCell,
     },
     {
-      field: 'requirement',
+      field: 'requirement.name',
       headerName: 'Requirement',
       flex: 1,
       minWidth: 120,
+      valueGetter: (_value, row) => row.requirement?.name || '',
       renderCell: params => {
         const requirementName = params.row.requirement?.name;
         if (!requirementName) return null;
@@ -31,10 +32,11 @@ export function getTestSetTestColumns(testSetType?: string): GridColDef[] {
       },
     },
     {
-      field: 'topic',
+      field: 'topic.name',
       headerName: 'Topic',
       flex: 1,
       minWidth: 120,
+      valueGetter: (_value, row) => row.topic?.name || '',
       renderCell: params => {
         const topicName = params.row.topic?.name;
         if (!topicName) return null;
@@ -42,10 +44,11 @@ export function getTestSetTestColumns(testSetType?: string): GridColDef[] {
       },
     },
     {
-      field: 'category',
+      field: 'category.name',
       headerName: 'Category',
       flex: 1,
       minWidth: 120,
+      valueGetter: (_value, row) => row.category?.name || '',
       renderCell: params => {
         const categoryName = params.row.category?.name;
         if (!categoryName) return null;

--- a/apps/frontend/src/utils/api-client/interfaces/test-set.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/test-set.ts
@@ -86,6 +86,18 @@ export interface TestSetBulkAssociateRequest {
   test_ids: UUID[];
 }
 
+// Test set disassociation request
+export interface TestSetBulkDisassociateRequest {
+  test_ids: UUID[];
+}
+
+export interface TestSetBulkDisassociateResponse {
+  success: boolean;
+  total_tests: number;
+  removed_associations: number;
+  message: string;
+}
+
 export interface TestSetBulkDeleteResponse {
   deleted_ids: string[];
   not_found_ids: string[];

--- a/apps/frontend/src/utils/api-client/test-sets-client.ts
+++ b/apps/frontend/src/utils/api-client/test-sets-client.ts
@@ -7,6 +7,8 @@ import {
   TestSet,
   TestSetCreate,
   TestSetBulkAssociateRequest,
+  TestSetBulkDisassociateRequest,
+  TestSetBulkDisassociateResponse,
   TestSetBulkDeleteResponse,
   GenerateTestsRequest,
   GenerateTestSetResponse,
@@ -404,6 +406,23 @@ export class TestSetsClient extends BaseApiClient {
       method: 'POST',
       body: JSON.stringify(request),
     });
+  }
+
+  async disassociateTestsFromTestSet(
+    testSetId: string,
+    testIds: string[]
+  ): Promise<TestSetBulkDisassociateResponse> {
+    const request: TestSetBulkDisassociateRequest = {
+      test_ids: testIds as UUID[],
+    };
+
+    return this.fetch<TestSetBulkDisassociateResponse>(
+      `${API_ENDPOINTS.testSets}/${testSetId}/disassociate`,
+      {
+        method: 'POST',
+        body: JSON.stringify(request),
+      }
+    );
   }
 
   async getTestSetTests(


### PR DESCRIPTION
## Purpose

Two user-reported bugs on a test set's Tests tab: a test assigned via the Assign drawer doesn't show up in the grid until you leave and re-enter the tab, and there was no way to remove a test from a test set once it was added.

## What Changed

- `GET /{test_set_identifier}/tests` now accepts `sort_by`/`sort_order` (was `order_by`/`order`), matching every other list endpoint and what the frontend actually sends. The old mismatched names meant sort requests were silently dropped and the endpoint always fell back to `created_at desc` — this was also the root cause of tests appearing unsorted.
- Migrated the Tests tab grid (`TestSetTestsGrid`) from a bespoke `BaseDataGrid` setup to the shared `EntityGrid` component, the same pattern already used by the main Tests page and the Annotations grid.
- Wired a `refreshTrigger` from the Assign flow down to the grid so a successful assign now triggers a real refetch instead of a no-op cache invalidation that nothing was subscribed to.
- Fixed the grid's column field names (`topic.name`, `requirement.name`, `category.name`) to match what the backend's sort whitelist actually accepts, and enabled real interactive server-side sorting (previously sorting was a client-only no-op against server-paginated data).
- Added a "Remove from test set" row action, backed by the existing (previously unused) `POST /test-sets/{id}/disassociate` endpoint — added the missing frontend client method and request/response types for it.

## Additional Context

None.

## Testing

- `tsc --noEmit`, ESLint, and Prettier all clean on the changed files.
- Full frontend Jest suite passes (248 suites / 2426 tests).
- Manually verified against a running dev instance: assigning a test now shows up in the grid immediately, column headers sort interactively against the server, and the new remove action successfully disassociates a test and updates the grid/count.