### PR TITLE
Fix nine GET /features tests hitting Postgres with a mocked org id

### DIFF
--- a/tests/backend/routes/test_features.py
+++ b/tests/backend/routes/test_features.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import (
+    get_db_session,
     get_tenant_context,
     get_tenant_db_session,
 )
@@ -45,14 +46,20 @@ def registered_sso():
 def mock_current_user():
     """Stub the auth/tenant chain.
 
-    The ``/features`` endpoint depends on ``get_tenant_context`` and
-    ``get_tenant_db_session`` (which transitively depend on
-    ``require_current_user_or_token``). Overriding those two deps directly
-    bypasses the entire auth/session machinery without needing a real DB.
+    ``/features`` resolves its organization through
+    ``get_current_organization_optional``, which reads
+    ``current_user.organization_id`` and loads the row with ``get_db_session``.
+    Both of those are stubbed here, along with the tenant pair other
+    dependencies on the route resolve through, so the endpoint never touches a
+    real session.
+
+    ``organization_id`` has to be set explicitly on the user stub: a bare
+    ``Mock`` would hand back a truthy child mock, which passes the dependency's
+    "has an org" guard and then reaches Postgres as an invalid UUID.
 
     The app's defense-in-depth backstop (``apply_auth_backstop``) also injects
     ``require_current_user_or_token`` directly on the route, so we override it
-    too — otherwise the backstop would reject the mocked request with 401.
+    too, otherwise the backstop would reject the mocked request with 401.
     """
     org_stub = Mock(spec=Organization)
     org_stub.id = _TEST_ORG_ID
@@ -61,16 +68,17 @@ def mock_current_user():
     db_stub.get.return_value = org_stub
 
     user_id = UUID("11111111-1111-1111-1111-111111111111")
-    user_stub = Mock(organization=org_stub, id=user_id)
+    user_stub = Mock(organization=org_stub, organization_id=_TEST_ORG_ID, id=user_id)
 
     def _override_tenant_context():
         return (_TEST_ORG_ID, user_id)
 
-    def _override_tenant_db_session():
+    def _override_db_session():
         yield db_stub
 
     app.dependency_overrides[get_tenant_context] = _override_tenant_context
-    app.dependency_overrides[get_tenant_db_session] = _override_tenant_db_session
+    app.dependency_overrides[get_tenant_db_session] = _override_db_session
+    app.dependency_overrides[get_db_session] = _override_db_session
     app.dependency_overrides[require_current_user_or_token] = lambda: user_stub
     yield user_stub
     app.dependency_overrides.clear()


### PR DESCRIPTION
## Purpose

Nine `GET /features` tests fail on `release/v0.14.0`. They pass on `main`, so the break is specific to this release line and blocks a clean backend suite for every branch cut from it.

The failure predates this branch, and predates the facets work merged in #2650. At `e82057d44`, the release head before either existed, `routers/features.py` already resolved its org through `get_current_organization_optional` while the `mock_current_user` fixture overrode only `get_tenant_context`, `get_tenant_db_session` and `require_current_user_or_token`. Both halves of the failure were already in place.

Each one dies the same way, with a `Mock` reaching Postgres as an organization id:

```
(psycopg2.errors.InvalidTextRepresentation) invalid input syntax for type uuid:
"<Mock name='mock.organization_id' id='...'>"
[SQL: SELECT ... FROM organization WHERE organization.id = %(pk_1)s::UUID]
```

## What Changed

One fixture, `mock_current_user` in `tests/backend/routes/test_features.py`.

- Sets `organization_id` on the user stub. A bare `Mock` returns a truthy child mock for any attribute, which passed the dependency's `if not current_user.organization_id` guard and then hit the database.
- Overrides `get_db_session` with the same stub session the fixture already builds, so the org lookup no longer reaches a real connection.
- Rewrites the fixture docstring, which still described the dependency graph the endpoint used before it changed.

No production code is touched.

## Additional Context

`test_features.py` is byte-identical on `main` and `release/v0.14.0`. Only `routers/features.py` differs, and that is the whole story:

| Branch | Org resolved via | Stubbed by the fixture |
| --- | --- | --- |
| `main` | `get_current_organization` → `get_tenant_context` + `get_tenant_db_session` | yes, both |
| `release/v0.14.0` | `get_current_organization_optional` → `require_current_user_or_token` + `get_db_session` | no, `get_db_session` was missing |

The fix belongs in the test rather than the router. `/features` uses the optional dependency deliberately, so a user mid-onboarding with no org yet gets default-tier limits instead of a 403, which is what lets the frontend size the invitation form before the org exists. Reverting the router to match `main` would delete that behaviour to make a test pass. The test simply was not updated when the endpoint's dependencies changed.

Two things this surfaced, filed as #2653 rather than widened into this PR: the two org-resolving dependencies disagree about where the organization id comes from, and `test_license_info_reflects_org` asserts the license provider is never handed `None` while the endpoint can now pass exactly that for a user with no org. The no-org path has no test today.

Since `features.py` has diverged between `main` and `release/v0.14.0`, this is worth a look when the release branch merges back.

## Testing

`ruff check`, `ruff format` and a compile check are clean.

The backend suite does not run automatically on PRs targeting `release/v0.14.0`, since `backend-test.yml` triggers on `pull_request: branches: [main]`. It was dispatched manually against this branch instead. Docker would not start locally, so CI is the only place these have been exercised.

Before and after, both full-suite runs:

- before the fix: 8304 passed, **9 failed**
- with the fix ([run 33177994867](https://github.com/rhesis-ai/rhesis/actions/runs/33177994867)): 8313 passed, 62 skipped, 1 xfailed, **0 failed**

8304 + 9 = 8313, so the nine features tests are the entire delta and nothing else moved.

To verify by hand: `cd apps/backend && uv run pytest ../../tests/backend/routes/test_features.py -v` (needs Docker for Testcontainers).
