### PR TITLE
fix(frontend): widen Actions column and fill empty grid column gap

### DIFF
--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -240,9 +240,11 @@ function isFixedWidthColumn(col: GridColDef): boolean {
  * - Explicit `flex` columns grow proportionally.
  * - `width` without `flex` is treated as a fixed cap (`maxWidth`).
  * - Unsized columns receive `flex: 1` to absorb remaining grid width.
+ * - When no column would receive flex, the first non-fixed column is
+ *   promoted to `flex: 1` so the grid always fills its container.
  */
 export function applyFlexColumnSizing(columns: GridColDef[]): GridColDef[] {
-  return columns.map(col => {
+  const mapped = columns.map(col => {
     const field = String(col.field);
     const normalized =
       field === 'actions' ? { ...col, hideable: false } : { ...col };
@@ -268,6 +270,22 @@ export function applyFlexColumnSizing(columns: GridColDef[]): GridColDef[] {
       minWidth: normalized.minWidth ?? 50,
     };
   });
+
+  const hasFlexColumn = mapped.some(col => col.flex != null && col.flex > 0);
+  if (!hasFlexColumn) {
+    const idx = columns.findIndex(
+      (orig, i) =>
+        !isFixedWidthColumn(mapped[i]) &&
+        orig.width != null &&
+        orig.maxWidth == null
+    );
+    if (idx !== -1) {
+      const { maxWidth: _mw, ...rest } = mapped[idx];
+      mapped[idx] = { ...rest, flex: 1, minWidth: rest.minWidth ?? rest.width ?? 50 };
+    }
+  }
+
+  return mapped;
 }
 
 // Create a styled version of DataGrid with Figma-aligned borders and headers

--- a/apps/frontend/src/components/common/__tests__/BaseDataGrid.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/BaseDataGrid.test.tsx
@@ -80,7 +80,7 @@ const sampleRows = [
 ];
 
 describe('applyFlexColumnSizing', () => {
-  it('caps width-only columns with maxWidth instead of converting to flex', () => {
+  it('promotes first non-fixed column to flex when no flex column exists', () => {
     const columns: GridColDef[] = [
       { field: 'title', headerName: 'Title', width: 300, minWidth: 150 },
       { field: 'status', headerName: 'Status', width: 120, minWidth: 90 },
@@ -89,15 +89,27 @@ describe('applyFlexColumnSizing', () => {
 
     const sized = applyFlexColumnSizing(columns);
 
-    expect(sized[0]).toMatchObject({
-      width: 300,
-      maxWidth: 300,
-      minWidth: 150,
-    });
-    expect(sized[0].flex).toBeUndefined();
+    expect(sized[0]).toMatchObject({ flex: 1, minWidth: 150 });
+    expect(sized[0].maxWidth).toBeUndefined();
     expect(sized[1]).toMatchObject({ width: 120, maxWidth: 120, minWidth: 90 });
+    expect(sized[1].flex).toBeUndefined();
     expect(sized[2]).toMatchObject({ width: 88, hideable: false });
     expect(sized[2].flex).toBeUndefined();
+  });
+
+  it('caps width-only columns when another column already has flex', () => {
+    const columns: GridColDef[] = [
+      { field: 'title', headerName: 'Title', width: 300, minWidth: 150 },
+      { field: 'desc', headerName: 'Description' },
+      { field: 'actions', headerName: '', width: 88 },
+    ];
+
+    const sized = applyFlexColumnSizing(columns);
+
+    expect(sized[0]).toMatchObject({ width: 300, maxWidth: 300, minWidth: 150 });
+    expect(sized[0].flex).toBeUndefined();
+    expect(sized[1]).toMatchObject({ flex: 1, minWidth: 50 });
+    expect(sized[2]).toMatchObject({ width: 88, hideable: false });
   });
 
   it('gives unsized columns flex to fill remaining width', () => {

--- a/apps/frontend/src/components/common/createRowActionsColumn.tsx
+++ b/apps/frontend/src/components/common/createRowActionsColumn.tsx
@@ -176,7 +176,7 @@ export function createRowActionsColumn({
   canEdit,
   canDelete,
   extraActions,
-  width = 88,
+  width = 100,
   editTooltip = 'Edit',
   deleteTooltip = 'Delete',
   deleteIcon: DeleteIconComponent = DeleteIcon,


### PR DESCRIPTION
## Summary

- Bump the default actions column width from 88px to 100px so the "Actions" header text is fully visible instead of truncating to "Acti...".
- When every data column has an explicit `width` and none has `flex`, `applyFlexColumnSizing` now promotes the first eligible column to `flex: 1` so the grid fills its container. This fixes the empty unlabeled column visible in the test-sets, knowledge, and tasks grids.

## Test plan

- [x] `BaseDataGrid` unit tests pass (14/14), including new test for the flex fallback
- [x] Test-sets tests pass (28/28)
- [x] `tsc --noEmit` clean
- [ ] Verify test-sets list no longer shows the empty column gap
- [ ] Verify "Actions" header is fully visible in every entity grid