### PR TITLE
Enable ruff bugbear and clear all 105 findings

### DIFF
--- a/.github/release_tools/publish.py
+++ b/.github/release_tools/publish.py
@@ -267,7 +267,7 @@ def publish_releases(repo_root: Path, dry_run: bool = False) -> bool:
 
     if dry_run:
         info("DRY RUN - Would create the following tags:")
-        for component, version, tag_name in tags_to_create:
+        for component, _version, tag_name in tags_to_create:
             info(f"  {tag_name}")
             info("    • Create and push tag")
             latest_info = " (marked as latest)" if component == "platform" else ""
@@ -311,7 +311,7 @@ def publish_releases(repo_root: Path, dry_run: bool = False) -> bool:
 
     if created_tags:
         info("Published releases:")
-        for component, version, tag_name in created_tags:
+        for _component, _version, tag_name in created_tags:
             info(f"  • {tag_name}")
 
     return True

--- a/agents/reg-advisor/tests/test_app.py
+++ b/agents/reg-advisor/tests/test_app.py
@@ -206,7 +206,7 @@ def test_an_unknown_attribute_still_raises() -> None:
 
     assert "app" in reg_advisor.__all__
     with pytest.raises(AttributeError):
-        reg_advisor.no_such_thing
+        _ = reg_advisor.no_such_thing
 
 
 def test_lifespan_starts_the_connector(monkeypatch):

