### PR TITLE
fix(frontend): distinguish editable fields from read-only in dark mode

### DIFF
--- a/apps/frontend/src/components/common/EditableField.tsx
+++ b/apps/frontend/src/components/common/EditableField.tsx
@@ -2,7 +2,10 @@
 
 import React from 'react';
 import { TextField, type TextFieldProps } from '@mui/material';
-import { readOnlyOutlinedFieldSx } from '@/components/common/drawerFormFieldSx';
+import {
+  editableOutlinedFieldSx,
+  readOnlyOutlinedFieldSx,
+} from '@/components/common/drawerFormFieldSx';
 
 export type EditableFieldProps = Omit<TextFieldProps, 'slotProps'> & {
   editing: boolean;
@@ -27,7 +30,7 @@ export default function EditableField({
       }}
       sx={[
         ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
-        ...(!editing ? [readOnlyOutlinedFieldSx] : []),
+        ...(!editing ? [readOnlyOutlinedFieldSx] : [editableOutlinedFieldSx]),
       ]}
     />
   );

--- a/apps/frontend/src/components/common/drawerFormFieldSx.ts
+++ b/apps/frontend/src/components/common/drawerFormFieldSx.ts
@@ -78,6 +78,13 @@ export const drawerOutlinedFieldSx: SxProps<Theme> = {
   },
 };
 
+/** Editable outlined field: transparent background so the border stands out against the card surface. */
+export const editableOutlinedFieldSx: SxProps<Theme> = {
+  '& .MuiOutlinedInput-root': {
+    backgroundColor: 'transparent',
+  },
+};
+
 /** Read-only outlined field: filled background, no border. */
 export const readOnlyOutlinedFieldSx: SxProps<Theme> = {
   '& .MuiOutlinedInput-notchedOutline': {


### PR DESCRIPTION
## Summary

- In dark mode, `EditableField` text fields looked identical in read and edit mode because the global theme applies the same `fieldSurface` background to all outlined inputs, and the border color (`#30363d`) has near-zero contrast against that fill (`#2a2e36`).
- Added `editableOutlinedFieldSx` that sets `backgroundColor: transparent` on the input root when in edit mode, so the card surface shows through and the outlined border becomes visible.
- Read mode keeps the filled background with no border (unchanged).

## Test plan

- [ ] Open Settings > Personal Information in dark mode
- [ ] Confirm read mode fields show a subtle fill with no border
- [ ] Click Edit and confirm fields now show a visible outlined border against the darker card surface
- [ ] Verify light mode still looks correct (no visual regression)
- [ ] Check the change-password drawer fields are unaffected