### PR TITLE
Cancel superseded test and lint runs on pull requests

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -21,6 +21,12 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel only on PR branches. Two merges landing close together share one group
+  # on main, and cancelling there leaves the earlier commit with no test verdict.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   # All test env vars (database, redis, JWT, etc.) are set in tests/backend/conftest.py
   # Only PYTHONPATH is needed here for module resolution in CI

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -15,6 +15,12 @@ on:
       - '.github/workflows/frontend-e2e-test.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel only on PR branches. Two merges landing close together share one group
+  # on main, and cancelling there leaves the earlier commit with no test verdict.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   prepare-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -17,6 +17,12 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel only on PR branches. Two merges landing close together share one group
+  # on main, and cancelling there leaves the earlier commit with no test verdict.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,12 @@ on:
     branches: [main, release/*]
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel only on PR branches. Two merges landing close together share one group
+  # on main, and cancelling there leaves the earlier commit with no test verdict.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/penelope-test.yml
+++ b/.github/workflows/penelope-test.yml
@@ -11,6 +11,12 @@ on:
     paths:
       - 'penelope/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel only on PR branches. Two merges landing close together share one group
+  # on main, and cancelling there leaves the earlier commit with no test verdict.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-penelope:
     runs-on: ubuntu-latest

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -19,6 +19,12 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel only on PR branches. Two merges landing close together share one group
+  # on main, and cancelling there leaves the earlier commit with no test verdict.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-sdk:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel only on PR branches. Two merges landing close together share one group
+  # on main, and cancelling there leaves the earlier commit with no test verdict.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Purpose

The test and lint workflows had no `concurrency` guard. A force-push to a PR left the previous runs going to completion, so a PR under active iteration could have three or four full backend test runs racing each other for runners while only the last one mattered.

## What Changed

Added the same block to the seven CI workflows — `backend-test`, `frontend-test`, `frontend-e2e-test`, `sdk-test`, `penelope-test`, `lint` and `security`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
  # Cancel only on PR branches. Two merges landing close together share one group
  # on main, and cancelling there leaves the earlier commit with no test verdict.
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Two deliberate details:

- `cancel-in-progress` is scoped to `pull_request` events, so runs on `main` and the nightly crons are never cancelled. Every commit that lands on `main` keeps its own verdict — if a merge cancelled the run for the commit before it, that commit would show "cancelled" rather than "passed" and leave a hole when bisecting.
- `github.event_name` is part of the group because `backend-test`, `frontend-test` and `sdk-test` have both `push: main` and a nightly `schedule`. `github.ref` is `refs/heads/main` for both, so without it the cron run and a main push share a group and queue behind each other for no reason.

Deployment, release and infrastructure workflows are deliberately untouched — those need queue-never-cancel guards keyed on the resource being written (environment, release tag, terraform state), which is a separate change with a different risk profile.

## Additional Context

- Both LangWatch (51 of 52 workflows guarded) and Opik (40 of 83) use this shape for CI. The group form here matches LangWatch's SDK CI workflows; the `cancel-in-progress` condition matches Opik's, which leaves a manual `workflow_dispatch` re-run alone where LangWatch's `github.ref != 'refs/heads/main'` would cancel it too. All seven of these workflows are dispatchable.
- Worth knowing: GitHub keeps only one *pending* run per group, so in a burst of three rapid merges the middle run is evicted while queued regardless of `cancel-in-progress`. The setting protects the currently-running commit, not every commit in a burst.

## Testing

All seven files parse as valid YAML with `concurrency.group` and `concurrency.cancel-in-progress` set. Real verification is behavioural: push twice in quick succession to this PR and confirm the first run for each workflow is cancelled while the second proceeds.
