### PR TITLE
Fix the SDK integration test setup

### DIFF
--- a/tests/sdk/connector/test_manager.py
+++ b/tests/sdk/connector/test_manager.py
@@ -17,7 +17,7 @@ def _make_create_task_mock():
     The mock ``create_task`` closes any coroutine it receives so that
     Python does not emit *RuntimeWarning: coroutine ... was never awaited*.
     """
-    mock_task = Mock(spec=["cancel"])
+    mock_task = Mock(spec=["cancel", "add_done_callback"])
 
     def _side_effect(coro, **kwargs):
         if inspect.iscoroutine(coro):

--- a/tests/sdk/integration/conftest.py
+++ b/tests/sdk/integration/conftest.py
@@ -6,6 +6,7 @@ from typing import Generator
 import psycopg2
 import pytest
 import requests
+from cryptography.fernet import Fernet
 from psycopg2.extras import RealDictCursor
 
 # ANSI color codes
@@ -17,6 +18,15 @@ NC = "\033[0m"  # No Color
 
 DATABASE_PORT = 10001
 BACKEND_PORT = 10003
+
+# Must match DB_ENCRYPTION_KEY in tests/docker-compose.test.yml. The backend stores
+# token.token with EncryptedString, so we have to encrypt it here before inserting
+# the row directly with SQL -- a plaintext value makes every authenticated request
+# fail with DecryptionError.
+DB_ENCRYPTION_KEY = "Zb21wZbPsUpb-c2JKj8uMugk767pWXHFTsjocd0Orac="
+
+# Fixed project the tests run against; must match TEST_PROJECT_ID in test_parameters.py.
+TEST_PROJECT_ID = "12340000-0000-4000-8000-000000001234"
 
 # LLM Provider types - hardcoded to keep SDK tests independent of backend code
 # Only includes providers actually used in tests (openai, anthropic, gemini)
@@ -133,6 +143,8 @@ def setup_test_data() -> None:
     except ImportError as e:
         pytest.fail(f"❌ Failed to generate token hash: {e}")
 
+    TOKEN_ENCRYPTED = Fernet(DB_ENCRYPTION_KEY.encode()).encrypt(TOKEN_VALUE.encode()).decode()
+
     print(f"{BLUE}Token: {TOKEN_VALUE}{NC}")
     print(f"{BLUE}Hash: {TOKEN_HASH}{NC}")
 
@@ -167,17 +179,23 @@ def setup_test_data() -> None:
             RETURNING id, organization_id
         ),
         new_token AS (
+            -- project_id scopes the token to the test project. Without it the
+            -- project_isolation RLS policy hides every project-scoped row from
+            -- routes that take no project in their path, and the SDK has no
+            -- other way to set app.current_project (it never sends X-Project-Id).
             INSERT INTO token (
                 token,
                 token_hash,
                 token_type,
-                user_id
+                user_id,
+                project_id
             )
             SELECT
                 %(token_value)s,
                 %(token_hash)s,
                 'bearer',
-                new_user.id
+                new_user.id,
+                %(project_id)s::uuid
             FROM new_user
             RETURNING user_id
         ),
@@ -185,7 +203,7 @@ def setup_test_data() -> None:
             -- Create project with specific ID "1234"
             INSERT INTO project (id, name, description, organization_id, user_id, owner_id)
             SELECT
-                '12340000-0000-4000-8000-000000001234'::uuid,
+                %(project_id)s::uuid,
                 'Test Project',
                 'Test project for integration tests',
                 new_user.organization_id,
@@ -193,13 +211,28 @@ def setup_test_data() -> None:
                 new_user.id
             FROM new_user
             ON CONFLICT (id) DO NOTHING
-            RETURNING organization_id, user_id
+            RETURNING id, organization_id, user_id
+        ),
+        new_membership AS (
+            -- The backend hides projects the caller is not an explicit member of,
+            -- so every project row created here needs a matching membership.
+            INSERT INTO project_membership (project_id, user_id, organization_id)
+            SELECT id, user_id, organization_id FROM new_project
+            ON CONFLICT DO NOTHING
+            RETURNING project_id
         )
         -- Return the organization_id and user_id for subsequent operations
         SELECT organization_id, id as user_id FROM new_user;
         """
 
-        cur.execute(sql, {"token_value": TOKEN_VALUE, "token_hash": TOKEN_HASH})
+        cur.execute(
+            sql,
+            {
+                "token_value": TOKEN_ENCRYPTED,
+                "token_hash": TOKEN_HASH,
+                "project_id": TEST_PROJECT_ID,
+            },
+        )
         result = cur.fetchone()
         conn.commit()
 
@@ -218,7 +251,7 @@ def setup_test_data() -> None:
         print(f"{CYAN}{TOKEN_VALUE}{NC}")
         print(f"{GREEN}════════════════════════════════════════════════{NC}")
         print()
-        print(f"{GREEN}✅ Test project created with ID: 12340000-0000-0000-0000-000000001234{NC}")
+        print(f"{GREEN}✅ Test project created with ID: {TEST_PROJECT_ID}{NC}")
         print()
 
         # Populate type_lookups with provider types

--- a/tests/sdk/integration/test_connector_integration.py
+++ b/tests/sdk/integration/test_connector_integration.py
@@ -24,18 +24,23 @@ DB_PASSWORD = "your-secured-password"
 DB_PORT = 10001
 
 
