### PR TITLE
Explain owner-only delete on disabled selection checkboxes

### DIFF
--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -16,6 +16,9 @@ import {
   CircularProgress,
   Menu,
   alpha,
+  Checkbox,
+  Tooltip,
+  type CheckboxProps,
 } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import IconButton from '@mui/material/IconButton';
@@ -91,6 +94,12 @@ interface BaseDataGridProps {
    * default.
    */
   isRowSelectable?: (params: GridRowParams) => boolean;
+  /**
+   * Tooltip shown on row checkboxes that `isRowSelectable` disabled — without
+   * it a greyed-out checkbox gives no reason, e.g. "Only the owner can delete
+   * this test run".
+   */
+  rowSelectionDisabledTooltip?: string;
   // Server-side sorting props
   sortingMode?: 'client' | 'server';
   sortModel?: GridSortModel;
@@ -281,7 +290,11 @@ export function applyFlexColumnSizing(columns: GridColDef[]): GridColDef[] {
     );
     if (idx !== -1) {
       const { maxWidth: _mw, ...rest } = mapped[idx];
-      mapped[idx] = { ...rest, flex: 1, minWidth: rest.minWidth ?? rest.width ?? 50 };
+      mapped[idx] = {
+        ...rest,
+        flex: 1,
+        minWidth: rest.minWidth ?? rest.width ?? 50,
+      };
     }
   }
 
