### PR TITLE
Prune stale AGENTS.md content and scope agent context

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,19 @@
   "enabledPlugins": {
     "ralph-loop@claude-plugins-official": true
   },
+  "claudeMdExcludes": [
+    "**/.venv/**"
+  ],
+  "permissions": {
+    "deny": [
+      "Read(./**/.venv/**)",
+      "Read(./**/node_modules/**)",
+      "Read(./**/.next/**)",
+      "Read(./**/dist/**)",
+      "Read(./**/build/**)",
+      "Read(./**/__pycache__/**)"
+    ]
+  },
   "hooks": {
     "WorktreeCreate": [
       {

--- a/.claude/skills/docs-design-tokens/SKILL.md
+++ b/.claude/skills/docs-design-tokens/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: docs-design-tokens
+description: Colour, font and design-token rules for the docs site — when hex is banned, when it is correct, and which surfaces ignore the theme. Use when styling docs components or editing CSS under docs/src.
+---
+
+# Docs design tokens
+
+Design tokens live in `docs/src/styles/tokens.css` as `--rh-*` custom properties, synced by hand
+from the marketing site's `@theme` block (`website/src/styles/tailwind.css`, a separate repo).
+
+## Colour
+
+- **No hex for anything on the theme or brand scale** — surfaces, text, borders, accents, CTAs — in
+  components or in `globals.css`. Use a token; if none fits, add one to `tokens.css` rather than
+  inlining a value. That includes CSS-variable *fallbacks*: write
+  `var(--card-bg, var(--rh-surface))`, not `var(--card-bg, #ffffff)`, or the fallback silently
+  renders a light surface in dark mode.
+- **Literal hex is correct for fixed decorative artwork**, and tokenising it would be wrong: the
+  German flag in `FooterOriginBadge`, the macOS window dots in `CodeBlock`/`FileTree`, and the
+  terminal palette and tint ramps in `FileTree`/`ChatExchange`/`ToolPurposeChip`. These carry
+  meaning independent of the theme. If a value would look broken in the other theme, it wants a
+  token; if it would look broken in any *other colour*, it wants to stay literal.
+- **Colour is neutral by default.** Chrome (navbar, sidebar, footer, body copy, headings, primary
+  buttons) sits on the neutral scale; the brand blues are for accents and links. Orange is for CTAs
+  only — don't reintroduce it as an icon or card accent.
+- The `--rhesis-*` names are legacy aliases kept pointing at `--rh-*`; prefer `--rh-*` in new code.
+
+## Theme-invariant surfaces
+
+**Check whether a surface follows the theme before tokenising it.** `CodeBlock` and `FileTree`
+render a dark terminal surface in *both* themes, with Shiki colours chosen for a dark background.
+They use the theme-invariant `--rh-codeblock-*` tokens; pointing them at `--rh-surface`/`--rh-text`
+turns them white in light mode and makes the syntax colours unreadable.
+
+## Fonts
+
+Sora for display/headings, Geist for UI and body, Geist Mono for code and the uppercase eyebrow
+labels. All self-hosted woff2 in `docs/public/fonts/`.
+
+## Nextra's accent ramp
+
+**Not set in CSS.** It comes from the `color` prop on `<Head>` in `docs/src/app/layout.jsx`, which
+Nextra emits as an inline `<style>` that beats any stylesheet. Nextra derives `primary-50` …
+`primary-800` from those HSL values, and the active sidebar link is `bg-primary-100` +
+`text-primary-800`. Change the prop; do not override the generated `x:` classes.

--- a/.claude/skills/docs-social-images/SKILL.md
+++ b/.claude/skills/docs-social-images/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: docs-social-images
+description: How the docs site generates per-page og:image cards, and the cache and font traps when changing them. Use when editing the OG card design, og-theme.js, or a page's social preview image.
+---
+
+# Docs social preview images
+
+Every page's `og:image` is generated per page by `docs/src/app/api/og/route.jsx` — title,
+description and section come from the page's own MDX, resolved through `lib/og-page.js`.
+
+**Adding a page needs nothing.** The card is generated from its frontmatter automatically.
+
+## Three traps
+
+- **Changing the card design means bumping `OG_VERSION`** in `lib/og-theme.js`. Crawlers cache
+  social images by URL; without a new `v=`, LinkedIn and Slack keep serving the old picture.
+  Editing a page's own title or description needs nothing — `h=` in the URL is a hash of the card
+  text, so it changes on its own.
+- **Card colours are literal hex in `lib/og-theme.js`, copied from `tokens.css`.** satori never
+  sees a stylesheet, so `var(--rh-*)` resolves to nothing. This is the one place hex is expected —
+  change both files together. See the `docs-design-tokens` skill for the token rules everywhere
+  else.
+- **Fonts are TTF subsets in `docs/public/fonts/og/`**, not the woff2 the site uses: satori cannot
+  decode woff2. Regenerate with `docs/scripts/generate-og-fonts.py` after a font change.
+
+## Hand-made images
+
+A page that needs one sets `ogImage: /path.png` in frontmatter. Use PNG or JPEG — social crawlers
+do not render webp reliably.

--- a/.claude/skills/ee-feature/SKILL.md
+++ b/.claude/skills/ee-feature/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: ee-feature
+description: Add a new Enterprise Edition feature behind a feature gate, across backend and frontend. Use when adding an EE-only capability such as SSO.
+---
+
+# Adding a new EE feature
+
+`FeatureRegistry` is for EE features only. A capability that ships in `apps/backend/` under MIT is
+unconditionally available and needs no gating — don't register it.
+
+1. Add a member to `FeatureName` in `app/features/__init__.py`.
+2. Implement the feature under `ee/backend/src/rhesis/backend/ee/<feature>/`.
+3. Register it in `ee/backend/src/rhesis/backend/ee/__init__.py:bootstrap()` by calling
+   `FeatureRegistry.register(Feature(...))` with an optional `runtime_check`, then
+   `app.include_router(...)` for any new endpoints.
+4. Gate routes with `Depends(require_feature(FeatureName.X))`. Use
+   `FeatureRegistry.is_available(name, org)` for org-aware checks elsewhere, and
+   `FeatureRegistry.is_registered(name)` for early-bailout checks before an org has been resolved
+   (e.g. inside an OIDC callback).
+5. Mirror the name in `apps/frontend/src/constants/features.ts` and wrap the UI in
+   `<FeatureGate feature={FeatureName.X}>`.
+
+## The import boundary
+
+Core code must never import from `rhesis.backend.ee.*`. The only core-side coupling is the
+`try/except ImportError` in `app/ee_bootstrap.py`, which is what lets a Community build run without
+the EE package installed. The `community-boundary` CI job fails the PR if you break this.
+
+Background on the registry and the gating dependencies is in `apps/backend/AGENTS.md`; the frontend
+half is in `apps/frontend/AGENTS.md`.

--- a/.claude/skills/update-branch/SKILL.md
+++ b/.claude/skills/update-branch/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: update-branch
+description: Rebase a feature branch onto main and force-push it safely. Use when updating, rebasing, or syncing a branch with main, or resolving rebase conflicts.
+---
+
+# Updating a Branch
+
+**Rebase onto `main`; don't merge `main` into the branch.**
+
+```bash
+git fetch origin && git rebase origin/main
+```
+
+Merging leaves a merge commit and interleaves unrelated `main` changes into the branch's history,
+which makes the PR diff noisy and stops the branch's own commits from reading as a clean sequence.
+
+## Conflicts
+
+Fix the files, `git add <file>`, then `git rebase --continue`. `git rebase --abort` puts the branch
+back the way it was.
+
+## Pushing after a rebase
+
+A rebase rewrites history, so an already-pushed branch needs:
+
+```bash
+git push --force-with-lease
+```
+
+`--force-with-lease` refuses to overwrite commits someone else pushed, which plain `--force` will
+do. On a branch someone else is working on, tell them before you force-push.
+
+**Never force-push `main`.**
+
+Pushing needs the user's go-ahead — see the commit rules in `AGENTS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,14 @@
 # Rhesis Project Rules
 
 Read natively by Cursor and imported by Claude Code (`CLAUDE.md` → `@AGENTS.md`). This file holds
-rules that apply repo-wide. Scoped rules live in each area's own `AGENTS.md`:
-`apps/backend/AGENTS.md`, `apps/frontend/AGENTS.md`, `sdk/AGENTS.md`, `docs/AGENTS.md`.
+rules that apply repo-wide. Each area has its own `AGENTS.md` for rules scoped to it, pulled in
+automatically when you read files there via a sibling `CLAUDE.md`:
+
+- `apps/backend/AGENTS.md` — ambient request scope, usage attribution, feature gating
+- `apps/frontend/AGENTS.md` — affordances, BFF auth, TypeScript/ESLint conventions
+- `sdk/AGENTS.md` — imports, test invocation
+- `docs/AGENTS.md` — docs writing rules, Nextra/MDX mechanics
+- `skills/rhesis/AGENTS.md` — the published public skill (everything there ships to users)
 
 ## Answering
 
@@ -23,7 +29,20 @@ not for ordinary code. Never restate what the next line does.
 
 ## Technology Stack
 
-Backend and Python SDK: Python 3.10+, `uv` with `pyproject.toml`, Pydantic 2.x, pytest.
+Backend and Python SDK: Python 3.12+, `uv` with `pyproject.toml`, Pydantic 2.x, pytest.
+
+### Python imports
+
+**Always absolute, never relative.** Write the full dotted path, including for a module's own
+siblings and inside a package's own `__init__.py`:
+
+```python
+from rhesis.backend.app.services.explorer.utils import build_test_tree  # yes
+from .utils import build_test_tree  # no
+from ..database import get_db  # no
+```
+
+Existing relative imports are being converted as the files around them are touched.
 
 ## Local Development
 
@@ -38,11 +57,11 @@ Backend and Python SDK: Python 3.10+, `uv` with `pyproject.toml`, Pydantic 2.x, 
 ## Worktrees
 
 Every worktree must come from `./rh worktree`, never from a bare `git worktree add`. Only
-`./rh worktree` symlinks `playground/` and `simulations/` back to the main checkout, so notes
-written there survive the worktree being removed — they're gitignored, so nothing else preserves
-them. It also gives the worktree its own dev ports and container names; a worktree without
-`.rhesis-ports` shares the main checkout's stack, and `./rh dev clean` in one would delete main's
-dev database.
+`./rh worktree` symlinks `playground/`, `simulations/` and `domain.local/` back to the main
+checkout, so notes written there survive the worktree being removed — they're gitignored, so
+nothing else preserves them. It also gives the worktree its own dev ports and container names; a
+worktree without `.rhesis-ports` shares the main checkout's stack, and `./rh dev clean` in one
+would delete main's dev database.
 
 A worktree that already exists without that setup isn't stuck — run `./rh worktree --init` from
 inside it.
@@ -62,9 +81,11 @@ Port blocks run out after 20 concurrent worktrees, so remove yours when done:
 
 ## Testing
 
-Tests live in `tests/backend/` and `tests/sdk/`, not next to source. See `apps/backend/AGENTS.md`
-and `sdk/AGENTS.md` for exact invocation commands (backend and SDK have different working-directory
-requirements).
+Tests live under `tests/` — `backend/`, `sdk/`, `frontend/`, plus `k6/`, `load/`, `notifications/`,
+`penelope/`, `polyphemus/`, `release_tools/` — never next to source.
+
+Each suite has different working-directory and Docker requirements. Backend: invoke the
+`backend-testing` skill. SDK: see `sdk/AGENTS.md`.
 
 ## Git Commits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,22 +104,5 @@ git checkout -b feature/short-description`.
   - Lowercase type/description, imperative mood, no trailing period, ≤50 chars
   - `BREAKING CHANGE:` in the footer for breaking changes
   - Example: `fix(backend): resolve timeout issue in user endpoint`
-
-## Updating a Branch
-
-- **Rebase a feature branch onto `main`; don't merge `main` into it:**
-  `git fetch origin && git rebase origin/main`. Merging leaves a merge commit and interleaves
-  unrelated `main` changes into the branch's history, which makes the PR diff noisy and stops the
-  branch's own commits from reading as a clean sequence.
-- On conflicts: fix the files, `git add <file>`, then `git rebase --continue`. `git rebase --abort`
-  puts the branch back the way it was.
-- A rebase rewrites history, so pushing an already-pushed branch needs
-  `git push --force-with-lease` — it refuses to overwrite commits someone else pushed, which plain
-  `--force` will do. On a branch someone else is working on, tell them before you force-push.
-- **Never force-push `main`.**
-
-## Task-specific workflows
-
-Opening a pull request, filing a GitHub issue, writing playground scripts, linting Python, and
-running `./rh worktree` each have their own skill — invoke `pull-request`, `github-issue`,
-`playground-script`, `python-linting`, or `worktree` when doing that task.
+- **Rebase a feature branch onto `main`; never merge `main` into it, and never force-push `main`.**
+  The rebase, conflict and force-push procedure is the `update-branch` skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,1 @@
 @AGENTS.md
-
-## Scoped rules
-
-Each area has its own `AGENTS.md` with rules specific to that part of the codebase, pulled in
-automatically when you read files there via a sibling `CLAUDE.md`:
-
-- `apps/backend/AGENTS.md` — ambient request scope, feature gating, codebase layout
-- `apps/frontend/AGENTS.md` — affordances, TypeScript/ESLint conventions, codebase layout
-- `sdk/AGENTS.md` — codebase layout, test invocation
-- `docs/AGENTS.md` — Nextra/MDX rules

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -1,36 +1,12 @@
 # Backend Rules
 
-FastAPI REST API with Celery task processing. Layered: routers → services → models/crud.
+FastAPI REST API with Celery task processing. Layered: routers → services → crud. Alongside
+`app/`: `alembic/` (migrations), `jobs/` (Celery tasks), `metrics/` (evaluation).
 See root `AGENTS.md` for repo-wide rules (commits, PRs, testing overview, tech stack).
-
-## Directory layout
-
-- `src/rhesis/backend/app/` — FastAPI core: `models/` (SQLAlchemy ORM), `schemas/` (Pydantic),
-  `routers/`, `services/` (business logic), `auth/`, `scope.py`/`models/scope_events.py` (tenant
-  scope), `features/` (feature gating)
-- `alembic/` — DB migrations
-- `jobs/` — Celery background tasks (`execution/`, `telemetry/`)
-- `metrics/` — evaluation metrics (DeepEval, RAGAS, native providers)
-
-## Imports
-
-**Always absolute, never relative.** Write the full dotted path, including for a module's own
-siblings:
-
-```python
-from rhesis.backend.app.schemas.explorer import TestTreeNode  # yes
-from rhesis.backend.app.services.explorer.utils import build_test_tree  # yes
-from .utils import build_test_tree  # no
-from ..database import get_db  # no
-```
-
-This holds inside a package's own `__init__.py` too. Existing relative imports are being converted
-as the files around them are touched.
 
 ## CRUD layout
 
-`app/crud/` is one module per entity — `crud/test.py`, `crud/test_set.py`, `crud/explorer.py`, and so on.
-`crud/__init__.py` is empty on purpose; **a new CRUD function goes in its entity's module**, and a
+`app/crud/` is one module per entity. **A new CRUD function goes in its entity's module**, and a
 new entity gets a new module.
 
 Layering is routers → services → crud, and the same "split, don't grow" rule runs down it: touching
@@ -134,11 +110,9 @@ Set `RHESIS_DISABLE_SCOPE_LISTENER=1` to disable both listeners without redeploy
 
 ### Test fixtures
 
-`tests/backend/conftest.py` provides:
-
-- `isolate_request_scope` (autouse) — resets `ContextVar`s to defaults per test; existing tests
-  are unaffected because the listener no-ops when `organization_id is None`
-- `bound_scope` — opt-in fixture for tests that exercise the listeners directly
+`tests/backend/conftest.py` provides `isolate_request_scope` (autouse, resets the `ContextVar`s
+per test) and `bound_scope` (opt-in, for tests that exercise the listeners directly). The autouse
+one is safe for existing tests because the listener no-ops when `organization_id is None`.
 
 ### Side-channel and in-request scope binding
 
@@ -160,25 +134,6 @@ queries silently return empty results or wrong counts with no error raised.
 block. Any `db.commit()` inside the block (which triggers the `after_begin` re-apply listener) uses
 the temporary project scope, not the caller's original scope. Safe to use repeatedly within a single
 request session.
-
-`bind_scope_to_session` callers (sessions they own outright):
-
-- `jobs/execution/batch/context.py`
-- `celery/signals.py`
-- `jobs/telemetry/evaluate.py`
-- `jobs/telemetry/post_ingest.py`
-- `jobs/execution/executors/data.py`
-- `routers/parameters.py`
-- `services/telemetry/conversation_linking.py`
-- `services/websocket/handlers/architect.py`
-
-`temporary_project_scope` callers (in-request, short project windows):
-
-- `services/organization.py` (three sites — onboarding endpoint/project seeding)
-
-`set_session_variables` callers (explicit GUC-only re-apply):
-
-- `routers/organization.py` (re-applies GUCs after mid-request `db.commit()` during onboarding)
 
 ### GUC reset ordering invariant
 
@@ -226,21 +181,22 @@ on response schemas that mixin `WithPermittedActions`. See `apps/frontend/AGENTS
 three-primitives frontend contract.
 
 Adding affordances to a new resource: add `WithPermittedActions` to the Pydantic response schema
-and annotate `resource_type` on the class. Key files: `schemas/affordances.py` (mixin),
-`auth/capabilities.py` (`Permission` enum, keep in sync with frontend `Capability` enum).
+and annotate `resource_type` on the class. The `Permission` enum in `auth/capabilities.py` must
+stay in sync with the frontend `Capability` enum.
 
 ## Feature Gating
 
 Gated capabilities (e.g. SSO) flow through a single primitive on the backend and a mirrored one on
 the frontend. No ad-hoc `if` checks scattered across routers or components.
 
-- `app/features/__init__.py` — the `FeatureRegistry`, `Feature` dataclass, `FeatureName` str-Enum,
-  and `LicenseProvider` protocol. `DefaultLicenseProvider` is the stub used today; a real one
-  installs via `FeatureRegistry.set_license_provider(...)` when licensing lands.
-- `app/features_bootstrap.py` — declarative list of features, called once from `main.py` lifespan.
-- `app/auth/feature_gates.py` — FastAPI dependencies `require_feature` (404 on denial, no
-  enumeration leak) and `has_feature` (bool for branching).
-- `app/routers/features.py` — `GET /features` returns license info and enabled feature names.
+`app/features/` holds the `FeatureRegistry`, the `FeatureName` str-Enum and the `LicenseProvider`
+protocol; `app/auth/feature_gates.py` has the `require_feature` dependency (404 on denial, so
+denied features don't leak by enumeration) and `has_feature` for branching.
+
+EE code is loaded through `app/ee_bootstrap.py`, the **only** core-side import of
+`rhesis.backend.ee` — a `try/except ImportError` so a Community build runs without it. That
+boundary is enforced by the `community-boundary` CI job; no other file under `apps/backend/src/`
+may import from `rhesis.backend.ee.*`.
 
 Community features are never registered. `FeatureRegistry` is for EE features only; if a
 capability ships in `apps/backend/` under MIT, it is unconditionally available and needs no gating.

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -34,11 +34,6 @@ Use `app/utils/` over `app/services/<domain>/` when more than one unrelated serv
 helper — e.g. `app/utils/response_extractor.py` is used by explorer's invocation *and* by metric
 evaluation, batch execution, and Penelope, none of which are endpoint-specific.
 
-## Testing and debugging
-
-Running the test suite and debugging the backend directly each have their own skill —
-invoke `backend-testing` or `backend-debug` when doing that task.
-
 ## Ambient Request Scope (Tenant Filtering & Stamping)
 
 All tenant context (`organization_id`, `user_id`, `project_id`) is stored **once per request** on
@@ -200,17 +195,3 @@ may import from `rhesis.backend.ee.*`.
 
 Community features are never registered. `FeatureRegistry` is for EE features only; if a
 capability ships in `apps/backend/` under MIT, it is unconditionally available and needs no gating.
-
-### Adding a new EE feature
-
-1. Add a member to `FeatureName` in `app/features/__init__.py`.
-2. Implement the feature under `ee/backend/src/rhesis/backend/ee/<feature>/`.
-3. Register it in `ee/backend/src/rhesis/backend/ee/__init__.py:bootstrap()` by calling
-   `FeatureRegistry.register(Feature(...))` with an optional `runtime_check`, then
-   `app.include_router(...)` for any new endpoints.
-4. Gate routes with `Depends(require_feature(FeatureName.X))`. Use
-   `FeatureRegistry.is_available(name, org)` for org-aware checks elsewhere and
-   `FeatureRegistry.is_registered(name)` for early-bailout checks before an org has been resolved
-   (e.g. inside an OIDC callback).
-5. Mirror the name in `apps/frontend/src/constants/features.ts` and wrap the UI in
-   `<FeatureGate feature={FeatureName.X}>` — see `apps/frontend/AGENTS.md`.

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -1,20 +1,15 @@
 # Frontend Rules
 
-Next.js 14+ with App Router and Material UI. See root `AGENTS.md` for repo-wide rules.
+Next.js 16 with App Router and Material UI. See root `AGENTS.md` for repo-wide rules.
 
-## Directory layout
-
-- `src/app/(protected)/` — authenticated routes, file-based, `[identifier]` dynamic routes
-- `src/components/common/` — reusable UI (BaseDataGrid, BaseTable, ActionBar, etc.)
-- `src/utils/api-client/` — typed backend API clients
-- `src/hooks/` — custom React hooks
-- `src/constants/capabilities.ts`, `src/constants/features.ts` — mirror backend enums, keep in sync
+Authenticated routes live under `src/app/(protected)/`; backend calls go through the typed clients
+in `src/utils/api-client/`.
 
 ## Affordances (Server-Driven Permissions)
 
-The backend resolves permitted actions per object and exposes them as `permitted_actions: string[]`
-via `WithPermittedActions`. The frontend consumes them through **three primitives only** — never
-roll your own ownership logic (`user.id === currentUserId`).
+The backend resolves permitted actions per object (see `apps/backend/AGENTS.md`). The frontend
+consumes them through **three primitives only** — never roll your own ownership logic
+(`user.id === currentUserId`).
 
 | Primitive                           | When to use                                                                                                       |
 | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
@@ -36,14 +31,20 @@ if (!canRead) return <AccessDenied resource="test runs" />;
 </Can>;
 ```
 
-Types carrying object-level affordances: `TestResult`, `ExperimentRead`, `Task`, `TestRun`,
-`Comment`. Everything else (Requirement, Metric, Endpoint, TestSet, Source, …) uses `useCan`/`<Can>`.
+A type carries object-level affordances if it extends `WithPermittedActions` — check with
+`grep -rn "extends WithPermittedActions" src`. Everything else uses `useCan`/`<Can>`.
 
 Every protected page must guard its READ capability with the `useCan` pattern above.
 
 Adding affordances to a new resource: extend the TS interface with `WithPermittedActions` from
 `@/types/affordances`, use `can(subject, …)` instead of `useCan`, and add the new capability string
 to `src/constants/capabilities.ts` (must mirror the backend `Permission` enum).
+
+**Import all four primitives from `@/components/common/Can`**, including `can` — that module
+re-exports it from `@/utils/affordances`. Both paths work at runtime, but only one is mockable in
+one place: a test that mocks `@/components/common/Can` does not intercept a component importing
+`can` from `@/utils/affordances`, and the check silently runs for real. Import `@/utils/affordances`
+directly only from non-React code (e.g. `src/utils/server-permissions.ts`).
 
 Tests rendering a component that uses any affordance primitive must mock the module:
 
@@ -55,9 +56,6 @@ jest.mock('@/components/common/Can', () => ({
   can: () => true,
 }));
 ```
-
-Key files: `src/components/common/Can.tsx` (primitives), `src/contexts/PermissionsContext.tsx`
-(ambient scope provider), `src/types/affordances.ts` (`WithPermittedActions` interface).
 
 ## BFF Auth Pattern (no client-side session tokens)
 
@@ -90,11 +88,13 @@ client component, follow the pattern above rather than copying an older prop-dri
 
 ## Feature Gating — frontend side
 
-Mirror `FeatureName` from the backend enum in `src/constants/features.ts`. `FeaturesProvider`
-(mounted in the protected layout) + `useFeature(name)` + `<FeatureGate feature={...}>` consume
-`GET /features` to conditionally render gated UI. Fail-closed: features are `false` during the
-initial fetch and on error. Typed client: `src/utils/api-client/features-client.ts`. See
-`apps/backend/AGENTS.md` for the full registration flow.
+`src/constants/features.ts` (`FeatureName`) and `src/constants/capabilities.ts` (`Capability`) are
+hand-mirrored from the backend enums and must stay in sync with them.
+
+`FeaturesProvider` (mounted in the protected layout) + `useFeature(name)` +
+`<FeatureGate feature={...}>` consume `GET /features` to conditionally render gated UI.
+Fail-closed: features are `false` during the initial fetch and on error. See
+`apps/backend/AGENTS.md` for the registration flow behind them.
 
 ## TypeScript & ESLint Conventions
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,7 +1,8 @@
 # Documentation Rules
 
-Apply whenever creating, modifying, or generating any documentation in this directory. Framework:
-Nextra, which processes MDX (Markdown + JSX).
+Rules for the docs site in `docs/` — apply whenever creating, modifying, or generating content
+here. Framework: Nextra, which processes MDX (Markdown + JSX). See root `AGENTS.md` for repo-wide
+rules.
 
 ## Writing rules
 
@@ -49,7 +50,7 @@ or restate what the page structure already shows.
   processing, request flow), one mermaid diagram with a one-line annotation beats paragraphs.
 - **Don't explain standard tools** (what ruff/pytest/Docker/git are). Show the command.
 - **Don't list obvious prerequisites** ("Git installed"). Compress to one line only when a version
-  constraint matters (Python 3.10+). Non-obvious prerequisites are a one-line link, not a section.
+  constraint matters (Python 3.12+). Non-obvious prerequisites are a one-line link, not a section.
 - **No file trees or tables describing self-describing files** (`docker-compose.yml` — "Docker
   Compose configuration"). Keep such listings only when the description is non-obvious.
 - **Keep code-block comments to non-obvious facts.** `# 1. Clone the repository` above
@@ -132,8 +133,7 @@ MDX files cannot directly import Material-UI icons — module resolution fails. 
 
 3. Use it in MDX with no imports: `<MyComponent />`
 
-Examples already following this pattern: `FeatureOverview.jsx`, `ArchitectureOverview.jsx`,
-`PlatformFeatures.jsx`.
+For existing examples: `grep -rln "@mui/icons-material" src/components/`.
 
 ### Colour, type, and design tokens
 
@@ -188,19 +188,8 @@ crawlers do not render webp reliably).
 
 - Kebab-case file names (`test-result-status.mdx`); organize by feature/topic, not file type.
 - Include code examples with a language tag (` ```python `, ` ```typescript `, ` ```bash `).
-
-```
-docs/
-├── src/
-│   ├── components/               # Reusable JSX components for MDX
-│   ├── app/                      # Next.js app directory
-│   └── mdx-components.js         # MDX component registry
-├── content/                      # All documentation content (MDX files)
-│   ├── _meta.tsx                 # Root navigation config
-│   ├── getting-started/, platform/, sdk/
-│   └── development/{backend,frontend,worker}/
-└── README.md
-```
+- MDX content lives in `content/`, JSX components in `src/components/`, registered in
+  `src/mdx-components.js`.
 
 Each directory needs a `_meta.tsx` for navigation:
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -135,55 +135,6 @@ MDX files cannot directly import Material-UI icons — module resolution fails. 
 
 For existing examples: `grep -rln "@mui/icons-material" src/components/`.
 
-### Colour, type, and design tokens
-
-Design tokens live in `src/styles/tokens.css` as `--rh-*` custom properties, synced by hand from the
-marketing site's `@theme` block (`website/src/styles/tailwind.css`). Rules:
-
-- **No hex for anything on the theme or brand scale** — surfaces, text, borders, accents, CTAs — in
-  components or in `globals.css`. Use a token; if none fits, add one to `tokens.css` rather than
-  inlining a value. That includes CSS-variable *fallbacks*: write
-  `var(--card-bg, var(--rh-surface))`, not `var(--card-bg, #ffffff)`, or the fallback silently
-  renders a light surface in dark mode.
-- **Literal hex is correct for fixed decorative artwork**, and tokenising it would be wrong: the
-  German flag in `FooterOriginBadge`, the macOS window dots in `CodeBlock`/`FileTree`, and the
-  terminal palette and tint ramps in `FileTree`/`ChatExchange`/`ToolPurposeChip`. These carry meaning
-  independent of the theme. If a value would look broken in the other theme, it wants a token; if it
-  would look broken in any *other colour*, it wants to stay literal.
-- The `--rhesis-*` names are legacy aliases kept pointing at `--rh-*`; prefer `--rh-*` in new code.
-- **Colour is neutral by default.** Chrome (navbar, sidebar, footer, body copy, headings, primary
-  buttons) sits on the neutral scale; the brand blues are for accents and links. Orange is for CTAs
-  only — don't reintroduce it as an icon or card accent.
-- **Check whether a surface is theme-following before tokenising it.** `CodeBlock` and `FileTree`
-  render a dark terminal surface in *both* themes, with Shiki colours chosen for a dark background.
-  They use the theme-invariant `--rh-codeblock-*` tokens; pointing them at `--rh-surface`/`--rh-text`
-  turns them white in light mode and makes the syntax colours unreadable.
-- **Fonts**: Sora for display/headings, Geist for UI and body, Geist Mono for code and the uppercase
-  eyebrow labels. All self-hosted woff2 in `public/fonts/`.
-- **Nextra's own accent ramp is not set in CSS.** It comes from the `color` prop on `<Head>` in
-  `src/app/layout.jsx`, which Nextra emits as an inline `<style>` that beats any stylesheet. Nextra
-  derives `primary-50` … `primary-800` from those HSL values, and the active sidebar link is
-  `bg-primary-100` + `text-primary-800`. Change the prop; do not override the generated `x:` classes.
-
-### Social preview images
-
-Every page's `og:image` is generated per page by `src/app/api/og/route.jsx` — title, description
-and section come from the page's own MDX, resolved through `lib/og-page.js`. Nothing to do when
-adding a page. Three rules:
-
-- **Changing the card design means bumping `OG_VERSION`** in `lib/og-theme.js`. Crawlers cache
-  social images by URL; without a new `v=`, LinkedIn and Slack keep serving the old picture.
-  Editing a page's own title or description needs nothing — `h=` in the URL is a hash of the card
-  text, so it changes on its own.
-- **Card colours are literal hex in `lib/og-theme.js`, copied from `tokens.css`.** satori never
-  sees a stylesheet, so `var(--rh-*)` resolves to nothing. This is the one place hex is expected —
-  change both files together.
-- **Fonts are TTF subsets in `public/fonts/og/`**, not the woff2 the site uses: satori cannot
-  decode woff2. Regenerate with `docs/scripts/generate-og-fonts.py` after a font change.
-
-A page that needs a hand-made image sets `ogImage: /path.png` in frontmatter (PNG or JPEG — social
-crawlers do not render webp reliably).
-
 ### Files and structure
 
 - Kebab-case file names (`test-result-status.mdx`); organize by feature/topic, not file type.

--- a/sdk/AGENTS.md
+++ b/sdk/AGENTS.md
@@ -3,30 +3,8 @@
 Python SDK for interacting with the Rhesis platform and running evaluations. See root `AGENTS.md`
 for repo-wide rules.
 
-## Directory layout
-
-- `src/rhesis/sdk/client.py` — main `RhesisClient`
-- `entities/` — API entity wrappers (Pythonic wrappers per resource)
-- `decorators/` — `@endpoint` and `@observe` for instrumentation
-- `connector/` — bidirectional connector for test execution
-- `metrics/providers/` — pluggable metric providers (DeepEval, RAGAS, native)
-- `models/providers/` — pluggable LLM providers (OpenAI, Anthropic, Gemini, Polyphemus, …)
-- `synthesizers/` — test data generation
-- `telemetry/` — OpenTelemetry integration, incl. `integrations/` for LangChain/LangGraph/AutoGen
-
-## Imports
-
-**Always absolute, never relative.** Write the full dotted path, including for a module's own
-siblings:
-
-```python
-from rhesis.sdk.metrics.providers.native import NativeMetric  # yes
-from .providers.native import NativeMetric  # no
-from ..client import RhesisClient  # no
-```
-
-This holds inside a package's own `__init__.py` too. Existing relative imports are being converted
-as the files around them are touched.
+Everything lives under `src/rhesis/sdk/`. `metrics/providers/` and `models/providers/` are both
+plugin points — a new metric backend or LLM provider goes in one of those, not in the caller.
 
 ## Testing
 


### PR DESCRIPTION
## Purpose

Every hand-maintained list in our `AGENTS.md` files had drifted from the code — and because these files are loaded into an agent's context automatically, a stale line is worse than no line: it sends you to a file that doesn't exist. A review of all six turned up 17 issues. The pattern behind most of them is that we were writing down things `grep` and `ls` already answer, then not updating them.

A second pass then measured the setup against the official guidance at code.claude.com/docs and fixed what deviated from it.

## What Changed

### Commit 1 — prune stale and duplicated content

**Deleted the enumerations that grep answers** (and that had all gone stale):

- The three scope-binding caller lists in `apps/backend/AGENTS.md` — listed 8/1/1 callers against an actual 15/7/5.
- Directory layouts in the backend, frontend and SDK files. The SDK one pointed at `src/rhesis/sdk/client.py`, which doesn't exist (`RhesisClient` is in `clients/rhesis.py`), and omitted six directories.
- The `docs/` file tree, which listed three directories (`getting-started/`, `platform/`, `development/`) that don't exist — and which `docs/AGENTS.md` itself bans four sections earlier ("No file trees or tables describing self-describing files").
- The object-level affordance type list (5 listed, 7 actual) and two "Key files:" lines whose symbols were already named in the surrounding prose.

**Fixed claims that were wrong:**

- `app/features_bootstrap.py` doesn't exist — the real entry point is `app/ee_bootstrap.py`, and it's called at import time from `main.py`, not from the lifespan. Rewrote the section around the actual EE import boundary that the `community-boundary` CI job enforces.
- "a real [license provider] installs … when licensing lands" — licensing has landed; `SignedTokenLicenseProvider` is wired up in `ee/__init__.py`.
- Python 3.10+ → 3.12+ (both `pyproject.toml` files say `>=3.12`), Next.js 14+ → 16.
- `./rh worktree` also symlinks `domain.local/`, which matters because notes there only survive worktree removal through that symlink.
- Root file listed two `tests/` subdirectories; there are nine.

**Fixed a real footgun.** The documented `jest.mock('@/components/common/Can', …)` only intercepts one of the two live import paths for `can`. A component importing it from `@/utils/affordances` runs the real permission check in tests, silently. The file now states the rule: import all four primitives from `@/components/common/Can`; reach for `@/utils/affordances` only from non-React code.

**Deduped rules stated in more than one place:** the absolute-imports rule (was verbatim in both the backend and SDK files) now lives once in the root file; the scoped-rules list is in `AGENTS.md` only, so Cursor sees it too, and `CLAUDE.md` is back to a bare `@AGENTS.md`; the feature-gating enum-sync rule went from three statements to one.

**Removed the `crud/__init__.py` note**, which was guidance for a refactor that has since finished.

### Commit 2 — scope agent context per the official guidance

**Excluded vendored `CLAUDE.md` files.** Installed venvs ship six of them. `pydantic_ai/CLAUDE.md` is a real instruction file written for that project's contributors ("Add capability flags to model profile classes instead of inline `isinstance()` checks…"), and a nested `CLAUDE.md` loads as soon as Claude reads a file in its directory — which happens the moment anyone debugs into the vendored SDK. `.gitignore` covers searches, not this. Added `claudeMdExcludes: ["**/.venv/**"]`, plus `permissions.deny` read rules for `.venv`, `node_modules`, `.next`, `dist`, `build` and `__pycache__`.

**Moved three multi-step procedures into skills**, per "if an entry is a multi-step procedure or only matters for one part of the codebase, move it to a skill":

| New skill | Moved from |
| --- | --- |
| `update-branch` | root "Updating a Branch" |
| `ee-feature` | backend "Adding a new EE feature" |
| `docs-design-tokens` | docs "Colour, type, and design tokens" |
| `docs-social-images` | docs "Social preview images" |

Each keeps the trap that made it worth writing: `--force-with-lease` vs `--force`, the `community-boundary` CI rule, when literal hex is correct, and the `OG_VERSION` crawler-cache bump. One rule stayed in the root file as an always-loaded bullet, because it's a "never": rebase rather than merge, and never force-push `main`.

**Dropped the two sections whose only content was naming skills** — the root "Task-specific workflows" list and the backend "Testing and debugging" section. Skill descriptions already carry the "Use when…" triggers those lists restated.

**Every file is now under the documented 200-line target:**

| File | Before | After |
| --- | --- | --- |
| `AGENTS.md` | 125 | 108 |
| `apps/backend/AGENTS.md` | 260 | 197 |
| `apps/frontend/AGENTS.md` | 127 | 127 |
| `docs/AGENTS.md` | 220 | 160 |
| `sdk/AGENTS.md` | 48 | 26 |

## Additional Context

- What the docs already endorse in our setup, left alone: the `CLAUDE.md` → `@AGENTS.md` import is the pattern they prescribe for repos that keep `AGENTS.md`; the per-area layering is their recommended monorepo split; `./rh worktree` symlinking `CLAUDE.local.md` already solves the worktree gap they warn about; and `WorktreeCreate`/`WorktreeRemove` hooks are the right mechanism for must-happen-every-time actions.
- Considered and skipped: `.claude/rules/` with `paths:` frontmatter. The docs present it as an alternative to per-directory files rather than an upgrade, and its stated criteria ("all conventions in one place", "the same rule applies to many scattered paths") don't fit a repo whose conventions are cleanly per-area.
- The deny rules use `./**/` relative patterns, which anchor to the session's working directory — correct for sessions started at the repo root or a worktree root, which is how this repo is used.
- Not addressed here: six components (`TestRunsGrid`, `TasksGrid`, `TaskDetailsCard`, and three under `experiments/`) still import `can` from `@/utils/affordances`, against the rule this PR documents. Their tests are the ones whose mocks don't take effect. That's a code change and wants its own PR.

## Testing

Docs and configuration only — no application code paths touched. Checks performed against this branch:

- `.claude/settings.json` parses, and all four new skills have valid `name`/`description` frontmatter.
- Every file path named across the six `AGENTS.md` files resolves, verified by script. The one exception is `website/src/styles/tailwind.css`, a pre-existing pointer to the marketing site in another repo, which the surrounding prose already identifies as such.
- No duplicate headings within any file, and no sentence of 12+ words repeated across files.
- No changed line exceeds the 100-character wrap the files already use.

To sanity-check the removals, the commands that replace them: `grep -rln bind_scope_to_session apps/backend/src ee`, `grep -rn "extends WithPermittedActions" apps/frontend/src`, `ls docs/content/`, `ls sdk/src/rhesis/sdk/`.

To confirm the context changes took effect, run `/context` in a session started at the repo root and check the list under **Memory files** — no `.venv` paths should appear.