-def _connector_status(base_url: str) -> dict:
+def _auth_headers(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def _connector_status(base_url: str, api_key: str) -> dict:
     """Fetch connector status for the test project."""
     response = requests.get(
         f"{base_url}/connector/status/{PROJECT_ID}",
         params={"environment": ENVIRONMENT},
+        headers=_auth_headers(api_key),
         timeout=5,
     )
     response.raise_for_status()
     return response.json()
 
 
-def _trigger_test(base_url: str, function_name: str, inputs: dict) -> dict:
+def _trigger_test(base_url: str, api_key: str, function_name: str, inputs: dict) -> dict:
     """Trigger connector execution through backend HTTP endpoint."""
     response = requests.post(
         f"{base_url}/connector/trigger",
@@ -45,6 +50,7 @@ def _trigger_test(base_url: str, function_name: str, inputs: dict) -> dict:
             "function_name": function_name,
             "inputs": inputs,
         },
+        headers=_auth_headers(api_key),
         timeout=10,
     )
     response.raise_for_status()
@@ -109,12 +115,12 @@ async def test_connector_endpoint_registration_and_trigger(docker_compose_test_e
         await _wait_until(
             lambda: any(
                 func["name"] == "sdk_echo"
-                for func in _connector_status(base_url).get("functions", [])
+                for func in _connector_status(base_url, api_key).get("functions", [])
             ),
             timeout=12,
         )
 
-        trigger_response = _trigger_test(base_url, "sdk_echo", {"input": "hello"})
+        trigger_response = _trigger_test(base_url, api_key, "sdk_echo", {"input": "hello"})
         assert trigger_response["success"] is True
         assert trigger_response["test_run_id"].startswith("test_")
 

--- a/tests/sdk/integration/test_test_set_execution.py
+++ b/tests/sdk/integration/test_test_set_execution.py
@@ -60,6 +60,7 @@ def _create_metric(name: str) -> dict:
             "min_score": 0,
             "max_score": 1,
             "threshold": 0.5,
+            "metric_scope": ["Single-Turn"],
         },
     )
 

--- a/tests/sdk/integration/test_test_set_metrics.py
+++ b/tests/sdk/integration/test_test_set_metrics.py
@@ -27,6 +27,7 @@ def _create_metric(name: str) -> dict:
             "min_score": 0,
             "max_score": 1,
             "threshold": 0.5,
+            "metric_scope": ["Single-Turn"],
         },
     )
 


### PR DESCRIPTION
## Purpose

The SDK integration suite has been failing on `main` for weeks — the latest scheduled run ([33355082772](https://github.com/rhesis-ai/rhesis/actions/runs/33355082772)) ended with 125 failures and 8 errors. It went unnoticed because `.github/workflows/sdk-test.yml` only runs the "Test SDK (full)" step on `push`, `schedule` and `workflow_dispatch`, so PR runs stay green while the integration step rots.

Every failure is in the test setup, not in SDK or backend source. The suite drifted behind four separate backend changes.

## What Changed

**`tests/sdk/integration/conftest.py`** — the setup inserts the org, user, token and project directly with SQL, and three of those inserts are now wrong:

- **The token was stored in plaintext.** `token.token` is an `EncryptedString` column, and since #2181 (`Require DB_ENCRYPTION_KEY and drop plaintext fallback`) `process_result_value` raises `DecryptionError` instead of returning an undecryptable value verbatim. Auth blew up on every single request, which accounts for essentially all 125 failures. The token is now Fernet-encrypted with the same key the compose file gives the backend.
- **No `project_membership` row.** `get_project` returns `None` for a caller with no membership row, so the fixed test project 404'd on every route that loads it.
- **The token had no project scope.** The `project_isolation` RLS policy admits a row only when `project_id` matches `app.current_project`. The backend sets that GUC from `X-Project-Id` or from `token.project_id`, and the SDK never sends the header — so routes that take no project in their path (`POST /experiments/{id}/versions` and friends) saw nothing. The test token is now scoped to the test project, which is what a real SDK API key looks like.

**`test_test_set_metrics.py`, `test_test_set_execution.py`** — send `metric_scope`, now required by `MetricCreate`. Both `_create_metric` helpers were 422ing.

**`test_connector_integration.py`** — `GET /connector/status/{project_id}` and `POST /connector/trigger` now require authentication; the helpers sent no `Authorization` header and got 401.

**`tests/sdk/connector/test_manager.py`** — separate, newer break. #2658 (ruff RUF006) added `task.add_done_callback` to `ConnectorManager._spawn`, but the mocked task is built with `spec=["cancel"]`, so three tests fail with `AttributeError`. This one fails the *fast* step, which is why runs [33376411295](https://github.com/rhesis-ai/rhesis/actions/runs/33376411295) and [33376216110](https://github.com/rhesis-ai/rhesis/actions/runs/33376216110) are red today.

## Additional Context

- Traced to #2181 (encryption fail-loud), the `MetricCreate.metric_scope` requirement, the project membership and `project_isolation` RLS work, the connector auth requirement, and #2658 (RUF006).
- No SDK or backend source is touched — every change is in `tests/`.
- Left alone deliberately: pre-existing ruff findings in `test_entities.py` and `test_parameters.py` (unused imports, import order). They are unrelated, and lint CI evidently does not cover `tests/`.
- Worth a follow-up: the integration step still does not run on PRs, so this can silently break again the same way.

## Testing

From a clean database:

```bash
cd sdk
make docker-clean
make test-integration
```

3062 passed, 19 skipped, 0 failures. Before this branch the same command gives 125 failures and 8 errors.

Ruff is clean on the changed files:

```bash
uvx ruff check tests/sdk/integration/conftest.py tests/sdk/integration/test_connector_integration.py tests/sdk/integration/test_test_set_metrics.py tests/sdk/integration/test_test_set_execution.py tests/sdk/connector/test_manager.py
```
