### PR TITLE
refactor(frontend): dedupe first-page params across list pages

### DIFF
--- a/apps/frontend/src/app/(protected)/annotations/page.tsx
+++ b/apps/frontend/src/app/(protected)/annotations/page.tsx
@@ -15,8 +15,7 @@ export default async function AnnotationsPage() {
 
   const { initialData, initialTotalCount } = await prefetchList(
     annotationsList.capability,
-    () =>
-      annotationsList.list(factory, firstPageParams(annotationsList))
+    () => annotationsList.list(factory, firstPageParams(annotationsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/annotations/page.tsx
+++ b/apps/frontend/src/app/(protected)/annotations/page.tsx
@@ -1,6 +1,6 @@
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { emptyFilters, listParams } from '@/utils/list';
+import { firstPageParams } from '@/utils/list';
 import AnnotationsPageClient from './components/AnnotationsPageClient';
 import { annotationsList } from './components/list';
 
@@ -16,15 +16,7 @@ export default async function AnnotationsPage() {
   const { initialData, initialTotalCount } = await prefetchList(
     annotationsList.capability,
     () =>
-      annotationsList.list(
-        factory,
-        listParams(annotationsList, {
-          page: 1,
-          pageSize: annotationsList.defaultPageSize,
-          sort: annotationsList.defaultSort,
-          filters: emptyFilters(annotationsList),
-        })
-      )
+      annotationsList.list(factory, firstPageParams(annotationsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/endpoints/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/page.tsx
@@ -15,8 +15,7 @@ export default async function EndpointsPage() {
 
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Endpoint.READ,
-    () =>
-      client.getEndpoints(firstPageParams(endpointsList))
+    () => client.getEndpoints(firstPageParams(endpointsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/endpoints/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/page.tsx
@@ -1,6 +1,6 @@
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { emptyFilters, listParams } from '@/utils/list';
+import { firstPageParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
 import EndpointsPageClient from './components/EndpointsPageClient';
 import { endpointsList } from './components/list';
@@ -16,14 +16,7 @@ export default async function EndpointsPage() {
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Endpoint.READ,
     () =>
-      client.getEndpoints(
-        listParams(endpointsList, {
-          page: 1,
-          pageSize: endpointsList.defaultPageSize,
-          sort: endpointsList.defaultSort,
-          filters: emptyFilters(endpointsList),
-        })
-      )
+      client.getEndpoints(firstPageParams(endpointsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/experiments/page.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/page.tsx
@@ -39,8 +39,7 @@ export default async function ExperimentsPage() {
 
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Experiment.READ,
-    () =>
-      experimentsList.list(factory, firstPageParams(experimentsList))
+    () => experimentsList.list(factory, firstPageParams(experimentsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/experiments/page.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/page.tsx
@@ -5,7 +5,7 @@ import { Alert, Paper } from '@mui/material';
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { emptyFilters, listParams } from '@/utils/list';
+import { firstPageParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
 import ExperimentsClientWrapper from './components/ExperimentsClientWrapper';
 import { experimentsList } from './components/list';
@@ -40,15 +40,7 @@ export default async function ExperimentsPage() {
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Experiment.READ,
     () =>
-      experimentsList.list(
-        factory,
-        listParams(experimentsList, {
-          page: 1,
-          pageSize: experimentsList.defaultPageSize,
-          sort: experimentsList.defaultSort,
-          filters: emptyFilters(experimentsList),
-        })
-      )
+      experimentsList.list(factory, firstPageParams(experimentsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/explorer/page.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/page.tsx
@@ -15,8 +15,7 @@ export default async function ExplorerPage() {
 
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Explorer.READ,
-    () =>
-      client.getExplorerTestSets(firstPageParams(explorerList))
+    () => client.getExplorerTestSets(firstPageParams(explorerList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/explorer/page.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/page.tsx
@@ -1,6 +1,6 @@
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { emptyFilters, listParams } from '@/utils/list';
+import { firstPageParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
 import ExplorerClient from './ExplorerClient';
 import { explorerList } from './components/list';
@@ -16,14 +16,7 @@ export default async function ExplorerPage() {
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Explorer.READ,
     () =>
-      client.getExplorerTestSets(
-        listParams(explorerList, {
-          page: 1,
-          pageSize: explorerList.defaultPageSize,
-          sort: explorerList.defaultSort,
-          filters: emptyFilters(explorerList),
-        })
-      )
+      client.getExplorerTestSets(firstPageParams(explorerList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/jobs/page.tsx
+++ b/apps/frontend/src/app/(protected)/jobs/page.tsx
@@ -14,8 +14,7 @@ export default async function JobsPage() {
 
   const { initialData, initialTotalCount } = await prefetchList(
     jobsList.capability,
-    () =>
-      jobsList.list(factory, firstPageParams(jobsList))
+    () => jobsList.list(factory, firstPageParams(jobsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/jobs/page.tsx
+++ b/apps/frontend/src/app/(protected)/jobs/page.tsx
@@ -1,6 +1,6 @@
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { emptyFilters, listParams } from '@/utils/list';
+import { firstPageParams } from '@/utils/list';
 import JobsPageClient from './components/JobsPageClient';
 import { jobsList } from './components/list';
 
@@ -15,15 +15,7 @@ export default async function JobsPage() {
   const { initialData, initialTotalCount } = await prefetchList(
     jobsList.capability,
     () =>
-      jobsList.list(
-        factory,
-        listParams(jobsList, {
-          page: 1,
-          pageSize: jobsList.defaultPageSize,
-          sort: jobsList.defaultSort,
-          filters: emptyFilters(jobsList),
-        })
-      )
+      jobsList.list(factory, firstPageParams(jobsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/knowledge/page.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/page.tsx
@@ -31,8 +31,7 @@ export default async function KnowledgePage() {
 
     const { initialData, initialTotalCount } = await prefetchList(
       Capability.Source.READ,
-      () =>
-        sourcesList.list(factory, firstPageParams(sourcesList))
+      () => sourcesList.list(factory, firstPageParams(sourcesList))
     );
 
     return (

--- a/apps/frontend/src/app/(protected)/knowledge/page.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/page.tsx
@@ -3,7 +3,7 @@ export const dynamic = 'force-dynamic';
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { emptyFilters, listParams } from '@/utils/list';
+import { firstPageParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
 import KnowledgeClientWrapper from './components/KnowledgeClientWrapper';
 import { sourcesList } from './components/list';
@@ -32,15 +32,7 @@ export default async function KnowledgePage() {
     const { initialData, initialTotalCount } = await prefetchList(
       Capability.Source.READ,
       () =>
-        sourcesList.list(
-          factory,
-          listParams(sourcesList, {
-            page: 1,
-            pageSize: sourcesList.defaultPageSize,
-            sort: sourcesList.defaultSort,
-            filters: emptyFilters(sourcesList),
-          })
-        )
+        sourcesList.list(factory, firstPageParams(sourcesList))
     );
 
     return (

--- a/apps/frontend/src/app/(protected)/metrics/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/page.tsx
@@ -24,8 +24,7 @@ export default async function MetricsPage() {
 
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Metric.READ,
-    () =>
-      client.getMetrics(firstPageParams(metricsList))
+    () => client.getMetrics(firstPageParams(metricsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/metrics/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { emptyFilters, listParams } from '@/utils/list';
+import { firstPageParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
 import MetricsClientComponent from './components/MetricsClient';
 import type { UUID } from 'crypto';
@@ -25,14 +25,7 @@ export default async function MetricsPage() {
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Metric.READ,
     () =>
-      client.getMetrics(
-        listParams(metricsList, {
-          page: 1,
-          pageSize: metricsList.defaultPageSize,
-          sort: metricsList.defaultSort,
-          filters: emptyFilters(metricsList),
-        })
-      )
+      client.getMetrics(firstPageParams(metricsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/requirements/page.tsx
+++ b/apps/frontend/src/app/(protected)/requirements/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { emptyFilters, listParams } from '@/utils/list';
+import { firstPageParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
 import RequirementsClient from './components/RequirementsClient';
 import { requirementsList } from './components/list';
@@ -26,14 +26,7 @@ export default async function RequirementsPage() {
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Requirement.READ,
     () =>
-      client.getRequirementsPage(
-        listParams(requirementsList, {
-          page: 1,
-          pageSize: requirementsList.defaultPageSize,
-          sort: requirementsList.defaultSort,
-          filters: emptyFilters(requirementsList),
-        })
-      )
+      client.getRequirementsPage(firstPageParams(requirementsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/requirements/page.tsx
+++ b/apps/frontend/src/app/(protected)/requirements/page.tsx
@@ -25,8 +25,7 @@ export default async function RequirementsPage() {
 
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Requirement.READ,
-    () =>
-      client.getRequirementsPage(firstPageParams(requirementsList))
+    () => client.getRequirementsPage(firstPageParams(requirementsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/tasks/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/page.tsx
@@ -15,8 +15,7 @@ export default async function TasksPage() {
 
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Task.READ,
-    () =>
-      tasksList.list(factory, firstPageParams(tasksList))
+    () => tasksList.list(factory, firstPageParams(tasksList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/tasks/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/page.tsx
@@ -1,6 +1,6 @@
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { emptyFilters, listParams } from '@/utils/list';
+import { firstPageParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
 import TasksPageClient from './components/TasksPageClient';
 import { tasksList } from './components/list';
@@ -16,15 +16,7 @@ export default async function TasksPage() {
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Task.READ,
     () =>
-      tasksList.list(
-        factory,
-        listParams(tasksList, {
-          page: 1,
-          pageSize: tasksList.defaultPageSize,
-          sort: tasksList.defaultSort,
-          filters: emptyFilters(tasksList),
-        })
-      )
+      tasksList.list(factory, firstPageParams(tasksList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/test-runs/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/page.tsx
@@ -15,8 +15,7 @@ export default async function TestRunsPage() {
 
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.TestRun.READ,
-    () =>
-      testRunsList.list(factory, firstPageParams(testRunsList))
+    () => testRunsList.list(factory, firstPageParams(testRunsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/test-runs/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/page.tsx
@@ -1,6 +1,6 @@
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { emptyFilters, listParams } from '@/utils/list';
+import { firstPageParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
 import TestRunsPageClient from './components/TestRunsPageClient';
 import { testRunsList } from './components/list';
@@ -16,15 +16,7 @@ export default async function TestRunsPage() {
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.TestRun.READ,
     () =>
-      testRunsList.list(
-        factory,
-        listParams(testRunsList, {
-          page: 1,
-          pageSize: testRunsList.defaultPageSize,
-          sort: testRunsList.defaultSort,
-          filters: emptyFilters(testRunsList),
-        })
-      )
+      testRunsList.list(factory, firstPageParams(testRunsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/test-sets/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/page.tsx
@@ -15,8 +15,7 @@ export default async function TestSetsPage() {
 
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.TestSet.READ,
-    () =>
-      testSetsList.list(factory, firstPageParams(testSetsList))
+    () => testSetsList.list(factory, firstPageParams(testSetsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/test-sets/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/page.tsx
@@ -1,6 +1,6 @@
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { emptyFilters, listParams } from '@/utils/list';
+import { firstPageParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
 import TestSetsPageClient from './components/TestSetsPageClient';
 import { testSetsList } from './components/list';
@@ -16,15 +16,7 @@ export default async function TestSetsPage() {
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.TestSet.READ,
     () =>
-      testSetsList.list(
-        factory,
-        listParams(testSetsList, {
-          page: 1,
-          pageSize: testSetsList.defaultPageSize,
-          sort: testSetsList.defaultSort,
-          filters: emptyFilters(testSetsList),
-        })
-      )
+      testSetsList.list(factory, firstPageParams(testSetsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/tests/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/page.tsx
@@ -1,6 +1,6 @@
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { emptyFilters, listParams } from '@/utils/list';
+import { firstPageParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
 import { parseInsightsFailedTestsSearchParams } from '@/app/(protected)/insights/utils/insights-failed-tests';
 import TestsPageClient from './components/TestsPageClient';
@@ -38,15 +38,7 @@ export default async function TestsPage({ searchParams }: TestsPageProps) {
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Test.READ,
     () =>
-      testsList.list(
-        factory,
-        listParams(testsList, {
-          page: 1,
-          pageSize: testsList.defaultPageSize,
-          sort: testsList.defaultSort,
-          filters: emptyFilters(testsList),
-        })
-      )
+      testsList.list(factory, firstPageParams(testsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/tests/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/page.tsx
@@ -37,8 +37,7 @@ export default async function TestsPage({ searchParams }: TestsPageProps) {
 
   const { initialData, initialTotalCount } = await prefetchList(
     Capability.Test.READ,
-    () =>
-      testsList.list(factory, firstPageParams(testsList))
+    () => testsList.list(factory, firstPageParams(testsList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/tokens/page.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/page.tsx
@@ -3,7 +3,7 @@ import { Alert, Paper } from '@mui/material';
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { emptyFilters, listParams } from '@/utils/list';
+import { firstPageParams } from '@/utils/list';
 import TokensPageClient from './components/TokensPageClient';
 import { tokensList } from './components/list';
 
@@ -33,15 +33,7 @@ export default async function TokensPage() {
   const { initialData, initialTotalCount } = await prefetchList(
     tokensList.capability,
     () =>
-      tokensList.list(
-        factory,
-        listParams(tokensList, {
-          page: 1,
-          pageSize: tokensList.defaultPageSize,
-          sort: tokensList.defaultSort,
-          filters: emptyFilters(tokensList),
-        })
-      )
+      tokensList.list(factory, firstPageParams(tokensList))
   );
 
   return (

--- a/apps/frontend/src/app/(protected)/tokens/page.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/page.tsx
@@ -32,8 +32,7 @@ export default async function TokensPage() {
   const factory = await createServerApiFactory();
   const { initialData, initialTotalCount } = await prefetchList(
     tokensList.capability,
-    () =>
-      tokensList.list(factory, firstPageParams(tokensList))
+    () => tokensList.list(factory, firstPageParams(tokensList))
   );
 
   return (


### PR DESCRIPTION
## Summary
- `utils/list/params.ts` already has `firstPageParams()` for "page 1, default sort, default page size, empty filters" — 13 list pages were inlining that same 6-line object by hand instead of calling it.
- Replaced the inline block with `firstPageParams(descriptor)` in: metrics, test-runs, tasks, endpoints, test-sets, experiments, tests, explorer, requirements, annotations, knowledge, jobs, tokens.
- Dropped the now-unused `listParams`/`emptyFilters` imports in each file.
- Mechanical change, no behavior difference.

## Test plan
- [ ] `npx tsc --noEmit`
- [ ] `npm run lint`
- [ ] Spot-check a couple of the affected pages (e.g. test-runs, tokens) load their first page correctly

