### PR TITLE
fix(frontend): align activity log level labels with text

### DIFF
--- a/apps/frontend/src/app/(protected)/jobs/[identifier]/components/ActivityLogViewer.tsx
+++ b/apps/frontend/src/app/(protected)/jobs/[identifier]/components/ActivityLogViewer.tsx
@@ -131,6 +131,7 @@ export default function ActivityLogViewer({
               key={entry.id}
               sx={{
                 display: 'flex',
+                alignItems: 'baseline',
                 gap: 1.5,
                 py: 0.25,
                 color:


### PR DESCRIPTION
## Summary

- The INFO/WARNING/ERROR level labels in the job activity log were vertically misaligned with the timestamp and message text, because the label uses a smaller caption font size.
- Added `alignItems: 'baseline'` to the log entry flex row so all three elements sit on the same text baseline.

## Test plan

- [ ] Open a job detail page, verify the level labels align with the timestamp and message text