### PR TITLE
Make the platform version the source of truth for backend and frontend

### DIFF
--- a/.github/release
+++ b/.github/release
@@ -4,8 +4,6 @@ Rhesis Platform Release Tool
 
 This script manages releases for individual components and platform-wide releases
 with automatic version bumping, changelog generation, and git tagging.
-
-This is a modular version that imports functionality from the release_tools/ directory.
 """
 
 import sys

--- a/.github/release_tools/__init__.py
+++ b/.github/release_tools/__init__.py
@@ -1,5 +1,3 @@
 """
-Rhesis Platform Release Tool - Modular Components
+Rhesis Platform Release Tool
 """
-
-__version__ = "2.0.0"

--- a/.github/release_tools/cli.py
+++ b/.github/release_tools/cli.py
@@ -8,6 +8,7 @@ import os
 import sys
 from pathlib import Path
 
+from .config import COMPONENTS, follows_platform
 from .processor import ReleaseProcessor
 from .publish import publish_releases
 from .utils import error, find_repository_root
@@ -20,15 +21,15 @@ def create_argument_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  %(prog)s backend --minor frontend --patch sdk --major
-  %(prog)s --dry-run backend --patch frontend --minor platform --major
+  %(prog)s platform --minor sdk --patch
+  %(prog)s --dry-run platform --major polyphemus --minor
   %(prog)s --no-branch sdk --patch  # Skip branch creation
   %(prog)s --publish  # Create tags and GitHub releases from current release branch
   %(prog)s --publish --dry-run  # Preview what would be published
 
 Components:
-  backend, frontend, worker, chatbot, polyphemus, sdk
-  platform (for platform-wide releases)
+  platform (backend and frontend ship with it and take its version)
+  sdk, polyphemus, ee-backend
 
 Version Types:
   --patch   (0.0.X)
@@ -38,7 +39,7 @@ Version Types:
 Publish Mode:
   Use --publish to create git tags and GitHub releases based on the current
   release branch. This will:
-  • Parse component versions from the current release branch
+  • Read each component's version off the release branch
   • Create missing git tags for each component
   • Push tags to remote repository
   • Create GitHub releases (requires gh CLI)
@@ -63,20 +64,31 @@ Publish Mode:
     return parser
 
 
+def bumpable_components() -> list[str]:
+    """Components a release can bump: everything with its own version, plus the platform"""
+    return ["platform"] + [name for name in COMPONENTS if not follows_platform(name)]
+
+
+def reject_platform_followers(component_bumps: dict) -> bool:
+    """Refuse a bump for a component that takes the platform's version.
+
+    release_config.json lives on main, so a stale one can still name backend or frontend.
+    """
+    named = [component for component in component_bumps if follows_platform(component)]
+    if not named:
+        return True
+
+    error(f"These components ship with the platform and cannot be bumped: {', '.join(named)}")
+    error("Bump 'platform' instead - they take its version automatically.")
+    return False
+
+
 def parse_component_arguments(remaining_args: list) -> dict:
     """Parse component arguments from remaining command line arguments"""
     component_bumps = {}
     i = 0
     while i < len(remaining_args):
-        if remaining_args[i] in [
-            "backend",
-            "frontend",
-            "worker",
-            "chatbot",
-            "polyphemus",
-            "sdk",
-            "platform",
-        ]:
+        if remaining_args[i] in bumpable_components():
             component = remaining_args[i]
             if i + 1 < len(remaining_args) and remaining_args[i + 1] in [
                 "--patch",
@@ -90,8 +102,12 @@ def parse_component_arguments(remaining_args: list) -> dict:
                 error(f"Missing version type for component: {component}")
                 error("Must be one of: --patch, --minor, --major")
                 return {}
+        elif follows_platform(remaining_args[i]):
+            reject_platform_followers({remaining_args[i]: ""})
+            return {}
         else:
             error(f"Unknown argument: {remaining_args[i]}")
+            error(f"Must be one of: {', '.join(bumpable_components())}")
             return {}
 
     return component_bumps
@@ -128,6 +144,8 @@ def main():
         bump_config_file = Path(repo_root, bump_config_file)
         with open(bump_config_file, "r") as f:
             component_bumps = json.load(f)
+        if not reject_platform_followers(component_bumps):
+            sys.exit(1)
     else:
         # Handle regular release mode
         component_bumps = parse_component_arguments(remaining)

--- a/.github/release_tools/config.py
+++ b/.github/release_tools/config.py
@@ -8,10 +8,17 @@ from pathlib import PurePosixPath
 class ComponentConfig:
     """Configuration for a component"""
 
-    def __init__(self, config_file: str, config_type: str, changelog_path: str):
+    def __init__(
+        self,
+        config_file: str,
+        config_type: str,
+        changelog_path: str,
+        follows_platform: bool = False,
+    ):
         self.config_file = config_file
         self.config_type = config_type
         self.changelog_path = changelog_path
+        self.follows_platform = follows_platform
 
     @property
     def path(self) -> str:
@@ -24,19 +31,23 @@ class ComponentConfig:
         return str(PurePosixPath(self.config_file).parent)
 
 
-# Component configurations
+# Component configurations.
+#
+# A follows_platform component ships as part of the platform: it takes the platform's version and
+# is covered by the platform's `v<version>` tag, so it is never bumped or tagged on its own. It
+# stays in here because it still keeps its own changelog, scoped to its own directory.
 COMPONENTS = {
     "backend": ComponentConfig(
-        "apps/backend/pyproject.toml", "pyproject", "apps/backend/CHANGELOG.md"
+        "apps/backend/pyproject.toml",
+        "pyproject",
+        "apps/backend/CHANGELOG.md",
+        follows_platform=True,
     ),
     "frontend": ComponentConfig(
-        "apps/frontend/package.json", "package", "apps/frontend/CHANGELOG.md"
-    ),
-    "worker": ComponentConfig(
-        "apps/worker/pyproject.toml", "pyproject", "apps/worker/CHANGELOG.md"
-    ),
-    "chatbot": ComponentConfig(
-        "apps/chatbot/requirements.txt", "requirements", "apps/chatbot/CHANGELOG.md"
+        "apps/frontend/package.json",
+        "package",
+        "apps/frontend/CHANGELOG.md",
+        follows_platform=True,
     ),
     "polyphemus": ComponentConfig(
         "apps/polyphemus/pyproject.toml", "pyproject", "apps/polyphemus/CHANGELOG.md"
@@ -50,6 +61,16 @@ COMPONENTS = {
 # Platform-specific files
 PLATFORM_VERSION_FILE = "VERSION"
 PLATFORM_CHANGELOG = "CHANGELOG.md"
+
+
+def follows_platform(component: str) -> bool:
+    """Whether a component takes the platform's version instead of carrying its own"""
+    return component in COMPONENTS and COMPONENTS[component].follows_platform
+
+
+def platform_followers() -> list[str]:
+    """Components released as part of the platform, in COMPONENTS order"""
+    return [name for name, config in COMPONENTS.items() if config.follows_platform]
 
 
 def get_component_path(component: str) -> str:

