### PR TITLE
Add function complexity and size ceilings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,23 @@ Tests live under `tests/` — `backend/`, `sdk/`, `frontend/`, plus `k6/`, `load
 Each suite has different working-directory and Docker requirements. Backend: invoke the
 `backend-testing` skill. SDK: see `sdk/AGENTS.md`.
 
+## Complexity Ceiling
+
+Cyclomatic complexity is capped at 20 per function — ruff's `C901`, configured in `ruff.toml` and
+enforced on every PR.
+
+It's a ceiling, not a target. The number doesn't say the code below it is fine; it stops the slow
+drift that produced a 1,700-line `services/organization.py` without any single change ever looking
+unreasonable.
+
+Every function already over the line is listed under `[lint.per-file-ignores]` with a one-line
+reason. That list is the debt register, and it only shrinks: when you split a listed function up,
+delete its entry in the same PR. Adding an entry is possible but is a real decision, so say why in
+the PR.
+
+Don't work around the ceiling with a helper that exists only to dodge the count. Split the function
+along a seam that makes sense on its own.
+
 ## Git Commits
 
 - **Never commit, push, or open a PR without asking first.** Show what changed, then wait for the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,22 +87,10 @@ Tests live under `tests/` — `backend/`, `sdk/`, `frontend/`, plus `k6/`, `load
 Each suite has different working-directory and Docker requirements. Backend: invoke the
 `backend-testing` skill. SDK: see `sdk/AGENTS.md`.
 
-## Complexity Ceiling
+## Complexity Ceilings
 
