### PR TITLE
Fix(frontend): 400 error on assigning test sets to test

### DIFF
--- a/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
+++ b/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
@@ -64,17 +64,18 @@ export default function LinkedTestSetsSection({
     try {
       const testSetsClient = new TestSetsClient();
       const response = await testSetsClient.getTestSets({
-        limit: 500,
+        limit: 100,
         sort_by: 'name',
         sort_order: 'asc',
       });
       setAvailable(response.data);
     } catch {
       setAvailable([]);
+      showNotification('Failed to load test sets', { severity: 'error' });
     } finally {
       setLoadingAvailable(false);
     }
-  }, []);
+  }, [showNotification]);
 
   const linkedIds = useMemo(
     () => new Set(testSets.map(ts => String(ts.id))),


### PR DESCRIPTION
## Purpose

On a test's detail page, the "Assign Test Set" drawer (Linked tab) appeared empty even when test sets existed in the environment. The drawer's fetch requested `limit: 500`, but the backend caps list requests at 100 and rejects anything higher with a 400. The failure was caught and silently replaced with an empty array, so the bug looked like "no test sets exist" instead of a request error.

## What Changed

- Lowered the test-set fetch limit in the Assign Test Set drawer from 500 to 100 (the backend's max).
- Surfaced fetch failures with an error notification instead of silently showing an empty list.

## Additional Context

If an environment has more than 100 test sets, this drawer still won't show all of them — same cap exists in other assign drawers (e.g. `SelectExperimentsDrawer.tsx`). Not addressed re; would need real pagination or server-side search.

## Testing

1. Open a test's detail page → Linked tab.
2. Click "Assign Test Set" (or "Assign to test set" if none linked yet).
3. Confirm the drawer lists existing test sets instead of showing empty.
4. Confirm assigning a test set still works and the list refreshes.

