### PR TITLE
Fix migration downgrades that silently drop their bind params

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -34,6 +34,14 @@ Use `app/utils/` over `app/services/<domain>/` when more than one unrelated serv
 helper — e.g. `app/utils/response_extractor.py` is used by explorer's invocation *and* by metric
 evaluation, batch execution, and Penelope, none of which are endpoint-specific.
 
+## Migrations
+
+**Casts in `sa.text()`: write `CAST(:x AS type)`, never `:x::type`.** SQLAlchemy skips any `:name`
+followed directly by another `:` — that's how it leaves `::` casts alone — so `ANY(:ids::uuid[])`
+binds nothing, sends the literal `:ids` to the server and fails with `syntax error at or near ":"`.
+Nothing warns you until the statement runs. Guarded by
+`tests/backend/alembic/test_bind_param_casts.py`.
+
 ## Ambient Request Scope (Tenant Filtering & Stamping)
 
 All tenant context (`organization_id`, `user_id`, `project_id`) is stored **once per request** on

--- a/apps/backend/src/rhesis/backend/alembic/versions/554e3e207a3f_add_default_rhesis_embedding_model.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/554e3e207a3f_add_default_rhesis_embedding_model.py
@@ -258,7 +258,7 @@ def downgrade() -> None:
         if rows:
             model_ids = [str(row[0]) for row in rows]
             session.execute(
-                text("DELETE FROM model WHERE id = ANY(:ids::uuid[])"),
+                text("DELETE FROM model WHERE id = ANY(CAST(:ids AS uuid[]))"),
                 {"ids": model_ids},
             )
 

--- a/apps/backend/src/rhesis/backend/alembic/versions/e8dd05d20cd0_add_default_rhesis_model_to_existing_.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/e8dd05d20cd0_add_default_rhesis_model_to_existing_.py
@@ -256,7 +256,7 @@ def downgrade() -> None:
         if rows:
             model_ids = [str(row[0]) for row in rows]
             session.execute(
-                text("DELETE FROM model WHERE id = ANY(:ids::uuid[])"),
+                text("DELETE FROM model WHERE id = ANY(CAST(:ids AS uuid[]))"),
                 {"ids": model_ids},
             )
 

