### PR TITLE
Fix grid flicker from unsettled loading states

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { Box, Typography, useTheme } from '@mui/material';
+import { Box, Skeleton, Typography, useTheme } from '@mui/material';
 import { GridColDef } from '@mui/x-data-grid';
 import { useSession } from 'next-auth/react';
 import EntityGrid, {
@@ -157,6 +157,13 @@ export default function EndpointsGrid({
           const project = endpoint.project_id
             ? projects[endpoint.project_id]
             : undefined;
+          // Unresolved project_id means "loading", not "absent".
+          const stillResolving =
+            loadingProjects && !!endpoint.project_id && !project;
+
+          if (stillResolving) {
+            return <Skeleton variant="text" width={120} />;
+          }
 
           return (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -192,7 +199,7 @@ export default function EndpointsGrid({
         },
       },
     ],
-    [projects, theme.typography.h5.fontSize]
+    [projects, loadingProjects, theme.typography.h5.fontSize]
   );
 
   // Only the top-level Endpoints page passes `onCreateClick` — that's when

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
@@ -428,9 +428,17 @@ describe('MetricTuningTab — the grid', () => {
    * Header text, groups included. Read off the grid rather than the whole page:
    * the add-case drawer stays mounted while closed, so its own Input and Output
    * fields would otherwise count as matches.
+   *
+   * Waits for the query to succeed: the grid stays visibility-hidden (and so
+   * absent from the accessible tree `getAllByRole` reads) for two animation
+   * frames after mount, to avoid a visible column-width snap.
    */
   const headerLabels = () =>
-    screen.getAllByRole('columnheader').map(header => header.textContent ?? '');
+    waitFor(() =>
+      screen
+        .getAllByRole('columnheader')
+        .map(header => header.textContent ?? '')
+    );
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -443,7 +451,7 @@ describe('MetricTuningTab — the grid', () => {
     render(<MetricTuningTab metricId={METRIC_ID} />);
 
     await screen.findByText('How are you?');
-    const labels = headerLabels();
+    const labels = await headerLabels();
     expect(labels).toContain('Case');
     expect(labels).toContain('Metric output');
     // Review stands outside the group bands, so its name appears exactly once.
@@ -458,7 +466,7 @@ describe('MetricTuningTab — the grid', () => {
     render(<MetricTuningTab metricId={METRIC_ID} />);
 
     await screen.findByText('How are you?');
-    const labels = headerLabels();
+    const labels = await headerLabels();
     expect(labels).toContain('Input');
     expect(labels).toContain('Output');
     expect(labels).toContain('Reference answer');
@@ -471,7 +479,7 @@ describe('MetricTuningTab — the grid', () => {
     render(<MetricTuningTab metricId={METRIC_ID} />);
 
     await screen.findByText('How are you?');
-    expect(headerLabels()).not.toContain('Reference answer');
+    expect(await headerLabels()).not.toContain('Reference answer');
   });
 
   it('leaves out the run and review groups before anything has been run', async () => {
@@ -480,7 +488,7 @@ describe('MetricTuningTab — the grid', () => {
     render(<MetricTuningTab metricId={METRIC_ID} />);
 
     await screen.findByText('How are you?');
-    const labels = headerLabels();
+    const labels = await headerLabels();
     expect(labels).not.toContain('Metric output');
     expect(labels).not.toContain('Review');
     expect(labels).not.toContain('Metric verdict');
@@ -619,6 +627,7 @@ describe('MetricTuningTab — reviewing', () => {
     expect(
       await screen.findByLabelText(/review invalidated/i)
     ).toBeInTheDocument();
+    await waitFor(() => expect(acceptMark()).toBeInTheDocument());
     expect(acceptMark()).toHaveAttribute('aria-pressed', 'false');
     expect(rejectMark()).toHaveAttribute('aria-pressed', 'false');
   });

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -685,6 +685,10 @@ export default function BaseDataGrid({
   // before revealing so that snap isn't visible.
   const [columnsMeasured, setColumnsMeasured] = useState(false);
   useLayoutEffect(() => {
+    if (!isReady) {
+      setColumnsMeasured(false);
+      return;
+    }
     let secondFrame = 0;
     const firstFrame = requestAnimationFrame(() => {
       secondFrame = requestAnimationFrame(() => setColumnsMeasured(true));

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -676,6 +676,25 @@ export default function BaseDataGrid({
     };
   }, []);
 
+  // Wait for initialization and persisted state to be loaded before rendering DataGrid
+  // This ensures initialState is correctly set before the grid mounts
+  const isReady = isInitialized && (!persistState || isPersistedStateLoaded);
+
+  // `flex` columns can render at a stale width until MUI re-measures after
+  // mount (known MUI issue, see mui/mui-x#3212, #19243) — wait two frames
+  // before revealing so that snap isn't visible.
+  const [columnsMeasured, setColumnsMeasured] = useState(false);
+  useLayoutEffect(() => {
+    let secondFrame = 0;
+    const firstFrame = requestAnimationFrame(() => {
+      secondFrame = requestAnimationFrame(() => setColumnsMeasured(true));
+    });
+    return () => {
+      cancelAnimationFrame(firstFrame);
+      cancelAnimationFrame(secondFrame);
+    };
+  }, [isReady]);
+
   // Subscribe to state change events for persistence
   useEffect(() => {
     if (!persistState || !isInitialized || !apiRef.current) return;
@@ -840,10 +859,6 @@ export default function BaseDataGrid({
     );
   }, [rowSelectionDisabledTooltip]);
 
-  // Wait for initialization and persisted state to be loaded before rendering DataGrid
-  // This ensures initialState is correctly set before the grid mounts
-  const isReady = isInitialized && (!persistState || isPersistedStateLoaded);
-
   if (!isReady) {
     return (
       <Box
@@ -870,6 +885,10 @@ export default function BaseDataGrid({
   }
 
   const dataGridSx: SxProps<Theme> = [
+    // Toolbar/footer are siblings of .MuiDataGrid-main, so they stay visible.
+    !columnsMeasured && {
+      '& .MuiDataGrid-main': { visibility: 'hidden' },
+    },
     disableColumnResize && {
       '& .MuiDataGrid-columnSeparator': {
         display: 'none',


### PR DESCRIPTION
## Purpose

This PR fixes two bugs .

**Bug 1 — DataGrid columns flicker on mount.** Grids using `flex` columns (Tests, Test Runs, Test Sets) briefly render columns at a collapsed width right after the page loads, then snap to their correct, final width a moment later. This is a known MUI DataGrid limitation (mui/mui-x#3212, #19243): MUI can't compute a flex column's pixel width until it measures the grid's actual container, and that measurement sometimes needs a second pass to settle. It resurfaced because a recent change switched these grids from fixed `width` columns to `flex`, so columns could grow to fill wide viewports.

**Bug 2 — Endpoints grid flashes "No project" before it loads.** On the Endpoints page, the "Project" column briefly shows "No project" for every row, then updates to the real project name a moment later. The endpoint rows themselves load immediately (server-prefetched), but the project name/icon comes from a separate client-side fetch that starts after the page mounts. Before thatch resolves, the code was treating "haven't found it in the lookup yet" the same as "confirmed to have no project."

## What Changed

- **BaseDataGrid**: hide the column headers/rows for up to two animation frames after mount, revealing them only once flex columns have settled at their real width. The toolbar and footer are untouched and still appear immediately.
- **EndpointsGrid**: the "Project" cell now checks the grid's existing `loadingProjects` flag before falling back to "No project" — while a row's project lookup is still in flight, it shows a skeleton instead of assuming "not found yet" means "has none."

## Testing

- `npx tsc --noEmit`, `npm run lint`, and the BaseDataGrid/EndpointsGrid/TestsGrid/TestnsGrid/TestSetsGrid/EntityGrid test suites all pass (69 tests).
- Manually verified against live grids with real data: no visible column-width jump on repeated page loads, no "No project" flash before the real project name appears.

