### PR TITLE
fix(frontend): deduplicate metric selection and guard unnamed metrics

### DIFF
--- a/apps/frontend/src/components/common/RunDrawer.tsx
+++ b/apps/frontend/src/components/common/RunDrawer.tsx
@@ -765,10 +765,14 @@ export default function RunDrawer(props: RunDrawerProps) {
     name: string;
     metric_scope?: MetricScope[];
   }) => {
-    setSelectedMetrics(prev => [
-      ...prev,
-      { id: metric.id, name: metric.name, scope: metric.metric_scope },
-    ]);
+    setSelectedMetrics(prev =>
+      prev.some(m => m.id === metric.id)
+        ? prev
+        : [
+            ...prev,
+            { id: metric.id, name: metric.name, scope: metric.metric_scope },
+          ]
+    );
   };
 
   const handleRemoveMetric = (metricId: UUID) => {

--- a/apps/frontend/src/components/common/SelectMetricsDialog.tsx
+++ b/apps/frontend/src/components/common/SelectMetricsDialog.tsx
@@ -218,7 +218,7 @@ export default function SelectMetricsDialog({
   const handleSelect = (metric: MetricDetail) => {
     onSelect({
       id: metric.id as UUID,
-      name: metric.name,
+      name: metric.name || 'Unnamed metric',
       metric_scope: metric.metric_scope,
     });
     onClose();


### PR DESCRIPTION
## Summary
- Make `handleAddMetric` idempotent so re-selecting a metric does not append a duplicate
- Add a fallback label for metrics with no name to prevent blank labels downstream

Addresses review comments from #2634.

## Test plan
- [ ] Open RunDrawer, add a metric, verify it appears once
- [ ] Attempt to re-select the same metric, verify no duplicate is added