@@ -540,6 +553,7 @@ export default function BaseDataGrid({
   onRowSelectionModelChange,
   rowSelectionModel,
   isRowSelectable,
+  rowSelectionDisabledTooltip,
   sortingMode = 'client',
   sortModel,
   onSortModelChange,
@@ -792,6 +806,29 @@ export default function BaseDataGrid({
     [resolveRowUrl, apiRef]
   );
 
+  // Row checkbox that explains why it is disabled. MUI marks a row's checkbox
+  // disabled from `isRowSelectable` but offers no way to say why, and the
+  // checkbox itself swallows pointer events while disabled — hence the span.
+  const TooltipCheckbox = React.useMemo(() => {
+    if (!rowSelectionDisabledTooltip) return undefined;
+    return React.forwardRef<HTMLButtonElement, CheckboxProps>(
+      function RowSelectionCheckbox(props, ref) {
+        const checkbox = <Checkbox {...props} ref={ref} />;
+        // baseCheckbox also renders the header and the columns panel; only the
+        // per-row ones carry this input name.
+        const isRowCheckbox =
+          (props.inputProps as { name?: string } | undefined)?.name ===
+          'select_row';
+        if (!props.disabled || !isRowCheckbox) return checkbox;
+        return (
+          <Tooltip title={rowSelectionDisabledTooltip}>
+            <span style={{ display: 'inline-flex' }}>{checkbox}</span>
+          </Tooltip>
+        );
+      }
+    );
+  }, [rowSelectionDisabledTooltip]);
+
   // Wait for initialization and persisted state to be loaded before rendering DataGrid
   // This ensures initialState is correctly set before the grid mounts
   const isReady = isInitialized && (!persistState || isPersistedStateLoaded);
@@ -816,6 +853,9 @@ export default function BaseDataGrid({
   }
   if (toolbarSlot) {
     resolvedSlots.toolbar = toolbarSlot;
+  }
+  if (TooltipCheckbox) {
+    resolvedSlots.baseCheckbox = TooltipCheckbox;
   }
 
   const dataGridSx: SxProps<Theme> = [

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -38,6 +38,7 @@ import {
   GridInitialState,
   GridRowParams,
   GridColumnMenu,
+  gridClasses,
   type GridColumnGroupingModel,
   type GridColumnMenuProps,
 } from '@mui/x-data-grid';
@@ -814,12 +815,22 @@ export default function BaseDataGrid({
     return React.forwardRef<HTMLButtonElement, CheckboxProps>(
       function RowSelectionCheckbox(props, ref) {
         const checkbox = <Checkbox {...props} ref={ref} />;
-        // baseCheckbox also renders the header and the columns panel; only the
-        // per-row ones carry this input name.
-        const isRowCheckbox =
+        // baseCheckbox also renders the columns panel, where `disabled` means
+        // "column can't be hidden" — only selection checkboxes carry this class.
+        const isSelectionCheckbox = props.className?.includes(
+          gridClasses.checkboxInput
+        );
+        // The header's select-all is disabled for a different reason
+        // (disableMultipleRowSelection), so it gets no tooltip. Unlike the
+        // class above, this name is internal to MUI: if it ever changes, a
+        // disabled header checkbox picks up the row wording, which is the
+        // worst that happens.
+        const isHeaderCheckbox =
           (props.inputProps as { name?: string } | undefined)?.name ===
-          'select_row';
-        if (!props.disabled || !isRowCheckbox) return checkbox;
+          'select_all_rows';
+        if (!props.disabled || !isSelectionCheckbox || isHeaderCheckbox) {
+          return checkbox;
+        }
         return (
           <Tooltip title={rowSelectionDisabledTooltip}>
             <span style={{ display: 'inline-flex' }}>{checkbox}</span>

--- a/apps/frontend/src/components/common/EntityGrid/EntityGrid.tsx
+++ b/apps/frontend/src/components/common/EntityGrid/EntityGrid.tsx
@@ -489,6 +489,12 @@ export default function EntityGrid<
               ? params => canDeleteRow(params.row)
               : undefined
           }
+          rowSelectionDisabledTooltip={
+            checkboxSelectionMode && deleteSpec?.capabilityMode === 'row'
+              ? (deleteSpec.notSelectableReason ??
+                `Only the owner can delete this ${deleteSpec.labelSingular}`)
+              : undefined
+          }
         />
 
         {deleteEnabled && (

--- a/apps/frontend/src/components/common/__tests__/BaseDataGrid.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/BaseDataGrid.test.tsx
@@ -16,14 +16,33 @@ jest.mock('@mui/x-data-grid', () => {
     loading,
     getRowId,
     onRowClick,
+    checkboxSelection,
+    isRowSelectable,
+    slots,
   }: {
     rows: GridRowModel[];
     columns: GridColDef[];
     loading?: boolean;
     getRowId?: (row: GridRowModel) => string | number;
     onRowClick?: (params: { row: GridRowModel }) => void;
+    checkboxSelection?: boolean;
+    isRowSelectable?: (params: { row: GridRowModel }) => boolean;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    slots?: { baseCheckbox?: React.ComponentType<any> };
   }) => {
     if (loading) return <div data-testid="datagrid-loading">Loading…</div>;
+    // Mirrors GridCellCheckboxRenderer: the row checkbox comes from the
+    // baseCheckbox slot and is disabled by isRowSelectable.
+    const BaseCheckbox = slots?.baseCheckbox;
+    const renderCheckbox = (row: GridRowModel) =>
+      checkboxSelection && BaseCheckbox ? (
+        <td>
+          <BaseCheckbox
+            disabled={isRowSelectable ? !isRowSelectable({ row }) : false}
+            inputProps={{ name: 'select_row' }}
+          />
+        </td>
+      ) : null;
     return (
       <table role="grid" data-testid="data-grid">
         <thead>
@@ -47,6 +66,7 @@ jest.mock('@mui/x-data-grid', () => {
                 onClick={() => onRowClick && onRowClick({ row })}
                 data-testid={`row-${rowKey}`}
               >
+                {renderCheckbox(row)}
                 {columns.map((col: GridColDef) => (
                   <td key={String(col.field)}>
                     {String(row[col.field] ?? '')}
@@ -106,7 +126,11 @@ describe('applyFlexColumnSizing', () => {
 
     const sized = applyFlexColumnSizing(columns);
 
-    expect(sized[0]).toMatchObject({ width: 300, maxWidth: 300, minWidth: 150 });
+    expect(sized[0]).toMatchObject({
+      width: 300,
+      maxWidth: 300,
+      minWidth: 150,
+    });
     expect(sized[0].flex).toBeUndefined();
     expect(sized[1]).toMatchObject({ flex: 1, minWidth: 50 });
     expect(sized[2]).toMatchObject({ width: 88, hideable: false });
@@ -233,5 +257,41 @@ describe('BaseDataGrid', () => {
       );
       expect(container.querySelector('.MuiPaper-root')).not.toBeInTheDocument();
     });
+  });
+});
+
+// Real timers: the tooltip's enter delay and userEvent's hover are easier to
+// drive without the fake-timer setup the suite above needs.
+describe('BaseDataGrid disabled row selection', () => {
+  const REASON = 'Only the owner can delete this test run';
+
+  const renderGrid = async (tooltip?: string) => {
+    render(
+      <BaseDataGrid
+        columns={sampleColumns}
+        rows={sampleRows}
+        checkboxSelection={true}
+        isRowSelectable={params => params.row.status === 'active'}
+        {...(tooltip && { rowSelectionDisabledTooltip: tooltip })}
+      />
+    );
+    await screen.findByRole('grid');
+  };
+
+  it('explains a disabled checkbox on hover', async () => {
+    const user = userEvent.setup();
+    await renderGrid(REASON);
+
+    // Only Bob is unselectable, so the reason labels exactly one element.
+    const anchor = screen.getByLabelText(REASON);
+    expect(screen.getByTestId('row-2')).toContainElement(anchor);
+    await user.hover(anchor);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(REASON);
+  });
+
+  it('adds no tooltip when no reason is given', async () => {
+    await renderGrid();
+    expect(screen.queryByLabelText(REASON)).toBeNull();
   });
 });

--- a/apps/frontend/src/components/common/__tests__/BaseDataGrid.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/BaseDataGrid.test.tsx
@@ -18,6 +18,7 @@ jest.mock('@mui/x-data-grid', () => {
     onRowClick,
     checkboxSelection,
     isRowSelectable,
+    disableMultipleRowSelection,
     slots,
   }: {
     rows: GridRowModel[];
@@ -27,18 +28,23 @@ jest.mock('@mui/x-data-grid', () => {
     onRowClick?: (params: { row: GridRowModel }) => void;
     checkboxSelection?: boolean;
     isRowSelectable?: (params: { row: GridRowModel }) => boolean;
+    disableMultipleRowSelection?: boolean;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     slots?: { baseCheckbox?: React.ComponentType<any> };
   }) => {
     if (loading) return <div data-testid="datagrid-loading">Loading…</div>;
-    // Mirrors GridCellCheckboxRenderer: the row checkbox comes from the
-    // baseCheckbox slot and is disabled by isRowSelectable.
+    // Mirrors GridCellCheckboxRenderer and GridHeaderCheckbox: both come from
+    // the baseCheckbox slot with the same class, and are disabled for
+    // different reasons — the row by isRowSelectable, the header by
+    // disableMultipleRowSelection.
     const BaseCheckbox = slots?.baseCheckbox;
+    const checkboxClass = original.gridClasses.checkboxInput;
     const renderCheckbox = (row: GridRowModel) =>
       checkboxSelection && BaseCheckbox ? (
         <td>
           <BaseCheckbox
             disabled={isRowSelectable ? !isRowSelectable({ row }) : false}
+            className={checkboxClass}
             inputProps={{ name: 'select_row' }}
           />
         </td>
@@ -47,6 +53,15 @@ jest.mock('@mui/x-data-grid', () => {
       <table role="grid" data-testid="data-grid">
         <thead>
           <tr>
+            {checkboxSelection && BaseCheckbox && (
+              <th>
+                <BaseCheckbox
+                  disabled={disableMultipleRowSelection === true}
+                  className={checkboxClass}
+                  inputProps={{ name: 'select_all_rows' }}
+                />
+              </th>
+            )}
             {columns.map((col: GridColDef) => (
               <th key={String(col.field)}>
                 {String(col.headerName ?? col.field)}
@@ -76,6 +91,21 @@ jest.mock('@mui/x-data-grid', () => {
             );
           })}
         </tbody>
+        {/* Stands in for the columns panel: same slot, no grid class, and
+            `disabled` there means the column can't be hidden. */}
+        {checkboxSelection && BaseCheckbox && (
+          <tfoot>
+            <tr>
+              <td>
+                <BaseCheckbox
+                  disabled={true}
+                  inputProps={{ name: 'status' }}
+                  data-testid="panel-checkbox"
+                />
+              </td>
+            </tr>
+          </tfoot>
+        )}
       </table>
     );
   };
@@ -265,13 +295,17 @@ describe('BaseDataGrid', () => {
 describe('BaseDataGrid disabled row selection', () => {
   const REASON = 'Only the owner can delete this test run';
 
-  const renderGrid = async (tooltip?: string) => {
+  const renderGrid = async (
+    tooltip?: string,
+    { singleSelection = false }: { singleSelection?: boolean } = {}
+  ) => {
     render(
       <BaseDataGrid
         columns={sampleColumns}
         rows={sampleRows}
         checkboxSelection={true}
         isRowSelectable={params => params.row.status === 'active'}
+        {...(singleSelection && { disableMultipleRowSelection: true })}
         {...(tooltip && { rowSelectionDisabledTooltip: tooltip })}
       />
     );
@@ -293,5 +327,25 @@ describe('BaseDataGrid disabled row selection', () => {
   it('adds no tooltip when no reason is given', async () => {
     await renderGrid();
     expect(screen.queryByLabelText(REASON)).toBeNull();
+  });
+
+  it('leaves the disabled select-all header alone', async () => {
+    // Its checkbox is disabled because selection is single-row, which the
+    // row-level reason would misdescribe.
+    await renderGrid(REASON, { singleSelection: true });
+
+    const labelled = screen.getAllByLabelText(REASON);
+    expect(labelled).toHaveLength(1);
+    expect(screen.getByTestId('row-2')).toContainElement(labelled[0]);
+  });
+
+  it('leaves checkboxes outside the grid selection alone', async () => {
+    await renderGrid(REASON);
+
+    // The columns panel renders through the same slot, where `disabled` means
+    // "column can't be hidden" — see the mock's panel checkbox.
+    const panel = screen.getByTestId('panel-checkbox');
+    expect(panel).not.toHaveAttribute('aria-label');
+    expect(screen.getAllByLabelText(REASON)).toHaveLength(1);
   });
 });

--- a/apps/frontend/src/utils/list/define.ts
+++ b/apps/frontend/src/utils/list/define.ts
@@ -137,6 +137,12 @@ export interface ListDeleteSpec<TResp = unknown> {
   getSkippedCount?(response: TResp): number;
   /** Reason shown alongside the skipped count, e.g. "not yours to delete". */
   skippedReason?: string;
+  /**
+   * Tooltip on the disabled checkbox of a row the caller can't delete, when
+   * `capabilityMode` is `'row'`. Defaults to "Only the owner can delete this
+   * <labelSingular>".
+   */
+  notSelectableReason?: string;
   /** Confirm-modal body override; `count` is 1 for a single-row delete. */
   confirmMessage?: (count: number) => string;
 }


### PR DESCRIPTION
## Purpose

Deleting a test run or a task is owner-only, so on those two grids the selection checkbox is disabled for rows belonging to someone else. Nothing said why. The checkbox just sat there greyed out, which reads as a bug rather than a rule. This adds a tooltip on hover.

## What Changed

- `BaseDataGrid` takes a new optional `rowSelectionDisabledTooltip`. When set, it swaps in a `baseCheckbox` slot that wraps disabled row checkboxes in a Tooltip. Two details worth knowing: a disabled checkbox has `pointer-events: none`, so the tooltip anchor is a `span` around it rather than the checkbox itself; and MUI reuses `baseCheckbox` for the header select-all and the columns panel, so the wrapper only applies to checkboxes carrying the row input name (`select_row`).
- `EntityGrid` passes the message whenever selection mode is on and the delete rule is per-row, defaulting to "Only the owner can delete this test run" / "...this task" from the spec's `labelSingular`.
- `ListDeleteSpec` gets an optional `notSelectableReason` to override that default per list.
- The mocked DataGrid in `BaseDataGrid.test.tsx` now renders the checkbox slot the way `GridCellCheckboxRenderer` does, so two new tests cover it: hovering a disabled checkbox shows the reason, and no wrapper appears when no reason is given.

## Additional Context

- Only test runs and tasks are affected in practice. Experiments also use `capabilityMode: 'row'` but have no bulk-delete endpoint, so their grid never enters checkbox selection mode and no tooltip appears. If experiments get bulk delete later, the tooltip turns on for them with no extra wiring.
- The wording matches the backend rule: `bulk_delete_items` with `owner_attr` restricts deletion to rows created by the caller and reports the rest in `forbidden_ids`.
- Targets `release/v0.14.0`.

## Testing

`npx jest src/components/common/__tests__/BaseDataGrid.test.tsx src/components/common/EntityGrid` passes (16 + 13). `npx tsc --noEmit`, `npx eslint`, and Prettier are clean on the changed files.

Manually: open Test Runs or Tasks as a user who does not own every row, turn on "Select test runs" in the toolbar, and hover a greyed-out checkbox. The tooltip should read "Only the owner can delete this test run". Checkboxes on your own rows behave as before, and the header select-all is untouched.
