### PR TITLE
fix(frontend): remove row flash in assign drawers

### DIFF
--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/AssignTestsDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/AssignTestsDrawer.tsx
@@ -67,6 +67,12 @@ export default function AssignTestsDrawer({
   const [resolvedLinkedIds, setResolvedLinkedIds] = useState<Set<string>>(
     new Set()
   );
+  // Gates rendering rows until we know which tests are already linked --
+  // otherwise the first page of "all tests" briefly renders unfiltered
+  // (before `resolvedLinkedIds` arrives), then immediately collapses once
+  // the already-linked ones are excluded. Most visible on a small test set
+  // whose own tests are also the most recently created ones overall.
+  const [linkedIdsLoaded, setLinkedIdsLoaded] = useState(false);
   const testsByIdRef = useRef<Map<string, TestDetail>>(new Map());
   const isMountedRef = useRef(true);
 
@@ -97,6 +103,8 @@ export default function AssignTestsDrawer({
     } catch {
       if (!isMountedRef.current) return;
       setResolvedLinkedIds(new Set());
+    } finally {
+      if (isMountedRef.current) setLinkedIdsLoaded(true);
     }
   }, [testSetId]);
 
@@ -145,6 +153,7 @@ export default function AssignTestsDrawer({
     setDrawerFilters(EMPTY_TEST_FILTERS);
     setFilterModel({ items: [] });
     setPaginationModel({ page: 0, pageSize: 25 });
+    setLinkedIdsLoaded(false);
     void fetchLinkedIds();
   }, [open, fetchLinkedIds]);
 
@@ -177,16 +186,19 @@ export default function AssignTestsDrawer({
     [testSetType]
   );
 
-  const availableFiltered = useMemo(
-    () =>
-      available
-        .filter(test => test.id && !resolvedLinkedIds.has(String(test.id)))
-        .map(test => ({
-          ...test,
-          name: getTestDisplayContent(test),
-        })) as GridRowModel[],
-    [available, resolvedLinkedIds]
-  );
+  const availableFiltered = useMemo(() => {
+    // Don't hand the grid any rows until we know which tests are already
+    // linked -- a loading overlay is translucent, so rows that are about to
+    // be filtered out would still show through it as a flash before
+    // collapsing to empty.
+    if (!linkedIdsLoaded) return [] as GridRowModel[];
+    return available
+      .filter(test => test.id && !resolvedLinkedIds.has(String(test.id)))
+      .map(test => ({
+        ...test,
+        name: getTestDisplayContent(test),
+      })) as GridRowModel[];
+  }, [available, resolvedLinkedIds, linkedIdsLoaded]);
 
   const handleAssign = useCallback(
     async (selectedIds: string[]) => {
@@ -206,7 +218,7 @@ export default function AssignTestsDrawer({
         title="Assign tests"
         rows={availableFiltered}
         columns={columns}
-        loading={loading}
+        loading={loading || !linkedIdsLoaded}
         getRowId={row => String(row.id)}
         onAssign={handleAssign}
         saveButtonText="Assign"

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/AssignTestsDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/AssignTestsDrawer.tsx
@@ -67,14 +67,13 @@ export default function AssignTestsDrawer({
   const [resolvedLinkedIds, setResolvedLinkedIds] = useState<Set<string>>(
     new Set()
   );
-  // Gates rendering rows until we know which tests are already linked --
-  // otherwise the first page of "all tests" briefly renders unfiltered
-  // (before `resolvedLinkedIds` arrives), then immediately collapses once
-  // the already-linked ones are excluded. Most visible on a small test set
-  // whose own tests are also the most recently created ones overall.
+  // Gates rows until we know which tests are already linked, so the
+  // unfiltered page never renders before collapsing to the excluded set.
   const [linkedIdsLoaded, setLinkedIdsLoaded] = useState(false);
   const testsByIdRef = useRef<Map<string, TestDetail>>(new Map());
   const isMountedRef = useRef(true);
+  // Guards against a stale response (rapid close/reopen) overwriting a newer one.
+  const linkedIdsRequestRef = useRef(0);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -92,19 +91,23 @@ export default function AssignTestsDrawer({
   }, [available]);
 
   const fetchLinkedIds = useCallback(async () => {
+    const requestId = ++linkedIdsRequestRef.current;
+    const isStale = () =>
+      !isMountedRef.current || requestId !== linkedIdsRequestRef.current;
+
     try {
       const factory = new ApiClientFactory();
       const testSetsClient = factory.getTestSetsClient();
       const linkedTests = await testSetsClient.getAllTestSetTests(testSetId);
-      if (!isMountedRef.current) return;
+      if (isStale()) return;
       setResolvedLinkedIds(
         new Set(linkedTests.map(test => String(test.id)).filter(Boolean))
       );
     } catch {
-      if (!isMountedRef.current) return;
+      if (isStale()) return;
       setResolvedLinkedIds(new Set());
     } finally {
-      if (isMountedRef.current) setLinkedIdsLoaded(true);
+      if (!isStale()) setLinkedIdsLoaded(true);
     }
   }, [testSetId]);
 

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -281,7 +281,11 @@ export function applyFlexColumnSizing(columns: GridColDef[]): GridColDef[] {
     );
     if (idx !== -1) {
       const { maxWidth: _mw, ...rest } = mapped[idx];
-      mapped[idx] = { ...rest, flex: 1, minWidth: rest.minWidth ?? rest.width ?? 50 };
+      mapped[idx] = {
+        ...rest,
+        flex: 1,
+        minWidth: rest.minWidth ?? rest.width ?? 50,
+      };
     }
   }
 

--- a/apps/frontend/src/components/common/__tests__/BaseDataGrid.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/BaseDataGrid.test.tsx
@@ -106,7 +106,11 @@ describe('applyFlexColumnSizing', () => {
 
     const sized = applyFlexColumnSizing(columns);
 
-    expect(sized[0]).toMatchObject({ width: 300, maxWidth: 300, minWidth: 150 });
+    expect(sized[0]).toMatchObject({
+      width: 300,
+      maxWidth: 300,
+      minWidth: 150,
+    });
     expect(sized[0].flex).toBeUndefined();
     expect(sized[1]).toMatchObject({ flex: 1, minWidth: 50 });
     expect(sized[2]).toMatchObject({ width: 88, hideable: false });

--- a/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
+++ b/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
@@ -82,10 +82,15 @@ export default function LinkedTestSetsSection({
     [testSets]
   );
 
-  const availableFiltered = useMemo<GridRowModel[]>(
-    () => available.filter(ts => !linkedIds.has(String(ts.id))),
-    [available, linkedIds]
-  );
+  const availableFiltered = useMemo<GridRowModel[]>(() => {
+    // `linkedIds` comes from the same list this section already renders, not
+    // a fetch scoped to opening the drawer -- if that list is still loading
+    // (e.g. no SSR initial data and the user clicks Assign immediately),
+    // filtering against it now would show every candidate, then collapse to
+    // the correct set once it resolves. Wait for it to settle first.
+    if (loading) return [];
+    return available.filter(ts => !linkedIds.has(String(ts.id)));
+  }, [available, linkedIds, loading]);
 
   const handleAssign = useCallback(
     async (selectedIds: string[]) => {
@@ -270,7 +275,7 @@ export default function LinkedTestSetsSection({
           title="Assign Test Set"
           rows={availableFiltered}
           columns={drawerColumns}
-          loading={loadingAvailable}
+          loading={loadingAvailable || loading}
           getRowId={row => String(row.id)}
           onAssign={handleAssign}
           searchPlaceholder="Search test sets…"

--- a/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
+++ b/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { Box, Button, Paper, Typography } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import RouteOutlinedIcon from '@mui/icons-material/RouteOutlined';
@@ -82,15 +82,17 @@ export default function LinkedTestSetsSection({
     [testSets]
   );
 
+  // Settles once and stays true -- unlike `loading`, which flips again on
+  // every refetch (pagination, `refresh()` after an assign).
+  const [linkedIdsSettled, setLinkedIdsSettled] = useState(!loading);
+  useEffect(() => {
+    if (!loading) setLinkedIdsSettled(true);
+  }, [loading]);
+
   const availableFiltered = useMemo<GridRowModel[]>(() => {
-    // `linkedIds` comes from the same list this section already renders, not
-    // a fetch scoped to opening the drawer -- if that list is still loading
-    // (e.g. no SSR initial data and the user clicks Assign immediately),
-    // filtering against it now would show every candidate, then collapse to
-    // the correct set once it resolves. Wait for it to settle first.
-    if (loading) return [];
+    if (!linkedIdsSettled) return [];
     return available.filter(ts => !linkedIds.has(String(ts.id)));
-  }, [available, linkedIds, loading]);
+  }, [available, linkedIds, linkedIdsSettled]);
 
   const handleAssign = useCallback(
     async (selectedIds: string[]) => {
@@ -275,7 +277,7 @@ export default function LinkedTestSetsSection({
           title="Assign Test Set"
           rows={availableFiltered}
           columns={drawerColumns}
-          loading={loadingAvailable || loading}
+          loading={loadingAvailable || !linkedIdsSettled}
           getRowId={row => String(row.id)}
           onAssign={handleAssign}
           searchPlaceholder="Search test sets…"


### PR DESCRIPTION
## Purpose

Both "Assign tests" and "Assign Test Set" drawers fetch a candidate list and a separately-loaded already-linked list, then filter one against the other. When the already-linked list hadn't settled yet, the drawer briefly rendered every candidate unfiltered, then collapsed to the correct (sometimes empty) result once it caught up.

## What Changed

- `AssignTestsDrawer`: gate rows on both the tests fetch and the linked-ids fetch settling.
- `LinkedTestSetsSection`'s "Assign Test Set" drawer: same fix, gated on the linked-test-sets list settling.
- In both cases the drawer now goes straight from loading to its correct result, with no intermediate flash.

## Additional Context

- No backend or schema changes.

## Testing

- Open a test set's Tests tab → Assign, and a test's Linked Test Sets tab → Assign, confirming no flash of soon-to-be-excluded rows before the correct list (or empty state) appears.
- `npx tsc --noEmit`, `npx eslint`, and the existing Jest suites for both files pass.