--- a/.github/release_tools/git_ops.py
+++ b/.github/release_tools/git_ops.py
@@ -7,13 +7,18 @@ import re
 import subprocess
 from typing import Dict, List, Optional
 
-from .config import get_component_path
+from .config import follows_platform, get_component_path
 from .utils import error, info, success, warn
 
 
 def get_last_tag(component: str) -> Optional[str]:
-    """Get the last git tag for a component"""
-    if component == "platform":
+    """Get the last git tag for a component.
+
+    A platform follower is never tagged on its own, so its release boundary is the platform tag.
+    Matching `{component}-v*` here would keep finding the stale tag from before it followed the
+    platform and hand the changelog several releases' worth of commits.
+    """
+    if component == "platform" or follows_platform(component):
         tag_pattern = "v*"
     else:
         tag_pattern = f"{component}-v*"

--- a/.github/release_tools/processor.py
+++ b/.github/release_tools/processor.py
@@ -13,6 +13,7 @@ from .changelog import (
     update_component_changelog,
     update_platform_changelog,
 )
+from .config import COMPONENTS, platform_followers
 from .git_ops import create_release_branch, get_commits_since_tag, get_last_tag
 from .utils import check_prerequisites, info, log, success, warn
 from .version import bump_version, get_current_version, update_version_file
@@ -52,6 +53,12 @@ class ReleaseProcessor:
             self.dry_run,
         )
 
+    @staticmethod
+    def _in_canonical_order(versions: Dict[str, str]) -> Dict[str, str]:
+        """Reorder versions to COMPONENTS order, platform first"""
+        order = ["platform"] + list(COMPONENTS)
+        return {name: versions[name] for name in order if name in versions}
+
     def process_releases(self) -> bool:
         """Process all releases"""
         log("Starting release process...")
