### PR TITLE
Trigger SDK tests on changes to their own files

### DIFF
--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -6,10 +6,16 @@ on:
     branches: [ main ]
     paths:
       - 'sdk/**'
+      - 'tests/sdk/**'
+      - 'tests/docker-compose.test.yml'
+      - '.github/workflows/sdk-test.yml'
   push:
     branches: [ main ]
     paths:
       - 'sdk/**'
+      - 'tests/sdk/**'
+      - 'tests/docker-compose.test.yml'
+      - '.github/workflows/sdk-test.yml'
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
## Purpose

`[Test] SDK` filters on `paths: ['sdk/**']` only, so a change confined to the SDK's own test files triggers no SDK check at all. #2663 rewrites the entire SDK integration suite and ran zero SDK checks — the workflow never fired, because that PR touches only `tests/`.

`backend-test.yml` already gets this right: it lists `tests/backend/**` and its own workflow file alongside the source paths. This brings `sdk-test.yml` in line.

## What Changed

Added three entries to the `pull_request` and `push` path filters:

- `tests/sdk/**` — the whole suite lives here, including its `pytest.ini`. This is the actual gap.
- `tests/docker-compose.test.yml` — defines the integration stack, builds the backend image, and carries the `DB_ENCRYPTION_KEY` the test setup depends on.
- `.github/workflows/sdk-test.yml` — so edits to the workflow are self-testing.

The `Test SDK (full)` step keeps its existing `if:` gate (push / workflow_dispatch / schedule). Not touched.

## Additional Context

- Follow-up to #2663, which fixes the integration suite itself. Independent of it — this PR changes only trigger paths, so the two can merge in either order.
- **This does not make backend-caused SDK breakage visible pre-merge.** All four root causes behind #2663 were backend changes (encryption fail-loud in #2181, the new required `metric_scope`, project membership on `get_project`, connector auth). None of them touch `sdk/**` or `tests/sdk/**`, so no path filter on this workflow would have caught them. With the integration step still PR-gated, that class of breakage remains visible only in the nightly run — which is precisely how it went unnoticed for weeks. Worth a separate decision: either run the integration step on PRs, add `apps/backend/**` to the triggers, or make a failing nightly loud (auto-open an issue).

## Testing

The path filter's real effect is only observable once this is on `main` — a PR cannot demonstrate that a *future* `tests/sdk/**`-only change triggers the workflow.

What this PR does demonstrate is the self-trigger case: because it edits `.github/workflows/sdk-test.yml`, `[Test] SDK` should appear in its own checks, where on the current `main` it would not. Confirm that check is present and green below.

YAML parses clean, and the step list and gating are unchanged:

```bash
python3 -c "
import yaml
d = yaml.safe_load(open('.github/workflows/sdk-test.yml'))
on = d[True] if True in d else d['on']
print(on['pull_request']['paths'])
for s in d['jobs']['test-sdk']['steps']:
    if 'name' in s: print(s['name'], '| if:', s.get('if', '<always>'))
"
```