--- a/tests/backend/alembic/test_bind_param_casts.py
+++ b/tests/backend/alembic/test_bind_param_casts.py
@@ -1,0 +1,121 @@
+"""Guard against `:param::type` inside ``text()`` SQL.
+
+SQLAlchemy's bind-parameter scanner skips any ``:name`` immediately followed
+by another ``:``. That rule exists so PostgreSQL's ``::`` cast syntax survives
+untouched, but it cannot tell the ``x`` in ``a::b`` apart from a parameter the
+author meant to bind. So ``text("... ANY(:ids::uuid[])")`` compiles with **zero**
+bind parameters, the params dict is silently dropped, and the literal string
+``:ids::uuid[]`` reaches the server -- which rejects it with
+``syntax error at or near ":"``.
+
+Nothing catches this at author time: ``text()`` accepts the string and
+``.compile()`` succeeds. It only fails when the statement runs, which is why one
+instance broke ~6300 backend tests in a single CI run and two others sat
+unnoticed in downgrade paths that CI never exercises.
+
+The fix is always ``CAST(:x AS type)``.
+
+Why a static AST check?
+-----------------------
+The bug is in the SQL string, not in runtime behaviour, so reading the source is
+enough -- no database, no app environment, milliseconds to run. Scoping to
+``text()`` call arguments (rather than grepping every string) keeps unrelated
+``::`` text out of it, such as the IPv6 literals in the EE SSO client.
+
+Limits
+------
+Only string literals written directly inside a ``text()`` call are checked,
+including implicitly concatenated ones. SQL assembled in a variable first, or
+built by f-string or ``.format()``, is out of scope; the goal is a fast guard
+against the common mistake, not an exhaustive SQL analyser.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[3]
+
+# Directories whose Python sources may build SQL through text().
+SEARCH_ROOTS = ("apps", "sdk", "ee", "scripts", "tests")
+
+# A bind parameter glued to a PostgreSQL cast: the `::` swallows the parameter.
+BAD_CAST = re.compile(r":[a-zA-Z_][a-zA-Z0-9_]*::")
+
+
+def _is_text_call(node: ast.AST) -> bool:
+    """True for `text(...)` and any attribute form such as `sa.text(...)`."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id == "text"
+    return isinstance(func, ast.Attribute) and func.attr == "text"
+
+
+def _string_parts(node: ast.AST) -> list[str]:
+    """Collect literal string pieces, following implicit concatenation."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return _string_parts(node.left) + _string_parts(node.right)
+    return []
+
+
+def _python_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SEARCH_ROOTS:
+        base = REPO_ROOT / root
+        if base.is_dir():
+            files.extend(p for p in base.rglob("*.py") if ".venv" not in p.parts)
+    return files
+
+
+def _offenders() -> list[str]:
+    """Return `path:line: sql` for every text() call with a glued cast."""
+    found: list[str] = []
+    for path in _python_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if not _is_text_call(node):
+                continue
+            for arg in node.args:
+                sql = "".join(_string_parts(arg))
+                if BAD_CAST.search(sql):
+                    rel = path.relative_to(REPO_ROOT)
+                    found.append(f"{rel}:{node.lineno}: {sql}")
+    return found
+
+
+def test_no_bind_param_glued_to_cast():
+    """No text() SQL binds a parameter directly onto a `::` cast."""
+    offenders = _offenders()
+    assert not offenders, (
+        "Bind parameter glued to a `::` cast — SQLAlchemy will not bind it and "
+        "PostgreSQL will reject the literal. Use CAST(:x AS type) instead:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_guard_detects_a_known_bad_pattern():
+    """The matcher itself catches the shape it is meant to catch."""
+    assert BAD_CAST.search("DELETE FROM model WHERE id = ANY(:ids::uuid[])")
+    assert not BAD_CAST.search("DELETE FROM model WHERE id = ANY(CAST(:ids AS uuid[]))")
+    # A cast with no bind parameter in front of it is ordinary PostgreSQL.
+    assert not BAD_CAST.search("SELECT now()::date")
+
+
+def test_guard_relies_on_ast_scoping_not_the_regex():
+    """The regex alone is not selective enough; restricting it to text() args is.
+
+    An IPv6 literal such as ``fd00:ec2::254`` matches the pattern, so a bare grep
+    over the repo reports the EE SSO client. Those strings are never arguments to
+    ``text()``, which is why the scan walks the AST instead.
+    """
+    assert BAD_CAST.search("fd00:ec2::254")
+    assert not _is_text_call(ast.parse("requests.get('fd00:ec2::254')").body[0].value)


### PR DESCRIPTION
## Purpose

Closes #2226, which asked for the `sa.text()` cast convention to be written down so it stops recurring. It had already recurred: two migration downgrades on `main` carry the same bug, and both fail outright when run.

The issue's stated cause is not what actually happens. It says `:table::regclass` "was parsed as two bind params (`:table` and `:regclass`)". In fact SQLAlchemy's scanner *skips* any `:name` followed directly by another `:` — that rule is precisely what lets PostgreSQL `::` casts pass through untouched. It cannot tell the `x` in `a::b` apart from a parameter you meant to bind, so `:ids::uuid[]` compiles with **zero** bind parameters, the params dict is silently dropped, and the literal `:ids` is sent to the server.

Nothing warns you at author time. `sa.text()` accepts the string and `.compile()` succeeds; the error only surfaces when the statement runs.

## What Changed

- **Fixed two broken downgrades.** `554e3e207a3f_add_default_rhesis_embedding_model.py` and `e8dd05d20cd0_add_default_rhesis_model_to_existing_.py` both ran `DELETE FROM model WHERE id = ANY(:ids::uuid[])`. Now `ANY(CAST(:ids AS uuid[]))`. These went unnoticed because CI never exercises downgrades — anyone downgrading past either revision today hits a hard failure.
- **Added `tests/backend/alembic/test_bind_param_casts.py`.** A static AST guard that fails on any `text()` call in the repo whose SQL glues a bind parameter onto a `::` cast. No database, no app environment, runs in milliseconds — modeled on the existing `test_ee_boundary.py` static check.
- **Documented the convention** in `apps/backend/AGENTS.md`: write `CAST(:x AS type)`, never `:x::type`, with the reason. Six lines.

The guard walks the AST rather than grepping because a plain regex scan also matches the IPv6 literals in `ee/sso/http_client.py` (`fd00:ec2::254`). One of the three tests pins that distinction, so a future "simplification" to a bare grep fails loudly instead of quietly reporting the SSO client.

## Additional Context

- Closes #2226
- The original instance of this bug broke ~6300 backend tests in a single CI run, fixed in passing on #2176 (`ab67bdf3a`) without anything being written down — which is what #2226 was filed about.

## Testing

Verified end-to-end against a throwaway PostgreSQL 16 container, passing the same params dict to both forms:

| SQL | bind params | result |
| --- | --- | --- |
| `ANY(:ids::uuid[])` | `[]` | `psycopg2.errors.SyntaxError: syntax error at or near ":"` |
| `ANY(CAST(:ids AS uuid[]))` | `['ids']` | ok, 1 row deleted |

The guard test suite:

```bash
cd apps/backend
uv run pytest ../../tests/backend/alembic/test_bind_param_casts.py -v
```

3 passed. `ruff check` clean on all changed files. To see the guard actually bite, revert either migration hunk and re-run — `test_no_bind_param_glued_to_cast` reports the file and line.