@@ -71,9 +78,24 @@ class ReleaseProcessor:
             version_changes[component] = f"v{current_version} -> v{new_version}"
 
         # Save version changes to a JSON file. This will be used to create the PR title and body in
-        # the create-release.yml workflow.
+        # the create-release.yml workflow. Platform followers are deliberately absent: they carry
+        # the platform's number, so listing them would repeat it once per component.
         with open("/tmp/version_changes.json", "w") as f:
             json.dump(version_changes, f)
+
+        # Platform followers take the platform's version rather than a bump of their own. Added
+        # after version_changes above, and before the second pass below, so they still get their
+        # version file and changelog written like any other component.
+        platform_version = self.component_versions.get("platform")
+        if platform_version:
+            for component in platform_followers():
+                self.component_versions[component] = platform_version
+                info(f"Component: {component} (follows platform)")
+                info(f"  Version: {platform_version}")
+                print()
+            # Canonical order, so the platform changelog's sections don't reshuffle from release to
+            # release depending on which components were bumped
+            self.component_versions = self._in_canonical_order(self.component_versions)
 
         if self.dry_run:
             warn("DRY RUN MODE - No changes will be made")
@@ -89,7 +111,6 @@ class ReleaseProcessor:
                 new_version,
                 self.repo_root,
                 self.dry_run,
-                self.component_bumps,
             ):
                 return False
 
@@ -174,16 +195,5 @@ class ReleaseProcessor:
 
         print()
         success("Release process completed! 🎉")
-
-        if not self.dry_run:
-            print()
-            info("Next steps:")
-            info("1. Review the changes made to version files and changelogs")
-            info(
-                '2. Commit the changes: git add . && git commit -m "Prepare release: <description>"'
-            )
-            info("3. Push and create PR: git push origin $(git branch --show-current)")
-            info("   • Use ./.github/create-pr.sh or ./.github/pr to create the PR")
-            info("4. After PR merge, use --publish to create tags and GitHub releases")
 
         return True

--- a/.github/release_tools/publish.py
+++ b/.github/release_tools/publish.py
@@ -9,7 +9,7 @@ import subprocess
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from .config import COMPONENTS, format_component_name
+from .config import COMPONENTS, follows_platform, format_component_name
 from .utils import error, find_repository_root, info, log, success, warn
 from .version import get_current_version
 
@@ -25,18 +25,18 @@ def get_current_branch() -> Optional[str]:
         return None
 
 
-def get_components_version(branch_name: str, repo_root: Path) -> Dict[str, str]:
-    """Parse component versions from a release branch name"""
+def get_components_version(repo_root: Path) -> Dict[str, str]:
+    """Read the version of every independently taggable component off the working tree"""
     components_versions = {}
 
-    # Check all components for versions different from default
     for component in COMPONENTS.keys():
+        # Platform followers are covered by the platform's own tag, so they get no tag of their own
+        if follows_platform(component):
+            continue
         try:
             current_version = get_current_version(component, repo_root)
-            if current_version and current_version != "0.1.0":
+            if current_version:
                 components_versions[component] = current_version
-            elif current_version == "0.1.0":
-                info(f"Component {component} has default version 0.1.0 - skipping")
         except Exception as e:
             warn(f"Failed to get version for component {component}: {e}")
             warn(f"Skipping component {component} due to version detection failure")
@@ -123,8 +123,9 @@ def get_changelog_content(changelog_path: Path) -> str:
     # (?=\n## \[|\Z)  - stops at next version header or end of file (positive lookahead)
     pattern = r"^## \[([^\]]+)\] - (\d{4}-\d{2}-\d{2})\n(.*?)(?=\n## \[|\Z)"
     match = re.search(pattern, content, re.MULTILINE | re.DOTALL)
