### PR TITLE
Centralize session-guard checks across SSR pages

### DIFF
--- a/apps/frontend/src/app/(protected)/architect/page.tsx
+++ b/apps/frontend/src/app/(protected)/architect/page.tsx
@@ -1,10 +1,10 @@
 import { Metadata } from 'next';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { hasServerCapability } from '@/utils/server-permissions';
 import { Capability } from '@/constants/capabilities';
 import type { ArchitectSession } from '@/utils/api-client/architect-client';
 import ArchitectClient from './components/ArchitectClient';
+import { requireSession } from '@/utils/require-session';
 
 export const metadata: Metadata = {
   title: 'Architect',
@@ -16,11 +16,7 @@ export const metadata: Metadata = {
  * "no initial data" so the client falls back to its own fetch.
  */
 export default async function ArchitectPage() {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('No session token available');
-  }
+  await requireSession();
 
   let initialSessions: ArchitectSession[] | undefined;
   if (await hasServerCapability(Capability.Architect.READ)) {

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/page.tsx
@@ -1,22 +1,18 @@
 import * as React from 'react';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import { isValidEndpointId } from '@/utils/is-valid-endpoint-id';
 import EndpointDetailPageClient from './components/EndpointDetailPageClient';
 import type { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import type { Project } from '@/utils/api-client/interfaces/project';
+import { requireSession } from '@/utils/require-session';
 
 interface PageProps {
   params: Promise<{ identifier: string }>;
 }
 
 export default async function EndpointPage({ params }: PageProps) {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('Authentication required');
-  }
+  await requireSession();
 
   const { identifier } = await params;
 

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/page.tsx
@@ -1,8 +1,6 @@
 export const dynamic = 'force-dynamic';
 
 import * as React from 'react';
-import { Alert, Paper } from '@mui/material';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import ExperimentDetailClient, {
@@ -11,23 +9,14 @@ import ExperimentDetailClient, {
 import { prefetch } from '@/utils/server-prefetch';
 import { Capability } from '@/constants/capabilities';
 import { fetchExperimentRuns } from './components/experiment-data';
+import { requireSession } from '@/utils/require-session';
 
 interface PageProps {
   params: Promise<{ identifier: string }>;
 }
 
 export default async function ExperimentDetailPage({ params }: PageProps) {
-  const session = await auth();
-
-  if (!session || session.error) {
-    return (
-      <Paper sx={{ p: 3 }}>
-        <Alert severity="error">
-          Authentication required. Please sign in to view this experiment.
-        </Alert>
-      </Paper>
-    );
-  }
+  await requireSession();
 
   const { identifier } = await params;
   const apiFactory = await createServerApiFactory();

--- a/apps/frontend/src/app/(protected)/experiments/page.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/page.tsx
@@ -1,14 +1,13 @@
 export const dynamic = 'force-dynamic';
 
 import * as React from 'react';
-import { Alert, Paper } from '@mui/material';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
 import { firstPageParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
 import ExperimentsClientWrapper from './components/ExperimentsClientWrapper';
 import { experimentsList } from './components/list';
+import { requireSession } from '@/utils/require-session';
 
 /**
  * Server-rendered shell for the Experiments index page.
@@ -23,17 +22,7 @@ import { experimentsList } from './components/list';
  * endpoint never returns another user's private experiments.
  */
 export default async function ExperimentsPage() {
-  const session = await auth();
-
-  if (!session || session.error) {
-    return (
-      <Paper sx={{ p: 3 }}>
-        <Alert severity="error">
-          Authentication required. Please sign in to view experiments.
-        </Alert>
-      </Paper>
-    );
-  }
+  await requireSession();
 
   const factory = await createServerApiFactory();
 

--- a/apps/frontend/src/app/(protected)/explorer/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/[identifier]/page.tsx
@@ -1,7 +1,7 @@
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import ExplorerDetail from './components/ExplorerDetail';
+import { requireSession } from '@/utils/require-session';
 
 interface ExplorerDetailPageProps {
   params: Promise<{
@@ -13,11 +13,7 @@ export default async function ExplorerDetailPage({
   params,
 }: ExplorerDetailPageProps) {
   const { identifier } = await params;
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('No session token available');
-  }
+  await requireSession();
 
   const clientFactory = await createServerApiFactory();
   const explorerClient = clientFactory.getExplorerClient();

--- a/apps/frontend/src/app/(protected)/insights/page.tsx
+++ b/apps/frontend/src/app/(protected)/insights/page.tsx
@@ -5,10 +5,10 @@ import {
   QueryClient,
   dehydrate,
 } from '@tanstack/react-query';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { getServerActiveProjectId } from '@/utils/server-active-project';
 import { hasServerCapability } from '@/utils/server-permissions';
+import { requireSession } from '@/utils/require-session';
 import { Capability } from '@/constants/capabilities';
 import { endpointKeys } from '@/constants/query-keys';
 import { INSIGHTS_ENDPOINT_COOKIE } from '@/utils/insights-endpoint';
@@ -37,11 +37,7 @@ const ENDPOINT_LIST_PARAMS = {
  * open to "no initial data" so the client falls back to its own fetches.
  */
 export default async function InsightsRoutePage() {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('No session token available');
-  }
+  await requireSession();
 
   const queryClient = new QueryClient();
   let initialEndpointId: string | undefined;

--- a/apps/frontend/src/app/(protected)/jobs/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/jobs/[identifier]/page.tsx
@@ -1,19 +1,15 @@
 import * as React from 'react';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import JobDetailClient from './components/JobDetailClient';
+import { requireSession } from '@/utils/require-session';
 
 interface PageProps {
   params: Promise<{ identifier: string }>;
 }
 
 export default async function JobDetailPage({ params }: PageProps) {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('Authentication required');
-  }
+  await requireSession();
 
   const { identifier } = await params;
   const client = (await createServerApiFactory()).getJobsClient();

--- a/apps/frontend/src/app/(protected)/knowledge/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/[identifier]/page.tsx
@@ -1,11 +1,9 @@
 export const dynamic = 'force-dynamic';
 
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import SourcePreviewClientWrapper from './components/SourcePreviewClientWrapper';
-import { Alert, Paper } from '@mui/material';
-import styles from '@/styles/Knowledge.module.css';
+import { requireSession } from '@/utils/require-session';
 
 interface SourcePreviewPageProps {
   params: Promise<{
@@ -20,49 +18,30 @@ interface SourcePreviewPageProps {
 export default async function SourcePreviewPage({
   params,
 }: SourcePreviewPageProps) {
+  const session = await requireSession();
+
+  const apiFactory = await createServerApiFactory();
+  const sourcesClient = apiFactory.getSourcesClient();
+
+  // Await params before using its properties (Next.js 15 requirement)
+  const resolvedParams = await params;
+
+  let source;
   try {
-    const session = await auth();
-
-    if (!session || session.error) {
-      return (
-        <Paper className={styles.errorContainer}>
-          <Alert severity="error">
-            Authentication required. Please sign in to view source content.
-          </Alert>
-        </Paper>
-      );
-    }
-
-    const apiFactory = await createServerApiFactory();
-    const sourcesClient = apiFactory.getSourcesClient();
-
-    // Await params before using its properties (Next.js 15 requirement)
-    const resolvedParams = await params;
-
-    // Fetch source details with content field
-    const source = await sourcesClient.getSourceWithContent(
+    source = await sourcesClient.getSourceWithContent(
       resolvedParams.identifier as `${string}-${string}-${string}-${string}-${string}`
-    );
-
-    return (
-      <SourcePreviewClientWrapper
-        source={source}
-        currentUserId={session.user?.id || ''}
-        currentUserName={session.user?.name || ''}
-        currentUserPicture={session.user?.picture || undefined}
-      />
     );
   } catch (error) {
     notFoundIfEntityMissing(error);
-
-    return (
-      <Paper className={styles.errorContainer}>
-        <Alert severity="error">
-          {error instanceof Error
-            ? error.message
-            : 'Failed to load source content. Please try again.'}
-        </Alert>
-      </Paper>
-    );
+    throw error;
   }
+
+  return (
+    <SourcePreviewClientWrapper
+      source={source}
+      currentUserId={session.user?.id || ''}
+      currentUserName={session.user?.name || ''}
+      currentUserPicture={session.user?.picture || undefined}
+    />
+  );
 }

--- a/apps/frontend/src/app/(protected)/knowledge/page.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/page.tsx
@@ -1,54 +1,30 @@
 export const dynamic = 'force-dynamic';
 
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
 import { firstPageParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
 import KnowledgeClientWrapper from './components/KnowledgeClientWrapper';
 import { sourcesList } from './components/list';
-import { Alert, Paper } from '@mui/material';
-import styles from '@/styles/Knowledge.module.css';
+import { requireSession } from '@/utils/require-session';
 
 /**
  * Server component for the Knowledge page
  */
 export default async function KnowledgePage() {
-  try {
-    const session = await auth();
+  await requireSession();
 
-    if (!session || session.error) {
-      return (
-        <Paper className={styles.errorContainer}>
-          <Alert severity="error">
-            Authentication required. Please sign in to view knowledge sources.
-          </Alert>
-        </Paper>
-      );
-    }
+  const factory = await createServerApiFactory();
 
-    const factory = await createServerApiFactory();
+  const { initialData, initialTotalCount } = await prefetchList(
+    Capability.Source.READ,
+    () => sourcesList.list(factory, firstPageParams(sourcesList))
+  );
 
-    const { initialData, initialTotalCount } = await prefetchList(
-      Capability.Source.READ,
-      () => sourcesList.list(factory, firstPageParams(sourcesList))
-    );
-
-    return (
-      <KnowledgeClientWrapper
-        initialData={initialData}
-        initialTotalCount={initialTotalCount}
-      />
-    );
-  } catch (error) {
-    return (
-      <Paper className={styles.errorContainer}>
-        <Alert severity="error">
-          {error instanceof Error
-            ? error.message
-            : 'Failed to load knowledge sources. Please try again.'}
-        </Alert>
-      </Paper>
-    );
-  }
+  return (
+    <KnowledgeClientWrapper
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+    />
+  );
 }

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/page.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { redirect } from 'next/navigation';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import MetricDetailPageTabs from './MetricDetailPageTabs';
@@ -8,6 +7,7 @@ import type { MetricDetail } from '@/utils/api-client/interfaces/metric';
 import type { UUID } from 'crypto';
 import { prefetch } from '@/utils/server-prefetch';
 import { Capability } from '@/constants/capabilities';
+import { requireSession } from '@/utils/require-session';
 import {
   fetchMetricLinkedRequirements,
   fetchMetricTuning,
@@ -19,11 +19,7 @@ interface PageProps {
 }
 
 export default async function MetricDetailPage({ params }: PageProps) {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('Authentication required');
-  }
+  await requireSession();
 
   const { identifier } = await params;
   const apiFactory = await createServerApiFactory();

--- a/apps/frontend/src/app/(protected)/metrics/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/page.tsx
@@ -1,8 +1,8 @@
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
 import { firstPageParams } from '@/utils/list';
 import { Capability } from '@/constants/capabilities';
+import { requireSession } from '@/utils/require-session';
 import MetricsClientComponent from './components/MetricsClient';
 import type { UUID } from 'crypto';
 import { metricsList } from './components/list';
@@ -13,11 +13,7 @@ import { metricsList } from './components/list';
  * on first load. See `prefetchList` for the permission-gating rationale.
  */
 export default async function MetricsPage() {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('Authentication required');
-  }
+  const session = await requireSession();
 
   const organizationId = session.user?.organization_id as UUID;
   const client = (await createServerApiFactory()).getMetricsClient();

--- a/apps/frontend/src/app/(protected)/onboarding/page.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/page.tsx
@@ -1,15 +1,12 @@
-import { auth } from '@/auth';
 import OnboardingPageClient from './components/OnboardingPageClient';
 import { getOnboardingVideoUrl } from '@/utils/onboarding-video';
 import { UUID } from 'crypto';
+import { requireSession } from '@/utils/require-session';
 
 export const dynamic = 'force-dynamic';
 
 export default async function OnboardingPage() {
-  const session = await auth();
-  if (!session || session.error) {
-    throw new Error('No session token available');
-  }
+  const session = await requireSession();
 
   if (!session?.user?.id) {
     throw new Error('No user ID available in session');

--- a/apps/frontend/src/app/(protected)/organizations/usage/page.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/page.tsx
@@ -1,8 +1,8 @@
-import { auth } from '@/auth';
 import { Capability } from '@/constants/capabilities';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import type { UsageResponse } from '@/utils/api-client/usage-client';
 import { hasServerCapability } from '@/utils/server-permissions';
+import { requireSession } from '@/utils/require-session';
 import UsagePageClient from './components/UsagePageClient';
 
 /**
@@ -12,11 +12,7 @@ import UsagePageClient from './components/UsagePageClient';
  * client falls back to its own fetch (fail open).
  */
 export default async function OrganizationUsagePage() {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('Authentication required');
-  }
+  await requireSession();
 
   let initialUsage: UsageResponse | undefined;
   if (await hasServerCapability(Capability.Usage.READ)) {

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
@@ -1,22 +1,18 @@
 import * as React from 'react';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import { isValidEndpointId } from '@/utils/is-valid-endpoint-id';
 import ProjectEndpointDetailPageClient from './components/ProjectEndpointDetailPageClient';
 import type { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import type { Project } from '@/utils/api-client/interfaces/project';
+import { requireSession } from '@/utils/require-session';
 
 interface PageProps {
   params: Promise<{ identifier: string; endpointId: string }>;
 }
 
 export default async function ProjectEndpointPage({ params }: PageProps) {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('Authentication required');
-  }
+  await requireSession();
 
   const { identifier, endpointId } = await params;
 

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { requireSession } from '@/utils/require-session';
 import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
 import type { Project } from '@/utils/api-client/interfaces/project';
 import ClientWrapper from './client-wrapper';
@@ -18,11 +18,7 @@ interface PageProps {
 }
 
 export default async function ProjectDetailPage({ params }: PageProps) {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('No session token available');
-  }
+  await requireSession();
 
   const apiFactory = await createServerApiFactory();
   const projectsClient = apiFactory.getProjectsClient();

--- a/apps/frontend/src/app/(protected)/projects/create-new/page.tsx
+++ b/apps/frontend/src/app/(protected)/projects/create-new/page.tsx
@@ -1,17 +1,11 @@
 import { Box } from '@mui/material';
-import { auth } from '@/auth';
 import CreateProjectClient from './components/CreateProjectClient';
 import { UUID } from 'crypto';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { requireSession } from '@/utils/require-session';
 
 export default async function CreateProjectPage() {
-  const session = await auth();
-
-  // Debug session information
-
-  if (!session || session.error) {
-    throw new Error('No session token available');
-  }
+  const session = await requireSession();
 
   if (!session?.user?.id) {
     throw new Error('No user ID available in session');

--- a/apps/frontend/src/app/(protected)/projects/page.tsx
+++ b/apps/frontend/src/app/(protected)/projects/page.tsx
@@ -1,12 +1,11 @@
 export const dynamic = 'force-dynamic';
 
-import { auth } from '@/auth';
-import { Alert, Paper } from '@mui/material';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { hasServerCapability } from '@/utils/server-permissions';
 import { Capability } from '@/constants/capabilities';
 import type { Project } from '@/utils/api-client/interfaces/project';
 import ProjectsClientWrapper from './components/ProjectsClientWrapper';
+import { requireSession } from '@/utils/require-session';
 
 /**
  * Server component for the Projects page. Prefetches the project list so the
@@ -14,17 +13,7 @@ import ProjectsClientWrapper from './components/ProjectsClientWrapper';
  * `undefined` and the client wrapper falls back to fetching on mount.
  */
 export default async function ProjectsPage() {
-  const session = await auth();
-
-  if (!session || session.error) {
-    return (
-      <Paper sx={{ p: 3 }}>
-        <Alert severity="error">
-          Authentication required. Please sign in to view projects.
-        </Alert>
-      </Paper>
-    );
-  }
+  await requireSession();
 
   let initialData: Project[] | undefined;
   if (await hasServerCapability(Capability.Project.READ)) {

--- a/apps/frontend/src/app/(protected)/requirements/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/requirements/[identifier]/page.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Metadata } from 'next';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import RequirementDetailClient from './components/RequirementDetailClient';
@@ -8,6 +7,7 @@ import { prefetch } from '@/utils/server-prefetch';
 import { Capability } from '@/constants/capabilities';
 import { fetchRequirementLinkedTests } from './components/linked-tests';
 import type { UUID } from 'crypto';
+import { requireSession } from '@/utils/require-session';
 
 interface PageProps {
   params: Promise<{ identifier: string }>;
@@ -26,11 +26,7 @@ export async function generateMetadata({
 }
 
 export default async function RequirementDetailPage({ params }: PageProps) {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('Authentication required');
-  }
+  await requireSession();
 
   const { identifier } = await params;
   // Server-side calls must go through createServerApiFactory: the session

--- a/apps/frontend/src/app/(protected)/requirements/page.tsx
+++ b/apps/frontend/src/app/(protected)/requirements/page.tsx
@@ -1,4 +1,3 @@
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
 import { firstPageParams } from '@/utils/list';
@@ -6,6 +5,7 @@ import { Capability } from '@/constants/capabilities';
 import RequirementsClient from './components/RequirementsClient';
 import { requirementsList } from './components/list';
 import type { UUID } from 'crypto';
+import { requireSession } from '@/utils/require-session';
 
 /**
  * Server component: fetches the first page of requirements before rendering so
@@ -13,11 +13,7 @@ import type { UUID } from 'crypto';
  * on first load. See `prefetchList` for the permission-gating rationale.
  */
 export default async function RequirementsPage() {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('Authentication required');
-  }
+  const session = await requireSession();
 
   const organizationId = session.user?.organization_id as UUID;
   const userId = (session.user?.id as UUID | undefined) ?? undefined;

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
@@ -1,21 +1,17 @@
 import * as React from 'react';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import TaskDetailClient from './components/TaskDetailClient';
 import { prefetch } from '@/utils/server-prefetch';
 import { Capability } from '@/constants/capabilities';
+import { requireSession } from '@/utils/require-session';
 
 interface PageProps {
   params: Promise<{ identifier: string }>;
 }
 
 export default async function TaskDetailPage({ params }: PageProps) {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('Authentication required');
-  }
+  await requireSession();
 
   const { identifier } = await params;
   const apiFactory = await createServerApiFactory();

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
@@ -1,8 +1,8 @@
 import { Box } from '@mui/material';
 import { Metadata } from 'next';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { requireSession } from '@/utils/require-session';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import type { UUID } from 'crypto';
 import ComparePageClient from './ComparePageClient';
@@ -33,10 +33,7 @@ export default async function TestRunComparePage({
   const initialBaselineId =
     typeof baselineParam === 'string' ? baselineParam : undefined;
 
-  const session = await auth();
-  if (!session || session.error) {
-    throw new Error('Authentication required');
-  }
+  await requireSession();
 
   const apiFactory = await createServerApiFactory();
   const testRunsClient = apiFactory.getTestRunsClient();

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { requireSession } from '@/utils/require-session';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import TestRunMainView from './components/TestRunMainViewClient';
 import { prefetch, prefetchList } from '@/utils/server-prefetch';
@@ -47,11 +47,7 @@ export default async function TestRunPage({
   const selectedResult = resolvedSearchParams?.selectedresult;
   const detailTab = resolvedSearchParams?.detailTab;
 
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('Authentication required');
-  }
+  const session = await requireSession();
 
   const apiFactory = await createServerApiFactory();
   const testRunsClient = apiFactory.getTestRunsClient();

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/page.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Box, CircularProgress } from '@mui/material';
 import { Metadata } from 'next';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import { prefetch, prefetchList } from '@/utils/server-prefetch';
 import { Capability } from '@/constants/capabilities';
 import { firstPageParams } from '@/utils/list';
+import { requireSession } from '@/utils/require-session';
 import { entityTasksList } from '@/components/tasks/list';
 import { format } from 'date-fns';
 
@@ -36,11 +36,7 @@ export async function generateMetadata({
 }
 
 export default async function TestSetPage({ params }: PageProps) {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('Authentication required');
-  }
+  const session = await requireSession();
 
   const { identifier } = await params;
   const apiFactory = await createServerApiFactory();

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/page.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { Box, Button, CircularProgress } from '@mui/material';
 import { Metadata } from 'next';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import { prefetch, prefetchList } from '@/utils/server-prefetch';
 import { Capability } from '@/constants/capabilities';
 import { fetchTestExecutionHistory } from '@/components/tests/test-execution-history';
 import { firstPageParams } from '@/utils/list';
+import { requireSession } from '@/utils/require-session';
 import { linkedTestSetsList } from '@/components/tests/list';
 import { entityTasksList } from '@/components/tasks/list';
 import Link from 'next/link';
@@ -41,11 +41,7 @@ export async function generateMetadata({
 }
 
 export default async function TestDetailPage({ params }: PageProps) {
-  const session = await auth();
-
-  if (!session || session.error) {
-    throw new Error('No session token available');
-  }
+  const session = await requireSession();
 
   const apiFactory = await createServerApiFactory();
   const testsClient = apiFactory.getTestsClient();

--- a/apps/frontend/src/app/(protected)/tokens/page.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/page.tsx
@@ -1,11 +1,10 @@
 import { Metadata } from 'next';
-import { Alert, Paper } from '@mui/material';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
 import { firstPageParams } from '@/utils/list';
 import TokensPageClient from './components/TokensPageClient';
 import { tokensList } from './components/list';
+import { requireSession } from '@/utils/require-session';
 
 export const metadata: Metadata = {
   title: 'API Tokens',
@@ -17,17 +16,7 @@ export const metadata: Metadata = {
  * first load. See `prefetchList` for the permission-gating rationale.
  */
 export default async function TokensPage() {
-  const session = await auth();
-
-  if (!session || session.error) {
-    return (
-      <Paper sx={{ p: 3 }}>
-        <Alert severity="error">
-          Authentication required. Please sign in to view API tokens.
-        </Alert>
-      </Paper>
-    );
-  }
+  await requireSession();
 
   const factory = await createServerApiFactory();
   const { initialData, initialTotalCount } = await prefetchList(

--- a/apps/frontend/src/app/(protected)/traces/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/traces/[identifier]/page.tsx
@@ -1,9 +1,8 @@
 export const dynamic = 'force-dynamic';
 
 import { redirect } from 'next/navigation';
-import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
-import { Alert, Paper } from '@mui/material';
+import { requireSession } from '@/utils/require-session';
 
 interface TraceByIdPageProps {
   params: Promise<{ identifier: string }>;
@@ -18,44 +17,13 @@ interface TraceByIdPageProps {
 export default async function TraceByIdPage({ params }: TraceByIdPageProps) {
   const { identifier } = await params;
 
-  try {
-    const session = await auth();
-    if (!session || session.error) {
-      return (
-        <Paper sx={{ p: 3 }}>
-          <Alert severity="error">
-            Authentication required. Please sign in to view traces.
-          </Alert>
-        </Paper>
-      );
-    }
+  await requireSession();
 
-    const clientFactory = await createServerApiFactory();
-    const client = clientFactory.getTelemetryClient();
-    const lookup = await client.lookupSpan(identifier);
+  const clientFactory = await createServerApiFactory();
+  const client = clientFactory.getTelemetryClient();
+  const lookup = await client.lookupSpan(identifier);
 
-    redirect(
-      `/traces?open_trace=${encodeURIComponent(lookup.trace_id)}&project_id=${encodeURIComponent(lookup.project_id)}`
-    );
-  } catch (error) {
-    if (
-      error &&
-      typeof error === 'object' &&
-      'digest' in error &&
-      typeof (error as { digest: unknown }).digest === 'string' &&
-      (error as { digest: string }).digest.startsWith('NEXT_REDIRECT')
-    ) {
-      throw error;
-    }
-
-    return (
-      <Paper sx={{ p: 3 }}>
-        <Alert severity="error">
-          {error instanceof Error
-            ? error.message
-            : 'Failed to resolve trace. The trace may have been deleted.'}
-        </Alert>
-      </Paper>
-    );
-  }
+  redirect(
+    `/traces?open_trace=${encodeURIComponent(lookup.trace_id)}&project_id=${encodeURIComponent(lookup.project_id)}`
+  );
 }

--- a/apps/frontend/src/app/(protected)/traces/page.tsx
+++ b/apps/frontend/src/app/(protected)/traces/page.tsx
@@ -1,13 +1,12 @@
 export const dynamic = 'force-dynamic';
 
-import { auth } from '@/auth';
-import { Alert, Paper } from '@mui/material';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { getServerActiveProjectId } from '@/utils/server-active-project';
 import { prefetchList } from '@/utils/server-prefetch';
 import { emptyFilters, listParams } from '@/utils/list';
 import TracesClientWrapper from './components/TracesClientWrapper';
 import { tracesList } from './components/list';
+import { requireSession } from '@/utils/require-session';
 
 interface TracesPageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -22,65 +21,42 @@ interface TracesPageProps {
  * scoped yet.
  */
 export default async function TracesPage({ searchParams }: TracesPageProps) {
-  try {
-    const session = await auth();
+  const session = await requireSession();
 
-    if (!session || session.error) {
-      return (
-        <Paper sx={{ p: 3 }}>
-          <Alert severity="error">
-            Authentication required. Please sign in to view traces.
-          </Alert>
-        </Paper>
-      );
-    }
+  const [params, scopedProjectId] = await Promise.all([
+    searchParams,
+    getServerActiveProjectId(),
+  ]);
+  const urlProjectId =
+    typeof params.project_id === 'string' ? params.project_id : '';
 
-    const [params, scopedProjectId] = await Promise.all([
-      searchParams,
-      getServerActiveProjectId(),
-    ]);
-    const urlProjectId =
-      typeof params.project_id === 'string' ? params.project_id : '';
-
-    let initialData;
-    let initialTotalCount = 0;
-    if (scopedProjectId) {
-      const factory = await createServerApiFactory();
-      const descriptor = tracesList(scopedProjectId, factory);
-      ({ initialData, initialTotalCount } = await prefetchList(
-        descriptor.capability,
-        () =>
-          descriptor.list(
-            factory,
-            listParams(descriptor, {
-              page: 1,
-              pageSize: descriptor.defaultPageSize,
-              sort: descriptor.defaultSort,
-              filters: { ...emptyFilters(descriptor), projectId: urlProjectId },
-            })
-          )
-      ));
-    }
-
-    return (
-      <TracesClientWrapper
-        currentUserId={session.user?.id || ''}
-        currentUserName={session.user?.name || ''}
-        currentUserPicture={session.user?.picture || undefined}
-        initialData={initialData}
-        initialTotalCount={initialTotalCount}
-      />
-    );
-  } catch (error) {
-    // Show error state instead of empty traces
-    return (
-      <Paper sx={{ p: 3 }}>
-        <Alert severity="error">
-          {error instanceof Error
-            ? error.message
-            : 'Failed to load traces. Please try again.'}
-        </Alert>
-      </Paper>
-    );
+  let initialData;
+  let initialTotalCount = 0;
+  if (scopedProjectId) {
+    const factory = await createServerApiFactory();
+    const descriptor = tracesList(scopedProjectId, factory);
+    ({ initialData, initialTotalCount } = await prefetchList(
+      descriptor.capability,
+      () =>
+        descriptor.list(
+          factory,
+          listParams(descriptor, {
+            page: 1,
+            pageSize: descriptor.defaultPageSize,
+            sort: descriptor.defaultSort,
+            filters: { ...emptyFilters(descriptor), projectId: urlProjectId },
+          })
+        )
+    ));
   }
+
+  return (
+    <TracesClientWrapper
+      currentUserId={session.user?.id || ''}
+      currentUserName={session.user?.name || ''}
+      currentUserPicture={session.user?.picture || undefined}
+      initialData={initialData}
+      initialTotalCount={initialTotalCount}
+    />
+  );
 }

--- a/apps/frontend/src/utils/require-session.ts
+++ b/apps/frontend/src/utils/require-session.ts
@@ -1,0 +1,17 @@
+import { auth } from '@/auth';
+import type { Session } from 'next-auth';
+
+/**
+ * Server-component guard: throws when there's no valid session, so the
+ * nearest `error.tsx` renders the generic error boundary. Centralizes the
+ * `if (!session || session.error) throw ...` check every page repeated with
+ * a slightly different message, even though `error.tsx` displays them all
+ * the same way.
+ */
+export async function requireSession(): Promise<Session> {
+  const session = await auth();
+  if (!session || session.error) {
+    throw new Error('Authentication required');
+  }
+  return session;
+}


### PR DESCRIPTION
## Purpose

Every server-rendered page under `(protected)` repeated `if (!session || session.error)` before rendering, but with three different thrown messages for the identical failure, and on 8 pages a hand-rolled inline alert instead of a throw at all. Centralize this into one helper so the check is consistent and every page's auth failure looks the same to the user.

## What Changed

- Add `requireSession()` in `utils/require-session.ts`: throws one consistent `Error('Authentication required')` when there's no session, otherwise returns it.
- Replace the repeated guard in 27 pages with `await requireSession()`.
- Remove the inline `<Paper><Alert>` fallback used by 8 pages (traces, traces/[identifier], experiments, experiments/[identifier], projects, knowledge, knowledge/[identifier], tokens) -- they now throw like every other page and go through the shared `error.tsx` boundary, which gives a fuller recovery UI (title, message, Try Again / Back buttons) instead of a dead-end banner.
- Remove the local `try/catch` that wrapped the entire page body on traces and knowledge (4 pages) -- git blame confirms it predates the shared error boundary and error-handling infra (`prefetchList`, `notFoundIfEntityMissing`) the rest of the app already uses. All failures on these pages now route through the same `error.tsx` as everywhere else.
- Restructure `knowledge/[identifier]/page.tsx` to match the standard detail-page pattern: `requireSession()` unguarded, then a narrow `try/catch` around just the entity fetch that calls `notFoundIfEntityMissing` and rethrows -- preserves the dedicated 404 page for a missing source.

## Additional Context

- Two deliberate UX changes to flag: `traces/[identifier]/page.tsx` no longer shows the custom "The trace may have been deleted" hint on a failed lookup -- it now shows the API error's own message. The `NEXT_REDIRECT` passthrough hack in that file is also gone, since it was only needed to stop the old catch-all from swallowing `redirect()`'s internal signal.
- `projects/create-new/page.tsx` and `onboarding/page.tsx` keep their separate `!session?.user?.id` check unchanged -- different concern from the session guard itself.

## Testing

- `npx tsc --noEmit`, `npx eslint`, and `npx prettier --check` pass on all changed files.
- Not yet manually verified in the browser -- before merging, sign out and hit a few affected pages (a list page, a detail page, and one of the 4 traces/knowledge pages) to confirm the shared error page renders as expected.

