### PR TITLE
Harden onboarding invite limits and fix dark mode inputs

### DIFF
--- a/apps/backend/src/rhesis/backend/app/dependencies.py
+++ b/apps/backend/src/rhesis/backend/app/dependencies.py
@@ -326,6 +326,25 @@ def get_current_organization(
     return org
 
 
+def get_current_organization_optional(
+    current_user: User = Depends(require_current_user_or_token),
+    db: Session = Depends(get_db_session),
+) -> Optional[Organization]:
+    """Return the caller's organization, or ``None`` if they have none yet.
+
+    Unlike :func:`get_current_organization`, this never raises on a missing
+    org -- it returns ``None`` so endpoints like ``GET /features`` can
+    degrade gracefully for users mid-onboarding (no org created yet)
+    instead of 403-ing.
+
+    Uses a plain (non-tenant-scoped) session since we only read the org
+    by primary key, not run tenant-filtered queries.
+    """
+    if not current_user.organization_id:
+        return None
+    return db.get(Organization, current_user.organization_id)
+
+
 async def bind_affordance_context(
     request: Request,
     db: Session = Depends(get_tenant_db_session),

--- a/apps/backend/src/rhesis/backend/app/routers/features.py
+++ b/apps/backend/src/rhesis/backend/app/routers/features.py
@@ -12,13 +12,13 @@ the wire format stable independent of Python enum evolution.
 
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
 from rhesis.backend.app.config.settings import get_application_settings
-from rhesis.backend.app.dependencies import get_current_organization
+from rhesis.backend.app.dependencies import get_current_organization_optional
 from rhesis.backend.app.features import FeatureRegistry
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.quota import QuotaRegistry, limits_to_wire
@@ -48,11 +48,16 @@ class FeaturesResponse(BaseModel):
 
 @router.get("", response_model=FeaturesResponse)
 def list_features(
-    org: Organization = Depends(get_current_organization),
+    org: Optional[Organization] = Depends(get_current_organization_optional),
 ) -> FeaturesResponse:
-    """Return license info and the set of features enabled for the current user's org."""
-    enabled = [f.name.value for f in FeatureRegistry.licensed_features(org)]
-    warnings = FeatureRegistry.feature_warnings(org)
+    """Return license info and the set of features enabled for the current user's org.
+
+    Works for users mid-onboarding who have no org yet: returns default-tier
+    limits and no enabled features, so the frontend can size the invitation
+    form to the tier's seat cap before the org exists.
+    """
+    enabled = [f.name.value for f in FeatureRegistry.licensed_features(org)] if org else []
+    warnings = FeatureRegistry.feature_warnings(org) if org else {}
     info = FeatureRegistry.license_info(org=org)
     limits = limits_to_wire(QuotaRegistry.get_limits(org))
     return FeaturesResponse(

--- a/apps/frontend/src/app/(protected)/onboarding/components/InviteTeamStep.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/components/InviteTeamStep.tsx
@@ -48,12 +48,13 @@ export default function InviteTeamStep({
 
   const limits = useLimits();
   const seatLimit = limits[QuotaResource.SEATS];
-  // The onboarding user occupies one seat, so invitable slots = limit - 1.
-  // null means unlimited; fall back to a sensible cap when limits haven't loaded.
+  // null = unlimited (licensed with no cap), undefined = not loaded yet.
   const maxInvites =
-    typeof seatLimit === 'number'
-      ? Math.max(1, seatLimit - 1)
-      : FALLBACK_MAX_INVITES;
+    seatLimit === null
+      ? FALLBACK_MAX_INVITES
+      : typeof seatLimit === 'number'
+        ? Math.max(0, seatLimit - 1)
+        : FALLBACK_MAX_INVITES;
 
   const step = ONBOARDING_STEPS[1];
 
@@ -229,9 +230,7 @@ export default function InviteTeamStep({
             fontSize: 16,
             lineHeight: '24px',
             cursor:
-              formData.invites.length >= maxInvites
-                ? 'not-allowed'
-                : 'pointer',
+              formData.invites.length >= maxInvites ? 'not-allowed' : 'pointer',
             opacity: formData.invites.length >= maxInvites ? 0.5 : 1,
             alignSelf: 'flex-start',
           }}

--- a/apps/frontend/src/app/(protected)/onboarding/components/InviteTeamStep.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/components/InviteTeamStep.tsx
@@ -31,6 +31,7 @@ interface InviteTeamStepProps {
   onBack: () => void;
 }
 
+const UNLIMITED_MAX_INVITES = 10;
 const FALLBACK_MAX_INVITES = 5;
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -51,7 +52,7 @@ export default function InviteTeamStep({
   // null = unlimited (licensed with no cap), undefined = not loaded yet.
   const maxInvites =
     seatLimit === null
-      ? FALLBACK_MAX_INVITES
+      ? UNLIMITED_MAX_INVITES
       : typeof seatLimit === 'number'
         ? Math.max(0, seatLimit - 1)
         : FALLBACK_MAX_INVITES;

--- a/apps/frontend/src/app/(protected)/onboarding/components/InviteTeamStep.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/components/InviteTeamStep.tsx
@@ -17,6 +17,8 @@ import { useState } from 'react';
 import OnboardingStepHeader from './OnboardingStepHeader';
 import OnboardingNavButtons from './OnboardingNavButtons';
 import { ONBOARDING_STEPS } from './onboarding-steps';
+import { useLimits } from '@/contexts/FeaturesContext';
+import { QuotaResource } from '@/constants/quota';
 
 interface FormData {
   invites: { id: string; email: string }[];
@@ -29,7 +31,7 @@ interface InviteTeamStepProps {
   onBack: () => void;
 }
 
-const MAX_TEAM_MEMBERS = 10;
+const FALLBACK_MAX_INVITES = 5;
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export default function InviteTeamStep({
@@ -44,6 +46,15 @@ export default function InviteTeamStep({
     [key: number]: { hasError: boolean; message: string };
   }>({});
 
+  const limits = useLimits();
+  const seatLimit = limits[QuotaResource.SEATS];
+  // The onboarding user occupies one seat, so invitable slots = limit - 1.
+  // null means unlimited; fall back to a sensible cap when limits haven't loaded.
+  const maxInvites =
+    typeof seatLimit === 'number'
+      ? Math.max(1, seatLimit - 1)
+      : FALLBACK_MAX_INVITES;
+
   const step = ONBOARDING_STEPS[1];
 
   const nonEmptyInvites = formData.invites.filter(invite =>
@@ -57,9 +68,9 @@ export default function InviteTeamStep({
       {};
     let hasError = false;
 
-    if (nonEmptyInvites.length > MAX_TEAM_MEMBERS) {
+    if (nonEmptyInvites.length > maxInvites) {
       setErrorMessage(
-        `You can invite a maximum of ${MAX_TEAM_MEMBERS} team members during onboarding.`
+        `You can invite a maximum of ${maxInvites} team members during onboarding.`
       );
       return false;
     }
@@ -136,9 +147,9 @@ export default function InviteTeamStep({
   };
 
   const addEmailField = () => {
-    if (formData.invites.length >= MAX_TEAM_MEMBERS) {
+    if (formData.invites.length >= maxInvites) {
       setErrorMessage(
-        `You can invite a maximum of ${MAX_TEAM_MEMBERS} team members during onboarding.`
+        `You can invite a maximum of ${maxInvites} team members during onboarding.`
       );
       return;
     }
@@ -218,13 +229,13 @@ export default function InviteTeamStep({
             fontSize: 16,
             lineHeight: '24px',
             cursor:
-              formData.invites.length >= MAX_TEAM_MEMBERS
+              formData.invites.length >= maxInvites
                 ? 'not-allowed'
                 : 'pointer',
-            opacity: formData.invites.length >= MAX_TEAM_MEMBERS ? 0.5 : 1,
+            opacity: formData.invites.length >= maxInvites ? 0.5 : 1,
             alignSelf: 'flex-start',
           }}
-          disabled={formData.invites.length >= MAX_TEAM_MEMBERS}
+          disabled={formData.invites.length >= maxInvites}
         >
           <AddIcon sx={{ fontSize: 24 }} />
           Add another email

--- a/apps/frontend/src/app/(protected)/onboarding/components/OnboardingPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/components/OnboardingPageClient.tsx
@@ -18,6 +18,7 @@ import { useNotifications } from '@/components/common/NotificationContext';
 import { writeActiveProjectId } from '@/utils/active-project';
 import { useCreateProject } from '@/hooks/useEndpoints';
 import { useCreateUser } from '@/hooks/useUsers';
+import { parseQuotaError } from '@/utils/quota';
 
 type OnboardingStatus =
   | 'idle'
@@ -166,7 +167,9 @@ export default function OnboardingPageClient({
               error?: string;
             }> = [];
 
-            const createUserPromises = validEmails.map(async email => {
+            // Send invitations sequentially so the backend quota gate
+            // sees each new seat before checking the next one.
+            for (const email of validEmails) {
               const userData = {
                 email: email,
                 organization_id: organization.id as UUID,
@@ -175,12 +178,28 @@ export default function OnboardingPageClient({
               };
 
               try {
-                const user = await createUser(userData);
+                await createUser(userData);
                 invitationResults.push({ email, success: true });
-                return user;
               } catch (error: unknown) {
-                let errorMessage = 'Unknown error';
+                if (parseQuotaError(error)) {
+                  invitationResults.push({
+                    email,
+                    success: false,
+                    error: 'Seat limit reached',
+                  });
+                  // Mark remaining emails as skipped and stop.
+                  const currentIndex = validEmails.indexOf(email);
+                  for (const remaining of validEmails.slice(currentIndex + 1)) {
+                    invitationResults.push({
+                      email: remaining,
+                      success: false,
+                      error: 'Seat limit reached',
+                    });
+                  }
+                  break;
+                }
 
+                let errorMessage = 'Unknown error';
                 if (error instanceof Error) {
                   errorMessage = error.message;
                 } else if (
@@ -198,13 +217,11 @@ export default function OnboardingPageClient({
                   success: false,
                   error: errorMessage,
                 });
-                return null;
               }
-            });
+            }
 
-            const createdUsers = await Promise.all(createUserPromises);
-            const successCount = createdUsers.filter(
-              user => user !== null
+            const successCount = invitationResults.filter(
+              r => r.success
             ).length;
             const failedCount = validEmails.length - successCount;
 
@@ -215,7 +232,7 @@ export default function OnboardingPageClient({
               );
             } else if (successCount > 0 && failedCount > 0) {
               notifications.show(
-                `Successfully invited ${successCount} team member${successCount === 1 ? '' : 's'}. ${failedCount} invitation${failedCount === 1 ? '' : 's'} failed.`,
+                `Successfully invited ${successCount} team member${successCount === 1 ? '' : 's'}. ${failedCount} invitation${failedCount === 1 ? '' : 's'} could not be sent.`,
                 { severity: 'warning' }
               );
 

--- a/apps/frontend/src/app/(protected)/onboarding/components/OnboardingPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/components/OnboardingPageClient.tsx
@@ -169,7 +169,8 @@ export default function OnboardingPageClient({
 
             // Send invitations sequentially so the backend quota gate
             // sees each new seat before checking the next one.
-            for (const email of validEmails) {
+            for (let i = 0; i < validEmails.length; i++) {
+              const email = validEmails[i];
               const userData = {
                 email: email,
                 organization_id: organization.id as UUID,
@@ -187,9 +188,7 @@ export default function OnboardingPageClient({
                     success: false,
                     error: 'Seat limit reached',
                   });
-                  // Mark remaining emails as skipped and stop.
-                  const currentIndex = validEmails.indexOf(email);
-                  for (const remaining of validEmails.slice(currentIndex + 1)) {
+                  for (const remaining of validEmails.slice(i + 1)) {
                     invitationResults.push({
                       email: remaining,
                       success: false,

--- a/apps/frontend/src/app/(protected)/onboarding/components/onboarding-steps.ts
+++ b/apps/frontend/src/app/(protected)/onboarding/components/onboarding-steps.ts
@@ -29,7 +29,7 @@ export const ONBOARDING_STEPS: OnboardingStepConfig[] = [
     sidebarSubtitle: 'Start collaborating with your team',
     contentTitle: 'Invite your team',
     contentDescription:
-      'Invite up to 10 colleagues during onboarding to join your organization. You can skip this step and add team members later.',
+      'Invite colleagues to join your organization. You can skip this step and add team members later.',
     icon: PersonAddOutlinedIcon,
   },
   {

--- a/apps/frontend/src/contexts/FeaturesContext.tsx
+++ b/apps/frontend/src/contexts/FeaturesContext.tsx
@@ -33,6 +33,7 @@ interface FeaturesState {
   license: LicenseInfo | null;
   enabled: ReadonlySet<string>;
   warnings: Readonly<Record<string, string>>;
+  limits: Readonly<Record<string, number | null>>;
   isLocalMode: boolean;
   rhesisKeyEnabled: boolean;
   loading: boolean;
@@ -43,6 +44,7 @@ const DEFAULT_STATE: FeaturesState = {
   license: null,
   enabled: new Set<string>(),
   warnings: {},
+  limits: {},
   isLocalMode: false,
   rhesisKeyEnabled: false,
   loading: true,
@@ -91,6 +93,7 @@ export function FeaturesProvider({
         license: null,
         enabled: new Set<string>(),
         warnings: {},
+        limits: {},
         isLocalMode: false,
         rhesisKeyEnabled: false,
         loading: false,
@@ -101,6 +104,7 @@ export function FeaturesProvider({
       license: data.license,
       enabled: new Set<string>(data.enabled),
       warnings: data.warnings ?? {},
+      limits: data.limits ?? {},
       isLocalMode: data.is_local ?? false,
       rhesisKeyEnabled: data.rhesis_key_enabled ?? false,
       loading: false,
@@ -163,6 +167,15 @@ export function useIsLocalMode(): boolean {
  */
 export function useRhesisKeyEnabled(): boolean {
   return useContext(FeaturesContext).rhesisKeyEnabled;
+}
+
+/**
+ * Per-resource quota limits from the current org's tier, keyed by
+ * resource name (e.g. `"seats"`, `"projects"`). `null` means unlimited.
+ * Empty while loading or on error.
+ */
+export function useLimits(): Readonly<Record<string, number | null>> {
+  return useContext(FeaturesContext).limits;
 }
 
 /**

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -608,15 +608,15 @@ const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
           root: {
             borderRadius: 8,
             ...(mode === 'dark' && {
-              color: '#ffffff',
+              color: gs.title,
+              backgroundColor: gs.fieldSurface,
             }),
           },
           notchedOutline: {
-            borderColor:
-              mode === 'light' ? GREYSCALE.light.border : GREYSCALE.dark.border,
+            borderColor: gs.border,
           },
           input: {
-            ...(mode === 'dark' && { color: '#ffffff' }),
+            ...(mode === 'dark' && { color: gs.title }),
           },
         },
       },

--- a/apps/frontend/src/utils/api-client/features-client.ts
+++ b/apps/frontend/src/utils/api-client/features-client.ts
@@ -11,6 +11,8 @@ export interface FeaturesResponse {
   enabled: string[];
   /** Per-feature warnings for features that are licensed but not operationally ready. */
   warnings?: Record<string, string>;
+  /** Per-resource quota limits for the current org's tier. */
+  limits?: Record<string, number | null>;
   /**
    * Whether this deployment runs in local/self-hosted mode. Single source of
    * truth for local-only UI -- optional to tolerate an older backend that


### PR DESCRIPTION
## Summary

- **Onboarding seat quota enforcement**: invitations are now sent sequentially (not concurrently) so the backend quota gate sees each new seat before checking the next. Stops on the first 402 and reports which invitations succeeded vs. were skipped. The invite step derives its field cap from the tier's seat limit via `GET /features` instead of a hardcoded constant.
- **`GET /features` tolerates no-org callers**: users mid-onboarding (no org yet) get default-tier limits and no enabled features, so the invite form knows the seat cap before the org exists.
- **Dark mode outlined inputs**: all `MuiOutlinedInput` fields now get a `fieldSurface` background fill in dark mode so they are visible against dark surfaces (drawers, modals, pages). Replaces hardcoded `#ffffff` text color with the `gs.title` theme token.

## Test plan

- [ ] Onboarding: verify invite step shows correct max fields for the tier (free tier: 2 invites)
- [ ] Onboarding: fill more emails than the seat limit allows, confirm only the allowed number succeed and the rest show "Seat limit reached"
- [ ] Dark mode: open any drawer (Change Password, Add tuning case, etc.) and confirm outlined fields have a visible fill and readable text
- [ ] Light mode: confirm outlined fields are unchanged (no background fill)