-    changelog_content = match.group(3)
-    return changelog_content
+    if not match:
+        raise ValueError(f"{changelog_path} has no '## [version] - date' section to release from")
+    return match.group(3)
 
 
 def create_github_release(
@@ -218,9 +219,9 @@ def publish_releases(repo_root: Path, dry_run: bool = False) -> bool:
 
     info(f"Current branch: {current_branch}")
 
-    # Parse components from branch
+    # Read the versions currently on the release branch
     try:
-        components_version = get_components_version(current_branch, repo_root)
+        components_version = get_components_version(repo_root)
     except Exception as e:
         error(f"Failed to parse release components: {e}")
         return False

--- a/.github/release_tools/version.py
+++ b/.github/release_tools/version.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 
 from .config import COMPONENTS, PLATFORM_VERSION_FILE
-from .utils import error, info, success, warn
+from .utils import error, info, success
 
 
 def get_current_version(component: str, repo_root: Path) -> str:
@@ -30,19 +30,13 @@ def get_current_version(component: str, repo_root: Path) -> str:
     try:
         if config.config_type == "pyproject":
             return _get_pyproject_version(config_path)
-        elif config.config_type == "package":
+        if config.config_type == "package":
             return _get_package_version(config_path)
-        elif config.config_type == "requirements":
-            warn(
-                f"Component {component} uses requirements.txt - "
-                "no version file, using default 0.1.0"
-            )
-            return "0.1.0"  # Default for requirements.txt based components
     except Exception as e:
         error(f"Failed to get version for component {component}: {e}")
         raise
 
-    return "0.1.0"
+    raise ValueError(f"Unknown config type for component {component}: {config.config_type}")
 
 
 def _get_pyproject_version(config_path: Path) -> str:
@@ -107,7 +101,6 @@ def update_version_file(
     new_version: str,
     repo_root: Path,
     dry_run: bool = False,
-    component_bumps: dict[str, str] | None = None,
 ) -> bool:
     """Update version in configuration file"""
     if component == "platform":
@@ -123,16 +116,13 @@ def update_version_file(
     if dry_run:
         info(f"Would update {config.config_file} version to: {new_version}")
         return True
-    bump_type = component_bumps[component]
 
     if config.config_type == "pyproject":
-        return _update_pyproject_version(config_path, bump_type)
-    elif config.config_type == "package":
+        return _update_pyproject_version(config_path, new_version)
+    if config.config_type == "package":
         return _update_package_version(config_path, new_version, repo_root)
-    elif config.config_type == "requirements":
-        info(f"Component {component} uses requirements.txt - version tracked via git tags only")
-        return True
 
+    error(f"Unknown config type for component {component}: {config.config_type}")
     return False
 
 
@@ -148,14 +138,17 @@ def _update_platform_version(new_version: str, repo_root: Path, dry_run: bool) -
     return True
 
 
-def _update_pyproject_version(config_path: Path, bump_type: str) -> bool:
-    """Update version in pyproject.toml"""
+def _update_pyproject_version(config_path: Path, new_version: str) -> bool:
+    """Update version in pyproject.toml.
+
+    Sets the version outright rather than using `uv version --bump`: bump_version has already
+    computed it, and a platform-following component has no bump type of its own.
+    """
     # --color never keeps escape codes out of the stderr we print on failure
     cmd = [
         "uv",
         "version",
-        "--bump",
-        bump_type,
+        new_version,
         "--color",
         "never",
         "--project",

--- a/.github/workflows/set-up-release.yml
+++ b/.github/workflows/set-up-release.yml
@@ -4,25 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       platform_bump:
-        description: 'Platform version bump'
-        required: false
-        type: choice
-        options:
-          - "none"
-          - patch
-          - minor
-          - major
-      backend_bump:
-        description: 'Backend version bump'
-        required: false
-        type: choice
-        options:
-          - "none"
-          - patch
-          - minor
-          - major
-      frontend_bump:
-        description: 'Frontend version bump'
+        description: 'Platform version bump (backend and frontend follow it)'
         required: false
         type: choice
         options:
@@ -80,14 +62,10 @@ jobs:
           # Create JSON using jq 
           jq -n \
             --arg platform "${{ github.event.inputs.platform_bump }}" \
-            --arg backend "${{ github.event.inputs.backend_bump }}" \
-            --arg frontend "${{ github.event.inputs.frontend_bump }}" \
             --arg sdk "${{ github.event.inputs.sdk_bump }}" \
             --arg polyphemus "${{ github.event.inputs.polyphemus_bump }}" \
             '{
               platform: $platform,
-              backend: $backend,
-              frontend: $frontend,
               sdk: $sdk,
               polyphemus: $polyphemus
             } | with_entries(select(.value != "" and .value != "none"))' > release_config.json
@@ -96,12 +74,6 @@ jobs:
           COMMIT_PARTS=()
           if [ -n "${{ github.event.inputs.platform_bump }}" ] && [ "${{ github.event.inputs.platform_bump }}" != "none" ]; then
             COMMIT_PARTS+=("platform - ${{ github.event.inputs.platform_bump }}")
-          fi
-          if [ -n "${{ github.event.inputs.backend_bump }}" ] && [ "${{ github.event.inputs.backend_bump }}" != "none" ]; then
-            COMMIT_PARTS+=("backend - ${{ github.event.inputs.backend_bump }}")
-          fi
-          if [ -n "${{ github.event.inputs.frontend_bump }}" ] && [ "${{ github.event.inputs.frontend_bump }}" != "none" ]; then
-            COMMIT_PARTS+=("frontend - ${{ github.event.inputs.frontend_bump }}")
           fi
           if [ -n "${{ github.event.inputs.sdk_bump }}" ] && [ "${{ github.event.inputs.sdk_bump }}" != "none" ]; then
             COMMIT_PARTS+=("sdk - ${{ github.event.inputs.sdk_bump }}")

--- a/docs/content/contribute/releasing.mdx
+++ b/docs/content/contribute/releasing.mdx
@@ -2,7 +2,7 @@
 
 A Rhesis release is produced by three workflows in the repository's GitHub Actions tab, run in order, followed by a manual merge and a manual production deploy. Each one is triggered by hand — nothing starts a release automatically.
 
-Components are versioned independently and tagged `<component>-v<version>`. The platform is the coordinated snapshot across them, tagged `v<version>` and marked as the latest GitHub release.
+The platform is the coordinated snapshot of the repository, tagged `v<version>` and marked as the latest GitHub release. The backend and the frontend ship as part of it: they take the platform's version and are covered by its tag, though each still keeps its own changelog. The SDK and Polyphemus are versioned independently and tagged `<component>-v<version>`.
 
 <Steps>
 
@@ -10,7 +10,7 @@ Components are versioned independently and tagged `<component>-v<version>`. The 
 
 Run `[Release] 1. Set up release config`.
 
-Choose a bump — `patch`, `minor`, or `major` — for each component going out, and leave everything else on `none`. The workflow records the selection in `release_config.json` and commits it to `main`.
+Choose a bump — `patch`, `minor`, or `major` — for each component going out, and leave everything else on `none`. Bumping the platform also moves the backend and the frontend to the new version, so there is nothing to select for them. The workflow records the selection in `release_config.json` and commits it to `main`.
 
 ### Create the release branch
 
@@ -58,7 +58,7 @@ Publishing tags the release and pushes the packages, but does not deploy product
 
 Publishing sets off several workflows that run independently of each other, so `[Release] 3. Publish` can succeed while one of them fails. After a release, confirm:
 
-- **Tags** — one `<component>-v<version>` per released component, plus `v<version>` for the platform.
+- **Tags** — `v<version>` for the platform, plus one `<component>-v<version>` per independently released component.
 - **GitHub releases** — created from the changelog entries, with the platform release marked as latest.
 - **PyPI** — `rhesis` and `rhesis-sdk` published. This is triggered by the `sdk-v*` tag, not by the publish workflow.
 - **GHCR images** — built from the `v*` platform tag.

--- a/tests/release_tools/test_components.py
+++ b/tests/release_tools/test_components.py
@@ -1,0 +1,132 @@
+"""Tests for which components the release tool releases, and how they get their version.
+
+The backend and the frontend ship with the platform: they take its version and are covered by its
+tag. Everything here pins that down, plus the guard that would have caught the `chatbot` entry
+pointing at a version file that had not existed for a long time.
+"""
+
+import json
+
+import pytest
+from release_tools.cli import bumpable_components, reject_platform_followers
+from release_tools.config import COMPONENTS, follows_platform, platform_followers
+from release_tools.git_ops import get_last_tag
+from release_tools.processor import ReleaseProcessor
+from release_tools.version import _update_package_version
+
+pytestmark = pytest.mark.unit
+
+
+def test_every_component_version_file_exists(repo_root):
+    """`chatbot` pointed at a deleted requirements.txt and was silently skipped every release."""
+    missing = [
+        f"{component} -> {config.config_file}"
+        for component, config in COMPONENTS.items()
+        if not (repo_root / config.config_file).exists()
+    ]
+
+    assert not missing, f"COMPONENTS entries whose version file does not exist: {missing}"
+
+
+def test_every_component_changelog_exists(repo_root):
+    """A component with no changelog cannot be released -- publish reads its notes from one."""
+    missing = [
+        f"{component} -> {config.changelog_path}"
+        for component, config in COMPONENTS.items()
+        if not (repo_root / config.changelog_path).exists()
+    ]
+
+    assert not missing, f"COMPONENTS entries whose changelog does not exist: {missing}"
+
+
+def test_backend_and_frontend_follow_the_platform():
+    assert platform_followers() == ["backend", "frontend"]
+    assert follows_platform("backend")
+    assert follows_platform("frontend")
+    assert not follows_platform("sdk")
+    assert not follows_platform("platform")
+
+
+def test_followers_are_not_bumpable():
+    assert "platform" in bumpable_components()
+    assert "sdk" in bumpable_components()
+    assert "backend" not in bumpable_components()
+    assert "frontend" not in bumpable_components()
+
+
+def test_a_bump_config_naming_a_follower_is_rejected(capsys):
+    """release_config.json lives on main, so a stale one can still name backend."""
+    assert not reject_platform_followers({"platform": "minor", "backend": "minor"})
+
+    out = capsys.readouterr().out
+    assert "backend" in out
+    assert "platform" in out
+
+
+def test_a_bump_config_without_followers_is_accepted():
+    assert reject_platform_followers({"platform": "minor", "sdk": "patch"})
+
+
+def test_a_follower_reads_its_last_tag_from_the_platform(monkeypatch):
+    """Its own `backend-v*` tags stopped moving, so matching them would span several releases."""
+    patterns = []
+
+    def fake_run(cmd, **kwargs):
+        patterns.append(cmd[-1])
+        raise AssertionError("stop after capturing the pattern")
+
+    monkeypatch.setattr("release_tools.git_ops.subprocess.run", fake_run)
+
+    for component in ("backend", "frontend", "platform", "sdk"):
+        with pytest.raises(AssertionError):
+            get_last_tag(component)
+
+    assert patterns == ["v*", "v*", "v*", "sdk-v*"]
+
+
+def test_a_platform_bump_gives_its_followers_the_platform_version(repo_root):
+    processor = ReleaseProcessor(repo_root, dry_run=True, gemini_api_key="", no_branch=True)
+
+    processor.component_bumps = {"platform": "minor"}
+    processor.process_releases()
+
+    platform_version = processor.component_versions["platform"]
+    assert processor.component_versions["backend"] == platform_version
+    assert processor.component_versions["frontend"] == platform_version
+
+    # Canonical order, so the platform changelog's sections don't reshuffle between releases
+    assert list(processor.component_versions) == ["platform", "backend", "frontend"]
+
+
+def test_followers_stay_out_of_the_release_pr_title(repo_root):
+    """They carry the platform's number, so listing them repeats it once per component."""
+    processor = ReleaseProcessor(repo_root, dry_run=True, gemini_api_key="", no_branch=True)
+
+    processor.component_bumps = {"platform": "minor"}
+    processor.process_releases()
+
+    with open("/tmp/version_changes.json") as f:
+        version_changes = json.load(f)
+
+    assert list(version_changes) == ["platform"]
+
+
+def test_a_platform_bump_does_not_touch_independent_components(repo_root):
+    processor = ReleaseProcessor(repo_root, dry_run=True, gemini_api_key="", no_branch=True)
+
+    processor.component_bumps = {"platform": "minor"}
+    processor.process_releases()
+
+    assert "sdk" not in processor.component_versions
+    assert "polyphemus" not in processor.component_versions
+
+
+def test_package_version_is_written_with_a_trailing_newline(tmp_path):
+    """Without it the frontend linter rewrites package.json right after the release tool does."""
+    path = tmp_path / "package.json"
+    path.write_text(json.dumps({"name": "frontend", "version": "0.14.0"}, indent=2) + "\n")
+
+    assert _update_package_version(path, "0.15.0", tmp_path)
+
+    assert json.loads(path.read_text())["version"] == "0.15.0"
+    assert path.read_text().endswith("}\n")


### PR DESCRIPTION
## Purpose

Backend, frontend and platform are three separately releasable components today, each with its own bump input, version file, git tag and GitHub release. They have not diverged since v0.7.0 — every release commit bumps all three to the same number. The independent versioning is bookkeeping that nothing consumes:

- GHCR images are tagged from the `v*` platform tag only. The `backend-v*` and `frontend-v*` tags trigger no workflow at all.
- Per-component k8s deploys are path-keyed and tag images by git SHA, never by version.
- Nothing compares the two versions to each other — no version header, no `/version` contract, and the SDK never inspects the backend version.

The platform now owns the number. Backend and frontend become areas *of* the platform: they share its version and keep their own changelogs, but are no longer independently bumped, tagged or released.

## What Changed

- **`follows_platform` flag** on `ComponentConfig`, set for `backend` and `frontend`. They stay in `COMPONENTS` because that dict drives changelog paths and git-log scoping, and both changelogs are being kept.
- **A platform bump propagates its version** into `apps/backend/pyproject.toml` and `apps/frontend/package.json`, and still generates both component changelogs. Followers are kept out of the release PR title so it doesn't repeat the same number three times.
- **A follower reads its last tag from `v*`**, not `backend-v*`. Without this the *second* release after this change would generate a changelog spanning two releases of commits.
- **No more `backend-v*` / `frontend-v*` tags or GitHub releases.**
- **`uv version <value>` instead of `uv version --bump <type>`**, since a follower has no bump type of its own. This also drops the `component_bumps` threading through `update_version_file`.
- **The two bump inputs are gone** from `[Release] 1. Set up release config`.
- **A stale `release_config.json` naming `backend` is rejected** with a message pointing at `platform` — that file lives on `main`, so it can outlive this change.

Their version fields stay populated, because both are load-bearing: the backend reads its version from installed package metadata for `FastAPI(version=...)`, the OpenAPI description and `GET /`; the frontend reads `package.json` at build time into `APP_VERSION` for the support drawer.

Cleanup of dead config the same code carried:

- **`chatbot` removed** — it pointed at `apps/chatbot/requirements.txt`, which does not exist, so it raised and was skipped on every publish. With it gone, the unused `"requirements"` config type goes too. The chatbot app itself is unaffected; its image builds from the platform tag.
- **`worker` removed** — never tagged, no changelog, version stuck at `0.1.0`.
- **The `!= "0.1.0"` skip heuristic removed** — it existed only for those two, and would silently drop a real component sitting at 0.1.0.
- **Dead `branch_name` parameter** dropped from `get_components_version`, along with a docstring describing something it did not do.
- **The "Next steps" block removed** — it printed on every CI run and told you to publish *after* merging, the opposite of the documented order.
- **`get_changelog_content`** now raises with the file path instead of `AttributeError`.

## Additional Context

- SDK and Polyphemus keep their own independent versions and `<component>-v<version>` tags. Only backend and frontend change.
- `ee-backend` is now reachable positionally (`release ee-backend --patch`) since it is in `COMPONENTS`; it wasn't before. It remains absent from the workflow inputs, so in CI it is still config-file-only. Existing inconsistency, left as-is.
- Not fixed here: `apps/frontend/package-lock.json` is stuck at `0.13.0` while `package.json` says `0.14.0` — the release tool never re-runs `npm install`. Pre-existing and unrelated.
- The root `CHANGELOG.md` still lists `Backend <version>` / `Frontend <version>` under the platform heading. Mildly redundant now, but suppressing it means diverging two loops in `update_platform_changelog` for no real gain.

## Testing

`tests/release_tools/test_components.py` is new — 11 tests covering the follower flag, tag resolution, rejection of a stale config, and the version propagation. It also guards that every `COMPONENTS` entry's version file and changelog exist on disk, which is what would have caught the `chatbot` entry.

```bash
uv run --with pytest --project .github/release_tools pytest tests/release_tools
```

18 passed. Note no CI workflow currently runs this suite.

Verified end to end by running the real tool on this branch (artifacts reverted afterwards):

```bash
echo '{"platform":"minor","sdk":"minor"}' > /tmp/rc.json
python3 .github/release --bump-config-file /tmp/rc.json --no-branch
```

- `VERSION`, `apps/backend/pyproject.toml`, `apps/frontend/package.json` and `sdk/pyproject.toml` all landed on `0.15.0`.
- Backend and frontend changelog sections generated correctly and correctly path-scoped (backend changes in the backend entry, frontend in the frontend entry).
- Root `CHANGELOG.md` got a complete platform section with per-component summaries.
- `get_components_version` returns only `polyphemus`, `sdk`, `ee-backend`, `platform` — no `backend-v*` / `frontend-v*`, and no chatbot or worker warnings.
- An SDK-only release (`{"sdk":"patch"}`) leaves backend and frontend untouched.
- A config naming `backend` exits 1 with the message pointing at `platform`.
