### PR TITLE
Add CI guard so backend changes cannot silently break the Java SDK

### DIFF
--- a/.github/workflows/java-sdk-test.yml
+++ b/.github/workflows/java-sdk-test.yml
@@ -1,0 +1,152 @@
+name: "[Test] Java SDK"
+
+# Guards the monorepo against breaking the rhesis-ai/rhesis-java SDK.
+#
+# The Java repo's own CI tests against ghcr.io/rhesis-ai/backend:latest, which is
+# only rebuilt on v* tags — so it never sees unreleased backend changes, and the
+# platform-released dispatch fires only after prd promotion. This workflow runs the
+# Java suite against a backend built from the PR, so breakage blocks the merge.
+#
+# PR runs: Java main only.
+# Nightly: Java main AND the latest Java release — what users actually have
+#          installed, and what Java main may already have adapted away from.
+#
+# Both run `make test`. The Java repo's `make test-integration` passes
+# -Dsurefire.skip=true, which is not a real Surefire property and is not defined
+# in their pom, so it does not actually skip the unit tests — and those are
+# Wiremock-based and finish in seconds, so there is nothing to save by trying.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'apps/backend/src/rhesis/backend/app/routers/**'
+      - 'apps/backend/src/rhesis/backend/app/schemas/**'
+      - 'apps/backend/src/rhesis/backend/app/models/**'
+      - 'apps/backend/src/rhesis/backend/app/auth/**'
+      - 'tests/docker-compose.test.yml'
+      - '.github/workflows/java-sdk-test.yml'
+  schedule:
+    - cron: '0 2 * * *'
+
+concurrency:
+  group: java-sdk-test-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    name: Plan matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      refs: ${{ steps.plan.outputs.refs }}
+    steps:
+      - name: Decide which Java refs to test
+        id: plan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_NIGHTLY: ${{ github.event_name == 'schedule' }}
+        run: |
+          set -euo pipefail
+
+          if [ "$IS_NIGHTLY" != "true" ]; then
+            # PRs get the cheap signal: one backend build, Java main.
+            echo 'refs=["main"]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Nightly also tests the newest published SDK, so we catch breakage that
+          # affects users on the released version even if Java main has moved on.
+          LATEST=$(gh api repos/rhesis-ai/rhesis-java/releases/latest --jq '.tag_name' 2>/dev/null || echo "")
+          if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
+            echo "::warning::Could not resolve the latest rhesis-java release; testing main only."
+            echo 'refs=["main"]' >> "$GITHUB_OUTPUT"
+          else
+            echo "Latest rhesis-java release: ${LATEST}"
+            printf 'refs=["main","%s"]\n' "$LATEST" >> "$GITHUB_OUTPUT"
+          fi
+
+  test-java-sdk:
+    name: Java ${{ matrix.ref }} vs this backend
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: ${{ fromJSON(needs.plan.outputs.refs) }}
+    steps:
+      - name: Check out monorepo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Check out rhesis-java (${{ matrix.ref }})
+        uses: actions/checkout@v6
+        with:
+          repository: rhesis-ai/rhesis-java
+          ref: ${{ matrix.ref }}
+          path: rhesis-java
+          persist-credentials: false
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build and start backend from this checkout
+        run: |
+          docker compose -f tests/docker-compose.test.yml --profile java \
+            up -d --build --wait
+
+      - name: Seed project scope on the local token
+        run: |
+          set -euo pipefail
+          # The Java suite lists projects in BaseIntegrationTest and needs a
+          # project-scoped token; local_init creates the token unscoped.
+          # token is encrypted at rest, so match on the plaintext obfuscated form.
+          docker compose -f tests/docker-compose.test.yml exec -T java-test-postgres \
+            psql -U rhesis-user -d rhesis-db -v ON_ERROR_STOP=1 -c \
+            "UPDATE token SET project_id = (SELECT id FROM project LIMIT 1)
+             WHERE token_obfuscated = 'rh-...oken';"
+
+          SCOPED=$(docker compose -f tests/docker-compose.test.yml exec -T java-test-postgres \
+            psql -U rhesis-user -d rhesis-db -tAc \
+            "SELECT count(*) FROM token
+             WHERE token_obfuscated = 'rh-...oken' AND project_id IS NOT NULL;")
+          if [ "${SCOPED//[[:space:]]/}" != "1" ]; then
+            echo "::error::rh-local-token was not project-scoped — Quick Start seeding did not produce both a token and a project."
+            exit 1
+          fi
+
+      - name: Run Java SDK tests
+        working-directory: rhesis-java
+        env:
+          RHESIS_API_KEY: rh-local-token
+          RHESIS_BASE_URL: http://localhost:10003
+        run: make test
+
+      - name: Backend logs on failure
+        if: failure()
+        run: docker compose -f tests/docker-compose.test.yml logs --tail 500 java-test-backend
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: java-sdk-reports-${{ matrix.ref }}
+          path: |
+            rhesis-java/target/surefire-reports/**
+            rhesis-java/target/failsafe-reports/**
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f tests/docker-compose.test.yml --profile java down -v

--- a/tests/README.md
+++ b/tests/README.md
@@ -817,6 +817,29 @@ services:
       - "10001:5432"
 ```
 
+**Java SDK tests** use the same file's `--profile java` (Backend 10003). This is the monorepo
+side of the [`[Test] Java SDK`](../.github/workflows/java-sdk-test.yml) workflow: it runs the
+[rhesis-ai/rhesis-java](https://github.com/rhesis-ai/rhesis-java) suite against a backend built
+from this checkout. The Java repo's own CI pins `ghcr.io/rhesis-ai/backend:latest`, which is only
+rebuilt on `v*` tags, so it never sees unreleased backend changes.
+
+The profile enables Quick Start so `local_init` seeds the org, project and `rh-local-token` the
+Java tests authenticate with. `token` is encrypted at rest, so scope the token by its plaintext
+`token_obfuscated` value:
+
+```bash
+docker compose -f tests/docker-compose.test.yml --profile java up -d --build --wait
+docker compose -f tests/docker-compose.test.yml exec -T java-test-postgres \
+  psql -U rhesis-user -d rhesis-db -c \
+  "UPDATE token SET project_id = (SELECT id FROM project LIMIT 1)
+   WHERE token_obfuscated = 'rh-...oken';"
+
+cd /path/to/rhesis-java
+RHESIS_API_KEY=rh-local-token RHESIS_BASE_URL=http://localhost:10003 make test-integration
+```
+
+The `sdk` and `java` profiles both publish the backend on 10003 — never run both at once.
+
 ### ⚙️ Environment Configuration
 
 ```bash

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -2,10 +2,12 @@
 # Backend tests use Testcontainers instead (see tests/backend/testcontainers_setup.py).
 #
 # Usage:
-#   SDK tests: docker compose -f tests/docker-compose.test.yml --profile sdk up -d --build
+#   SDK tests:  docker compose -f tests/docker-compose.test.yml --profile sdk up -d --build
+#   Java tests: docker compose -f tests/docker-compose.test.yml --profile java up -d --build --wait
 #
 # Port allocation:
-#   SDK: PostgreSQL 10001, Redis 10002, Backend 10003
+#   SDK:  PostgreSQL 10001, Redis 10002, Backend 10003
+#   Java: Backend 10003 (same port as sdk — never run both profiles at once)
 
 # SDK backend environment configuration
 x-sdk-database-config: &sdk-database-config
@@ -29,6 +31,41 @@ x-sdk-backend-config: &sdk-backend-config
   RHESIS_CONNECTOR_DISABLED: true
   API_BASE_URL: "http://localhost:10003"
   OTEL_RHESIS_TELEMETRY_ENABLED: "false"
+
+# Java SDK backend environment configuration
+#
+# Runs the rhesis-ai/rhesis-java suite against a backend built from THIS checkout,
+# instead of the published ghcr.io/rhesis-ai/backend:latest that the Java repo's own
+# docker-compose.test.yml pins — that image is only rebuilt on v* tags, so the Java
+# tests there never see unreleased backend changes.
+#
+# Quick Start is enabled so local_init seeds the org, project and the rh-local-token
+# that the Java integration tests authenticate with. It stays off in the sdk profile.
+
+x-java-database-config: &java-database-config
+  DB_NAME: rhesis-db
+  APP_DB_USER: rhesis-user
+  APP_DB_PASS: your-secured-password # trufflehog:ignore
+  DB_PORT: 5432
+  DB_DRIVER: postgresql
+  DB_HOST: java-test-postgres
+  DB_ENCRYPTION_KEY: Zb21wZbPsUpb-c2JKj8uMugk767pWXHFTsjocd0Orac=
+
+x-java-redis-config: &java-redis-config
+  BROKER_URL: redis://:rhesis-redis-pass@java-test-redis:6379/0
+  CELERY_RESULT_BACKEND: redis://:rhesis-redis-pass@java-test-redis:6379/1
+
+x-java-backend-config: &java-backend-config
+  FRONTEND_URL: "http://localhost:3000"
+  JWT_SECRET_KEY: ci-test-jwt-secret
+  SESSION_SECRET_KEY: ci-test-session-secret
+  LOG_LEVEL: DEBUG
+  RHESIS_CONNECTOR_DISABLED: "true"
+  API_BASE_URL: "http://localhost:10003"
+  OTEL_RHESIS_TELEMETRY_ENABLED: "false"
+  QUICK_START: "true"
+  BACKEND_ENV: local
+  ENABLE_RHESIS_KEY: "true"
 
 services:
   # ==========================================================================
@@ -103,6 +140,71 @@ services:
       - ../apps/backend/src:/app/apps/backend/src
       - ../apps/backend/start.sh:/app/apps/backend/start.sh
 
+  # ==========================================================================
+  # Java SDK Integration Tests (--profile java)
+  # Backend: 10003. Postgres and Redis are not published — the token seeding
+  # step reaches them through `docker compose exec`.
+  # ==========================================================================
+
+  java-test-postgres:
+    image: mirror.gcr.io/pgvector/pgvector:pg16
+    profiles: ["java"]
+    environment:
+      POSTGRES_DB: rhesis-db
+      POSTGRES_USER: rhesis-user
+      POSTGRES_PASSWORD: your-secured-password
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U rhesis-user -d rhesis-db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - java-test-network
+    env_file: []
+    tmpfs:
+      - /var/lib/postgresql/data
+
+  java-test-redis:
+    image: mirror.gcr.io/redis:7-alpine
+    profiles: ["java"]
+    command: redis-server --requirepass rhesis-redis-pass
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "rhesis-redis-pass", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - java-test-network
+    env_file: []
+    tmpfs:
+      - /data
+
+  java-test-backend:
+    build:
+      context: ..
+      dockerfile: apps/backend/Dockerfile.dev
+    profiles: ["java"]
+    environment:
+      <<: [*java-database-config, *java-redis-config, *java-backend-config]
+    ports:
+      - "10003:8080"
+    depends_on:
+      java-test-postgres:
+        condition: service_healthy
+      java-test-redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 60s
+    networks:
+      - java-test-network
+    env_file: []
+
 networks:
   sdk-test-network:
+    driver: bridge
+  java-test-network:
     driver: bridge


### PR DESCRIPTION
## Purpose

Changes in this monorepo can break the [rhesis-java](https://github.com/rhesis-ai/rhesis-java) SDK, and today nothing catches it before release. The Java repo's own CI pins `ghcr.io/rhesis-ai/backend:latest`, and that image is only rebuilt on `v*` tags — so its integration tests always run against the *last released* backend and never see unreleased changes. The existing `platform-released` dispatch from `publish-release.yml` does fire the Java tests, but only after `promote-prd-config`, so it reports breakage once production already has it. It is a detector, not a guard.

This adds the guard: run the Java suite against a backend built from the PR, in this repo, so a break blocks the merge. It has to live here rather than as a `repository_dispatch` because a run in `rhesis-java` produces no status check on a monorepo PR, and so cannot gate anything.

## What Changed

- **`.github/workflows/java-sdk-test.yml`** (new) — checks out `rhesis-ai/rhesis-java` alongside this repo, builds the backend from the PR, and runs the Java suite against it. A `plan` job decides which Java refs to test; a matrix job runs them with `fail-fast: false`. PR runs test Java `main`. Nightly (02:00) also tests the latest Java release tag, since that is what users actually have installed and Java `main` may already have adapted away from a backend change. Test reports upload on both outcomes; backend logs dump on failure.
- **`tests/docker-compose.test.yml`** — new `java` profile (`java-test-postgres`, `java-test-redis`, `java-test-backend`) building the backend from `apps/backend/Dockerfile.dev`. Quick Start is enabled so `local_init` seeds the org, project and `rh-local-token` the Java tests authenticate with. The existing `sdk` profile is untouched. Both publish the backend on 10003, so they must not run at once — noted in the file and the README.
- **`tests/README.md`** — documents the profile and the local repro.

PR runs are path-filtered to `routers/`, `schemas/`, `models/` and `auth/`. That covers most API-shape breakage but not every service-layer change; the nightly run is the wider net. If nightly starts finding things the filter misses, widen it to `apps/backend/**`.

## Additional Context

- **This workflow will be red on merge, and the failure is real.** It immediately caught a regression: `POST /test_sets/{id}/execute/{endpoint_id}` returns a 500 on a Quick Start backend with no `RHESIS_API_KEY`, where the released backend succeeds. Filed as #2671 for someone else to decide on — it needs a product call about whether that key should be required, not just a code fix. `TestRunIntegrationTest.testExecuteTestSet` errors and `testTestRunStatusDeserialization` skips as a cascade; that is one root cause, not two.
- Two notes on the Java repo, neither fixed here: its `test.yml` sends `client_payload[ref]` on the `platform-released` dispatch but never reads it, and its `make test-integration` passes `-Dsurefire.skip=true`, which is not a real Surefire property and is not defined in its `pom.xml`, so unit tests run regardless. This workflow just runs `make test` rather than pretend to skip them.
- The `platform-released` dispatch is still worth keeping as a post-release net for config and infra drift this workflow cannot see. Moving it before `promote-prd-config` would let a failure abort the release instead of reporting after prd is live.

## Testing

Verified end-to-end locally by running the real Java suite both ways against the same config:

| Backend | Result |
| --- | --- |
| `ghcr.io/rhesis-ai/backend:latest` | **BUILD SUCCESS** — 23 integration tests, 0 errors, 3 skipped |
| Built from this branch | **BUILD FAILURE** — 1 error, 4 skipped (the issue above) |

To reproduce:

```bash
docker compose -f tests/docker-compose.test.yml --profile java up -d --build --wait
docker compose -f tests/docker-compose.test.yml exec -T java-test-postgres \
  psql -U rhesis-user -d rhesis-db -c \
  "UPDATE token SET project_id = (SELECT id FROM project LIMIT 1)
   WHERE token_obfuscated = 'rh-...oken';"

git clone --depth 1 https://github.com/rhesis-ai/rhesis-java.git
cd rhesis-java
RHESIS_API_KEY=rh-local-token RHESIS_BASE_URL=http://localhost:10003 make test
```

One trap worth knowing if you touch the seeding step: the `token` column is encrypted at rest, so `WHERE token = 'rh-local-token'` matches zero rows. The workflow matches on the plaintext `token_obfuscated` value instead, and asserts exactly one row came back project-scoped so a seeding failure gives a clear error rather than a confusing test failure.

Both compose profiles validated with `docker compose config -q`.
