### PR TITLE
Fix test filters offering values no listed test carries

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/test.py
+++ b/apps/backend/src/rhesis/backend/app/crud/test.py
@@ -55,10 +55,17 @@ def get_test_facets(
             .filter(col.isnot(None), *test_predicates)
         )
         if test_set_id is not None:
+            # The association table is tenant-scoped too, so it carries the org
+            # predicate as well: Test being filtered already rules out
+            # cross-org rows, but neither join should be the one thing holding
+            # that line.
             query = query.join(
                 test_test_set_association,
                 test_test_set_association.c.test_id == Test.id,
-            ).filter(test_test_set_association.c.test_set_id == test_set_id)
+            ).filter(
+                test_test_set_association.c.test_set_id == test_set_id,
+                test_test_set_association.c.organization_id == organization_id,
+            )
         return [name for (name,) in query.distinct().order_by(col).all()]
 
     return {

--- a/apps/backend/src/rhesis/backend/app/crud/test.py
+++ b/apps/backend/src/rhesis/backend/app/crud/test.py
@@ -1,0 +1,69 @@
+"""Per-entity CRUD for tests.
+
+Follows the split convention described in ``apps/backend/AGENTS.md`` --
+anything that would have been added to ``crud/__init__.py`` goes here.
+"""
+
+from uuid import UUID
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.models.category import Category
+from rhesis.backend.app.models.requirement import Requirement
+from rhesis.backend.app.models.test import Test, test_test_set_association
+from rhesis.backend.app.models.topic import Topic
+from rhesis.backend.app.models.type_lookup import TypeLookup
+
+
+def get_test_facets(
+    db: Session,
+    *,
+    organization_id: str,
+    project_id: UUID | None = None,
+    test_set_id: UUID | None = None,
+) -> dict[str, list[str]]:
+    """Return the distinct requirement/category/topic/test-type values that
+    appear on at least one visible test.
+
+    When *test_set_id* is provided, only tests linked to that set are
+    considered, so a filter drawer offers exactly the values its grid can match.
+
+    Every predicate on ``Test`` is spelled out here rather than left to the
+    ambient listeners, because neither one covers this query shape: the
+    soft-delete listener reads ``column_descriptions``, which for a
+    column-narrowed select names the lookup table and not ``Test``, and the
+    scope listener's ``with_loader_criteria`` is likewise keyed to the entities
+    the ORM sees selected. Without these, soft-deleted and out-of-project tests
+    would contribute filter options.
+    """
+    test_predicates = [
+        Test.deleted_at.is_(None),
+        Test.explorer_row.is_(False),
+        Test.metric_id.is_(None),
+        Test.organization_id == organization_id,
+    ]
+    if project_id is not None:
+        # Mirrors the ambient project predicate: org-wide rows carry no project.
+        test_predicates.append(or_(Test.project_id == project_id, Test.project_id.is_(None)))
+
+    def _distinct_names(entity_cls, fk_col, name_attr: str = "name") -> list[str]:
+        col = getattr(entity_cls, name_attr)
+        query = (
+            db.query(col)
+            .join(Test, fk_col == entity_cls.id)
+            .filter(col.isnot(None), *test_predicates)
+        )
+        if test_set_id is not None:
+            query = query.join(
+                test_test_set_association,
+                test_test_set_association.c.test_id == Test.id,
+            ).filter(test_test_set_association.c.test_set_id == test_set_id)
+        return [name for (name,) in query.distinct().order_by(col).all()]
+
+    return {
+        "requirements": _distinct_names(Requirement, Test.requirement_id),
+        "categories": _distinct_names(Category, Test.category_id),
+        "topics": _distinct_names(Topic, Test.topic_id),
+        "test_types": _distinct_names(TypeLookup, Test.test_type_id, "type_value"),
+    }

--- a/apps/backend/src/rhesis/backend/app/routers/test.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test.py
@@ -11,9 +11,11 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.quota_gates import require_quota
+from rhesis.backend.app.auth.rbac import project_id_from_scope
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.crud import endpoint as endpoint_crud
 from rhesis.backend.app.crud import file as file_crud
+from rhesis.backend.app.crud.test import get_test_facets
 from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
@@ -236,6 +238,26 @@ def read_tests(
         serialized = jsonable_encoder(tests)
         return JSONResponse(content=apply_select(serialized, select))
     return tests
+
+
+@router.get("/facets", response_model=schemas.TestFacets)
+def read_test_facets(
+    test_set_id: UUID | None = Query(None, description="Scope facets to a specific test set"),
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Return the distinct values a test filter drawer can offer.
+
+    Optionally scoped to a single test set via ``test_set_id``.
+    """
+    organization_id, _ = tenant_context
+    return get_test_facets(
+        db,
+        organization_id=organization_id,
+        project_id=project_id_from_scope(db),
+        test_set_id=test_set_id,
+    )
 
 
 @router.get("/{test_id}/test_sets", response_model=List[schemas.TestSet])

--- a/apps/backend/src/rhesis/backend/app/schemas/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/__init__.py
@@ -140,6 +140,7 @@ from .test import (
     TestDetail,
     TestExecuteRequest,
     TestExecuteResponse,
+    TestFacets,
     TestPromptCreate,
     TestTag,
     TestUpdate,

--- a/apps/backend/src/rhesis/backend/app/schemas/test.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test.py
@@ -5,9 +5,9 @@ from pydantic import UUID4, BaseModel, ConfigDict, field_validator
 
 from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.references import (
-    RequirementReference,
     CategoryReference,
     PromptReference,
+    RequirementReference,
     StatusReference,
     TopicReference,
     TypeLookupReference,
@@ -342,3 +342,12 @@ class ConversationTestExtractionResponse(BaseModel):
     expected_response: Optional[str] = None
     # Multi-turn fields
     test_configuration: Optional[Dict[str, Any]] = None
+
+
+class TestFacets(BaseModel):
+    """Distinct filterable values across tests."""
+
+    requirements: List[str]
+    categories: List[str]
+    topics: List[str]
+    test_types: List[str]

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
@@ -46,19 +46,6 @@ function toFilters(state: EntityGridFilterState<TestFilters>) {
   };
 }
 
-const drawerAdapter: EntityGridDrawerAdapter<TestFilters> = {
-  empty: EMPTY_TEST_FILTERS,
-  countActive: countActiveTestFilters,
-  render: props => (
-    <TestFilterDrawer
-      open={props.open}
-      onClose={props.onClose}
-      filters={props.filters}
-      onApply={props.onApply}
-    />
-  ),
-};
-
 export default function TestSetTestsGrid({
   testSetId,
   testSetType,
@@ -70,6 +57,23 @@ export default function TestSetTestsGrid({
   const notifications = useNotifications();
   const canEditTestSet = useCan(Capability.TestSet.UPDATE);
   const canExport = useCan(Capability.TestSet.EXPORT);
+
+  const drawerAdapter: EntityGridDrawerAdapter<TestFilters> = useMemo(
+    () => ({
+      empty: EMPTY_TEST_FILTERS,
+      countActive: countActiveTestFilters,
+      render: props => (
+        <TestFilterDrawer
+          open={props.open}
+          onClose={props.onClose}
+          filters={props.filters}
+          onApply={props.onApply}
+          testSetId={testSetId}
+        />
+      ),
+    }),
+    [testSetId]
+  );
 
   const descriptor = useMemo(() => testSetTestsList(testSetId), [testSetId]);
   const columns: GridColDef[] = useMemo(

--- a/apps/frontend/src/app/(protected)/tests/components/TestFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestFilterDrawer.tsx
@@ -89,12 +89,14 @@ export default function TestFilterDrawer({
   const categoryOptions = facets?.categories ?? [];
   const topicOptions = facets?.topics ?? [];
 
-  // An empty facet means "not loaded yet" or "no tests here" -- in both cases
-  // show every type rather than a chipless section. `draft.testType` is kept so
-  // an already-applied type stays clickable (and so unsettable) either way.
+  // Until the facets land there is nothing to narrow by, so show every type
+  // rather than a chipless section. Once they have, offer only the types in
+  // scope -- an empty list is a real answer and leaves no chips, the same way
+  // an empty test set leaves the dropdowns above with no options. Any applied
+  // type stays listed so the filter can still be clicked off.
   const testTypeOptions = React.useMemo(
     () =>
-      facets?.test_types.length
+      facets
         ? TEST_TYPE_FILTER_OPTIONS.filter(
             o =>
               facets.test_types.includes(o.value) || draft.testType === o.value

--- a/apps/frontend/src/app/(protected)/tests/components/TestFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestFilterDrawer.tsx
@@ -8,11 +8,9 @@ import {
   filterChipSx,
   filterDrawerTextFieldSx,
 } from '@/components/common/FilterDrawer';
-import { filterUniqueValidOptions } from '@/components/common/BaseDrawer';
 import { TEST_TYPE_FILTER_OPTIONS } from '@/constants/test-types';
-import { useRequirements, useCategories, useTopics } from '@/hooks/useLookups';
+import { useTestFacets } from '@/hooks/useLookups';
 import ActivityPresenceFiltersSection from '@/components/common/ActivityPresenceFilters';
-import { EntityType } from '@/types/entity-type';
 import {
   EMPTY_ACTIVITY_PRESENCE_FILTERS,
   countActivePresenceFilters,
@@ -69,6 +67,8 @@ interface TestFilterDrawerProps {
   onClose: () => void;
   filters: TestFilters;
   onApply: (filters: TestFilters) => void;
+  /** Scope filter options to a test set. Omit for the global tests list. */
+  testSetId?: string;
 }
 
 export default function TestFilterDrawer({
@@ -76,33 +76,31 @@ export default function TestFilterDrawer({
   onClose,
   filters,
   onApply,
+  testSetId,
 }: TestFilterDrawerProps) {
   const [draft, setDraft] = React.useState<TestFilters>(filters);
 
-  const { data: rawRequirements, isLoading: loadingRequirements } =
-    useRequirements(open);
-  const { data: rawCategories, isLoading: loadingCategories } = useCategories(
-    EntityType.TEST,
+  const { data: facets, isLoading: loadingOptions } = useTestFacets(
+    testSetId,
     open
   );
-  const { data: rawTopics, isLoading: loadingTopics } = useTopics(
-    EntityType.TEST,
-    open
-  );
-  const loadingOptions =
-    loadingRequirements || loadingCategories || loadingTopics;
 
-  const requirementOptions = React.useMemo(
-    () => filterUniqueValidOptions(rawRequirements ?? []).map(b => b.name),
-    [rawRequirements]
-  );
-  const categoryOptions = React.useMemo(
-    () => filterUniqueValidOptions(rawCategories ?? []).map(c => c.name),
-    [rawCategories]
-  );
-  const topicOptions = React.useMemo(
-    () => filterUniqueValidOptions(rawTopics ?? []).map(t => t.name),
-    [rawTopics]
+  const requirementOptions = facets?.requirements ?? [];
+  const categoryOptions = facets?.categories ?? [];
+  const topicOptions = facets?.topics ?? [];
+
+  // An empty facet means "not loaded yet" or "no tests here" -- in both cases
+  // show every type rather than a chipless section. `draft.testType` is kept so
+  // an already-applied type stays clickable (and so unsettable) either way.
+  const testTypeOptions = React.useMemo(
+    () =>
+      facets?.test_types.length
+        ? TEST_TYPE_FILTER_OPTIONS.filter(
+            o =>
+              facets.test_types.includes(o.value) || draft.testType === o.value
+          )
+        : TEST_TYPE_FILTER_OPTIONS,
+    [facets, draft.testType]
   );
 
   React.useEffect(() => {
@@ -150,7 +148,7 @@ export default function TestFilterDrawer({
     >
       <FilterSection title="Test Type">
         <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-          {TEST_TYPE_FILTER_OPTIONS.map(opt => (
+          {testTypeOptions.map(opt => (
             <Box
               key={opt.value}
               component="button"

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -281,7 +281,11 @@ export function applyFlexColumnSizing(columns: GridColDef[]): GridColDef[] {
     );
     if (idx !== -1) {
       const { maxWidth: _mw, ...rest } = mapped[idx];
-      mapped[idx] = { ...rest, flex: 1, minWidth: rest.minWidth ?? rest.width ?? 50 };
+      mapped[idx] = {
+        ...rest,
+        flex: 1,
+        minWidth: rest.minWidth ?? rest.width ?? 50,
+      };
     }
   }
 

--- a/apps/frontend/src/components/common/__tests__/BaseDataGrid.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/BaseDataGrid.test.tsx
@@ -106,7 +106,11 @@ describe('applyFlexColumnSizing', () => {
 
     const sized = applyFlexColumnSizing(columns);
 
-    expect(sized[0]).toMatchObject({ width: 300, maxWidth: 300, minWidth: 150 });
+    expect(sized[0]).toMatchObject({
+      width: 300,
+      maxWidth: 300,
+      minWidth: 150,
+    });
     expect(sized[0].flex).toBeUndefined();
     expect(sized[1]).toMatchObject({ flex: 1, minWidth: 50 });
     expect(sized[2]).toMatchObject({ width: 88, hideable: false });

--- a/apps/frontend/src/constants/query-keys.ts
+++ b/apps/frontend/src/constants/query-keys.ts
@@ -7,7 +7,12 @@ function createEntityKeys<T extends string>(root: T) {
   };
 }
 
-export const testKeys = createEntityKeys('tests');
+export const testKeys = {
+  ...createEntityKeys('tests'),
+  /** Distinct filter values, optionally narrowed to one test set. */
+  facets: (testSetId?: string) =>
+    ['tests', 'facets', testSetId ?? null] as const,
+};
 export const testSetKeys = createEntityKeys('test-sets');
 export const testRunKeys = createEntityKeys('test-runs');
 export const endpointKeys = createEntityKeys('endpoints');

--- a/apps/frontend/src/hooks/useLookups.ts
+++ b/apps/frontend/src/hooks/useLookups.ts
@@ -9,6 +9,7 @@ import {
   tagKeys,
   userKeys,
   typeLookupKeys,
+  testKeys,
   testSetKeys,
 } from '@/constants/query-keys';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -19,6 +20,7 @@ import { Topic } from '@/utils/api-client/interfaces/topic';
 import { Tag } from '@/utils/api-client/interfaces/tag';
 import { User } from '@/utils/api-client/interfaces/user';
 import { TestSet } from '@/utils/api-client/interfaces/test-set';
+import type { TestFacets } from '@/utils/api-client/interfaces/tests';
 import { TypeLookup } from '@/utils/api-client/interfaces/type-lookup';
 import { getPriorities } from '@/utils/task-lookup';
 import type { Priority } from '@/utils/api-client/interfaces/task';
@@ -180,6 +182,21 @@ export function useTypeLookups(filter: string, enabled = true) {
         });
       return types;
     },
+    enabled: enabled && isAuthenticated,
+    staleTime: STALE_TIME,
+  });
+}
+
+/**
+ * Distinct requirement/category/topic/test-type values that actually appear on
+ * tests. Pass `testSetId` to scope to a single test set.
+ */
+export function useTestFacets(testSetId?: string, enabled = true) {
+  const isAuthenticated = useIsAuthenticated();
+  return useQuery<TestFacets>({
+    queryKey: testKeys.facets(testSetId),
+    queryFn: () =>
+      new ApiClientFactory().getTestsClient().getTestFacets(testSetId),
     enabled: enabled && isAuthenticated,
     staleTime: STALE_TIME,
   });

--- a/apps/frontend/src/utils/api-client/interfaces/tests.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/tests.ts
@@ -180,3 +180,10 @@ export interface ConversationTestExtractionResponse {
   expected_response?: string;
   test_configuration?: Record<string, unknown>;
 }
+
+export interface TestFacets {
+  requirements: string[];
+  categories: string[];
+  topics: string[];
+  test_types: string[];
+}

--- a/apps/frontend/src/utils/api-client/tests-client.ts
+++ b/apps/frontend/src/utils/api-client/tests-client.ts
@@ -11,6 +11,7 @@ import {
   TestExecuteResponse,
   ConversationToTestRequest,
   ConversationTestExtractionResponse,
+  TestFacets,
   PriorityLevel,
 } from './interfaces/tests';
 import { TestSet } from './interfaces/test-set';
@@ -116,6 +117,14 @@ export class TestsClient extends BaseApiClient {
     }
 
     return allData;
+  }
+
+  async getTestFacets(testSetId?: string): Promise<TestFacets> {
+    const params = new URLSearchParams();
+    if (testSetId) params.append('test_set_id', testSetId);
+    const qs = params.toString();
+    const url = `${API_ENDPOINTS.tests}/facets${qs ? `?${qs}` : ''}`;
+    return this.fetch<TestFacets>(url, { cache: 'no-store' });
   }
 
   async getTest(id: string): Promise<TestDetail> {

--- a/tests/backend/routes/test_test_facets.py
+++ b/tests/backend/routes/test_test_facets.py
@@ -1,0 +1,187 @@
+"""
+Tests for GET /tests/facets endpoint.
+
+The endpoint backs the test filter drawers: it returns the distinct
+requirement/category/topic/test-type values that actually appear on visible
+tests, so a drawer only offers values its grid can match.
+
+Names are suffixed with a per-run token so assertions stay valid regardless of
+what other fixtures leave in the organization.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.models.test import test_test_set_association
+
+
+@pytest.fixture
+def facet_scenario(test_db: Session, test_organization, db_user, db_status, db_test_set) -> dict:
+    """Build tests whose lookup values cover every visibility case the query handles.
+
+    Returns the unique names so each test can assert on its own rows only.
+    """
+    token = uuid.uuid4().hex[:8]
+    org_id, user_id = test_organization.id, db_user.id
+
+    def _lookup(model, name):
+        row = model(name=name, organization_id=org_id, user_id=user_id)
+        test_db.add(row)
+        return row
+
+    names = {
+        "linked_req": f"ZZFacetReqLinked-{token}",
+        "unlinked_req": f"ZZFacetReqUnlinked-{token}",
+        "deleted_req": f"ZZFacetReqDeleted-{token}",
+        "explorer_req": f"ZZFacetReqExplorer-{token}",
+        "category": f"ZZFacetCategory-{token}",
+        "topic": f"ZZFacetTopic-{token}",
+        "test_type": f"ZZFacetType-{token}",
+    }
+
+    linked_req = _lookup(models.Requirement, names["linked_req"])
+    unlinked_req = _lookup(models.Requirement, names["unlinked_req"])
+    deleted_req = _lookup(models.Requirement, names["deleted_req"])
+    explorer_req = _lookup(models.Requirement, names["explorer_req"])
+    category = _lookup(models.Category, names["category"])
+    topic = _lookup(models.Topic, names["topic"])
+
+    test_type = models.TypeLookup(
+        type_name="TestType",
+        type_value=names["test_type"],
+        organization_id=org_id,
+        user_id=user_id,
+    )
+    test_db.add(test_type)
+    test_db.flush()
+
+    def _test(**kwargs):
+        row = models.Test(
+            organization_id=org_id,
+            user_id=user_id,
+            status_id=db_status.id,
+            **kwargs,
+        )
+        test_db.add(row)
+        return row
+
+    # Visible, and linked to the test set: the only row a scoped query may see.
+    linked = _test(
+        requirement_id=linked_req.id,
+        category_id=category.id,
+        topic_id=topic.id,
+        test_type_id=test_type.id,
+    )
+    # Visible, but outside the test set.
+    _test(requirement_id=unlinked_req.id)
+    # Excluded rows: each one previously leaked its value into the drawer.
+    _test(requirement_id=deleted_req.id, deleted_at=datetime.now(timezone.utc))
+    _test(requirement_id=explorer_req.id, explorer_row=True)
+    test_db.flush()
+
+    test_db.execute(
+        test_test_set_association.insert().values(
+            test_id=linked.id,
+            test_set_id=db_test_set.id,
+            organization_id=org_id,
+            user_id=user_id,
+        )
+    )
+    test_db.flush()
+
+    return {"names": names, "test_set_id": db_test_set.id}
+
+
+class TestGetTestFacets:
+    """Tests for GET /tests/facets"""
+
+    def test_returns_values_from_visible_tests(
+        self, authenticated_client: TestClient, facet_scenario
+    ):
+        """Every facet reports the value carried by a visible test."""
+        names = facet_scenario["names"]
+
+        response = authenticated_client.get("/tests/facets")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert names["linked_req"] in data["requirements"]
+        assert names["unlinked_req"] in data["requirements"]
+        assert names["category"] in data["categories"]
+        assert names["topic"] in data["topics"]
+        assert names["test_type"] in data["test_types"]
+
+    def test_excludes_soft_deleted_tests(self, authenticated_client: TestClient, facet_scenario):
+        """A soft-deleted test contributes nothing.
+
+        Regression test: the ambient soft-delete listener does not reach the
+        joined Test in this column-narrowed query, so the predicate is explicit
+        in the CRUD layer. Without it the drawer offered dead values.
+        """
+        names = facet_scenario["names"]
+
+        response = authenticated_client.get("/tests/facets")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert names["deleted_req"] not in response.json()["requirements"]
+
+    def test_excludes_explorer_rows(self, authenticated_client: TestClient, facet_scenario):
+        """Explorer-owned tests are absent, matching what GET /tests lists."""
+        names = facet_scenario["names"]
+
+        response = authenticated_client.get("/tests/facets")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert names["explorer_req"] not in response.json()["requirements"]
+
+    def test_scopes_to_test_set(self, authenticated_client: TestClient, facet_scenario):
+        """test_set_id narrows facets to values on tests linked to that set."""
+        names = facet_scenario["names"]
+
+        response = authenticated_client.get(
+            "/tests/facets", params={"test_set_id": str(facet_scenario["test_set_id"])}
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["requirements"] == [names["linked_req"]]
+        assert data["categories"] == [names["category"]]
+        assert data["topics"] == [names["topic"]]
+        assert data["test_types"] == [names["test_type"]]
+
+    def test_unknown_test_set_returns_empty_facets(
+        self, authenticated_client: TestClient, facet_scenario
+    ):
+        """An unknown test set yields empty lists rather than unscoped values."""
+        response = authenticated_client.get(
+            "/tests/facets", params={"test_set_id": str(uuid.uuid4())}
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            "requirements": [],
+            "categories": [],
+            "topics": [],
+            "test_types": [],
+        }
+
+    def test_rejects_malformed_test_set_id(self, authenticated_client: TestClient):
+        """A non-UUID test_set_id is a validation error, not a silent full scan."""
+        response = authenticated_client.get("/tests/facets", params={"test_set_id": "not-a-uuid"})
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_requires_authentication(self, client: TestClient):
+        """Unauthenticated requests are rejected."""
+        response = client.get("/tests/facets")
+
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )


### PR DESCRIPTION
## Purpose

The filter drawer on the tests list, the test set detail grid, and the assign tests drawer populated Requirement, Category and Topic from the global `/requirements`, `/categories` and `/topics` endpoints. Those return every lookup row in the organization, so the drawers offered values that none of the listed tests carry. On a test set detail page they offered values from tests outside that set entirely, which is where it was most visible.

## What Changed

- Adds `GET /tests/facets`, returning the distinct requirement, category, topic and test type values that appear on visible tests. An optional `test_set_id` narrows it to a single test set.
- Points the filter drawer at that endpoint. The test set detail grid passes its `test_set_id`. The tests list and the assign drawer stay unscoped, since both list tests org wide.
- Narrows the Test Type chips to the types actually present, so a set holding only single turn tests stops offering Multi-Turn. An already applied type stays clickable so a filter cannot get stuck on.
- Replaces three lookup requests per drawer open with one.

## Additional Context

- Targets `release/v0.14.0` rather than `main`.
- Every predicate on `Test` in the facets query is explicit rather than left to the ambient scope and soft delete listeners, because neither one covers this query shape. The soft delete listener only fires for `db.query()` and only filters entities in `column_descriptions`, which for a column narrowed select names the lookup table and not `Test`. The scope listener's `with_loader_criteria` is keyed the same way. Compiling the statement confirmed it: the listener contributed `requirement.deleted_at IS NULL` and nothing at all for `test`. Without the explicit predicates, soft deleted and out of project tests contributed filter values.
- The tests router had no test file before this, marked missing in `tests/backend/routes/STATUS.md`. This adds coverage for the new endpoint only, so the rest of that router stays uncovered and the status table is unchanged.
- Facets are cached for five minutes, matching the other lookup hooks. Editing a test's topic will not refresh the options until that window passes.
- Facets always exclude explorer owned and metric owned tests, while `get_test_set_tests` does not. These only diverge on a metric's tuning test set, which is hidden from the test set list and reachable only by direct URL.

## Testing

Static checks are clean locally: `ruff check`, `ruff format`, `tsc --noEmit`, `eslint` and `prettier`.

`tests/backend/routes/test_test_facets.py` adds seven cases covering values from visible tests, the soft delete exclusion, the explorer row exclusion, test set scoping, an unknown test set, a malformed `test_set_id`, and authentication.

These tests have not been executed. Docker was unavailable locally so Testcontainers could not start Postgres, and CI is the first thing to run them. One assertion to watch: `test_scopes_to_test_set` uses exact list equality, which will need relaxing to membership checks if another fixture links tests to `db_test_set`.

To verify by hand, open the filter drawer on a test set detail page and confirm Requirement, Category and Topic only offer values that appear in that set's grid. Then open the same drawer on the tests list, which should still offer the full org wide set.
