### PR TITLE
Fix redundant server re-fetches and traces flash on detail tabs

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -28,6 +28,7 @@ import BaseDrawer from '@/components/common/BaseDrawer';
 import { FilterState } from './TestRunFilterBar';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
+import type { TraceSummary } from '@/utils/api-client/interfaces/telemetry';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { useViewingEntity } from '@/contexts/NotificationsContext';
 import { NotificationSection } from '@/constants/notifications';
@@ -118,6 +119,9 @@ interface TestRunMainViewProps {
   initialTestResults?: TestResultDetail[];
   /** Whether the test set has other runs to compare with, when the server already checked. */
   initialHasComparisonRuns?: boolean;
+  /** Server-prefetched first page of this run's traces; see `TestRunTracesTab`. */
+  initialTraces?: TraceSummary[];
+  initialTracesTotalCount?: number;
 }
 
 export default function TestRunMainView({
@@ -131,6 +135,8 @@ export default function TestRunMainView({
   initialDetailTab,
   initialTestResults,
   initialHasComparisonRuns,
+  initialTraces,
+  initialTracesTotalCount,
 }: TestRunMainViewProps) {
   const testRun = useLiveTestRun(testRunId, initialTestRun);
   // Already watching this run live on screen -- a completion notification
@@ -143,9 +149,14 @@ export default function TestRunMainView({
   const queryClient = useQueryClient();
 
   const preferLinkedEntities = Boolean(initialSelectedTestId);
-  const activeTab = tabIndexFromKey(
-    searchParams.get('tab'),
-    preferLinkedEntities && !searchParams.get('tab')
+  // Resolved once from the URL on load (so deep links like ?selectedresult=
+  // or a legacy ?tab= alias land on the right tab). Later switches are local
+  // state -- see handleTabChange -- so they don't force a server round trip.
+  const [activeTab, setActiveTab] = useState(() =>
+    tabIndexFromKey(
+      searchParams.get('tab'),
+      preferLinkedEntities && !searchParams.get('tab')
+    )
   );
 
   // Fetch test results for the Tests tab.
@@ -170,15 +181,9 @@ export default function TestRunMainView({
     initialTestResults,
   });
 
-  const handleTabChange = useCallback(
-    (newValue: number) => {
-      const key = TAB_KEYS[newValue];
-      const params = new URLSearchParams(searchParams.toString());
-      params.set('tab', key);
-      router.push(`?${params.toString()}`, { scroll: false });
-    },
-    [router, searchParams]
-  );
+  const handleTabChange = useCallback((newValue: number) => {
+    setActiveTab(newValue);
+  }, []);
 
   const [isDownloading, setIsDownloading] = useState(false);
   const [isRerunDrawerOpen, setIsRerunDrawerOpen] = useState(false);
@@ -703,6 +708,8 @@ export default function TestRunMainView({
           currentUserId={currentUserId}
           currentUserName={currentUserName}
           currentUserPicture={currentUserPicture}
+          initialTraces={initialTraces}
+          initialTracesTotalCount={initialTracesTotalCount}
         />
       </TabPanel>
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTracesTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTracesTab.tsx
@@ -6,12 +6,17 @@ import TimelineOutlinedIcon from '@mui/icons-material/TimelineOutlined';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import TracesClient from '@/app/(protected)/traces/components/TracesClient';
+import type { TraceSummary } from '@/utils/api-client/interfaces/telemetry';
 
 interface TestRunTracesTabProps {
   testRunId: string;
   currentUserId: string;
   currentUserName: string;
   currentUserPicture?: string;
+  /** Server-prefetched first page of this run's traces -- lets the empty
+   * state render on first paint instead of flashing the grid first. */
+  initialTraces?: TraceSummary[];
+  initialTracesTotalCount?: number;
 }
 
 export default function TestRunTracesTab({
@@ -19,8 +24,15 @@ export default function TestRunTracesTab({
   currentUserId,
   currentUserName,
   currentUserPicture,
+  initialTraces,
+  initialTracesTotalCount,
 }: TestRunTracesTabProps) {
-  const [showEmptyHint, setShowEmptyHint] = useState(false);
+  // initialTraces is undefined when the server didn't know (no scoped
+  // project, unauthorized, fetch failure) -- only a defined page can tell us
+  // it's actually empty; otherwise fall back to discovering it client-side.
+  const [showEmptyHint, setShowEmptyHint] = useState(
+    initialTraces !== undefined && initialTracesTotalCount === 0
+  );
 
   const handleUnfilteredEmpty = useCallback((empty: boolean) => {
     setShowEmptyHint(empty);
@@ -63,6 +75,8 @@ export default function TestRunTracesTab({
             currentUserPicture={currentUserPicture}
             fixedTestRunId={testRunId}
             onUnfilteredEmpty={handleUnfilteredEmpty}
+            initialData={initialTraces}
+            initialTotalCount={initialTracesTotalCount}
           />
         </Paper>
       </Box>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
@@ -3,10 +3,13 @@ import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import TestRunMainView from './components/TestRunMainViewClient';
-import { prefetch } from '@/utils/server-prefetch';
+import { prefetch, prefetchList } from '@/utils/server-prefetch';
 import { Capability } from '@/constants/capabilities';
 import { fetchSmallTestRunResults } from './hooks/test-run-results';
 import { hasOtherRunsForTestSet } from './components/comparison-runs';
+import { getServerActiveProjectId } from '@/utils/server-active-project';
+import { emptyFilters, listParams } from '@/utils/list';
+import { tracesList } from '@/app/(protected)/traces/components/list';
 
 interface _PageProps {
   params: Promise<{ identifier: string }>;
@@ -61,10 +64,15 @@ export default async function TestRunPage({
     throw error;
   }
 
-  // Results for the Summary/Test Cases tabs (small runs only) and the
-  // "can compare" check, so both tabs open without a client round trip.
+  // Results for the Summary/Test Cases tabs (small runs only), the "can
+  // compare" check, and page 1 of this run's traces -- so all three tabs
+  // open with their real content (or empty state) instead of a grid
+  // skeleton that flips to empty a moment later.
   const testSetId = testRun.test_configuration?.test_set?.id;
-  const [testResults, hasComparisonRuns] = await Promise.all([
+  const scopedProjectId = (await getServerActiveProjectId()) ?? null;
+  const tracesDescriptor = tracesList(scopedProjectId, apiFactory);
+
+  const [testResults, hasComparisonRuns, tracesPage] = await Promise.all([
     prefetch(Capability.TestResult.READ, () =>
       fetchSmallTestRunResults(apiFactory, identifier)
     ),
@@ -73,6 +81,22 @@ export default async function TestRunPage({
           hasOtherRunsForTestSet(apiFactory, testSetId, identifier)
         )
       : Promise.resolve(false),
+    scopedProjectId
+      ? prefetchList(tracesDescriptor.capability, () =>
+          tracesDescriptor.list(
+            apiFactory,
+            listParams(tracesDescriptor, {
+              page: 1,
+              pageSize: tracesDescriptor.defaultPageSize,
+              sort: tracesDescriptor.defaultSort,
+              filters: {
+                ...emptyFilters(tracesDescriptor),
+                testRunId: identifier,
+              },
+            })
+          )
+        )
+      : Promise.resolve({ initialData: undefined, initialTotalCount: 0 }),
   ]);
 
   // PageLayout is rendered by TestRunMainView, not here: its title carries a
@@ -102,6 +126,8 @@ export default async function TestRunPage({
       initialDetailTab={typeof detailTab === 'string' ? detailTab : undefined}
       initialTestResults={testResults}
       initialHasComparisonRuns={hasComparisonRuns}
+      initialTraces={tracesPage.initialData}
+      initialTracesTotalCount={tracesPage.initialTotalCount}
     />
   );
 }

--- a/apps/frontend/src/hooks/useDetailTabNav.ts
+++ b/apps/frontend/src/hooks/useDetailTabNav.ts
@@ -1,41 +1,33 @@
 'use client';
 
-import { useCallback } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useState } from 'react';
 
 /**
- * Shared hook for URL-based tab navigation on entity detail pages.
+ * Shared hook for tab navigation on entity detail pages.
  *
- * Reads `?tab=<key>` from the URL and returns the active tab index.
- * `handleTabChange` updates the URL param without scrolling.
+ * Tab state is local to the client and doesn't sync to the URL, so switching
+ * tabs never triggers a server round-trip -- the detail page's data is
+ * server-fetched once on load and already sits in props for every tab.
  *
  * @example
  * const TAB_KEYS = ['basic', 'linked', 'tasks'] as const;
  * const { activeTab, handleTabChange } = useDetailTabNav(TAB_KEYS);
  */
 export function useDetailTabNav<T extends string>(
-  tabKeys: readonly T[],
-  paramName = 'tab'
+  tabKeys: readonly T[]
 ): {
   activeTab: number;
   handleTabChange: (newIndex: number) => void;
 } {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  const activeTab = (() => {
-    const idx = tabKeys.indexOf(searchParams.get(paramName) as T);
-    return idx >= 0 ? idx : 0;
-  })();
+  const [activeTab, setActiveTab] = useState(0);
 
   const handleTabChange = useCallback(
     (newIndex: number) => {
-      const key = tabKeys[newIndex];
-      const params = new URLSearchParams(searchParams.toString());
-      params.set(paramName, key);
-      router.push(`?${params.toString()}`, { scroll: false });
+      if (newIndex >= 0 && newIndex < tabKeys.length) {
+        setActiveTab(newIndex);
+      }
     },
-    [router, searchParams, tabKeys, paramName]
+    [tabKeys.length]
   );
 
   return { activeTab, handleTabChange };


### PR DESCRIPTION
## Purpose

Switching tabs on entity detail pages (tests, test-sets, tasks, experiments, metrics, requirements, test-runs) re-ran the whole Server Component on every click, because tab state was synced to the URL via `router.push` on pages that are already forced dynamic (they call `auth()`). Each click re-fetched data that was already sitting in props from the initial load. Separately, the test-run Traces tab always rendered an empty grid before flipping to the "No traces" message, since it only learned traces were empty after a client-side fetch resolved.

## What Changed

- `useDetailTabNav` now tracks the active tab as local state instead of a URL param, so tab switches on the six pages sharing this hook are instant with no server round trip.
- `test-runs/[identifier]` keeps its real external deep links (`?selectedresult=`, legacy `?tab=` aliases) working by resolving the tab from the URL once on mount, then switching to local state for subsequent clicks.
- The test-run detail page now prefetches page 1 of the run's traces server-side (same pattern as the standalone `/traces` page), so the Traces tab can render its empty state on first paint instead of flashing the grid first.

## Additional Context

No backend or schema changes. No new dependencies.

## Testing

- `npx tsc --noEmit` and `npm run lint` pass.
- Manually verified: clicking between tabs on a test/test-set/test-run detail page no longer shows a loading flicker; a test run with no traces shows the empty state immediately instead of a grid flash; deep links with `?selectedresult=` and legacy `?tab=` values on test-runs still land on the right tab.