### PR TITLE
Parallelize identifier-only SSR prefetches on detail pages

### DIFF
--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/page.tsx
@@ -33,6 +33,12 @@ export default async function ExperimentDetailPage({ params }: PageProps) {
   const apiFactory = await createServerApiFactory();
   const client = apiFactory.getParametersClient();
 
+  // Runs only needs `identifier`, not the experiment itself, so it can fetch
+  // alongside `getExperiment` instead of waiting behind it.
+  const runsPromise = prefetch(Capability.Experiment.READ, () =>
+    fetchExperimentRuns(apiFactory, identifier)
+  );
+
   let initialExperiment: ExperimentDetailData;
   try {
     const experiment = await client.getExperiment(identifier);
@@ -46,9 +52,7 @@ export default async function ExperimentDetailPage({ params }: PageProps) {
     throw error;
   }
 
-  const runs = await prefetch(Capability.Experiment.READ, () =>
-    fetchExperimentRuns(apiFactory, identifier)
-  );
+  const runs = await runsPromise;
 
   return (
     <ExperimentDetailClient

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/page.tsx
@@ -33,8 +33,7 @@ export default async function ExperimentDetailPage({ params }: PageProps) {
   const apiFactory = await createServerApiFactory();
   const client = apiFactory.getParametersClient();
 
-  // Runs only needs `identifier`, not the experiment itself, so it can fetch
-  // alongside `getExperiment` instead of waiting behind it.
+  // Runs only needs `identifier`, not the experiment itself.
   const runsPromise = prefetch(Capability.Experiment.READ, () =>
     fetchExperimentRuns(apiFactory, identifier)
   );

--- a/apps/frontend/src/app/(protected)/explorer/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/[identifier]/page.tsx
@@ -22,22 +22,26 @@ export default async function ExplorerDetailPage({
   const clientFactory = await createServerApiFactory();
   const explorerClient = clientFactory.getExplorerClient();
 
+  // The test set name lookup only needs `identifier`, so it fetches
+  // alongside the tree/topics instead of waiting behind them. A failure
+  // here fails open to the identifier as a fallback name, same as before.
+  const testSetsClient = clientFactory.getTestSetsClient();
+  const testSetNamePromise = testSetsClient
+    .getTestSet(identifier)
+    .then(testSet => testSet.name || identifier)
+    .catch(error => {
+      notFoundIfEntityMissing(error);
+      return identifier;
+    });
+
   try {
-    const [treeNodes, topics] = await Promise.all([
+    const [treeNodes, topics, testSetName] = await Promise.all([
       explorerClient.getTree(identifier),
       explorerClient.getTopics(identifier),
+      testSetNamePromise,
     ]);
 
     const tests = treeNodes.filter(node => node.label !== 'topic_marker');
-
-    let testSetName = identifier;
-    try {
-      const testSetsClient = clientFactory.getTestSetsClient();
-      const testSet = await testSetsClient.getTestSet(identifier);
-      testSetName = testSet.name || identifier;
-    } catch (error) {
-      notFoundIfEntityMissing(error);
-    }
 
     return (
       <ExplorerDetail

--- a/apps/frontend/src/app/(protected)/explorer/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/[identifier]/page.tsx
@@ -22,9 +22,7 @@ export default async function ExplorerDetailPage({
   const clientFactory = await createServerApiFactory();
   const explorerClient = clientFactory.getExplorerClient();
 
-  // The test set name lookup only needs `identifier`, so it fetches
-  // alongside the tree/topics instead of waiting behind them. A failure
-  // here fails open to the identifier as a fallback name, same as before.
+  // Only needs `identifier`; fails open to the identifier as a fallback name.
   const testSetsClient = clientFactory.getTestSetsClient();
   const testSetNamePromise = testSetsClient
     .getTestSet(identifier)

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
@@ -32,22 +32,23 @@ export default async function ProjectEndpointPage({ params }: PageProps) {
 
   const factory = await createServerApiFactory();
 
-  let endpoint: Endpoint;
-  try {
-    endpoint = await factory.getEndpointsClient().getEndpoint(endpointId);
-  } catch (error) {
-    notFoundIfEntityMissing(error);
-    throw error;
+  // `project` is looked up from the route param, not from `endpoint`, so it
+  // can fetch alongside the endpoint instead of waiting behind it.
+  const [endpointResult, projectResult] = await Promise.allSettled([
+    factory.getEndpointsClient().getEndpoint(endpointId),
+    factory.getProjectsClient().getProject(identifier),
+  ]);
+
+  if (endpointResult.status === 'rejected') {
+    notFoundIfEntityMissing(endpointResult.reason);
+    throw endpointResult.reason;
   }
+  const endpoint: Endpoint = endpointResult.value;
 
   // The project only feeds breadcrumbs, so a failure here falls back to the
   // client fetch instead of failing the page.
-  let project: Project | undefined;
-  try {
-    project = await factory.getProjectsClient().getProject(identifier);
-  } catch {
-    project = undefined;
-  }
+  const project: Project | undefined =
+    projectResult.status === 'fulfilled' ? projectResult.value : undefined;
 
   return (
     <ProjectEndpointDetailPageClient

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
@@ -32,8 +32,7 @@ export default async function ProjectEndpointPage({ params }: PageProps) {
 
   const factory = await createServerApiFactory();
 
-  // `project` is looked up from the route param, not from `endpoint`, so it
-  // can fetch alongside the endpoint instead of waiting behind it.
+  // `project` is looked up from the route param, not from `endpoint`.
   const [endpointResult, projectResult] = await Promise.allSettled([
     factory.getEndpointsClient().getEndpoint(endpointId),
     factory.getProjectsClient().getProject(identifier),

--- a/apps/frontend/src/app/(protected)/requirements/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/requirements/[identifier]/page.tsx
@@ -40,6 +40,13 @@ export default async function RequirementDetailPage({ params }: PageProps) {
   const apiFactory = await createServerApiFactory();
   const client = apiFactory.getRequirementClient();
 
+  // Linked Tests tab; Linked Metrics already arrive on the requirement. This
+  // only needs `identifier`, so it fetches alongside the requirement instead
+  // of waiting behind it.
+  const linkedTestsPromise = prefetch(Capability.Test.READ, () =>
+    fetchRequirementLinkedTests(apiFactory, identifier)
+  );
+
   let requirement;
   try {
     requirement = await client.getRequirementWithMetrics(identifier as UUID);
@@ -50,10 +57,7 @@ export default async function RequirementDetailPage({ params }: PageProps) {
 
   const serializedRequirement = JSON.parse(JSON.stringify(requirement));
 
-  // Linked Tests tab; Linked Metrics already arrive on the requirement.
-  const linkedTests = await prefetch(Capability.Test.READ, () =>
-    fetchRequirementLinkedTests(apiFactory, identifier)
-  );
+  const linkedTests = await linkedTestsPromise;
 
   return (
     <RequirementDetailClient

--- a/apps/frontend/src/app/(protected)/requirements/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/requirements/[identifier]/page.tsx
@@ -40,9 +40,8 @@ export default async function RequirementDetailPage({ params }: PageProps) {
   const apiFactory = await createServerApiFactory();
   const client = apiFactory.getRequirementClient();
 
-  // Linked Tests tab; Linked Metrics already arrive on the requirement. This
-  // only needs `identifier`, so it fetches alongside the requirement instead
-  // of waiting behind it.
+  // Linked Tests tab; Linked Metrics already arrive on the requirement.
+  // Only needs `identifier`, not the requirement itself.
   const linkedTestsPromise = prefetch(Capability.Test.READ, () =>
     fetchRequirementLinkedTests(apiFactory, identifier)
   );

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
@@ -21,9 +21,7 @@ export default async function TaskDetailPage({ params }: PageProps) {
   const apiFactory = await createServerApiFactory();
   const client = apiFactory.getTasksClient();
 
-  // Comments tab, so it opens with content in place. This only needs
-  // `identifier`, so it fetches alongside the task instead of waiting
-  // behind it.
+  // Comments tab; only needs `identifier`, not the task itself.
   const commentsPromise = prefetch(Capability.Comment.READ, () =>
     apiFactory.getCommentsClient().getComments('Task', identifier)
   );

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
@@ -21,6 +21,13 @@ export default async function TaskDetailPage({ params }: PageProps) {
   const apiFactory = await createServerApiFactory();
   const client = apiFactory.getTasksClient();
 
+  // Comments tab, so it opens with content in place. This only needs
+  // `identifier`, so it fetches alongside the task instead of waiting
+  // behind it.
+  const commentsPromise = prefetch(Capability.Comment.READ, () =>
+    apiFactory.getCommentsClient().getComments('Task', identifier)
+  );
+
   let task;
   try {
     task = await client.getTask(identifier);
@@ -29,10 +36,7 @@ export default async function TaskDetailPage({ params }: PageProps) {
     throw error;
   }
 
-  // Comments tab, so it opens with content in place.
-  const comments = await prefetch(Capability.Comment.READ, () =>
-    apiFactory.getCommentsClient().getComments('Task', identifier)
-  );
+  const comments = await commentsPromise;
 
   return (
     <TaskDetailClient

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
@@ -56,11 +56,8 @@ export default async function TestRunPage({
   const apiFactory = await createServerApiFactory();
   const testRunsClient = apiFactory.getTestRunsClient();
 
-  // Results for the Summary/Test Cases tabs (small runs only) and page 1 of
-  // this run's traces only need `identifier` (and the active-project cookie,
-  // which is free to read), so they fetch alongside `getTestRun` instead of
-  // waiting behind it. Only the "can compare" check genuinely needs the
-  // fetched test run (its test set id).
+  // Test results and traces only need `identifier`; only "can compare"
+  // needs the fetched test run's test set id.
   const scopedProjectId = (await getServerActiveProjectId()) ?? null;
   const tracesDescriptor = tracesList(scopedProjectId, apiFactory);
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
@@ -56,6 +56,34 @@ export default async function TestRunPage({
   const apiFactory = await createServerApiFactory();
   const testRunsClient = apiFactory.getTestRunsClient();
 
+  // Results for the Summary/Test Cases tabs (small runs only) and page 1 of
+  // this run's traces only need `identifier` (and the active-project cookie,
+  // which is free to read), so they fetch alongside `getTestRun` instead of
+  // waiting behind it. Only the "can compare" check genuinely needs the
+  // fetched test run (its test set id).
+  const scopedProjectId = (await getServerActiveProjectId()) ?? null;
+  const tracesDescriptor = tracesList(scopedProjectId, apiFactory);
+
+  const testResultsPromise = prefetch(Capability.TestResult.READ, () =>
+    fetchSmallTestRunResults(apiFactory, identifier)
+  );
+  const tracesPagePromise = scopedProjectId
+    ? prefetchList(tracesDescriptor.capability, () =>
+        tracesDescriptor.list(
+          apiFactory,
+          listParams(tracesDescriptor, {
+            page: 1,
+            pageSize: tracesDescriptor.defaultPageSize,
+            sort: tracesDescriptor.defaultSort,
+            filters: {
+              ...emptyFilters(tracesDescriptor),
+              testRunId: identifier,
+            },
+          })
+        )
+      )
+    : Promise.resolve({ initialData: undefined, initialTotalCount: 0 });
+
   let testRun;
   try {
     testRun = await testRunsClient.getTestRun(identifier);
@@ -64,39 +92,16 @@ export default async function TestRunPage({
     throw error;
   }
 
-  // Results for the Summary/Test Cases tabs (small runs only), the "can
-  // compare" check, and page 1 of this run's traces -- so all three tabs
-  // open with their real content (or empty state) instead of a grid
-  // skeleton that flips to empty a moment later.
   const testSetId = testRun.test_configuration?.test_set?.id;
-  const scopedProjectId = (await getServerActiveProjectId()) ?? null;
-  const tracesDescriptor = tracesList(scopedProjectId, apiFactory);
 
   const [testResults, hasComparisonRuns, tracesPage] = await Promise.all([
-    prefetch(Capability.TestResult.READ, () =>
-      fetchSmallTestRunResults(apiFactory, identifier)
-    ),
+    testResultsPromise,
     testSetId
       ? prefetch(Capability.TestRun.READ, () =>
           hasOtherRunsForTestSet(apiFactory, testSetId, identifier)
         )
       : Promise.resolve(false),
-    scopedProjectId
-      ? prefetchList(tracesDescriptor.capability, () =>
-          tracesDescriptor.list(
-            apiFactory,
-            listParams(tracesDescriptor, {
-              page: 1,
-              pageSize: tracesDescriptor.defaultPageSize,
-              sort: tracesDescriptor.defaultSort,
-              filters: {
-                ...emptyFilters(tracesDescriptor),
-                testRunId: identifier,
-              },
-            })
-          )
-        )
-      : Promise.resolve({ initialData: undefined, initialTotalCount: 0 }),
+    tracesPagePromise,
   ]);
 
   // PageLayout is rendered by TestRunMainView, not here: its title carries a

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/page.tsx
@@ -46,10 +46,8 @@ export default async function TestSetPage({ params }: PageProps) {
   const apiFactory = await createServerApiFactory();
   const testSetsClient = apiFactory.getTestSetsClient();
 
-  // First pages of the Tests and Tasks tabs, so they render with rows in
-  // place instead of a client-side spinner. The tests total doubles as the
-  // header count. These only need `identifier`, so they fetch alongside
-  // `getTestSet` instead of waiting behind it.
+  // First pages of the Tests and Tasks tabs; the tests total doubles as the
+  // header count. Only needs `identifier`, not `testSet`.
   const linkedTests = testSetTestsList(identifier);
   const tasks = entityTasksList('TestSet', identifier);
   const tabsPromise = Promise.all([

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/page.tsx
@@ -46,6 +46,24 @@ export default async function TestSetPage({ params }: PageProps) {
   const apiFactory = await createServerApiFactory();
   const testSetsClient = apiFactory.getTestSetsClient();
 
+  // First pages of the Tests and Tasks tabs, so they render with rows in
+  // place instead of a client-side spinner. The tests total doubles as the
+  // header count. These only need `identifier`, so they fetch alongside
+  // `getTestSet` instead of waiting behind it.
+  const linkedTests = testSetTestsList(identifier);
+  const tasks = entityTasksList('TestSet', identifier);
+  const tabsPromise = Promise.all([
+    prefetchList(linkedTests.capability, () =>
+      linkedTests.list(apiFactory, firstPageParams(linkedTests))
+    ),
+    prefetchList(tasks.capability, () =>
+      tasks.list(apiFactory, firstPageParams(tasks))
+    ),
+    prefetch(Capability.Comment.READ, () =>
+      apiFactory.getCommentsClient().getComments('TestSet', identifier)
+    ),
+  ]);
+
   let testSet;
   try {
     testSet = await testSetsClient.getTestSet(identifier);
@@ -66,22 +84,7 @@ export default async function TestSetPage({ params }: PageProps) {
     }
   }
 
-  // First pages of the Tests and Tasks tabs, so they render with rows in
-  // place instead of a client-side spinner. The tests total doubles as the
-  // header count.
-  const linkedTests = testSetTestsList(identifier);
-  const tasks = entityTasksList('TestSet', identifier);
-  const [testsPage, tasksPage, comments] = await Promise.all([
-    prefetchList(linkedTests.capability, () =>
-      linkedTests.list(apiFactory, firstPageParams(linkedTests))
-    ),
-    prefetchList(tasks.capability, () =>
-      tasks.list(apiFactory, firstPageParams(tasks))
-    ),
-    prefetch(Capability.Comment.READ, () =>
-      apiFactory.getCommentsClient().getComments('TestSet', identifier)
-    ),
-  ]);
+  const [testsPage, tasksPage, comments] = await tabsPromise;
   const testCount =
     testsPage.initialData !== undefined
       ? testsPage.initialTotalCount

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/page.tsx
@@ -52,6 +52,26 @@ export default async function TestDetailPage({ params }: PageProps) {
   const promptsClient = apiFactory.getPromptsClient();
   const { identifier } = await params;
 
+  // First pages of the Linked Test Sets and Tasks tabs, so they open with
+  // rows in place instead of a spinner. These only need `identifier`, so
+  // they fetch alongside `getTest` instead of waiting behind it.
+  const linkedTestSets = linkedTestSetsList(identifier);
+  const tasks = entityTasksList('Test', identifier);
+  const tabsPromise = Promise.all([
+    prefetchList(linkedTestSets.capability, () =>
+      linkedTestSets.list(apiFactory, firstPageParams(linkedTestSets))
+    ),
+    prefetchList(tasks.capability, () =>
+      tasks.list(apiFactory, firstPageParams(tasks))
+    ),
+    prefetch(Capability.Comment.READ, () =>
+      apiFactory.getCommentsClient().getComments('Test', identifier)
+    ),
+    prefetch(Capability.TestResult.READ, () =>
+      fetchTestExecutionHistory(apiFactory, identifier)
+    ),
+  ]);
+
   let test;
   try {
     test = await testsClient.getTest(identifier);
@@ -75,25 +95,8 @@ export default async function TestDetailPage({ params }: PageProps) {
     content = test.prompt?.content || '';
   }
 
-  // First pages of the Linked Test Sets and Tasks tabs, so they open with
-  // rows in place instead of a spinner.
-  const linkedTestSets = linkedTestSetsList(identifier);
-  const tasks = entityTasksList('Test', identifier);
   const [linkedTestSetsPage, tasksPage, comments, executionHistory] =
-    await Promise.all([
-      prefetchList(linkedTestSets.capability, () =>
-        linkedTestSets.list(apiFactory, firstPageParams(linkedTestSets))
-      ),
-      prefetchList(tasks.capability, () =>
-        tasks.list(apiFactory, firstPageParams(tasks))
-      ),
-      prefetch(Capability.Comment.READ, () =>
-        apiFactory.getCommentsClient().getComments('Test', identifier)
-      ),
-      prefetch(Capability.TestResult.READ, () =>
-        fetchTestExecutionHistory(apiFactory, identifier)
-      ),
-    ]);
+    await tabsPromise;
 
   const title = content
     ? content.length > 45

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/page.tsx
@@ -52,9 +52,8 @@ export default async function TestDetailPage({ params }: PageProps) {
   const promptsClient = apiFactory.getPromptsClient();
   const { identifier } = await params;
 
-  // First pages of the Linked Test Sets and Tasks tabs, so they open with
-  // rows in place instead of a spinner. These only need `identifier`, so
-  // they fetch alongside `getTest` instead of waiting behind it.
+  // First pages of the Linked Test Sets and Tasks tabs; only need
+  // `identifier`, not `test`.
   const linkedTestSets = linkedTestSetsList(identifier);
   const tasks = entityTasksList('Test', identifier);
   const tabsPromise = Promise.all([


### PR DESCRIPTION
## Purpose

Several server-rendered detail pages fetched their main entity, then only afterward started prefetching a tab's sub-resource data — even though that sub-resource fetch only needed the route identifier, not anything returned by the entity fetch. This waterfall adds an unnecessary network round-trip to first paint on each of these pages.

## What Changed

- `experiments/[identifier]`: the runs prefetch now starts alongside `getExperiment` instead of waiting behind it plus `getSchema`/`getEnvironments`.
- `requirements/[identifier]`: the linked-tests prefetch now starts alongside the requirement fetch.
- `tasks/[identifier]`: the comments prefetch now starts alongside the task fetch.
- `projects/[identifier]/endpoints/[endpointId]`: the endpoint and project fetches now run concurrently via `Promise.allSettled` — the project was always keyed off the route param, never the endpoint.
- `test-runs/[identifier]`: the test results and traces-page prefetches now start alongside `getTestRun`; only the  compare" check still waits, since it genuinely needs the fetched run's test set id.
- `test-sets/[identifier]`, `tests/[identifier]`: the tab prefetches (tests/tasks/comments/execution history) now start alongside the entity fetch and its dependent lookup (type lookup / prompt), instead of after both.
- `explorer/[identifier]`: the test set name lookup now starts alongside the tree/topics fetch, keeping its original fail-open fallback to the identifier on error.

## Additional Context

- Every prefetch helper here already fails open (returns `undefined`/a fallback on error), so parallelizing introduces no new failure mode — the only trade-off is a wted backend call if the entity fetch 404s, which was already true for pages that used `Promise.all`.
- Left `test-runs/[identifier]/compare` alone. Its fetch chain needs a larger restructuring (a sequential paginated results loop) that's riskier to fold into this PR.

## Testing

- `npx tsc --noEmit`, `npx eslint`, and `npx prettier --check` pass on all changed files.
- Manually checked on the browser (locally).
