### PR TITLE
Move project membership out of the organization service

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/project.py
+++ b/apps/backend/src/rhesis/backend/app/crud/project.py
@@ -167,7 +167,7 @@ def delete_project(
     # Project soft-delete does not cascade to project_membership, so drop the
     # memberships and repair affected users' default_project first. Staged in the
     # same transaction; delete_item's commit persists both.
-    from rhesis.backend.app.services.organization import unenroll_all_project_members
+    from rhesis.backend.app.services.project_membership import unenroll_all_project_members
 
     unenroll_all_project_members(db, project_id, organization_id)
     return delete_item(
@@ -237,7 +237,7 @@ def add_project_member(
     """
     from rhesis.backend.app.models.project_membership import ProjectMembership
     from rhesis.backend.app.scope import bypass_tenant_filter
-    from rhesis.backend.app.services.organization import enroll_user_in_project
+    from rhesis.backend.app.services.project_membership import enroll_user_in_project
 
     with bypass_tenant_filter():
         existing = (
@@ -278,7 +278,7 @@ def remove_project_member(
         ProjectSelfRemovalError: if requester_user_id == user_id.
         ProjectOwnerRemovalError: if user_id is the project owner.
     """
-    from rhesis.backend.app.services.organization import unenroll_user_from_project
+    from rhesis.backend.app.services.project_membership import unenroll_user_from_project
 
     removed = unenroll_user_from_project(
         db, user_id, project_id, organization_id, requester_user_id=requester_user_id

--- a/apps/backend/src/rhesis/backend/app/management/recover_org_owner.py
+++ b/apps/backend/src/rhesis/backend/app/management/recover_org_owner.py
@@ -111,7 +111,7 @@ def run(
         # ownership change takes effect on the next authorize() call rather than
         # waiting out the TTL. Reuses the canonical helper (it swallows and logs
         # its own failures, so a cache outage never blocks recovery).
-        from rhesis.backend.app.services.organization import _bust_permission_cache
+        from rhesis.backend.app.services.project_membership import _bust_permission_cache
 
         if previous_owner_id:
             _bust_permission_cache(previous_owner_id, org_uuid)

--- a/apps/backend/src/rhesis/backend/app/routers/project.py
+++ b/apps/backend/src/rhesis/backend/app/routers/project.py
@@ -47,7 +47,7 @@ def create_project(
     _quota_gate: Organization = Depends(require_quota(QuotaResource.PROJECTS)),
 ):
     """Create a new project. The creating user is automatically enrolled as a member."""
-    from rhesis.backend.app.services.organization import enroll_user_in_project
+    from rhesis.backend.app.services.project_membership import enroll_user_in_project
 
     organization_id, user_id = tenant_context
 
@@ -230,7 +230,7 @@ def remove_project_member(
     The project owner cannot be removed, and a user cannot remove themselves.
     Both rules are enforced by the service layer regardless of how it is called.
     """
-    from rhesis.backend.app.services.organization import (
+    from rhesis.backend.app.services.project_membership import (
         ProjectOwnerRemovalError,
         ProjectSelfRemovalError,
     )

--- a/apps/backend/src/rhesis/backend/app/services/organization.py
+++ b/apps/backend/src/rhesis/backend/app/services/organization.py
@@ -3,12 +3,11 @@ import logging
 import os
 import uuid
 from contextlib import ExitStack
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Type
 
 from sqlalchemy import inspect
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm import Session, joinedload, with_parent
-from sqlalchemy.orm.attributes import flag_modified
 
 from rhesis.backend.app import models, schemas
 from rhesis.backend.app.config.settings import get_application_settings
@@ -23,6 +22,7 @@ from rhesis.backend.app.models.metric import requirement_metric_association
 from rhesis.backend.app.models.test import test_test_set_association
 from rhesis.backend.app.schemas.tag import EntityType
 from rhesis.backend.app.scope import bypass_tenant_filter
+from rhesis.backend.app.services.project_membership import enroll_user_in_project
 from rhesis.backend.app.services.test_set import execute_test_set_on_endpoint
 from rhesis.backend.app.utils.crud_utils import (
     create_default_rhesis_model,
@@ -34,84 +34,6 @@ from rhesis.backend.app.utils.crud_utils import (
     get_or_create_type_lookup,
 )
 from rhesis.backend.app.utils.query_utils import QueryBuilder
-
-# ---------------------------------------------------------------------------
-# Service-layer exceptions
-# ---------------------------------------------------------------------------
-
-
-class ProjectServiceError(Exception):
-    """Base class for project membership service errors."""
-
-
-class ProjectOwnerRemovalError(ProjectServiceError):
-    """Raised when attempting to remove the project owner from a project."""
-
-
-class ProjectSelfRemovalError(ProjectServiceError):
-    """Raised when the requesting user attempts to remove themselves from a project."""
-
-
-# ---------------------------------------------------------------------------
-
-
-def _set_default_project_if_empty(db: Session, user_id: uuid.UUID, project_id: uuid.UUID) -> None:
-    """Set the user's default_project setting to this project if they have none.
-
-    Never clobbers an existing default. Stores {"id", "name"} so the frontend can
-    display the name without an extra lookup.
-    """
-    user = db.query(models.User).filter(models.User.id == user_id).first()
-    if user is None:
-        return
-    if user.settings.default_project is not None:
-        return
-    project = db.query(models.Project).filter(models.Project.id == project_id).first()
-    if project is None:
-        return
-    user.settings.update({"default_project": {"project_id": str(project.id), "name": project.name}})
-    flag_modified(user, "user_settings")
-
-
-def _reassign_default_project_if_removed(
-    db: Session,
-    user_id: uuid.UUID,
-    removed_project_id: uuid.UUID,
-    organization_id: uuid.UUID,
-) -> None:
-    """If the removed project was the user's default, repoint or clear the default.
-
-    Picks the user's earliest remaining membership; clears the setting if none remain.
-    """
-    user = db.query(models.User).filter(models.User.id == user_id).first()
-    if user is None:
-        return
-    current = user.settings.default_project
-    current_pid = current.get("project_id") or current.get("id") if current else None
-    if not current_pid or str(current_pid) != str(removed_project_id):
-        return
-
-    remaining = (
-        db.query(models.Project)
-        .join(models.ProjectMembership, models.ProjectMembership.project_id == models.Project.id)
-        .filter(
-            models.ProjectMembership.user_id == user_id,
-            models.ProjectMembership.organization_id == organization_id,
-            models.ProjectMembership.project_id != removed_project_id,
-        )
-        .order_by(models.Project.created_at.asc())
-        .first()
-    )
-    if remaining is not None:
-        user.settings.update(
-            {"default_project": {"project_id": str(remaining.id), "name": remaining.name}}
-        )
-    else:
-        settings = user.settings.raw
-        settings.pop("default_project", None)
-        user.user_settings = settings
-    flag_modified(user, "user_settings")
-
 
 _logger = logging.getLogger(__name__)
 
@@ -133,162 +55,6 @@ _ORG_WIDE_METRIC_BACKEND_TYPES = frozenset({"deepeval", "ragas", "garak", "rhesi
 # organizations created afterward.
 _OWASP_NAME_PREFIX = "OWASP"
 _OWASP_TAG_NAME = "OWASP"
-
-
-def _bust_permission_cache(user_id: uuid.UUID, organization_id: uuid.UUID) -> None:
-    """Bust the permission cache for *user_id* within *organization_id*.
-
-    Called after any project-membership write so the next ``authorize()`` call
-    re-evaluates against the database rather than returning a stale cached result.
-    Failures are logged but never re-raised — a cache-bust error degrades to
-    relying on the TTL, not to a service error.
-    """
-    try:
-        from rhesis.backend.app.services.permission_cache import get_permission_cache
-
-        get_permission_cache().bust_user(user_id, organization_id)
-    except Exception as exc:  # pragma: no cover
-        _logger.warning(
-            "permission cache bust failed for user %s org %s (non-fatal): %s",
-            user_id,
-            organization_id,
-            exc,
-        )
-
-
-def enroll_user_in_project(
-    db: Session,
-    user_id: uuid.UUID,
-    project_id: uuid.UUID,
-    organization_id: uuid.UUID,
-    *,
-    role_id: Optional[uuid.UUID] = None,
-) -> None:
-    """Enroll a user in a project and set their default_project if unset.
-
-    Uses INSERT … ON CONFLICT DO NOTHING so concurrent enrollments for the same
-    (project_id, user_id) pair are safe — the unique constraint
-    ``uq_project_membership_project_user`` silently absorbs the duplicate rather
-    than raising an IntegrityError.
-
-    ``role_id`` is an optional FK placeholder for the EE role table (SP8).  In
-    community mode it is always ``None`` (binary membership).  Phase 2 will pass
-    a real role UUID here when inviting users with an explicit role.
-
-    Executes the INSERT immediately within the current transaction; the caller is
-    still responsible for committing (or rolling back).
-
-    Busts the permission cache for *user_id* so the next ``authorize()`` call
-    re-evaluates against the database (plan §1.6 / §8b revocation requirement).
-    """
-    from sqlalchemy.dialects.postgresql import insert as pg_insert
-
-    # role_id is nullable; passing None inserts a binary (no-role) membership.
-    stmt = (
-        pg_insert(models.ProjectMembership)
-        .values(
-            project_id=project_id,
-            user_id=user_id,
-            organization_id=organization_id,
-            role_id=role_id,
-        )
-        .on_conflict_do_nothing(constraint="uq_project_membership_project_user")
-    )
-    db.execute(stmt)
-
-    # _set_default_project_if_empty does db.query() calls; bypass the ambient
-    # project/org filter so the user and project are always found.
-    with bypass_tenant_filter():
-        _set_default_project_if_empty(db, user_id, project_id)
-
-    _bust_permission_cache(user_id, organization_id)
-
-
-def unenroll_user_from_project(
-    db: Session,
-    user_id: uuid.UUID,
-    project_id: uuid.UUID,
-    organization_id: uuid.UUID,
-    *,
-    requester_user_id: Optional[uuid.UUID] = None,
-) -> bool:
-    """Remove a user's ProjectMembership and repair their default_project if needed.
-
-    Raises:
-        ProjectSelfRemovalError: if requester_user_id matches user_id (self-removal).
-        ProjectOwnerRemovalError: if user_id is the project owner.
-
-    Returns True if a membership was removed, False if none existed. Does NOT
-    commit; the caller is responsible for committing.
-
-    Busts the permission cache for *user_id* so the revocation takes effect on
-    the next ``authorize()`` call rather than waiting out the TTL (plan §8b).
-    """
-    with bypass_tenant_filter():
-        # Self-removal guard — checked here so non-HTTP callers also get the protection.
-        if requester_user_id is not None and str(requester_user_id) == str(user_id):
-            raise ProjectSelfRemovalError("A user cannot remove themselves from a project")
-
-        # Owner guard — query the project to check owner_id.
-        project = db.query(models.Project).filter(models.Project.id == project_id).first()
-        if project and project.owner_id and str(project.owner_id) == str(user_id):
-            raise ProjectOwnerRemovalError("The project owner cannot be removed from a project")
-
-        membership = (
-            db.query(models.ProjectMembership)
-            .filter_by(
-                project_id=project_id,
-                user_id=user_id,
-                organization_id=organization_id,
-            )
-            .first()
-        )
-        if membership is None:
-            return False
-
-        # Hard delete (not soft delete): the uq_project_membership_project_user
-        # unique constraint would otherwise block re-enrolling the same user.
-        db.delete(membership)
-        _reassign_default_project_if_removed(db, user_id, project_id, organization_id)
-
-    _bust_permission_cache(user_id, organization_id)
-    return True
-
-
-def unenroll_all_project_members(
-    db: Session,
-    project_id: uuid.UUID,
-    organization_id: uuid.UUID,
-) -> int:
-    """
-    Remove every ProjectMembership for a project and repair affected users' defaults.
-
-    Intended for project deletion: project soft-delete does not cascade to the
-    membership table, so without this the rows are orphaned and users keep a
-    default_project pointing at a dead project. Returns the number of memberships
-    removed. Does NOT commit; the caller is responsible for committing.
-
-    Busts the permission cache for every removed member (plan §8b).
-    """
-    with bypass_tenant_filter():
-        memberships = (
-            db.query(models.ProjectMembership)
-            .filter_by(project_id=project_id, organization_id=organization_id)
-            .all()
-        )
-        user_ids = [m.user_id for m in memberships]
-        for membership in memberships:
-            db.delete(membership)
-        # Flush the deletes so the per-user default repair sees the rows as gone
-        # when it scans for a replacement membership.
-        db.flush()
-        for user_id in user_ids:
-            _reassign_default_project_if_removed(db, user_id, project_id, organization_id)
-
-    for user_id in user_ids:
-        _bust_permission_cache(user_id, organization_id)
-
-    return len(user_ids)
 
 
 def load_initial_data(db: Session, organization_id: str, user_id: str) -> Dict[str, str]:
@@ -1319,9 +1085,6 @@ def _get_entity_identifier(model_name: str, item: dict) -> str:
         return item.get("type_value", "")  # TypeLookup uses type_value as identifier
     else:
         return item.get("name", "")  # Default to name for other entities
-
-
-_logger = logging.getLogger(__name__)
 
 
 def _inject_garak_metrics(initial_data: dict) -> None:

--- a/apps/backend/src/rhesis/backend/app/services/project_membership.py
+++ b/apps/backend/src/rhesis/backend/app/services/project_membership.py
@@ -1,20 +1,32 @@
-"""Helpers for discovering a caller's project memberships.
+"""Reading and writing a caller's project memberships.
 
-Shared by any endpoint that needs to search across a caller's OTHER projects
-under real RLS scope (project_isolation is FORCE-enabled and keyed on the
-`app.current_project` GUC, so a lookup scoped to the active project cannot
-see rows in a different one — see ``routers/resolve.py`` for the full
-rationale). ``project_membership`` carries no ``project_isolation`` policy
-(dropped intentionally in the ``b8c9d0e1f2a3`` migration), so it's queryable
-at org scope; wrapped in ``bypass_tenant_filter()`` only because it *does*
-have a ``project_id`` column that the ORM auto-filter would otherwise pin to
-the active project.
+Discovery (``list_other_member_projects``) is shared by any endpoint that needs
+to search across a caller's OTHER projects under real RLS scope
+(project_isolation is FORCE-enabled and keyed on the `app.current_project` GUC,
+so a lookup scoped to the active project cannot see rows in a different one —
+see ``routers/resolve.py`` for the full rationale). ``project_membership``
+carries no ``project_isolation`` policy (dropped intentionally in the
+``b8c9d0e1f2a3`` migration), so it's queryable at org scope; wrapped in
+``bypass_tenant_filter()`` only because it *does* have a ``project_id`` column
+that the ORM auto-filter would otherwise pin to the active project.
+
+The enroll/unenroll functions additionally keep each affected user's
+``default_project`` setting pointing at a project they can still reach, and bust
+the permission cache so a membership change takes effect on the next
+``authorize()`` call rather than waiting out the TTL.
 """
 
+import logging
+import uuid
+from typing import Optional
+
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
 
 from rhesis.backend.app import models
 from rhesis.backend.app.scope import bypass_tenant_filter
+
+_logger = logging.getLogger(__name__)
 
 
 def list_other_member_projects(
@@ -44,3 +56,237 @@ def list_other_member_projects(
         )
 
     return [(str(pid), name) for pid, name in rows if str(pid) != (exclude_project_id or "")]
+
+
+# ---------------------------------------------------------------------------
+# Service-layer exceptions
+# ---------------------------------------------------------------------------
+
+
+class ProjectServiceError(Exception):
+    """Base class for project membership service errors."""
+
+
+class ProjectOwnerRemovalError(ProjectServiceError):
+    """Raised when attempting to remove the project owner from a project."""
+
+
+class ProjectSelfRemovalError(ProjectServiceError):
+    """Raised when the requesting user attempts to remove themselves from a project."""
+
+
+# ---------------------------------------------------------------------------
+
+
+def _set_default_project_if_empty(db: Session, user_id: uuid.UUID, project_id: uuid.UUID) -> None:
+    """Set the user's default_project setting to this project if they have none.
+
+    Never clobbers an existing default. Stores {"id", "name"} so the frontend can
+    display the name without an extra lookup.
+    """
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if user is None:
+        return
+    if user.settings.default_project is not None:
+        return
+    project = db.query(models.Project).filter(models.Project.id == project_id).first()
+    if project is None:
+        return
+    user.settings.update({"default_project": {"project_id": str(project.id), "name": project.name}})
+    flag_modified(user, "user_settings")
+
+
+def _reassign_default_project_if_removed(
+    db: Session,
+    user_id: uuid.UUID,
+    removed_project_id: uuid.UUID,
+    organization_id: uuid.UUID,
+) -> None:
+    """If the removed project was the user's default, repoint or clear the default.
+
+    Picks the user's earliest remaining membership; clears the setting if none remain.
+    """
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if user is None:
+        return
+    current = user.settings.default_project
+    current_pid = current.get("project_id") or current.get("id") if current else None
+    if not current_pid or str(current_pid) != str(removed_project_id):
+        return
+
+    remaining = (
+        db.query(models.Project)
+        .join(models.ProjectMembership, models.ProjectMembership.project_id == models.Project.id)
+        .filter(
+            models.ProjectMembership.user_id == user_id,
+            models.ProjectMembership.organization_id == organization_id,
+            models.ProjectMembership.project_id != removed_project_id,
+        )
+        .order_by(models.Project.created_at.asc())
+        .first()
+    )
+    if remaining is not None:
+        user.settings.update(
+            {"default_project": {"project_id": str(remaining.id), "name": remaining.name}}
+        )
+    else:
+        settings = user.settings.raw
+        settings.pop("default_project", None)
+        user.user_settings = settings
+    flag_modified(user, "user_settings")
+
+
+def _bust_permission_cache(user_id: uuid.UUID, organization_id: uuid.UUID) -> None:
+    """Bust the permission cache for *user_id* within *organization_id*.
+
+    Called after any project-membership write so the next ``authorize()`` call
+    re-evaluates against the database rather than returning a stale cached result.
+    Failures are logged but never re-raised — a cache-bust error degrades to
+    relying on the TTL, not to a service error.
+    """
+    try:
+        from rhesis.backend.app.services.permission_cache import get_permission_cache
+
+        get_permission_cache().bust_user(user_id, organization_id)
+    except Exception as exc:  # pragma: no cover
+        _logger.warning(
+            "permission cache bust failed for user %s org %s (non-fatal): %s",
+            user_id,
+            organization_id,
+            exc,
+        )
+
+
+def enroll_user_in_project(
+    db: Session,
+    user_id: uuid.UUID,
+    project_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    *,
+    role_id: Optional[uuid.UUID] = None,
+) -> None:
+    """Enroll a user in a project and set their default_project if unset.
+
+    Uses INSERT … ON CONFLICT DO NOTHING so concurrent enrollments for the same
+    (project_id, user_id) pair are safe — the unique constraint
+    ``uq_project_membership_project_user`` silently absorbs the duplicate rather
+    than raising an IntegrityError.
+
+    ``role_id`` is an optional FK placeholder for the EE role table (SP8).  In
+    community mode it is always ``None`` (binary membership).  Phase 2 will pass
+    a real role UUID here when inviting users with an explicit role.
+
+    Executes the INSERT immediately within the current transaction; the caller is
+    still responsible for committing (or rolling back).
+
+    Busts the permission cache for *user_id* so the next ``authorize()`` call
+    re-evaluates against the database (plan §1.6 / §8b revocation requirement).
+    """
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    # role_id is nullable; passing None inserts a binary (no-role) membership.
+    stmt = (
+        pg_insert(models.ProjectMembership)
+        .values(
+            project_id=project_id,
+            user_id=user_id,
+            organization_id=organization_id,
+            role_id=role_id,
+        )
+        .on_conflict_do_nothing(constraint="uq_project_membership_project_user")
+    )
+    db.execute(stmt)
+
+    # _set_default_project_if_empty does db.query() calls; bypass the ambient
+    # project/org filter so the user and project are always found.
+    with bypass_tenant_filter():
+        _set_default_project_if_empty(db, user_id, project_id)
+
+    _bust_permission_cache(user_id, organization_id)
+
+
+def unenroll_user_from_project(
+    db: Session,
+    user_id: uuid.UUID,
+    project_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    *,
+    requester_user_id: Optional[uuid.UUID] = None,
+) -> bool:
+    """Remove a user's ProjectMembership and repair their default_project if needed.
+
+    Raises:
+        ProjectSelfRemovalError: if requester_user_id matches user_id (self-removal).
+        ProjectOwnerRemovalError: if user_id is the project owner.
+
+    Returns True if a membership was removed, False if none existed. Does NOT
+    commit; the caller is responsible for committing.
+
+    Busts the permission cache for *user_id* so the revocation takes effect on
+    the next ``authorize()`` call rather than waiting out the TTL (plan §8b).
+    """
+    with bypass_tenant_filter():
+        # Self-removal guard — checked here so non-HTTP callers also get the protection.
+        if requester_user_id is not None and str(requester_user_id) == str(user_id):
+            raise ProjectSelfRemovalError("A user cannot remove themselves from a project")
+
+        # Owner guard — query the project to check owner_id.
+        project = db.query(models.Project).filter(models.Project.id == project_id).first()
+        if project and project.owner_id and str(project.owner_id) == str(user_id):
+            raise ProjectOwnerRemovalError("The project owner cannot be removed from a project")
+
+        membership = (
+            db.query(models.ProjectMembership)
+            .filter_by(
+                project_id=project_id,
+                user_id=user_id,
+                organization_id=organization_id,
+            )
+            .first()
+        )
+        if membership is None:
+            return False
+
+        # Hard delete (not soft delete): the uq_project_membership_project_user
+        # unique constraint would otherwise block re-enrolling the same user.
+        db.delete(membership)
+        _reassign_default_project_if_removed(db, user_id, project_id, organization_id)
+
+    _bust_permission_cache(user_id, organization_id)
+    return True
+
+
+def unenroll_all_project_members(
+    db: Session,
+    project_id: uuid.UUID,
+    organization_id: uuid.UUID,
+) -> int:
+    """
+    Remove every ProjectMembership for a project and repair affected users' defaults.
+
+    Intended for project deletion: project soft-delete does not cascade to the
+    membership table, so without this the rows are orphaned and users keep a
+    default_project pointing at a dead project. Returns the number of memberships
+    removed. Does NOT commit; the caller is responsible for committing.
+
+    Busts the permission cache for every removed member (plan §8b).
+    """
+    with bypass_tenant_filter():
+        memberships = (
+            db.query(models.ProjectMembership)
+            .filter_by(project_id=project_id, organization_id=organization_id)
+            .all()
+        )
+        user_ids = [m.user_id for m in memberships]
+        for membership in memberships:
+            db.delete(membership)
+        # Flush the deletes so the per-user default repair sees the rows as gone
+        # when it scans for a replacement membership.
+        db.flush()
+        for user_id in user_ids:
+            _reassign_default_project_if_removed(db, user_id, project_id, organization_id)
+
+    for user_id in user_ids:
+        _bust_permission_cache(user_id, organization_id)
+
+    return len(user_ids)

--- a/tests/backend/auth/test_permission_cache.py
+++ b/tests/backend/auth/test_permission_cache.py
@@ -480,7 +480,7 @@ class TestRevocationTiming(_AuthzCacheTestBase):
 
     def test_enroll_busts_cache(self):
         """enroll_user_in_project must bust the permission cache for the user."""
-        from rhesis.backend.app.services.organization import enroll_user_in_project
+        from rhesis.backend.app.services.project_membership import enroll_user_in_project
 
         # Prime cache with a deny.
         get_permission_cache().set(USER_ID, ORG_ID, PROJECT_ID, "test_set:read", False)
@@ -488,7 +488,9 @@ class TestRevocationTiming(_AuthzCacheTestBase):
         db = MagicMock()
         db.execute.return_value = None
 
-        with patch("rhesis.backend.app.services.organization._set_default_project_if_empty"):
+        with patch(
+            "rhesis.backend.app.services.project_membership._set_default_project_if_empty"
+        ):
             enroll_user_in_project(db, USER_ID, PROJECT_ID, ORG_ID)
 
         # Cache must be busted.
@@ -496,7 +498,7 @@ class TestRevocationTiming(_AuthzCacheTestBase):
 
     def test_unenroll_busts_cache(self):
         """unenroll_user_from_project must bust the permission cache for the user."""
-        from rhesis.backend.app.services.organization import unenroll_user_from_project
+        from rhesis.backend.app.services.project_membership import unenroll_user_from_project
 
         # Prime cache with an allow.
         get_permission_cache().set(USER_ID, ORG_ID, PROJECT_ID, "test_set:read", True)
@@ -525,7 +527,9 @@ class TestRevocationTiming(_AuthzCacheTestBase):
 
         db.query.side_effect = _query
 
-        with patch("rhesis.backend.app.services.organization._reassign_default_project_if_removed"):
+        with patch(
+            "rhesis.backend.app.services.project_membership._reassign_default_project_if_removed"
+        ):
             result = unenroll_user_from_project(
                 db, USER_ID, PROJECT_ID, ORG_ID, requester_user_id=OTHER_USER_ID
             )
@@ -571,7 +575,7 @@ class TestRevocationTiming(_AuthzCacheTestBase):
 
     def test_unenroll_all_busts_each_member(self):
         """unenroll_all_project_members must bust the cache for every removed member."""
-        from rhesis.backend.app.services.organization import unenroll_all_project_members
+        from rhesis.backend.app.services.project_membership import unenroll_all_project_members
 
         cache = get_permission_cache()
         cache.set(USER_ID, ORG_ID, PROJECT_ID, "test_set:read", True)
@@ -592,7 +596,9 @@ class TestRevocationTiming(_AuthzCacheTestBase):
         db.query.side_effect = _query
         db.flush.return_value = None
 
-        with patch("rhesis.backend.app.services.organization._reassign_default_project_if_removed"):
+        with patch(
+            "rhesis.backend.app.services.project_membership._reassign_default_project_if_removed"
+        ):
             count = unenroll_all_project_members(db, PROJECT_ID, ORG_ID)
 
         assert count == 2

--- a/tests/backend/auth/test_sp6_membership_hardening.py
+++ b/tests/backend/auth/test_sp6_membership_hardening.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import models
 from rhesis.backend.app.models.project_membership import ProjectMembership
 from rhesis.backend.app.scope import bypass_tenant_filter
-from rhesis.backend.app.services.organization import (
+from rhesis.backend.app.services.project_membership import (
     ProjectOwnerRemovalError,
     ProjectSelfRemovalError,
     enroll_user_in_project,

--- a/tests/backend/routes/test_project_membership.py
+++ b/tests/backend/routes/test_project_membership.py
@@ -42,7 +42,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import models
 from rhesis.backend.app.models.project_membership import ProjectMembership
 from rhesis.backend.app.scope import bypass_tenant_filter
-from rhesis.backend.app.services.organization import (
+from rhesis.backend.app.services.project_membership import (
     enroll_user_in_project,
     unenroll_user_from_project,
 )


### PR DESCRIPTION
## Purpose

`services/organization.py` was the largest file in the backend at 1715 lines, and it held two concerns that have nothing to do with each other: seeding a new organization's demo data, and project membership writes. Adding someone to a project and seeding an org's example test sets do not belong in the same module.

The membership half already had a natural home — `services/project_membership.py` owns the read side (`list_other_member_projects`) — so this moves the write side there rather than inventing a new module. Both directions of project membership now live in one place.

## What Changed

Moved from `organization.py` to `project_membership.py`:

- `ProjectServiceError`, `ProjectOwnerRemovalError`, `ProjectSelfRemovalError`
- `_set_default_project_if_empty`, `_reassign_default_project_if_removed` — the `default_project` repair helpers
- `_bust_permission_cache`
- `enroll_user_in_project`, `unenroll_user_from_project`, `unenroll_all_project_members`

`organization.py` 1715 → 1479 lines; `project_membership.py` 46 → 292.

Two things the split surfaced:

- **A duplicate logger.** `organization.py` had `_logger = logging.getLogger(__name__)` at both line 116 and line 1324, the second silently rebinding the first. Splitting the file put them next to each other and made it obvious. Removed.
- **`load_initial_data` calls `enroll_user_in_project`**, so `organization.py` now imports from `project_membership`. Not a cycle: `project_membership` depends only on `models` and `scope`.

Call sites updated: 6 in source (`crud/project.py` ×3, `routers/project.py` ×2, `management/recover_org_owner.py`), 5 test imports, and **3 `mock.patch` target strings** in `test_permission_cache.py` that named the old module path. Those last ones are the real hazard in a move like this — a stale patch target fails at runtime, not at import, so neither the type checker nor ruff would catch it.

## Additional Context

**This does not shrink the complexity debt list, and is not meant to.** The `per-file-ignores` entry for `organization.py` exists because `load_initial_data` (C901 36, 138 statements) and `rollback_initial_data` (C901 26) are too big as *functions*; both stay where they are, so the entry is unchanged and `ruff.toml` is untouched. Splitting a file never shrinks a function. `project_membership.py` trips no ceiling and needs no entry.

Decomposing `load_initial_data` itself is the follow-up, and it is a much larger job: it is ~680 lines of sequential "process each entity type" stages whose later stages resolve entities the earlier ones created, so the local lookup maps have to become a context object first. Worth doing behind working rollback tests — three of which are currently skipped for an unrelated OOM in `rollback_initial_data`'s recursive relationship walker.

## Testing

Pure relocation — no behaviour change intended, so the existing tests are the check. Run after rebasing onto current `main`:

```bash
cd apps/backend
uv run pytest ../../tests/backend/auth \
               ../../tests/backend/crud \
               ../../tests/backend/routes/test_project_membership.py \
               ../../tests/backend/services/test_organization.py -q
```

567 passed, 1 skipped. Also green: `routes/test_organization.py`, `routes/test_transaction_management.py`, `routes/test_project.py`, `services/test_transaction_management.py`, `ee/rbac/test_project_members_authz.py`, `test_ee_boundary.py`.

The only skips are pre-existing: the `rollback_initial_data` OOM ones and one unrelated missing-field case. `ruff check` clean on all 8 files.