-Cyclomatic complexity is capped at 20 per function — ruff's `C901`, configured in `ruff.toml` and
-enforced on every PR.
-
-It's a ceiling, not a target. The number doesn't say the code below it is fine; it stops the slow
-drift that produced a 1,700-line `services/organization.py` without any single change ever looking
-unreasonable.
-
-Every function already over the line is listed under `[lint.per-file-ignores]` with a one-line
-reason. That list is the debt register, and it only shrinks: when you split a listed function up,
-delete its entry in the same PR. Adding an entry is possible but is a real decision, so say why in
-the PR.
-
-Don't work around the ceiling with a helper that exists only to dodge the count. Split the function
-along a seam that makes sense on its own.
+`ruff.toml` caps paths, branches and statements per function. When you trip one, split the
+function; don't silence it with a `per-file-ignores` entry. That debt list only shrinks.
 
 ## Git Commits
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,6 +17,8 @@ select = [
     "RUF013",
     # noqa directives for violations that no longer happen.
     "RUF100",
+    # mccabe: cyclomatic complexity ceiling, see [lint.mccabe] below.
+    "C90",
 ]
 ignore = [
     # FastAPI puts Depends() in argument defaults by design.
@@ -37,6 +39,12 @@ external = [
     "SLF001",
 ]
 
+# A ceiling, not a target. Every function already over it is listed under
+# per-file-ignores below; the rule's job is to stop new ones appearing, and the
+# list only shrinks.
+[lint.mccabe]
+max-complexity = 20
+
 [lint.per-file-ignores]
 "__init__.py" = [
     "F401",
@@ -52,6 +60,56 @@ external = [
 "apps/backend/src/rhesis/backend/app/scope.py" = [
     "B039",
 ]
+
+# ---------------------------------------------------------------------------
+# C901 debt: functions above the complexity ceiling as of 2026-08-31. Adding a
+# line here means the function is too branchy to fix right now — not that the
+# ceiling doesn't apply. Delete the entry once the function is split up.
+# ---------------------------------------------------------------------------
+# publish_releases: tag-and-release flow with dry-run, skip and confirm branches.
+".github/release_tools/publish.py" = ["C901"]
+# sync_metrics_to_organizations: per-org loop with verbose, commit and error paths.
+"apps/backend/src/rhesis/backend/alembic/utils/metric_sync.py" = ["C901"]
+# query_traces: one filter branch per optional trace query parameter.
+"apps/backend/src/rhesis/backend/app/crud/telemetry.py" = ["C901"]
+# invoke_endpoint: stateless vs stateful, file inputs, deferred tracing, five failure modes.
+"apps/backend/src/rhesis/backend/app/services/endpoint/service.py" = ["C901"]
+# suggestion_pipeline_stream: interleaves generate, embed and evaluate events in one stream.
+"apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py" = ["C901"]
+# rows_to_test_data: every imported column is optional, so each one costs a branch.
+"apps/backend/src/rhesis/backend/app/services/file_import/builder.py" = ["C901"]
+# _extract_from_source: hand-rolled bracket and quote scanner over garak probe source.
+"apps/backend/src/rhesis/backend/app/services/garak/probes/extraction.py" = ["C901"]
+# _async_invoke: frame shapes vary per endpoint, plus connection failure handling.
+"apps/backend/src/rhesis/backend/app/services/invokers/websocket_invoker.py" = ["C901"]
+# load_initial_data walks every entity type in initial_data.json; rollback_initial_data
+# deletes them back out in dependency order.
+"apps/backend/src/rhesis/backend/app/services/organization.py" = ["C901"]
+# bulk_create_tests: flush batching plus per-row validation and DB error mapping.
+"apps/backend/src/rhesis/backend/app/services/test.py" = ["C901"]
+# prefetch_execution_context: one guarded lookup per piece of shared batch state.
+"apps/backend/src/rhesis/backend/jobs/execution/batch/context.py" = ["C901"]
+# _extract_model_data: aggregates optional metrics per model, per category, per file.
+"apps/polyphemus/src/rhesis/polyphemus/benchmarking/results_curator.py" = ["C901"]
+# plot_precision_comparison: matplotlib code with a branch per precision label and bar series.
+"apps/polyphemus/src/rhesis/polyphemus/benchmarking/scripts/generate_benchmark_plots.py" = ["C901"]
+# print_generation_summary, print_evaluation_summary: console reports with a branch
+# per optional statistic.
+"apps/polyphemus/src/rhesis/polyphemus/benchmarking/tester.py" = ["C901"]
+# check_task_detailed: probes the active, reserved and scheduled queues for one task id.
+"apps/worker/task_manager.py" = ["C901"]
+# run_token_exchange: RFC 8693 flow, where each mandated check is its own rejection branch.
+"ee/backend/src/rhesis/backend/ee/sso/token_exchange/exchange.py" = ["C901"]
+# display_continuity_results: example script that prints continuity heuristics turn by turn.
+"penelope/examples/test_multi_turn_continuity.py" = ["C901"]
+# _is_potentially_unsafe_query: heuristic scanner, one branch per safe-pattern class.
+"scripts/check_organization_filtering.py" = ["C901"]
+# endpoint, decorator: switch on sync/async, binding, mappings and serializers.
+"sdk/src/rhesis/sdk/decorators/endpoint.py" = ["C901"]
+# create_langchain_callback: one callback per LangChain event, closed over shared span state.
+"sdk/src/rhesis/sdk/telemetry/integrations/langchain/callback.py" = ["C901"]
+# client: fixture builds an app with a route per error class.
+"tests/backend/security/test_error_handlers.py" = ["C901"]
 
 [lint.isort]
 known-first-party = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -19,6 +19,10 @@ select = [
     "RUF100",
     # mccabe: cyclomatic complexity ceiling, see [lint.mccabe] below.
     "C90",
+    # pylint: function size ceilings, see [lint.pylint] below. C901 counts paths
+    # through a function, not its length, so it waves the long flat ones through.
+    "PLR0912",
+    "PLR0915",
 ]
 ignore = [
     # FastAPI puts Depends() in argument defaults by design.
@@ -39,11 +43,14 @@ external = [
     "SLF001",
 ]
 
-# A ceiling, not a target. Every function already over it is listed under
-# per-file-ignores below; the rule's job is to stop new ones appearing, and the
-# list only shrinks.
+# Ceilings, not targets. Functions already over one are listed under
+# per-file-ignores below.
 [lint.mccabe]
 max-complexity = 20
+
+[lint.pylint]
+max-branches = 25
+max-statements = 80
 
 [lint.per-file-ignores]
 "__init__.py" = [
@@ -54,6 +61,7 @@ max-complexity = 20
 "**/alembic/versions/*.py" = [
     "E501",
     "E402",
+    "PLR0915",
 ]
 # RequestScope is @dataclass(frozen=True), so the shared default instance cannot
 # be mutated and cannot leak between requests. B039 is wrong here.
@@ -61,47 +69,64 @@ max-complexity = 20
     "B039",
 ]
 
-# ---------------------------------------------------------------------------
-# C901 debt: functions above the complexity ceiling as of 2026-08-31. Adding a
-# line here means the function is too branchy to fix right now — not that the
-# ceiling doesn't apply. Delete the entry once the function is split up.
-# ---------------------------------------------------------------------------
+# Complexity debt as of 2026-08-31. An entry here means the function is too big to
+# fix right now, not that the ceiling doesn't apply — delete it once the function
+# is split up.
+
 # publish_releases: tag-and-release flow with dry-run, skip and confirm branches.
 ".github/release_tools/publish.py" = ["C901"]
+# main: example script that runs every scenario back to back.
+"agents/research-assistant/examples/test_scenarios.py" = ["PLR0915"]
 # sync_metrics_to_organizations: per-org loop with verbose, commit and error paths.
 "apps/backend/src/rhesis/backend/alembic/utils/metric_sync.py" = ["C901"]
 # query_traces: one filter branch per optional trace query parameter.
 "apps/backend/src/rhesis/backend/app/crud/telemetry.py" = ["C901"]
+# lifespan: the whole startup and shutdown sequence in one context manager.
+"apps/backend/src/rhesis/backend/app/main.py" = ["PLR0915"]
 # invoke_endpoint: stateless vs stateful, file inputs, deferred tracing, five failure modes.
-"apps/backend/src/rhesis/backend/app/services/endpoint/service.py" = ["C901"]
+"apps/backend/src/rhesis/backend/app/services/endpoint/service.py" = ["C901", "PLR0912", "PLR0915"]
 # suggestion_pipeline_stream: interleaves generate, embed and evaluate events in one stream.
-"apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py" = ["C901"]
+"apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py" = ["C901", "PLR0915"]
 # rows_to_test_data: every imported column is optional, so each one costs a branch.
 "apps/backend/src/rhesis/backend/app/services/file_import/builder.py" = ["C901"]
 # _extract_from_source: hand-rolled bracket and quote scanner over garak probe source.
 "apps/backend/src/rhesis/backend/app/services/garak/probes/extraction.py" = ["C901"]
 # _async_invoke: frame shapes vary per endpoint, plus connection failure handling.
-"apps/backend/src/rhesis/backend/app/services/invokers/websocket_invoker.py" = ["C901"]
+"apps/backend/src/rhesis/backend/app/services/invokers/websocket_invoker.py" = [
+    "C901",
+    "PLR0912",
+    "PLR0915",
+]
 # load_initial_data walks every entity type in initial_data.json; rollback_initial_data
 # deletes them back out in dependency order.
-"apps/backend/src/rhesis/backend/app/services/organization.py" = ["C901"]
+"apps/backend/src/rhesis/backend/app/services/organization.py" = ["C901", "PLR0912", "PLR0915"]
 # bulk_create_tests: flush batching plus per-row validation and DB error mapping.
-"apps/backend/src/rhesis/backend/app/services/test.py" = ["C901"]
+"apps/backend/src/rhesis/backend/app/services/test.py" = ["C901", "PLR0912", "PLR0915"]
 # prefetch_execution_context: one guarded lookup per piece of shared batch state.
-"apps/backend/src/rhesis/backend/jobs/execution/batch/context.py" = ["C901"]
+"apps/backend/src/rhesis/backend/jobs/execution/batch/context.py" = ["C901", "PLR0912", "PLR0915"]
+# execute_tests_sequentially: runs, records and reports a whole test run in one pass.
+"apps/backend/src/rhesis/backend/jobs/execution/sequential.py" = ["PLR0915"]
 # _extract_model_data: aggregates optional metrics per model, per category, per file.
-"apps/polyphemus/src/rhesis/polyphemus/benchmarking/results_curator.py" = ["C901"]
+"apps/polyphemus/src/rhesis/polyphemus/benchmarking/results_curator.py" = [
+    "C901",
+    "PLR0912",
+    "PLR0915",
+]
 # plot_precision_comparison: matplotlib code with a branch per precision label and bar series.
-"apps/polyphemus/src/rhesis/polyphemus/benchmarking/scripts/generate_benchmark_plots.py" = ["C901"]
+"apps/polyphemus/src/rhesis/polyphemus/benchmarking/scripts/generate_benchmark_plots.py" = [
+    "C901",
+    "PLR0912",
+    "PLR0915",
+]
 # print_generation_summary, print_evaluation_summary: console reports with a branch
 # per optional statistic.
-"apps/polyphemus/src/rhesis/polyphemus/benchmarking/tester.py" = ["C901"]
+"apps/polyphemus/src/rhesis/polyphemus/benchmarking/tester.py" = ["C901", "PLR0912"]
 # check_task_detailed: probes the active, reserved and scheduled queues for one task id.
 "apps/worker/task_manager.py" = ["C901"]
 # run_token_exchange: RFC 8693 flow, where each mandated check is its own rejection branch.
-"ee/backend/src/rhesis/backend/ee/sso/token_exchange/exchange.py" = ["C901"]
+"ee/backend/src/rhesis/backend/ee/sso/token_exchange/exchange.py" = ["C901", "PLR0912", "PLR0915"]
 # display_continuity_results: example script that prints continuity heuristics turn by turn.
-"penelope/examples/test_multi_turn_continuity.py" = ["C901"]
+"penelope/examples/test_multi_turn_continuity.py" = ["C901", "PLR0912", "PLR0915"]
 # _is_potentially_unsafe_query: heuristic scanner, one branch per safe-pattern class.
 "scripts/check_organization_filtering.py" = ["C901"]
 # endpoint, decorator: switch on sync/async, binding, mappings and serializers.


### PR DESCRIPTION
Every increment that grew `services/organization.py` to 1,714 lines was individually reasonable,
and no threshold ever tripped. This adds the thresholds.

Nothing is refactored here. The point is the gradient: set a ceiling above where we are today,
list what's already over it, and stop new ones appearing.

## The ceilings

| Rule | Ceiling | Counts |
| --- | --- | --- |
| `C901` | 20 | independent paths through a function |
| `PLR0912` | 25 | branches |
| `PLR0915` | 80 | statements |

20 is where the debt list stays reviewable: at 15 we'd have 39 functions over the line, at ruff's
default of 10, 155.

`PLR0912`/`PLR0915` are there because `C901` measures shape, not size — a 100-statement function
with no branching sails past it. `app/main.py`'s `lifespan` (107 statements) and
`jobs/execution/sequential.py`'s `execute_tests_sequentially` (90) are exactly that, and only the
size rules catch them.

## The debt list

24 functions across 21 files are already over `C901`; adding the size rules costs three more files.
Each gets a `per-file-ignores` entry with a one-line reason for what makes it branchy:

```toml
# invoke_endpoint: stateless vs stateful, file inputs, deferred tracing, five failure modes.
"apps/backend/src/rhesis/backend/app/services/endpoint/service.py" = ["C901", "PLR0912", "PLR0915"]
```

That list is the register, and it only shrinks: split a listed function up, delete its entry in the
same PR.

Alembic migrations get `PLR0915` on the glob that already exempts them from `E501`/`E402` — they're
frozen records.

## Rules deliberately left out

Pylint's other two size rules cap arguments and returns. Both are a poor fit here:

- `PLR0913`/`PLR0917` fire on FastAPI routers, where one query parameter *is* one argument —
  `routers/telemetry.py`'s `list_traces` has 25, all `Query(...)` filters. Same category as `B008`.
  Suppressing it means blanket-ignoring the router layer, which leaves the rule doing nothing.
- `PLR0911` mostly hits guard-clause dispatchers where 10 early returns beat the nested alternative.

Tighter thresholds on the two rules we did take would also have been expensive: `56` statements and
`21` branches instead of `80`/`25` puts 121 findings across 76 files on the debt list, versus 28
across 15.

## Testing

- `uvx ruff check .` reports zero `C901`/`PLR0912`/`PLR0915` repo-wide.
- `make lint` passes in `apps/backend`, `sdk` and `penelope`.
- A planted 85-statement function with no branching is caught by `PLR0915` and ignored by `C901`,
  which is why both are here.

Config only — no behaviour change.