--- a/agents/research-assistant/examples/test_scenarios.py
+++ b/agents/research-assistant/examples/test_scenarios.py
@@ -934,7 +934,7 @@ MULTI_TURN_SCENARIOS = {
 def run_all_multi_turn_scenarios(verbose: bool = True) -> list[dict]:
     """Run all multi-turn scenarios."""
     all_results = []
-    for scenario_id, scenario_info in MULTI_TURN_SCENARIOS.items():
+    for _scenario_id, scenario_info in MULTI_TURN_SCENARIOS.items():
         if verbose:
             print(f"\n\n{'#' * 70}")
             print(f"# Running: {scenario_info['name']}")

--- a/apps/backend/src/rhesis/backend/alembic/utils/metric_sync.py
+++ b/apps/backend/src/rhesis/backend/alembic/utils/metric_sync.py
@@ -115,6 +115,52 @@ def load_requirements_from_initial_data() -> List[Dict[str, Any]]:
     return data.get("requirement") or data.get("behavior", [])
 
 
+def _cached_type_lookup(
+    session: Session,
+    cache: Dict[tuple, Any],
+    organization_id: str,
+    user_id: str,
+    type_name: str,
+    type_value: str,
+) -> Any:
+    """get_or_create_type_lookup, memoised per organization.
+
+    Module-level and explicitly parameterised rather than a closure over the
+    per-org loop variables, which would capture them by reference (B023).
+    """
+    key = (type_name, type_value)
+    if key not in cache:
+        cache[key] = get_or_create_type_lookup(
+            db=session,
+            type_name=type_name,
+            type_value=type_value,
+            organization_id=organization_id,
+            user_id=user_id,
+            commit=False,
+        )
+    return cache[key]
+
+
+def _cached_status(
+    session: Session,
+    cache: Dict[str, Any],
+    organization_id: str,
+    user_id: str,
+    name: str,
+) -> Any:
+    """get_or_create_status for metrics, memoised per organization."""
+    if name not in cache:
+        cache[name] = get_or_create_status(
+            db=session,
+            name=name,
+            entity_type=EntityType.METRIC,
+            organization_id=organization_id,
+            user_id=user_id,
+            commit=False,
+        )
+    return cache[name]
+
+
 def sync_metrics_to_organizations(
     session: Session,
     metric_names: List[str] | None = None,
@@ -223,31 +269,12 @@ def sync_metrics_to_organizations(
             # so memoising avoids re-querying it once per metric.
             type_lookup_cache: Dict[tuple, Any] = {}
             status_cache: Dict[str, Any] = {}
-
-            def _cached_type_lookup(type_name: str, type_value: str):
-                key = (type_name, type_value)
-                if key not in type_lookup_cache:
-                    type_lookup_cache[key] = get_or_create_type_lookup(
-                        db=session,
-                        type_name=type_name,
-                        type_value=type_value,
-                        organization_id=organization_id,
-                        user_id=user_id,
-                        commit=False,
-                    )
-                return type_lookup_cache[key]
-
-            def _cached_status(name: str):
-                if name not in status_cache:
-                    status_cache[name] = get_or_create_status(
-                        db=session,
-                        name=name,
-                        entity_type=EntityType.METRIC,
-                        organization_id=organization_id,
-                        user_id=user_id,
-                        commit=False,
-                    )
-                return status_cache[name]
+            cached_type_lookup = functools.partial(
+                _cached_type_lookup, session, type_lookup_cache, organization_id, user_id
+            )
+            cached_status = functools.partial(
+                _cached_status, session, status_cache, organization_id, user_id
+            )
 
             org_created = 0
             org_skipped = 0
@@ -263,13 +290,13 @@ def sync_metrics_to_organizations(
 
                 try:
                     # Get or create the metric type
-                    metric_type = _cached_type_lookup("MetricType", metric_item["metric_type"])
+                    metric_type = cached_type_lookup("MetricType", metric_item["metric_type"])
 
                     # Get or create the backend type
-                    backend_type = _cached_type_lookup("BackendType", metric_item["backend_type"])
+                    backend_type = cached_type_lookup("BackendType", metric_item["backend_type"])
 
                     # Get or create the status
-                    status = _cached_status(metric_item["status"])
+                    status = cached_status(metric_item["status"])
 
                     # Create metric data
                     metric_data = {

--- a/apps/backend/src/rhesis/backend/alembic/versions/97b38ee1a6e1_backfill_garak_notes_encoding.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/97b38ee1a6e1_backfill_garak_notes_encoding.py
@@ -92,9 +92,10 @@ def _build_prompt_trigger_map(probe_class_name: str) -> Optional[Dict[str, str]]
         if not hasattr(instance, "prompts") or not hasattr(instance, "triggers"):
             return None
 
+        # Probes may declare fewer triggers than prompts; pair what lines up.
         return {
             str(p).strip().replace("\r\n", "\n"): str(t)
-            for p, t in zip(instance.prompts, instance.triggers)
+            for p, t in zip(instance.prompts, instance.triggers, strict=False)
         }
 
     except Exception as exc:

--- a/apps/backend/src/rhesis/backend/app/services/connector/handlers/base.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/handlers/base.py
@@ -1,14 +1,17 @@
 """Base handler class for SDK WebSocket message handlers."""
 
 import logging
-from abc import ABC
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
-class BaseHandler(ABC):
-    """Base class for SDK WebSocket message handlers."""
+class BaseHandler:
+    """Shared logging helpers for SDK WebSocket message handlers.
+
+    Not an ABC: handlers share these helpers but declare no common contract, and
+    an ABC with no abstract methods enforces nothing anyway.
+    """
 
     def __init__(self):
         """Initialize the handler."""

--- a/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
@@ -140,7 +140,7 @@ def _generate_cluster_labels(
 
         # Get all embeddings in this cluster
         mask = cluster_ids == cluster_id
-        cluster_embeddings = [e for e, m in zip(embeddings, mask) if m]
+        cluster_embeddings = [e for e, m in zip(embeddings, mask, strict=True) if m]
         cluster_coords = umap_50d[mask]
 
         # Find closest to centroid
@@ -297,7 +297,7 @@ def build_2d_graph(
 
     # Build scatter points
     points = []
-    for embedding, cluster_id, coords_2d in zip(embeddings, cluster_ids, umap_2d):
+    for embedding, cluster_id, coords_2d in zip(embeddings, cluster_ids, umap_2d, strict=True):
         points.append(
             _scatter_point(
                 embedding,

--- a/apps/backend/src/rhesis/backend/app/services/explorer/evaluation.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/evaluation.py
@@ -422,7 +422,12 @@ async def evaluate_tests_for_explorer_set(
 
     # gather preserves order, so each outcome still lines up with its test.
     set_explorer_test_metadata(
-        db, [(test, meta) for test, (_, meta) in zip(eligible, evaluated) if meta is not None]
+        db,
+        [
+            (test, meta)
+            for test, (_, meta) in zip(eligible, evaluated, strict=True)
+            if meta is not None
+        ],
     )
     all_outcomes = [outcome for outcome, _ in evaluated]
 

--- a/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
@@ -355,7 +355,7 @@ async def generate_suggestions(
                 user_id,
                 embedder=embedder,
             )
-            for item, vec in zip(suggestions, vectors):
+            for item, vec in zip(suggestions, vectors, strict=True):
                 item["embedding"] = vec
 
             suggestions = sort_by_diversity(suggestions)

--- a/apps/backend/src/rhesis/backend/app/services/file_import/parsers.py
+++ b/apps/backend/src/rhesis/backend/app/services/file_import/parsers.py
@@ -207,7 +207,8 @@ def _parse_xlsx(file_bytes: bytes) -> List[Dict[str, Any]]:
             if all(cell is None or str(cell).strip() == "" for cell in row):
                 continue
             row_dict = {}
-            for header, value in zip(headers, row):
+            # Uploaded sheets have ragged rows; short rows drop the missing columns.
+            for header, value in zip(headers, row, strict=False):
                 if not header:
                     continue
                 row_dict[header] = value

--- a/apps/backend/src/rhesis/backend/app/services/garak/probes/service.py
+++ b/apps/backend/src/rhesis/backend/app/services/garak/probes/service.py
@@ -87,7 +87,7 @@ class GarakProbeService:
         import garak.probes
 
         modules = []
-        for importer, modname, ispkg in pkgutil.iter_modules(garak.probes.__path__):
+        for _importer, modname, _ispkg in pkgutil.iter_modules(garak.probes.__path__):
             if modname not in self.EXCLUDED_MODULES:
                 modules.append(modname)
 

--- a/apps/backend/src/rhesis/backend/app/services/invokers/tracing.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/tracing.py
@@ -206,18 +206,20 @@ async def create_invocation_trace(
         "error": None,
     }
 
+    # Nothing below the yield can run without a project to attach the span to, so
+    # skip tracing up front. Returning out of the finally instead would cancel the
+    # re-raise below and report a failed invocation as a success (B012).
+    if endpoint.project_id is None:
+        logger.debug(f"Skipping trace creation for endpoint {endpoint.id} - no project_id assigned")
+        yield trace_context
+        return
+
     try:
         yield trace_context
     except Exception as e:
         trace_context["error"] = e
         raise
     finally:
-        if endpoint.project_id is None:
-            logger.debug(
-                f"Skipping trace creation for endpoint {endpoint.id} - no project_id assigned"
-            )
-            return
-
         end_time = datetime.now(timezone.utc)
         result = trace_context.get("result")
         error = trace_context.get("error")

--- a/apps/backend/src/rhesis/backend/app/services/preflight/orchestrator.py
+++ b/apps/backend/src/rhesis/backend/app/services/preflight/orchestrator.py
@@ -244,7 +244,7 @@ async def run_preflight_checks_multi(
         check_keys = [k for k, _ in tasks]
         coros = [coro for _, coro in tasks]
         task_results = await asyncio.gather(*coros, return_exceptions=True)
-        for comp_key, tr in zip(check_keys, task_results):
+        for comp_key, tr in zip(check_keys, task_results, strict=True):
             if isinstance(tr, Exception):
                 base_check_id = comp_key.split(":")[0]
                 logger.error(

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/conversation_linking.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/conversation_linking.py
@@ -210,7 +210,7 @@ class ConversationLinkingCache(RedisBackedCache):
 
         matched = []
         delete_keys: List[str] = []
-        for tid, val in zip(trace_ids, values):
+        for tid, val in zip(trace_ids, values, strict=True):
             if val is None:
                 continue
             data = json.loads(val)
@@ -277,7 +277,7 @@ class ConversationLinkingCache(RedisBackedCache):
 
         matched = {}
         delete_keys = []
-        for tid, val in zip(trace_ids, values):
+        for tid, val in zip(trace_ids, values, strict=True):
             if val is not None:
                 matched[tid] = val
                 delete_keys.append(f"{_PREFIX_OUTPUT}{tid}")
@@ -356,7 +356,7 @@ class ConversationLinkingCache(RedisBackedCache):
 
         matched = {}
         delete_keys = []
-        for tid, val in zip(trace_ids, values):
+        for tid, val in zip(trace_ids, values, strict=True):
             if val is not None:
                 data = json.loads(val)
                 matched[tid] = (

--- a/apps/backend/src/rhesis/backend/app/services/test_config_generator.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_config_generator.py
@@ -56,7 +56,7 @@ class TestConfigGeneratorService:
         which is too slow for this interactive step; in that case use the fast
         system generation model setting.
         """
-        gen_settings = getattr(self.user.settings.models, "generation")
+        gen_settings = self.user.settings.models.generation
         model_id = gen_settings.model_id
         use_fast_default = False
         if model_id:

--- a/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
@@ -48,7 +48,7 @@ TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
 
 def _resolve_config_llm(db: Session, user: User):
     """Resolve the LLM for test-config generation (same logic as TestConfigGeneratorService)."""
-    gen_settings = getattr(user.settings.models, "generation")
+    gen_settings = user.settings.models.generation
     model_id = gen_settings.model_id
     use_fast_default = False
     if model_id:

--- a/apps/backend/src/rhesis/backend/app/services/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_run.py
@@ -118,7 +118,7 @@ def get_test_results_for_test_run(
         # Add requirement metrics columns
         test_metrics = result.test_metrics.get("metrics", {}) if result.test_metrics else {}
 
-        for requirement_id, requirement_data in requirement_map.items():
+        for _requirement_id, requirement_data in requirement_map.items():
             requirement = requirement_data["requirement"]
             metrics = requirement_data["metrics"]
 

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -977,7 +977,7 @@ def _build_search_filters_for_model(model: Type[T], search_data: Dict[str, Any])
 
     # Always include organization_id in search if available
     if "organization_id" in columns and "organization_id" in search_data:
-        search_filters.append(getattr(model, "organization_id") == search_data["organization_id"])
+        search_filters.append(model.organization_id == search_data["organization_id"])
 
     # Handle model-specific identifying fields
     if model.__name__ == "TypeLookup":

--- a/apps/backend/src/rhesis/backend/app/utils/name_generator.py
+++ b/apps/backend/src/rhesis/backend/app/utils/name_generator.py
@@ -42,7 +42,7 @@ def generate_memorable_name(db: Session, organization_id: UUID, max_attempts: in
     Returns:
         str: A unique memorable name like "swift-raven" or "creative-dolphin"
     """
-    for attempt in range(max_attempts):
+    for _attempt in range(max_attempts):
         # Generate random combination
         adjective = random.choice(POSITIVE_ADJECTIVES)
         animal = random.choice(ANIMALS)

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/runner.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/runner.py
@@ -149,7 +149,7 @@ async def _run_gather(
         await asyncio.gather(watchdog, return_exceptions=True)
 
     results: List[Dict[str, Any]] = []
-    for test_id, result in zip(test_ids, raw):
+    for test_id, result in zip(test_ids, raw, strict=True):
         if isinstance(result, asyncio.CancelledError):
             logger.info(f"[BATCH] Test {test_id} cancelled mid-flight")
             results.append({"test_id": test_id, "status": "cancelled", "execution_time": 0})

--- a/apps/backend/src/rhesis/backend/metrics/evaluator.py
+++ b/apps/backend/src/rhesis/backend/metrics/evaluator.py
@@ -228,7 +228,7 @@ class MetricEvaluator:
         )
 
         results: Dict[str, Any] = {}
-        for bv, br in zip(configs_by_backend.keys(), backend_results):
+        for bv, br in zip(configs_by_backend.keys(), backend_results, strict=True):
             if isinstance(br, Exception):
                 logger.error(f"Backend '{bv}' async evaluation failed: {br}")
                 continue

--- a/apps/backend/src/rhesis/backend/metrics/strategies/local.py
+++ b/apps/backend/src/rhesis/backend/metrics/strategies/local.py
@@ -214,7 +214,8 @@ class LocalStrategy:
                 return key, result
 
         coros = [
-            _eval_one(key, cn, m, mc, b) for (cn, m, mc, b), key in zip(metric_tasks, metric_keys)
+            _eval_one(key, cn, m, mc, b)
+            for (cn, m, mc, b), key in zip(metric_tasks, metric_keys, strict=True)
         ]
 
         try:
@@ -405,7 +406,7 @@ class LocalStrategy:
         future_to_metric: Dict[concurrent.futures.Future, Tuple[str, str, MetricConfig, str]] = {}
 
         for (class_name, metric, metric_config, backend), unique_key in zip(
-            metric_tasks, metric_keys
+            metric_tasks, metric_keys, strict=True
         ):
             # ThreadPoolExecutor does not carry contextvars into its workers
             # the way asyncio.to_thread does, and an LLM judge running here

--- a/apps/polyphemus/src/rhesis/polyphemus/benchmarking/scripts/generate_benchmark_plots.py
+++ b/apps/polyphemus/src/rhesis/polyphemus/benchmarking/scripts/generate_benchmark_plots.py
@@ -453,7 +453,7 @@ def plot_metric_breakdown(data, output_dir):
     colors = ["#2ecc71", "#3498db", "#e74c3c", "#f39c12"]
     positions = [x - 1.5 * width, x - 0.5 * width, x + 0.5 * width, x + 1.5 * width]
 
-    for i, (metric, color, pos) in enumerate(zip(metrics_data.keys(), colors, positions)):
+    for _i, (metric, color, pos) in enumerate(zip(metrics_data.keys(), colors, positions, strict=True)):
         ax.bar(pos, metrics_data[metric], width, label=metric, color=color, alpha=0.8)
 
     ax.set_xlabel("Models (Sorted by Overall Quality)", fontsize=12, fontweight="bold")
@@ -655,7 +655,7 @@ def plot_quality_vs_compliance_scatter(data, output_dir):
         )
 
     # Find best model (highest combined score)
-    combined_scores = [(c + o) / 2 for c, o in zip(compliance_rates, overall_scores)]
+    combined_scores = [(c + o) / 2 for c, o in zip(compliance_rates, overall_scores, strict=True)]
     best_idx = np.argmax(combined_scores)
     ax.scatter(
         [compliance_rates[best_idx]],
@@ -1001,7 +1001,7 @@ def plot_precision_comparison(data, output_dir):
             if max(gen_times) > 0:
                 ax2_twin = ax2.twinx()
                 efficiency = [score / time if time > 0 else 0
-                             for score, time in zip(overall_scores, gen_times)]
+                             for score, time in zip(overall_scores, gen_times, strict=True)]
                 ax2_twin.plot(x, efficiency, 'go--', linewidth=2, markersize=8,
                              label='Efficiency (Score/Time)', alpha=0.7)
                 ax2_twin.set_ylabel('Efficiency (Score/Time)', fontsize=11,

--- a/penelope/src/rhesis/penelope/context.py
+++ b/penelope/src/rhesis/penelope/context.py
@@ -823,7 +823,7 @@ class TestState:
 
         metrics = {}
 
-        for i, metric_result in enumerate(self.metric_results):
+        for _i, metric_result in enumerate(self.metric_results):
             # Flatten the metric result
             metric_dict = self._flatten_metric_result(metric_result)
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,6 +6,15 @@ select = [
     "I",
     "E",
     "F",
+    # bugbear: legal, typed code that is still a trap — zip() truncation,
+    # loop-variable closures, return inside finally.
+    "B",
+]
+ignore = [
+    # FastAPI puts Depends() in argument defaults by design.
+    "B008",
+    # Bare `raise` inside except is idiomatic here; we re-raise more than we chain.
+    "B904",
 ]
 
 [lint.per-file-ignores]
@@ -17,6 +26,11 @@ select = [
 "**/alembic/versions/*.py" = [
     "E501",
     "E402",
+]
+# RequestScope is @dataclass(frozen=True), so the shared default instance cannot
+# be mutated and cannot leak between requests. B039 is wrong here.
+"apps/backend/src/rhesis/backend/app/scope.py" = [
+    "B039",
 ]
 
 [lint.isort]

--- a/sdk/src/rhesis/sdk/decorators/endpoint.py
+++ b/sdk/src/rhesis/sdk/decorators/endpoint.py
@@ -339,7 +339,7 @@ def endpoint(
             provided_params = set(kwargs.keys())
 
             # Map positional args to parameter names
-            for i, arg_value in enumerate(args):
+            for i, _arg_value in enumerate(args):
                 if i < len(param_names):
                     provided_params.add(param_names[i])
 

--- a/sdk/src/rhesis/sdk/entities/test_set.py
+++ b/sdk/src/rhesis/sdk/entities/test_set.py
@@ -1491,7 +1491,7 @@ class TestSet(BaseEntity):
         tests: List[Test] = []
 
         with open(filepath, "r", encoding="utf-8") as jsonlfile:
-            for line_num, line in enumerate(jsonlfile, 1):
+            for _line_num, line in enumerate(jsonlfile, 1):
                 line = line.strip()
                 if not line:
                     continue  # Skip empty lines

--- a/sdk/src/rhesis/sdk/models/base.py
+++ b/sdk/src/rhesis/sdk/models/base.py
@@ -134,6 +134,16 @@ class BaseModel(ABC):
     def __init__(self, model_name: str, *args, **kwargs):
         self.model_name = model_name
 
+    @abstractmethod
+    def generate_batch(self, *args, **kwargs) -> List[Any]:
+        """Run the model over multiple inputs.
+
+        The one contract every model type shares — BaseLLM and BaseEmbedder both
+        redeclare it abstract with their own signature. Declared here so this class
+        is genuinely abstract: an ABC with no abstract method enforces nothing, and
+        subclasses rely on inheriting ABCMeta from it (B024).
+        """
+
     def get_model_name(self) -> str:
         return f"{self.__class__.__name__}: {self.model_name}"
 

--- a/sdk/src/rhesis/sdk/models/providers/litellm.py
+++ b/sdk/src/rhesis/sdk/models/providers/litellm.py
@@ -131,6 +131,7 @@ class LiteLLM(BaseLLM):
         extra_headers = {"Connection": "close", **(kwargs.pop("extra_headers", None) or {})}
         timeout = kwargs.pop("timeout", self.timeout)
         response = await acompletion(
+            *args,
             model=self.model_name,
             messages=messages,
             response_format=schema,
@@ -139,7 +140,6 @@ class LiteLLM(BaseLLM):
             api_version=self.api_version,
             extra_headers=extra_headers,
             timeout=timeout,
-            *args,
             **kwargs,
         )
 
@@ -198,6 +198,7 @@ class LiteLLM(BaseLLM):
         # requested. A caller-supplied stream_options still wins.
         stream_options = kwargs.pop("stream_options", None) or {"include_usage": True}
         response = await acompletion(
+            *args,
             model=self.model_name,
             messages=messages,
             response_format=schema,
@@ -208,7 +209,6 @@ class LiteLLM(BaseLLM):
             api_version=self.api_version,
             extra_headers=extra_headers,
             timeout=timeout,
-            *args,
             **kwargs,
         )
         async for chunk in response:  # type: ignore[union-attr]
@@ -263,6 +263,7 @@ class LiteLLM(BaseLLM):
 
         timeout = kwargs.pop("timeout", self.timeout)
         responses = batch_completion(
+            *args,
             model=self.model_name,
             messages=messages,
             response_format=response_format,
@@ -271,7 +272,6 @@ class LiteLLM(BaseLLM):
             api_version=self.api_version,
             n=n,
             timeout=timeout,
-            *args,
             **kwargs,
         )
 

--- a/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
+++ b/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
@@ -332,10 +332,10 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
         kwargs["vertex_credentials"] = self.model["vertex_credentials"]
 
         return await super().a_generate(
+            *args,
             prompt=prompt,
             system_prompt=system_prompt,
             schema=schema,
-            *args,
             **kwargs,
         )
 
@@ -369,11 +369,11 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
         kwargs["vertex_credentials"] = self.model["vertex_credentials"]
 
         return super().generate_batch(
+            *args,
             prompts=prompts,
             system_prompt=system_prompt,
             schema=schema,
             n=n,
-            *args,
             **kwargs,
         )
 

--- a/sdk/src/rhesis/sdk/synthesizers/base.py
+++ b/sdk/src/rhesis/sdk/synthesizers/base.py
@@ -464,7 +464,7 @@ class TestSetSynthesizer(ABC):
             )
 
         all_tests: List[Dict[str, Any]] = []
-        for i, (response, expected_size) in enumerate(zip(responses, batch_sizes)):
+        for i, (response, expected_size) in enumerate(zip(responses, batch_sizes, strict=True)):
             tests = self._process_batch_response(response, expected_size, i + 1)
             all_tests.extend(tests)
 

--- a/sdk/src/rhesis/sdk/synthesizers/owasp_synthesizer.py
+++ b/sdk/src/rhesis/sdk/synthesizers/owasp_synthesizer.py
@@ -186,7 +186,7 @@ class OWASPSynthesizer(TestSetSynthesizer):
         counts = self._distribute(num_tests, len(sections))
         all_tests: List[Dict[str, Any]] = []
 
-        for section, n in zip(sections, counts):
+        for section, n in zip(sections, counts, strict=True):
             if n == 0:
                 continue
             logger.info(

--- a/sdk/src/rhesis/sdk/telemetry/integrations/genai.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/genai.py
@@ -907,7 +907,7 @@ def set_processor_exporter(processor: SpanProcessor, exporter: SpanExporter) -> 
         return
     # Older OTEL Batch SDK or SimpleSpanProcessor: span_exporter is a plain
     # attribute we can set directly.
-    setattr(processor, "span_exporter", exporter)
+    processor.span_exporter = exporter
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/auth/test_rbac.py
+++ b/tests/backend/auth/test_rbac.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import uuid
 from unittest.mock import MagicMock
 
+from dataclasses import FrozenInstanceError
+
 import pytest
 
 from rhesis.backend.app.auth.capabilities import get_all_capabilities
@@ -130,7 +132,7 @@ class TestPrincipal:
 
     def test_principal_is_frozen(self):
         p = _principal()
-        with pytest.raises(Exception):
+        with pytest.raises(FrozenInstanceError):
             p.user_id = uuid.uuid4()  # type: ignore[misc]
 
     def test_principal_equality_ignores_scopes(self):

--- a/tests/backend/ee/rbac/test_sp7_catalog.py
+++ b/tests/backend/ee/rbac/test_sp7_catalog.py
@@ -24,6 +24,7 @@ Run with:
 from __future__ import annotations
 
 import pytest
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app.features import FeatureName, FeatureRegistry
@@ -267,7 +268,7 @@ class TestBuiltInRoleRLSPolicy:
             )
 
         # NULL-org (built-in) row: rejected — a tenant must not mint a global role.
-        with pytest.raises(Exception):
+        with pytest.raises(ProgrammingError):
             with test_db.begin_nested():
                 test_db.execute(
                     text(
@@ -277,7 +278,7 @@ class TestBuiltInRoleRLSPolicy:
                 )
 
         # Cross-org row: rejected.
-        with pytest.raises(Exception):
+        with pytest.raises(ProgrammingError):
             with test_db.begin_nested():
                 test_db.execute(
                     text(

--- a/tests/backend/jobs/test_usage_accrual_task.py
+++ b/tests/backend/jobs/test_usage_accrual_task.py
@@ -89,7 +89,7 @@ class TestAccrueUsage:
 
         monkeypatch.setattr("rhesis.backend.jobs.usage.increment_usage", boom)
 
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError):
             accrue_usage("org-1", QuotaResource.TRACING_SPANS.value, 10)
 
     def test_closes_session_even_when_retrying(self, fake_session, fake_bind_scope, monkeypatch):
@@ -98,7 +98,7 @@ class TestAccrueUsage:
             lambda *a, **k: (_ for _ in ()).throw(RuntimeError("db unreachable")),
         )
 
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError):
             accrue_usage("org-1", QuotaResource.TRACING_SPANS.value, 10)
 
         assert fake_session.closed is True

--- a/tests/backend/metrics/test_e2e_flow.py
+++ b/tests/backend/metrics/test_e2e_flow.py
@@ -414,7 +414,7 @@ class TestE2EFlow:
         assert isinstance(result["metrics"], dict)
 
         # Verify metrics structure has expected fields
-        for metric_name, metric_data in result["metrics"].items():
+        for _metric_name, metric_data in result["metrics"].items():
             assert isinstance(metric_data, dict)
             # Should have key metric fields (exact structure may vary)
             assert "score" in metric_data or "passed" in metric_data

--- a/tests/backend/metrics/test_local_strategy_metric_keys.py
+++ b/tests/backend/metrics/test_local_strategy_metric_keys.py
@@ -30,8 +30,14 @@ class TestUniqueMetricKeyDeterminism:
         # The lower id ("111...") always gets the bare key, the higher id
         # always gets the suffix -- independent of which came first in the
         # input list.
-        assert dict(zip([a.id, b.id], keys_forward)) == {a.id: "Accuracy", b.id: "Accuracy_1"}
-        assert dict(zip([b.id, a.id], keys_reversed)) == {a.id: "Accuracy", b.id: "Accuracy_1"}
+        assert dict(zip([a.id, b.id], keys_forward, strict=True)) == {
+            a.id: "Accuracy",
+            b.id: "Accuracy_1",
+        }
+        assert dict(zip([b.id, a.id], keys_reversed, strict=True)) == {
+            a.id: "Accuracy",
+            b.id: "Accuracy_1",
+        }
 
     def test_keys_align_positionally_with_input_tasks(self):
         strategy = LocalStrategy()

--- a/tests/backend/routes/test_auth.py
+++ b/tests/backend/routes/test_auth.py
@@ -508,7 +508,7 @@ class TestAuthPerformance:
                 start_time = time.time()
 
                 # Make 20 verify requests
-                for i in range(20):
+                for _i in range(20):
                     response = client.post(
                         "/auth/verify",
                         json={"session_token": "test_token"},

--- a/tests/backend/routes/test_connector.py
+++ b/tests/backend/routes/test_connector.py
@@ -12,6 +12,7 @@ import uuid
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from starlette.websockets import WebSocketDisconnect
 from fastapi import HTTPException, status
 from fastapi.testclient import TestClient
 
@@ -66,7 +67,7 @@ class TestConnectorWebSocket:
         with patch("rhesis.backend.app.routers.connector.authenticate_websocket") as mock_auth:
             mock_auth.side_effect = HTTPException(status_code=401, detail="Invalid token")
 
-            with pytest.raises(Exception):  # WebSocket will raise on auth failure
+            with pytest.raises(WebSocketDisconnect):  # WebSocket will raise on auth failure
                 with authenticated_client.websocket_connect(
                     "/connector/ws",
                     headers={

--- a/tests/backend/routes/test_metric_tuning_improve.py
+++ b/tests/backend/routes/test_metric_tuning_improve.py
@@ -828,7 +828,7 @@ class TestWhatTheModelIsShown:
             for index in range(len(comments))
         ]
         _run(test_db, tuning_metric, test_org_id)
-        for case, comment in zip(created, comments):
+        for case, comment in zip(created, comments, strict=True):
             _reject(authenticated_client, tuning_metric.id, case["id"], comment)
 
         body = _improved(authenticated_client, tuning_metric.id)

--- a/tests/backend/routes/test_tag.py
+++ b/tests/backend/routes/test_tag.py
@@ -620,7 +620,7 @@ class TestTagPerformance(TagTestMixin, BaseEntityTests):
         """Test tag assignment performance with multiple entities"""
         # Create multiple requirements
         requirements = []
-        for i in range(5):
+        for _i in range(5):
             requirement = self._create_test_requirement(authenticated_client)
             requirements.append(requirement)
 

--- a/tests/backend/routes/test_telemetry_query.py
+++ b/tests/backend/routes/test_telemetry_query.py
@@ -274,7 +274,7 @@ class TestTraceListEndpoint:
         """
         # Create traces with different characteristics
         # 3 development + 3 production traces
-        for i in range(3):
+        for _i in range(3):
             dev_span = TraceDataFactory.sample_data(project_id=str(db_project.id))
             dev_span["environment"] = "development"
             dev_span["span_name"] = "ai.llm.invoke"

--- a/tests/backend/routes/test_token.py
+++ b/tests/backend/routes/test_token.py
@@ -667,7 +667,7 @@ class TestTokenPerformance(TokenTestMixin, BaseEntityTests):
 
         created_tokens = []
         for security_type in security_types:
-            for i in range(3):  # 3 tokens per security type
+            for _i in range(3):  # 3 tokens per security type
                 token_data = TokenDataFactory.edge_case_data(security_type)
                 response = authenticated_client.post(
                     self.endpoints.create,
@@ -700,7 +700,7 @@ class TestTokenPerformance(TokenTestMixin, BaseEntityTests):
 
         created_tokens = []
         for exp_type in expiration_types:
-            for i in range(2):  # 2 tokens per expiration type
+            for _i in range(2):  # 2 tokens per expiration type
                 token_data = TokenDataFactory.edge_case_data(exp_type)
                 response = authenticated_client.post(
                     self.endpoints.create,

--- a/tests/backend/routes/test_type_lookup.py
+++ b/tests/backend/routes/test_type_lookup.py
@@ -593,7 +593,7 @@ class TestTypeLookupPerformance(TypeLookupTestMixin, BaseEntityTests):
 
         created_type_lookups = []
         for category in categories:
-            for i in range(3):  # 3 type lookups per category
+            for _i in range(3):  # 3 type lookups per category
                 type_lookup_data = TypeLookupDataFactory.edge_case_data(category)
                 response = authenticated_client.post(
                     self.endpoints.create,
@@ -652,7 +652,7 @@ class TestTypeLookupPerformance(TypeLookupTestMixin, BaseEntityTests):
         """Test performance with diverse reference data distribution"""
         # Create type lookups across different reference types using the factory's categories
         reference_types = []
-        for i in range(10):  # Create 10 different reference type lookups
+        for _i in range(10):  # Create 10 different reference type lookups
             type_lookup_data = TypeLookupDataFactory.edge_case_data("entity_types")
             response = authenticated_client.post(
                 self.endpoints.create,

--- a/tests/backend/security/test_router_error_leaks.py
+++ b/tests/backend/security/test_router_error_leaks.py
@@ -242,7 +242,7 @@ def _dict_leaks(node: ast.AST, taint: Taint) -> bool:
         return False
     return any(
         isinstance(key, ast.Constant) and key.value in BODY_KEYS and _references(value, taint)
-        for key, value in zip(node.keys, node.values)
+        for key, value in zip(node.keys, node.values, strict=True)
     )
 
 

--- a/tests/backend/security/test_visibility_filter.py
+++ b/tests/backend/security/test_visibility_filter.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -261,7 +262,7 @@ class TestPublicRemoved:
     """The migration should have removed 'public' from the CHECK constraint."""
 
     def test_public_rejected_by_db(self, test_db: Session, test_org_id, authenticated_user_id):
-        with pytest.raises(Exception):
+        with pytest.raises(IntegrityError):
             _insert_test_set(
                 test_db,
                 visibility="public",

--- a/tests/backend/services/connector/mapping/test_mapper_service.py
+++ b/tests/backend/services/connector/mapping/test_mapper_service.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from rhesis.backend.app.services.connector.mapping.mapper_service import (
     MappingResult,
@@ -46,7 +47,7 @@ class TestMappingResult:
         assert result.confidence == 0.5
 
         # Invalid confidence (too high)
-        with pytest.raises(Exception):  # Pydantic ValidationError
+        with pytest.raises(ValidationError):  # Pydantic ValidationError
             MappingResult(
                 request_mapping={},
                 response_mapping={},
@@ -56,7 +57,7 @@ class TestMappingResult:
             )
 
         # Invalid confidence (negative)
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             MappingResult(
                 request_mapping={},
                 response_mapping={},

--- a/tests/backend/services/explorer/test_tree.py
+++ b/tests/backend/services/explorer/test_tree.py
@@ -102,7 +102,7 @@ class TestTestTreeData:
         data = TestTreeData(sample_nodes)
         nodes = list(data)
         assert len(nodes) == len(sample_nodes)
-        for iterated, original in zip(nodes, sample_nodes):
+        for iterated, original in zip(nodes, sample_nodes, strict=True):
             assert iterated is original
 
     def test_init_deduplicates_by_id(self):

--- a/tests/backend/services/garak/test_garak_live.py
+++ b/tests/backend/services/garak/test_garak_live.py
@@ -439,7 +439,8 @@ class TestGarakUpgradeReadiness:
 
             warnings.warn(
                 f"{len(failed_imports)} taxonomy detectors not found in current "
-                f"garak version - review GarakTaxonomy.MODULE_MAPPINGS"
+                f"garak version - review GarakTaxonomy.MODULE_MAPPINGS",
+                stacklevel=2,
             )
 
     def test_garak_version_tracking(self):

--- a/tests/backend/services/test_transaction_management.py
+++ b/tests/backend/services/test_transaction_management.py
@@ -103,7 +103,7 @@ class TestServiceTransactionManagement:
         }
 
         # Create a test set with invalid organization_id to trigger exception
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match="Failed to create test set: Invalid UUID format"):
             test_set_service.bulk_create_test_set(
                 test_db, test_set_data, "invalid-org-id", authenticated_user_id
             )
@@ -173,7 +173,7 @@ class TestServiceTransactionManagement:
         ]
 
         # Create tests with invalid organization_id to trigger exception
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match="Failed to create tests: Invalid UUID format"):
             test_service.bulk_create_tests(
                 test_db, tests_data, "invalid-org-id", authenticated_user_id
             )
@@ -510,7 +510,7 @@ class TestServiceTransactionManagement:
             ],
         }
 
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match="Failed to create test set: Invalid UUID format"):
             test_set_service.bulk_create_test_set(
                 test_db, test_set_data2, "invalid-org-id", authenticated_user_id
             )

--- a/tests/backend/services/websocket/test_rate_limiter.py
+++ b/tests/backend/services/websocket/test_rate_limiter.py
@@ -28,7 +28,7 @@ class TestRateLimiterSecurity:
         conn_id = "test_conn_1"
 
         # All 5 requests within the limit should be allowed
-        for i in range(5):
+        for _i in range(5):
             assert rate_limiter.is_allowed(conn_id) is True
 
     def test_messages_exceeding_limit_are_rejected(self, rate_limiter):
@@ -73,7 +73,7 @@ class TestRateLimiterSecurity:
         assert rate_limiter.is_allowed(conn_a) is False
 
         # conn_b should still have its full limit
-        for i in range(5):
+        for _i in range(5):
             assert rate_limiter.is_allowed(conn_b) is True
 
         # Now conn_b should be at limit
@@ -95,7 +95,7 @@ class TestRateLimiterCleanup:
         rate_limiter.remove_connection(conn_id)
 
         # Should have full limit again
-        for i in range(5):
+        for _i in range(5):
             assert rate_limiter.is_allowed(conn_id) is True
 
     def test_get_remaining_shows_correct_count(self, rate_limiter):

--- a/tests/backend/utils/test_model_encryption.py
+++ b/tests/backend/utils/test_model_encryption.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from cryptography.fernet import Fernet
 from faker import Faker
 from sqlalchemy import text
@@ -202,7 +203,7 @@ class TestModelEncryption:
         test_db.add(model)
 
         # Should raise IntegrityError due to nullable=False
-        with pytest.raises(Exception):
+        with pytest.raises(IntegrityError):
             test_db.commit()
 
         test_db.rollback()

--- a/tests/backend/utils/test_soft_delete_querybuilder.py
+++ b/tests/backend/utils/test_soft_delete_querybuilder.py
@@ -157,7 +157,7 @@ class TestQueryBuilderSoftDelete:
         """Test that only_deleted() chains with pagination methods."""
         # Create and delete multiple requirements
         deleted_requirements = []
-        for i in range(5):
+        for _i in range(5):
             requirement = crud_utils.create_item(
                 test_db,
                 models.Requirement,

--- a/tests/backend/utils/test_token_encryption.py
+++ b/tests/backend/utils/test_token_encryption.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from faker import Faker
 from sqlalchemy import text
 
@@ -257,7 +258,7 @@ class TestTokenEncryption:
         test_db.add(token)
 
         # Should raise IntegrityError due to nullable=False
-        with pytest.raises(Exception):
+        with pytest.raises(IntegrityError):
             test_db.commit()
 
         test_db.rollback()

--- a/tests/sdk/entities/test_test_set.py
+++ b/tests/sdk/entities/test_test_set.py
@@ -734,7 +734,7 @@ class TestJsonRoundTrip:
 
             # Verify
             assert len(imported.tests) == len(sample_test_set.tests)
-            for orig, imp in zip(sample_test_set.tests, imported.tests):
+            for orig, imp in zip(sample_test_set.tests, imported.tests, strict=True):
                 assert orig.category == imp.category
                 assert orig.topic == imp.topic
                 assert orig.requirement == imp.requirement
@@ -1046,7 +1046,7 @@ class TestJsonlRoundTrip:
 
             # Verify
             assert len(imported.tests) == len(sample_test_set.tests)
-            for orig, imp in zip(sample_test_set.tests, imported.tests):
+            for orig, imp in zip(sample_test_set.tests, imported.tests, strict=True):
                 assert orig.category == imp.category
                 assert orig.topic == imp.topic
                 assert orig.requirement == imp.requirement
@@ -1129,7 +1129,7 @@ class TestJsonlRoundTrip:
             )
 
             assert len(imported.tests) == len(sample_test_set.tests)
-            for orig, imp in zip(sample_test_set.tests, imported.tests):
+            for orig, imp in zip(sample_test_set.tests, imported.tests, strict=True):
                 assert orig.category == imp.category
                 assert orig.topic == imp.topic
                 assert orig.requirement == imp.requirement
@@ -1190,7 +1190,7 @@ class TestJsonlRoundTrip:
 
             # Both should have same data
             assert len(from_json.tests) == len(from_jsonl.tests)
-            for json_test, jsonl_test in zip(from_json.tests, from_jsonl.tests):
+            for json_test, jsonl_test in zip(from_json.tests, from_jsonl.tests, strict=True):
                 assert json_test.category == jsonl_test.category
                 assert json_test.prompt.content == jsonl_test.prompt.content
         finally:

--- a/tests/sdk/metrics/providers/garak/test_factory.py
+++ b/tests/sdk/metrics/providers/garak/test_factory.py
@@ -274,7 +274,7 @@ class TestFactoryDetectorPaths:
 
     def test_all_paths_follow_naming_convention(self, factory):
         """Test that all paths follow the garak.detectors.<module>.<Class> convention."""
-        for detector_name, path in factory.DETECTOR_PATHS.items():
+        for _detector_name, path in factory.DETECTOR_PATHS.items():
             if path is not None:
                 parts = path.split(".")
                 assert len(parts) == 4, f"Path {path} doesn't have 4 parts"

--- a/tests/sdk/models/providers/test_azure_ai.py
+++ b/tests/sdk/models/providers/test_azure_ai.py
@@ -2,7 +2,7 @@ import os
 from unittest.mock import Mock, patch
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from rhesis.sdk.models.providers.azure_ai import (
     DEFAULT_MODEL_NAME,
@@ -159,7 +159,7 @@ class TestAzureAILLMGenerate:
             api_key="test_key",
             api_base="https://endpoint.inference.ai.azure.com/",
         )
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             llm.generate("test", schema=StrictSchema)
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")

--- a/tests/sdk/models/providers/test_azure_openai.py
+++ b/tests/sdk/models/providers/test_azure_openai.py
@@ -2,7 +2,7 @@ import os
 from unittest.mock import Mock, patch
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from rhesis.sdk.models.providers.azure_openai import (
     DEFAULT_MODEL_NAME,
@@ -181,7 +181,7 @@ class TestAzureOpenAILLMGenerate:
             api_key="test_key",
             api_base="https://resource.openai.azure.com/",
         )
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             llm.generate("test", schema=StrictSchema)
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")

--- a/tests/sdk/models/providers/test_gemini.py
+++ b/tests/sdk/models/providers/test_gemini.py
@@ -2,7 +2,7 @@ import os
 from unittest.mock import Mock, patch
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from rhesis.sdk.models.providers.gemini import (
     DEFAULT_MODEL_NAME,
@@ -129,7 +129,7 @@ class TestGeminiLLM:
         llm = GeminiLLM(api_key="test_key")
         prompt = "Generate a person's information"
 
-        with pytest.raises(Exception):  # Should raise validation error
+        with pytest.raises(ValidationError):  # Should raise validation error
             llm.generate(prompt, schema=TestSchema)
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")

--- a/tests/sdk/models/providers/test_hugginface.py
+++ b/tests/sdk/models/providers/test_hugginface.py
@@ -6,7 +6,7 @@ pytest.importorskip("torch")
 pytest.importorskip("transformers")
 
 import torch
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from rhesis.sdk.errors import (
     HUGGINGFACE_MODEL_NOT_LOADED,
@@ -504,7 +504,7 @@ class TestHuggingFaceLLM:
         # Mock decode to return invalid JSON (missing age field)
         mock_tokenizer.decode.return_value = '{"name": "John"}'
 
-        with pytest.raises(Exception):  # Should raise validation error
+        with pytest.raises(ValidationError):  # Should raise validation error
             llm.generate("Generate person data", schema=TestSchema)
 
     # Tests for metadata tracking

--- a/tests/sdk/models/providers/test_litellm.py
+++ b/tests/sdk/models/providers/test_litellm.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from rhesis.sdk.config import DEFAULT_LLM_TIMEOUT
 from rhesis.sdk.models import LiteLLM
@@ -181,7 +181,7 @@ class TestLiteLLM:
         llm = LiteLLM(model_name=model_name)
         prompt = "Generate a person's information"
 
-        with pytest.raises(Exception):  # Should raise validation error
+        with pytest.raises(ValidationError):  # Should raise validation error
             llm.generate(prompt, schema=TestSchema)
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -428,7 +428,7 @@ class TestLiteLLM:
         llm = LiteLLM(model_name)
         prompts = ["Generate data"]
 
-        with pytest.raises(Exception):  # Should raise validation error
+        with pytest.raises(ValidationError):  # Should raise validation error
             llm.generate_batch(prompts, schema=TestSchema)
 
     @patch("rhesis.sdk.models.providers.litellm.batch_completion")

--- a/tests/sdk/models/providers/test_litellm_proxy.py
+++ b/tests/sdk/models/providers/test_litellm_proxy.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 import requests
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from rhesis.sdk.models.providers.litellm_proxy import (
     DEFAULT_API_BASE,
@@ -201,7 +201,7 @@ class TestLiteLLMProxyGenerate:
         mock_post.return_value = _mock_openai_response('{"name": "Alice"}')
 
         llm = LiteLLMProxy(model_name="gemini")
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             llm.generate("test", schema=StrictSchema)
 
     @patch("rhesis.sdk.models.providers.litellm_proxy.requests.post")

--- a/tests/sdk/models/providers/test_openrouter.py
+++ b/tests/sdk/models/providers/test_openrouter.py
@@ -2,7 +2,7 @@ import os
 from unittest.mock import Mock, patch
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from rhesis.sdk.models.providers.openrouter import (
     DEFAULT_MODEL_NAME,
@@ -123,7 +123,7 @@ class TestOpenRouterLLM:
         llm = OpenRouterLLM(api_key="test_key")
         prompt = "Generate a person's information"
 
-        with pytest.raises(Exception):  # Should raise validation error
+        with pytest.raises(ValidationError):  # Should raise validation error
             llm.generate(prompt, schema=TestSchema)
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")

--- a/tests/sdk/models/providers/test_polyphemus.py
+++ b/tests/sdk/models/providers/test_polyphemus.py
@@ -2,7 +2,7 @@ import os
 from unittest.mock import Mock, patch
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from rhesis.sdk.models.providers.polyphemus import (
     DEFAULT_POLYPHEMUS_URL,
@@ -168,7 +168,7 @@ class TestPolyphemusLLM:
         llm = PolyphemusLLM(api_key="test_key")
         prompt = "Generate a person's information"
 
-        with pytest.raises(Exception):  # Should raise validation error
+        with pytest.raises(ValidationError):  # Should raise validation error
             llm.generate(prompt, schema=TestSchema)
 
     @patch("rhesis.sdk.models.providers.polyphemus.requests.post")

--- a/tests/sdk/synthesizers/test_multi_turn_synthesizer.py
+++ b/tests/sdk/synthesizers/test_multi_turn_synthesizer.py
@@ -1,6 +1,8 @@
 import os
 from unittest.mock import Mock, patch
 
+import pytest
+
 from rhesis.sdk.models.base import BaseLLM
 from rhesis.sdk.synthesizers.multi_turn.base import (
     FlatTests,
@@ -530,8 +532,5 @@ def test_generate_raises_with_reason_when_all_batches_fail(mock_generate_batch):
     synthesizer = MultiTurnSynthesizer(config=config, model=mock_model, batch_size=10)
     synthesizer.last_error = "Polyphemus did not respond in time."
 
-    try:
+    with pytest.raises(ValueError, match="Polyphemus did not respond in time."):
         synthesizer.generate(num_tests=5)
-        assert False, "expected ValueError"
-    except ValueError as e:
-        assert "Polyphemus did not respond in time." in str(e)

--- a/tests/sdk/telemetry/test_custom_observers.py
+++ b/tests/sdk/telemetry/test_custom_observers.py
@@ -34,7 +34,7 @@ class TestCreateObserver:
         observer.add_method("query", "ai.database.query")
 
         assert hasattr(observer, "query")
-        assert callable(getattr(observer, "query"))
+        assert callable(observer.query)
 
     def test_add_method_with_operation_type(self):
         """Test adding method with operation type."""
@@ -374,7 +374,7 @@ class TestCustomObserverIntegration:
             "query", "ai.database.query", operation_type="database.query", table="default"
         )
 
-        query_method = getattr(observer, "query")
+        query_method = observer.query
         docstring = query_method.__doc__
 
         assert "Convenience decorator for query operations" in docstring

--- a/tests/sdk/telemetry/test_exporter.py
+++ b/tests/sdk/telemetry/test_exporter.py
@@ -584,7 +584,7 @@ class TestExporterDeadlineAndShutdown:
         # should see strictly less than the previous (budget shrinking).
         assert len(timeouts_seen) >= 2
         assert timeouts_seen[0] <= 10
-        for prev, curr in zip(timeouts_seen, timeouts_seen[1:]):
+        for prev, curr in zip(timeouts_seen, timeouts_seen[1:], strict=False):
             assert curr < prev, f"timeout did not shrink: {timeouts_seen}"
 
 


### PR DESCRIPTION
## Purpose

Step 3a of the CI-gates rollout in [Borrowing Haystack's Brakes](https://claude.ai/code/artifact/06c50e43-174d-4ff6-88e0-b3c9345670af): enable ruff's `flake8-bugbear` family and clear every finding. Follows #2646, which turned `ruff check` back on for the backend with the rules we already had.

Bugbear catches code that is legal, passes `E`/`F`, and would pass a type checker, and is still a trap: `zip()` silently truncating to the shorter sequence, closures capturing a loop variable by reference, an `ABC` with no abstract method so subclasses can skip the contract, a `return` inside `finally` that cancels a re-raise. One of the findings was a live bug in endpoint invocation tracing.

## What Changed

- **`ruff.toml` selects `"B"`**, with `B008` and `B904` ignored — the same two Haystack excludes and no others. `B008` is FastAPI putting `Depends()` in argument defaults, which is correct code and 1,020 hits.
- **105 findings fixed across the repo.** 104 changed; one is a documented false positive with a per-file ignore carrying its reason (`B039` on `app/scope.py` — `RequestScope` is `@dataclass(frozen=True)`, so the shared default cannot be mutated or leak between requests).
- **`B012` — the live bug.** `create_invocation_trace()` returned out of its `finally` when the endpoint had no `project_id`. `contextlib` reads that clean generator exit as "exception suppressed", so a failed invocation never reached the caller. And because `result` is only assigned *inside* the `async with` in `endpoint/service.py`, what actually surfaced was an `UnboundLocalError` naming the wrong file, with the real failure discarded. The guard moved above the `try`.
- **`B905` (29) — `zip()` with an explicit `strict=`.** 26 are equal-length by construction (`asyncio.gather` results, per-embedding arrays, a Redis `mget` over the same keys) and get `strict=True`. Three are genuinely ragged and get `strict=False` with a comment: the xlsx importer reading user rows, a garak migration where probes may declare fewer triggers than prompts, and a pairwise `zip(xs, xs[1:])`.
- **`B023` (10) — all in one function.** `metric_sync`'s two per-org cache helpers were closures over the organisation loop variables. Moved to module level, bound per iteration with `functools.partial`.
- **`B017` (23) — real exception types in tests.** Every type was determined by running the test and reading the traceback, not inferred: `ValidationError` ×11, `IntegrityError` ×3, `ProgrammingError` ×2, `RuntimeError` ×2, `FrozenInstanceError`, `WebSocketDisconnect`.
- **`B024` (2) — opposite fixes for the same finding.** `BaseHandler` drops `ABC` (nothing beneath it uses `@abstractmethod`). `sdk/models/base.py:BaseModel` keeps it and declares `generate_batch` abstract instead — removing `ABC` there silently disables every `@abstractmethod` in `BaseLLM` and `BaseEmbedder`, which inherit `ABCMeta` from it.
- **`B026` (5), `B007` (25), `B009`/`B010` (6), `B011`/`B018`/`B028` (3)** — `*args` moved ahead of keyword arguments in the LiteLLM and Vertex AI providers; unused loop variables renamed; constant-name `getattr`/`setattr` inlined; `assert False` became a `pytest.raises` block; `warnings.warn` got a `stacklevel`.

Six commits, ordered so every commit is green: the fixes land before the rule is switched on.

## Additional Context

- Follows #2646 (`cef1832`), which uncommented `ruff check` for the backend.
- **Three things worth a reviewer's attention, all recorded in section 08 of the artifact:**
  - The `B024` fix in the SDK backfired on the first attempt and was caught by `test_base_llm_cannot_be_instantiated`. Same rule, same finding text, opposite correct fix in the two places it fired — worth knowing before the next sweep.
  - `B905`'s autofix writes `strict=False` everywhere, which is a declaration that silent truncation is intended. It would have been wrong in 26 of 29 cases, so this family was read rather than swept. `TRY400` in step 3b has the reverse risk.
  - Three `B017` sites in `test_transaction_management.py` could not be narrowed, because `services/test_set.py:290` raises a bare `Exception`. They pin the message with `match=` for now; that is `TRY002`, eight hits, waiting in step 3b.
- **Follow-up, not in this PR:** `lint.yml` runs `make lint` in `apps/backend`, `sdk` and `penelope`, each linting its own package. `tests/` sits at the repo root inside none of them, so no workflow lints a single test file — which is why this sweep came in at 105 rather than the 40 the source-only estimate predicted. 50 of these fixes are in files nothing gates, so nothing stops them coming back. Section 04 of the artifact has the bill (527 findings, 146 unformatted files, of which 181 are one legitimate fixture star-import pattern) and the three per-file relaxations it needs.

## Testing

CI covers this, but locally on this branch:

```bash
# the gate itself
uvx ruff check . --select B --ignore B008,B904     # All checks passed!
cd apps/backend && make lint                       # All checks passed! / 850 files already formatted
cd sdk && make lint                                # All checks passed! / 200 files already formatted
cd penelope && make lint                           # All checks passed!

# full suites
cd apps/backend && uv run pytest ../../tests/backend    # 8282 passed, 52 skipped, 1 xfailed
cd sdk && uv run pytest ../tests/sdk --ignore=../tests/sdk/integration   # 2920 passed, 17 skipped
```

The `B012` fix has no dedicated regression test yet — `tests/backend/services/invokers/test_tracing.py::test_create_invocation_trace_with_none_project_id` covers the no-project path but not the raising case. Worth adding if a reviewer wants it before merge.
