### PR TITLE
ci: stop persisting the job token on every checkout

### DIFF
--- a/.github/workflows/backend-k8s.yml
+++ b/.github/workflows/backend-k8s.yml
@@ -53,6 +53,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -80,6 +82,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/chatbot-k8s.yml
+++ b/.github/workflows/chatbot-k8s.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          persist-credentials: true  # the release-branch push below needs the app token on disk
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
 

--- a/.github/workflows/docs-k8s.yml
+++ b/.github/workflows/docs-k8s.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Build backend test image
         run: docker compose -f ../../tests/docker-compose.frontend.yml build frontend-test-backend
@@ -54,6 +56,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -125,6 +129,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/frontend-k8s.yml
+++ b/.github/workflows/frontend-k8s.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -78,6 +80,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/k8s-build-push.yml
+++ b/.github/workflows/k8s-build-push.yml
@@ -55,6 +55,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Resolve GCP credentials and authenticate
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Check for file changes
         if: github.event_name == 'pull_request'
@@ -77,6 +79,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -97,6 +101,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install uv
@@ -121,6 +126,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -151,6 +158,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           # Depth 1 makes check-hardcoded-styles.js scan every file, not the diff.
           fetch-depth: 2
 
@@ -183,6 +191,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -204,6 +214,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -222,6 +234,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/otel-collector-k8s.yml
+++ b/.github/workflows/otel-collector-k8s.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment

--- a/.github/workflows/penelope-test.yml
+++ b/.github/workflows/penelope-test.yml
@@ -18,6 +18,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
       with:
+        persist-credentials: false
         fetch-depth: 0  # Needed for git diff
 
     - name: Set up Python

--- a/.github/workflows/polyphemus-k8s.yml
+++ b/.github/workflows/polyphemus-k8s.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment

--- a/.github/workflows/polyphemus-vertex-ai.yml
+++ b/.github/workflows/polyphemus-vertex-ai.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
@@ -94,6 +96,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/publish-ghcr-images.yml
+++ b/.github/workflows/publish-ghcr-images.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -116,6 +118,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -174,6 +178,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Setup Python build environment
       uses: ./.github/actions/setup-python-build
@@ -50,6 +52,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Setup Python build environment
       uses: ./.github/actions/setup-python-build

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v6
         with:
+          persist-credentials: true  # the push to main below needs the app token on disk
           ref: main
           token: ${{ steps.generate-token.outputs.token }}
 
@@ -214,6 +215,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          persist-credentials: true  # the publish script pushes tags with the app token
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
 

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
       with:
+        persist-credentials: false
         fetch-depth: 0  # Needed for git diff
 
     - name: Set up Python

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Secret Scanning
@@ -42,6 +43,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Check for file changes
         if: github.event_name == 'pull_request'
@@ -107,6 +110,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0

--- a/.github/workflows/set-up-release.yml
+++ b/.github/workflows/set-up-release.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          persist-credentials: true  # the version-bump push below needs the app token on disk
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set up Git

--- a/.github/workflows/sync-skill.yml
+++ b/.github/workflows/sync-skill.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           path: source
 
       - name: Set up Python
@@ -55,6 +56,7 @@ jobs:
       - name: Checkout mirror
         uses: actions/checkout@v6
         with:
+          persist-credentials: true  # the mirror push below needs the app token on disk
           repository: ${{ github.repository_owner }}/skills
           token: ${{ steps.generate-token.outputs.token }}
           path: mirror

--- a/.github/workflows/telemetry-processor-k8s.yml
+++ b/.github/workflows/telemetry-processor-k8s.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment

--- a/.github/workflows/terraform-infrastructure.yml
+++ b/.github/workflows/terraform-infrastructure.yml
@@ -86,6 +86,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/tf-setup
         id: tf_setup
@@ -171,6 +173,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/tf-setup
         id: tf_setup

--- a/.github/workflows/worker-k8s.yml
+++ b/.github/workflows/worker-k8s.yml
@@ -53,6 +53,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment


### PR DESCRIPTION
## What

`actions/checkout` defaults to writing the job's `GITHUB_TOKEN` into `.git/config`, where it stays for the rest of the job — readable by any later step, any script, and anything those scripts import. Several of our workflows install and run third-party Python and npm dependencies immediately after checkout.

This sets `persist-credentials: false` on every checkout that never touches a remote, and states it explicitly as `true` on the five that push.

## The five that keep credentials

Each already passes an app `token:` — the default was carrying it silently, now it's declared with a comment saying which push needs it:

| Workflow | Job | Why |
|---|---|---|
| `create-release.yml` | `release` | pushes the release branch |
| `publish-release.yml` | `promote-prd-config` | pushes to `main` |
| `publish-release.yml` | `publish` | `release_tools/publish.py` pushes tags |
| `set-up-release.yml` | `update-release-config` | pushes the version bump |
| `sync-skill.yml` | `sync` | pushes to the skills mirror |

The keep-list came from grepping every `git push` / `git fetch` / `git ls-remote` under `.github/`, including the Python release tools — not just the workflow YAML.

## Scope

- 44 checkout steps across 24 workflow files: 39 → `false`, 5 → `true`.
- No code changes, no test changes, no action version bumps.

## Verification

All 24 files still parse as YAML, and a walk of the parsed step trees confirms 39 `false` / 5 `true` / 0 unset.
