### PR TITLE
fix(backend): enable loki compactor retention and reduce dev retention

### DIFF
--- a/kubernetes/base/loki/loki-application.yaml
+++ b/kubernetes/base/loki/loki-application.yaml
@@ -42,6 +42,7 @@ spec:
             retention_period: PLACEHOLDER
           compactor:
             retention_enabled: true
+            delete_request_store: filesystem
             working_directory: /var/loki/compactor
             compaction_interval: 10m
             retention_delete_delay: 2h

--- a/kubernetes/base/loki/loki-application.yaml
+++ b/kubernetes/base/loki/loki-application.yaml
@@ -46,7 +46,7 @@ spec:
             working_directory: /var/loki/compactor
             compaction_interval: 10m
             retention_delete_delay: 2h
-            retention_delete_worker_count: 150
+            retention_delete_worker_count: 10
           # Multitenancy header (X-Scope-OrgID) is required; Alloy and Grafana use tenant "rhesis"
           auth_enabled: true
         chunksCache:

--- a/kubernetes/base/loki/loki-application.yaml
+++ b/kubernetes/base/loki/loki-application.yaml
@@ -40,6 +40,12 @@ spec:
                   period: 24h
           limits_config:
             retention_period: PLACEHOLDER
+          compactor:
+            retention_enabled: true
+            working_directory: /var/loki/compactor
+            compaction_interval: 10m
+            retention_delete_delay: 2h
+            retention_delete_worker_count: 150
           # Multitenancy header (X-Scope-OrgID) is required; Alloy and Grafana use tenant "rhesis"
           auth_enabled: true
         chunksCache:

--- a/kubernetes/clusters/dev/loki/kustomization.yaml
+++ b/kubernetes/clusters/dev/loki/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 configMapGenerator:
   - name: loki-config
     literals:
-      - retention-period=360h
+      - retention-period=72h
       - storage-size=10Gi
     options:
       annotations:


### PR DESCRIPTION
## Summary

- Enables the Loki compactor with `retention_enabled: true` in the base Helm values (all envs). Without this, `limits_config.retention_period` was ignored and old chunks accumulated indefinitely until disk filled.
- Reduces dev retention from 360h (15 days) to 72h (3 days). Dev doesn't need more than 3 days of logs.
- Triggered by Grafana "PVC almost full" alert: `storage-loki-0` in `monitoring` namespace was at ~8% free on dev.

| Env | Retention | Compactor | Disk |
|-----|-----------|-----------|------|
| dev | **72h** (was 360h) | **enabled** (was disabled) | 10Gi |
| stg | 360h (unchanged) | **enabled** (was disabled) | 10Gi |
| prd | 720h (unchanged) | **enabled** (was disabled) | 20Gi |

## Test plan

- [ ] ArgoCD syncs `dev-loki` application after merge
- [ ] Loki pod restarts with compactor section in `/config` endpoint (`retention_enabled: true`)
- [ ] Disk usage on `storage-loki-0` decreases within ~2h (retention_delete_delay) as the compactor purges data older than 72h
- [ ] Grafana alert resolves
- [ ] Verify stg and prd Loki pods also pick up the compactor config