### PR TITLE
Collapse backend pytest markers to five and fix dead test config

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -73,7 +73,7 @@ jobs:
         # would re-sync the venv *without* the EE extra, dropping rhesis-backend-ee
         # before the EE tests under tests/backend/ee/ run.
         run: |
-          uv run --extra cpu --extra ee pytest ../../tests/backend --ignore=../../tests/backend/integration -n 4 --timeout=120 --timeout-method=thread --reruns=1
+          uv run --extra cpu --extra ee pytest ../../tests/backend -n 4 --timeout=120 --timeout-method=thread --reruns=1
         working-directory: apps/backend
 
   # Verifies that the MIT-only build stays clean: no core module may import

--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -34,8 +34,8 @@ format_diff:
 
 # Tests (Postgres/Redis start automatically via Testcontainers)
 test:
-	uv run --extra cpu pytest ../../tests/backend --ignore=../../tests/backend/integration -n 4 --timeout=120 --timeout-method=thread --reruns=1
+	uv run --extra cpu pytest ../../tests/backend -n 4 --timeout=120 --timeout-method=thread --reruns=1
 
 # Re-run only failed tests
 test-lf:
-	uv run --extra cpu pytest ../../tests/backend --lf --ignore=../../tests/backend/integration --timeout=120 --timeout-method=thread
+	uv run --extra cpu pytest ../../tests/backend --lf --timeout=120 --timeout-method=thread

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -226,13 +226,15 @@ addopts = "-o asyncio_default_fixture_loop_scope=function -p no:plugins"
 filterwarnings = [
     "ignore::pytest.PytestDeprecationWarning:pytest_asyncio.plugin",
 ]
+# Keep in sync with tests/pytest.ini — which of the two pytest picks up depends
+# on whether a path argument is passed (a path under tests/ makes tests/pytest.ini
+# the config file and this section is ignored entirely).
 markers = [
     "unit: fast tests with mocked dependencies",
     "integration: tests with real external services",
     "slow: tests that take >5 seconds",
-    "ai: tests involving AI model calls",
-    "critical: core functionality tests",
     "security: security and vulnerability tests",
+    "ee: tests that require the EE package (rhesis-backend-ee) to be installed",
 ]
 
 [build-system]

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ editable, so `import rhesis.backend...` resolves. From the repo root it doesn't.
 | `k6/` | Load tests against deployed environments | `tests/k6` |
 | `frontend/` | Holds only a README — see [Frontend](#frontend) | — |
 
-`pytest.ini` and `conftest.py` at this level declare the shared markers and a few fixtures. The
+`pytest.ini` at this level declares the shared markers, `conftest.py` a few fixtures. The
 two compose files here provide backing services: `docker-compose.test.yml` for the SDK integration
 suite, `docker-compose.frontend.yml` for the frontend E2E suite.
 
@@ -27,7 +27,9 @@ suite, `docker-compose.frontend.yml` for the frontend E2E suite.
 
 Run from `apps/backend`. A bare `uv run pytest` there picks up its `pyproject.toml` as the
 configfile, whose `testpaths` covers both `../../tests/backend` and `../../tests/notifications`.
-Pass an explicit path and pytest uses `tests/pytest.ini` instead — same markers, no `testpaths`.
+Pass an explicit path and pytest uses `tests/pytest.ini` instead — same markers, but its
+`addopts` and `pythonpath` are dropped, since only the winning configfile's settings apply. This is
+what CI and `make test` do.
 
 ```bash
 cd apps/backend
@@ -98,12 +100,17 @@ k6 load tests run against `api.rhesis.ai` and `app.rhesis.ai`, not a local stack
 
 ## Markers
 
-Markers categorize tests instead of separate directories. Declared in `tests/pytest.ini`; the
-backend and SDK configs repeat the subset they use.
+Declared in `tests/pytest.ini`; `apps/backend/pyproject.toml` repeats the same set. Five markers:
 
-- Scope: `unit`, `integration`, `slow`, `performance`
-- Area: `service`/`services`, `crud`, `routes`, `auth`, `utils`, `tasks`, `database`, `transaction`
-- Other: `critical`, `security`, `ai`, `ee` (needs `rhesis-backend-ee` installed)
+- Scope: `unit`, `integration`, `slow`
+- Other: `security`, `ee` (needs `rhesis-backend-ee` installed)
+
+Nothing selects on them — no CI job, Makefile target or fixture reads a marker. They exist so `-m`
+is available if a suite grows into needing it. Note that roughly half of backend tests carry no
+marker at all, so `-m unit` runs well short of the whole fast suite.
+
+There are no area markers: select a directory by path instead of by marker, e.g.
+`../../tests/backend/crud/` rather than `-m crud`.
 
 ```bash
 uv run pytest ../../tests/backend -m unit

--- a/tests/backend/README.md
+++ b/tests/backend/README.md
@@ -44,14 +44,22 @@ tests/backend/
     └── test_helpers.py
 ```
 
-### 🎯 Backend-Specific Markers
+### 🎯 Markers
+
+There are no backend-specific markers. The whole set is declared in
+`tests/pytest.ini` and shared across every suite:
+
 ```python
-# Use these markers in combination with global ones
-@pytest.mark.database     # Tests requiring database
-@pytest.mark.auth        # Authentication/authorization tests
-@pytest.mark.api         # API endpoint tests
-@pytest.mark.celery      # Celery worker tests
+@pytest.mark.unit         # fast tests with mocked dependencies
+@pytest.mark.integration  # tests with real external services
+@pytest.mark.slow         # tests that take >5 seconds
+@pytest.mark.security     # security and vulnerability tests
+@pytest.mark.ee           # tests that need the rhesis-backend-ee package
 ```
+
+Markers are labels only — no CI job or Makefile target selects on them, and area
+markers were removed because the directory layout already says the same thing
+(use a path, e.g. `../../tests/backend/crud/`, instead of `-m crud`).
 
 ## ⚙️ Configuration & Setup
 
@@ -599,12 +607,6 @@ pytest tests/backend/ -m unit -v
 
 # Integration tests only  
 pytest tests/backend/ -m integration -v
-
-# Database tests
-pytest tests/backend/ -m database -v
-
-# API tests
-pytest tests/backend/ -m api -v
 
 # Security tests
 pytest tests/backend/ -m security -v

--- a/tests/backend/auth/test_sp3_superuser.py
+++ b/tests/backend/auth/test_sp3_superuser.py
@@ -55,7 +55,6 @@ def _unique_user(test_db: Session, org_id: str) -> models.User:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.routes
 class TestOrgOwnerCreation:
     """POST /organizations/ must ignore client-supplied owner_id and use the
     authenticated caller's user_id instead."""
@@ -138,7 +137,6 @@ class TestSuperuserJwtRemoval:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.routes
 class TestUserUpdateAuthorization:
     """PUT /users/{id} authorization matrix after is_superuser removal.
 
@@ -228,7 +226,6 @@ class TestUserUpdateAuthorization:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.routes
 class TestRecycleBinOrgScoped:
     """Recycle bin endpoints are org-scoped for all authenticated members.
     require_superuser was confirmed dead code (never wired) and has been removed.

--- a/tests/backend/auth/test_sp6_membership_hardening.py
+++ b/tests/backend/auth/test_sp6_membership_hardening.py
@@ -170,7 +170,6 @@ class TestRoleIdColumn:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.routes
 class TestMemberEndpointGating:
     """GET/POST/DELETE /projects/{id}/members authorization.
 

--- a/tests/backend/auth/test_transaction_management.py
+++ b/tests/backend/auth/test_transaction_management.py
@@ -26,8 +26,6 @@ from rhesis.backend.app.utils.encryption import hash_token
 
 
 @pytest.mark.unit
-@pytest.mark.auth
-@pytest.mark.transaction
 class TestAuthTransactionManagement:
     """🔄 Test automatic transaction management in auth utilities"""
 

--- a/tests/backend/crud/test_explorer_crud.py
+++ b/tests/backend/crud/test_explorer_crud.py
@@ -99,7 +99,6 @@ def _create_test(
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestFindUnusedTestSetName:
     """🏷️ Explorer import naming"""
 
@@ -160,7 +159,6 @@ class TestFindUnusedTestSetName:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestGetTestInTestSet:
     """🔎 Membership-scoped test lookup"""
 
@@ -233,7 +231,6 @@ class TestGetTestInTestSet:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestGetTestsUnderTopic:
     """🌳 Topic subtree matching"""
 
@@ -342,7 +339,6 @@ class TestGetTestsUnderTopic:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestCreateExplorerTest:
     """➕ The prompt+test insert pair"""
 
@@ -406,7 +402,6 @@ class TestCreateExplorerTest:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestUpdateExplorerTest:
     """✏️ Selective test updates"""
 
@@ -492,7 +487,6 @@ class TestUpdateExplorerTest:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestReassignTestsTopic:
     """🔀 Moving tests between topics"""
 
@@ -538,7 +532,6 @@ class TestReassignTestsTopic:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestRemoveTestsFromTestSet:
     """✂️ Detaching tests from a set"""
 
@@ -618,7 +611,6 @@ class TestRemoveTestsFromTestSet:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestAdaptiveSettingsWrites:
     """⚙️ Replace vs patch on adaptive_settings"""
 
@@ -674,7 +666,6 @@ class TestAdaptiveSettingsWrites:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestSetExplorerTestMetadata:
     """📝 Batched metadata writes"""
 

--- a/tests/backend/crud/test_metric_crud.py
+++ b/tests/backend/crud/test_metric_crud.py
@@ -29,7 +29,6 @@ from rhesis.backend.app.crud.metric import (
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestMetricOperations:
     """📊 Test metric operations"""
 
@@ -100,7 +99,6 @@ class TestMetricOperations:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestRequirementMetricOperations:
     """📊🎯 Test requirement-metric association operations"""
 

--- a/tests/backend/crud/test_model_get_contract.py
+++ b/tests/backend/crud/test_model_get_contract.py
@@ -14,7 +14,6 @@ from rhesis.backend.app.schemas.model import ModelCreate
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestGetModelSoftDeleteContract:
     def test_get_model_returns_none_for_deleted(
         self, test_db: Session, test_org_id: str, authenticated_user_id: str

--- a/tests/backend/crud/test_requirement_metric_security.py
+++ b/tests/backend/crud/test_requirement_metric_security.py
@@ -29,7 +29,6 @@ from rhesis.backend.app.crud.metric import (
 
 
 @pytest.mark.security
-@pytest.mark.crud
 class TestRequirementMetricSecurity:
     """🔒 Security tests for requirement-metric operations"""
 

--- a/tests/backend/crud/test_tag_crud.py
+++ b/tests/backend/crud/test_tag_crud.py
@@ -23,7 +23,6 @@ from rhesis.backend.app.crud import tag as tag_crud
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestTagOperations:
     """🏷️ Test tag CRUD operations"""
 

--- a/tests/backend/crud/test_test_crud.py
+++ b/tests/backend/crud/test_test_crud.py
@@ -28,7 +28,6 @@ from rhesis.backend.app.utils.crud_utils import count_items
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestTestOperations:
     """🧪 Test test operations"""
 
@@ -225,7 +224,6 @@ class TestTestOperations:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestBulkDeleteTests:
     """🧪 test_crud.bulk_delete_tests"""
 
@@ -406,7 +404,6 @@ class TestBulkDeleteTests:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestGetTestsExcludesExplorer:
     """test_crud.get_tests must omit explorer tests (general test list API)."""
 

--- a/tests/backend/crud/test_test_run_cascade_delete.py
+++ b/tests/backend/crud/test_test_run_cascade_delete.py
@@ -69,7 +69,6 @@ def db_test_run_large_batch(
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestTestRunCascadeDelete:
     """🧪 Test test run cascade deletion operations"""
 

--- a/tests/backend/crud/test_test_set_crud.py
+++ b/tests/backend/crud/test_test_set_crud.py
@@ -18,7 +18,6 @@ from rhesis.backend.app.utils.database_exceptions import ItemDeletedException
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestTestSetSoftDeleteContract:
     """A soft-deleted test set must raise ItemDeletedException, not return None."""
 
@@ -74,7 +73,6 @@ class TestTestSetSoftDeleteContract:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestUpdateTestSetAttributesSoftDeleteHandling:
     """update_test_set_attributes must still no-op when a linked test set is deleted.
 

--- a/tests/backend/crud/test_token_crud.py
+++ b/tests/backend/crud/test_token_crud.py
@@ -22,7 +22,6 @@ from rhesis.backend.app.utils.encryption import hash_token
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestTokenOperations:
     """🔑 Test token operations"""
 

--- a/tests/backend/crud/test_transaction_management.py
+++ b/tests/backend/crud/test_transaction_management.py
@@ -44,8 +44,6 @@ from tests.backend.routes.fixtures.data_factories import (
 
 
 @pytest.mark.unit
-@pytest.mark.crud
-@pytest.mark.transaction
 class TestCRUDTransactionManagement:
     """🔄 Test automatic transaction management in CRUD operations"""
 

--- a/tests/backend/db/test_config.py
+++ b/tests/backend/db/test_config.py
@@ -33,7 +33,6 @@ def test_database_url_configuration():
 
 
 @pytest.mark.integration
-@pytest.mark.database
 def test_database_connection(test_db):
     """🔗 Test that database connection works with test database."""
     # Verify we can execute a simple query
@@ -49,7 +48,6 @@ def test_database_connection(test_db):
 
 
 @pytest.mark.integration
-@pytest.mark.database
 def test_test_data_manager(test_db):
     """👥 Test the TestDataManager utility."""
     manager = TestDataManager(test_db)
@@ -92,7 +90,6 @@ def test_different_database_urls():
 
 
 @pytest.mark.integration
-@pytest.mark.database
 def test_fastapi_client_database_integration(client):
     """🌐 Test that FastAPI client uses test database."""
     # Make a request that would interact with the database

--- a/tests/backend/jobs/test_transaction_management.py
+++ b/tests/backend/jobs/test_transaction_management.py
@@ -29,8 +29,6 @@ from tests.backend.routes.fixtures.data_factories import TestDataFactory
 
 
 @pytest.mark.unit
-@pytest.mark.tasks
-@pytest.mark.transaction
 class TestTaskTransactionManagement:
     """🔄 Test automatic transaction management in task execution"""
 

--- a/tests/backend/routes/conftest.py
+++ b/tests/backend/routes/conftest.py
@@ -132,24 +132,5 @@ def test_debug_info(request):
     }
 
 
-# === CONDITIONAL FIXTURES ===
-
-
-@pytest.fixture
-def skip_if_slow(request):
-    """
-    🐌 Skip slow tests unless explicitly requested
-
-    Skips tests marked with @pytest.mark.slow unless --runslow is passed.
-    """
-    if hasattr(request.config, "getoption") and request.config.getoption(
-        "--runslow", default=False
-    ):
-        return
-
-    if request.node.get_closest_marker("slow"):
-        pytest.skip("Slow test skipped (use --runslow to run)")
-
-
 # This makes all fixtures automatically available to any test file
 # in the routes/ directory without explicit imports

--- a/tests/backend/routes/test_auth.py
+++ b/tests/backend/routes/test_auth.py
@@ -235,7 +235,6 @@ class TestEmailRegistration:
 
 
 @pytest.mark.unit
-@pytest.mark.critical
 class TestAuthLogout:
     """Test authentication logout endpoint"""
 
@@ -312,7 +311,6 @@ class TestAuthLogout:
 
 
 @pytest.mark.unit
-@pytest.mark.critical
 class TestAuthVerify:
     """Test authentication verification endpoint"""
 
@@ -421,7 +419,6 @@ class TestAuthVerify:
 
 
 @pytest.mark.integration
-@pytest.mark.critical
 class TestAuthenticationFlow:
     """Test complete authentication flow integration"""
 

--- a/tests/backend/routes/test_base/authentication.py
+++ b/tests/backend/routes/test_base/authentication.py
@@ -15,7 +15,6 @@ from .core import BaseEntityTests
 
 
 @pytest.mark.unit
-@pytest.mark.critical
 class BaseAuthenticationTests(BaseEntityTests):
     """Base class for authentication tests"""
 

--- a/tests/backend/routes/test_base/crud.py
+++ b/tests/backend/routes/test_base/crud.py
@@ -19,7 +19,6 @@ fake = Faker()
 
 
 @pytest.mark.unit
-@pytest.mark.critical
 class BaseCRUDTests(BaseEntityTests):
     """Base class for CRUD operation tests"""
 

--- a/tests/backend/routes/test_base/list_operations.py
+++ b/tests/backend/routes/test_base/list_operations.py
@@ -18,7 +18,6 @@ fake = Faker()
 
 
 @pytest.mark.integration
-@pytest.mark.critical
 class BaseListOperationTests(BaseEntityTests):
     """Base class for list operation tests"""
 

--- a/tests/backend/routes/test_base/user_relationships.py
+++ b/tests/backend/routes/test_base/user_relationships.py
@@ -18,7 +18,6 @@ fake = Faker()
 
 
 @pytest.mark.unit
-@pytest.mark.critical
 class BaseUserRelationshipTests(BaseEntityTests):
     """Base class for testing user relationship fields (user_id, owner_id, assignee_id)"""
 

--- a/tests/backend/routes/test_endpoint.py
+++ b/tests/backend/routes/test_endpoint.py
@@ -134,7 +134,6 @@ class TestEndpointStandardRoutes(EndpointTestMixin, BaseEntityRouteTests):
 
 # Endpoint-specific tests for invocation and schema functionality
 @pytest.mark.integration
-@pytest.mark.critical
 class TestEndpointInvocation(EndpointTestMixin, BaseEntityTests):
     """Test endpoint invocation functionality"""
 
@@ -496,7 +495,6 @@ class TestEndpointSpecificEdgeCases(EndpointTestMixin, BaseEntityTests):
         assert data["name"] == ""  # Empty name is preserved
 
 
-@pytest.mark.performance
 class TestEndpointPerformance(EndpointTestMixin, BaseEntityTests):
     """Performance tests for endpoint operations"""
 

--- a/tests/backend/routes/test_explorer.py
+++ b/tests/backend/routes/test_explorer.py
@@ -359,7 +359,6 @@ def explorer_and_regular_test_sets(test_db: Session, test_org_id, authenticated_
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestListExplorerTestSetsEndpoint:
     """Test GET /explorer"""
 
@@ -543,7 +542,6 @@ class TestListExplorerTestSetsEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestCreateExplorerTestSetEndpoint:
     """Test POST /explorer"""
 
@@ -612,7 +610,6 @@ class TestCreateExplorerTestSetEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestImportExplorerTestSetEndpoint:
     """Test POST /explorer/import/{source_test_set_id}"""
 
@@ -699,7 +696,6 @@ class TestImportExplorerTestSetEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestExportRegularTestSetFromExplorerEndpoint:
     """Test POST /explorer/export/{source_test_set_id}"""
 
@@ -831,7 +827,6 @@ class TestExportRegularTestSetFromExplorerEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestDeleteExplorerTestSetEndpoint:
     """Test DELETE /explorer/{test_set_identifier}"""
 
@@ -907,7 +902,6 @@ class TestDeleteExplorerTestSetEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestBulkDeleteExplorerTestSetsEndpoint:
     """Test DELETE /explorer/bulk"""
 
@@ -948,7 +942,6 @@ class TestBulkDeleteExplorerTestSetsEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestExplorerTreeEndpoint:
     """Test GET /explorer/{test_set_id}/tree"""
 
@@ -1051,7 +1044,6 @@ class TestExplorerTreeEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestExplorerTestsEndpoint:
     """Test GET /explorer/{test_set_id}/tests"""
 
@@ -1113,7 +1105,6 @@ class TestExplorerTestsEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestExplorerTopicsEndpoint:
     """Test GET /explorer/{test_set_id}/topics"""
 
@@ -1181,7 +1172,6 @@ class TestExplorerTopicsEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestCreateExplorerTopicEndpoint:
     """Test POST /explorer/{test_set_id}/topics"""
 
@@ -1297,7 +1287,6 @@ class TestCreateExplorerTopicEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestCreateExplorerTestEndpoint:
     """Test POST /explorer/{test_set_id}/tests"""
 
@@ -1479,7 +1468,6 @@ class TestCreateExplorerTestEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestUpdateExplorerTestEndpoint:
     """Test PUT /explorer/{test_set_id}/tests/{test_id}"""
 
@@ -1619,7 +1607,6 @@ class TestUpdateExplorerTestEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestDeleteExplorerTestEndpoint:
     """Test DELETE /explorer/{test_set_id}/tests/{test_id}"""
 
@@ -1816,7 +1803,6 @@ def deep_topic_test_set(test_db: Session, test_org_id, authenticated_user_id):
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestUpdateExplorerTopicEndpoint:
     """Test PUT /explorer/{test_set_id}/topics/{topic_path}"""
 
@@ -1966,7 +1952,6 @@ class TestUpdateExplorerTopicEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestDeleteExplorerTopicEndpoint:
     """Test DELETE /explorer/{test_set_id}/topics/{topic_path}"""
 
@@ -2059,7 +2044,6 @@ class TestDeleteExplorerTopicEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestGenerateOutputsEndpoint:
     """Test POST /explorer/{test_set_id}/generate_outputs"""
 
@@ -2206,7 +2190,6 @@ class TestGenerateOutputsEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestEvaluateEndpoint:
     """Test POST /explorer/{test_set_id}/evaluate"""
 

--- a/tests/backend/routes/test_home.py
+++ b/tests/backend/routes/test_home.py
@@ -7,7 +7,6 @@ response formats, and user experience flows.
 
 from unittest.mock import Mock, patch
 
-import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
@@ -489,7 +488,6 @@ class TestHomePerformance:
     ⚡ Performance tests for home endpoints
     """
 
-    @pytest.mark.performance
     def test_home_endpoint_response_time(self, client: TestClient):
         """
         ⚡ Test home endpoint response time
@@ -507,7 +505,6 @@ class TestHomePerformance:
         response_time = end_time - start_time
         assert response_time < 1.0  # Should respond within 1 second
 
-    @pytest.mark.performance
     def test_protected_endpoint_response_time(self, client: TestClient):
         """
         ⚡ Test protected endpoint response time

--- a/tests/backend/routes/test_metric_tuning.py
+++ b/tests/backend/routes/test_metric_tuning.py
@@ -138,7 +138,6 @@ def _load_case(db: Session, case_id) -> models.Test:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestListTuningCases:
     """GET /metrics/{metric_id}/tuning/cases"""
 
@@ -200,7 +199,6 @@ class TestListTuningCases:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestOnlyCustomMetricsCanBeTuned:
     """A framework-provided metric has no prompt the organization owns."""
 
@@ -242,7 +240,6 @@ class TestOnlyCustomMetricsCanBeTuned:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestCreateTuningCase:
     """POST /metrics/{metric_id}/tuning/cases"""
 
@@ -421,7 +418,6 @@ class TestCreateTuningCase:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestACaseNobodyHasRun:
     """A case can be captured now and judged after a run."""
 
@@ -451,7 +447,6 @@ class TestACaseNobodyHasRun:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestUpdateTuningCase:
     """PUT /metrics/{metric_id}/tuning/cases/{case_id}"""
 
@@ -561,7 +556,6 @@ class TestUpdateTuningCase:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestCasesStoredBeforeTheRename:
     """`expected_output` was renamed `reference_answer`."""
 
@@ -620,7 +614,6 @@ class TestCasesStoredBeforeTheRename:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestDeleteTuningCase:
     """DELETE /metrics/{metric_id}/tuning/cases/{case_id}"""
 
@@ -658,7 +651,6 @@ class TestDeleteTuningCase:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestTuningRowsAreUnreachable:
     """Metric-owned rows are reachable only through their metric.
 

--- a/tests/backend/routes/test_metric_tuning_reviews.py
+++ b/tests/backend/routes/test_metric_tuning_reviews.py
@@ -258,7 +258,6 @@ def _by_id(cases: List[dict]) -> dict:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestTheFourOutcomes:
     """Every outcome is reachable, and each one reports itself rather than another."""
 
@@ -333,7 +332,6 @@ class TestTheFourOutcomes:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestARejectionNeedsAComment:
     """The comment is the thing the feature produces, so a rejection without one
     records nothing worth keeping."""
@@ -389,7 +387,6 @@ class TestARejectionNeedsAComment:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestReviewingOneCase:
     """POST /metrics/{metric_id}/tuning/cases/{case_id}/review"""
 
@@ -494,7 +491,6 @@ class TestReviewingOneCase:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestAcceptTheRest:
     """POST /metrics/{metric_id}/tuning/reviews/accept-rest"""
 
@@ -625,7 +621,6 @@ class TestAcceptTheRest:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestReviewHistory:
     """What the stored list of reviews does as judgements pile up."""
 
@@ -757,7 +752,6 @@ class TestReviewHistory:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestReviewsAreInvisibleToTheMetric:
     """A scorecard has to reflect the metric's judgement, not its ability to
     read a reviewer's hint."""

--- a/tests/backend/routes/test_metric_tuning_runs.py
+++ b/tests/backend/routes/test_metric_tuning_runs.py
@@ -366,7 +366,6 @@ def _run(test_db: Session, metric: models.Metric, org_id, *results, user_id=None
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestStartTuningRun:
     """POST /metrics/{metric_id}/tuning/run"""
 
@@ -532,7 +531,6 @@ class TestStartTuningRun:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestReadTuningRun:
     """GET /metrics/{metric_id}/tuning/run"""
 
@@ -572,7 +570,6 @@ class TestReadTuningRun:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestRunResults:
     """What a finished run leaves on the cases."""
 
@@ -908,7 +905,6 @@ class TestRunResults:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestRunsAndStandingReviews:
     """What a re-run does to the reviews already on the cases.
 
@@ -1012,7 +1008,6 @@ class TestRunsAndStandingReviews:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestAgreement:
     """The one number for the whole set, read off GET /tuning/run.
 
@@ -1243,7 +1238,6 @@ class TestAgreement:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestARunThatNeverFinishes:
     """A `running` claim nobody is behind must not wedge the metric forever.
 
@@ -1372,7 +1366,6 @@ class TestARunThatNeverFinishes:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestADispatchThatNeverReachesAWorker:
     """The claim is committed before dispatch, so a broker failure needs releasing.
 
@@ -1427,7 +1420,6 @@ class TestADispatchThatNeverReachesAWorker:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestARunThatPredatesItsMetric:
     """Whether the numbers on screen still belong to the metric above them.
 

--- a/tests/backend/routes/test_project_membership.py
+++ b/tests/backend/routes/test_project_membership.py
@@ -122,7 +122,6 @@ def project_via_api(authenticated_client, project_factory):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.routes
 class TestProjectListingMembership:
     """GET /projects/ must only return projects the authenticated user is a member of."""
 
@@ -247,7 +246,6 @@ class TestProjectListingMembership:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.routes
 class TestProjectCreatorAutoEnroll:
     """When creating a project via the API, the creator is automatically enrolled."""
 
@@ -275,7 +273,6 @@ class TestProjectCreatorAutoEnroll:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.routes
 class TestProjectMembersAPI:
     """Tests for GET / POST / DELETE /projects/{id}/members."""
 
@@ -410,7 +407,6 @@ class TestProjectMembersAPI:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.routes
 class TestProjectByIdMembershipEnforcement:
     """GET / PUT / DELETE /projects/{id} must require project membership.
 

--- a/tests/backend/routes/test_prompt_template.py
+++ b/tests/backend/routes/test_prompt_template.py
@@ -482,7 +482,6 @@ class TestPromptTemplateRelationships(PromptTemplateTestMixin, BaseEntityTests):
 # === PROMPT TEMPLATE PERFORMANCE TESTS ===
 
 
-@pytest.mark.performance
 class TestPromptTemplatePerformance(PromptTemplateTestMixin, BaseEntityTests):
     """Prompt template performance tests"""
 

--- a/tests/backend/routes/test_recycle.py
+++ b/tests/backend/routes/test_recycle.py
@@ -26,7 +26,6 @@ from tests.backend.routes.fixtures.data_factories import (
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestRecycleModelsEndpoint:
     """Test the /recycle/models endpoint."""
 
@@ -77,7 +76,6 @@ class TestRecycleModelsEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestRecycleGetDeletedEndpoint:
     """Test the GET /recycle/{model_name} endpoint."""
 
@@ -193,7 +191,6 @@ class TestRecycleGetDeletedEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestRecycleRestoreEndpoint:
     """Test the POST /recycle/{model_name}/{item_id}/restore endpoint."""
 
@@ -289,7 +286,6 @@ class TestRecycleRestoreEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestRecyclePermanentDeleteEndpoint:
     """Test the DELETE /recycle/{model_name}/{item_id} endpoint."""
 
@@ -364,7 +360,6 @@ class TestRecyclePermanentDeleteEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestRecycleStatsEndpoint:
     """Test the GET /recycle/stats/counts endpoint."""
 
@@ -406,7 +401,6 @@ class TestRecycleStatsEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestRecycleBulkRestoreEndpoint:
     """Test the POST /recycle/bulk-restore/{model_name} endpoint."""
 
@@ -496,7 +490,6 @@ class TestRecycleBulkRestoreEndpoint:
 
 
 @pytest.mark.integration
-@pytest.mark.routes
 class TestRecycleEmptyBinEndpoint:
     """Test the DELETE /recycle/empty/{model_name} endpoint."""
 

--- a/tests/backend/routes/test_source.py
+++ b/tests/backend/routes/test_source.py
@@ -457,7 +457,6 @@ class TestSourceLanguageHandling(SourceTestMixin, BaseEntityTests):
 # === SOURCE PERFORMANCE TESTS ===
 
 
-@pytest.mark.performance
 class TestSourcePerformance(SourceTestMixin, BaseEntityTests):
     """Source performance tests"""
 

--- a/tests/backend/routes/test_status.py
+++ b/tests/backend/routes/test_status.py
@@ -609,7 +609,6 @@ class TestStatusHierarchy(StatusTestMixin, BaseEntityTests):
 # === STATUS PERFORMANCE TESTS ===
 
 
-@pytest.mark.performance
 class TestStatusPerformance(StatusTestMixin, BaseEntityTests):
     """Status performance tests"""
 

--- a/tests/backend/routes/test_tag.py
+++ b/tests/backend/routes/test_tag.py
@@ -587,7 +587,6 @@ class TestTagAssignments(TagTestMixin, BaseEntityTests):
 # === TAG PERFORMANCE TESTS ===
 
 
-@pytest.mark.performance
 class TestTagPerformance(TagTestMixin, BaseEntityTests):
     """Tag performance tests"""
 

--- a/tests/backend/routes/test_token.py
+++ b/tests/backend/routes/test_token.py
@@ -625,7 +625,6 @@ class TestTokenManagement(TokenTestMixin, BaseEntityTests):
 # === TOKEN PERFORMANCE TESTS ===
 
 
-@pytest.mark.performance
 class TestTokenPerformance(TokenTestMixin, BaseEntityTests):
     """Token performance tests"""
 

--- a/tests/backend/routes/test_topic.py
+++ b/tests/backend/routes/test_topic.py
@@ -240,7 +240,6 @@ class TestTopicHierarchy(TopicTestMixin, BaseEntityTests):
 # === TOPIC PERFORMANCE TESTS ===
 
 
-@pytest.mark.performance
 class TestTopicPerformance(TopicTestMixin, BaseEntityTests):
     """Topic performance tests"""
 

--- a/tests/backend/routes/test_transaction_management.py
+++ b/tests/backend/routes/test_transaction_management.py
@@ -25,8 +25,6 @@ from tests.backend.routes.fixtures.data_factories import OrganizationDataFactory
 
 
 @pytest.mark.unit
-@pytest.mark.routes
-@pytest.mark.transaction
 class TestRouterTransactionManagement:
     """🔄 Test automatic transaction management in router operations"""
 

--- a/tests/backend/routes/test_type_lookup.py
+++ b/tests/backend/routes/test_type_lookup.py
@@ -557,7 +557,6 @@ class TestTypeLookupCategorization(TypeLookupTestMixin, BaseEntityTests):
 # === TYPE LOOKUP PERFORMANCE TESTS ===
 
 
-@pytest.mark.performance
 class TestTypeLookupPerformance(TypeLookupTestMixin, BaseEntityTests):
     """Type lookup performance tests"""
 

--- a/tests/backend/services/explorer/test_evaluation.py
+++ b/tests/backend/services/explorer/test_evaluation.py
@@ -152,7 +152,6 @@ class TestMetricVerdict:
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-@pytest.mark.service
 class TestEvaluateTestsForExplorerSet:
     """Test evaluate_tests_for_explorer_set."""
 

--- a/tests/backend/services/explorer/test_invocation.py
+++ b/tests/backend/services/explorer/test_invocation.py
@@ -37,7 +37,6 @@ def _invoker(test_db, organization_id, user_id, max_concurrency=10, endpoint_id=
 
 
 @pytest.mark.integration
-@pytest.mark.service
 @pytest.mark.asyncio
 class TestEndpointInvoker:
     """Test the shared endpoint invocation helper."""

--- a/tests/backend/services/explorer/test_responses.py
+++ b/tests/backend/services/explorer/test_responses.py
@@ -28,7 +28,6 @@ _SVC_PATCH = "rhesis.backend.app.dependencies.get_endpoint_service"
 
 
 @pytest.mark.integration
-@pytest.mark.service
 @pytest.mark.asyncio
 class TestGenerateOutputsForTests:
     """Test generate_outputs_for_tests with mocked endpoint response."""

--- a/tests/backend/services/explorer/test_settings.py
+++ b/tests/backend/services/explorer/test_settings.py
@@ -67,7 +67,6 @@ def _create_metric(db: Session, organization_id: str, user_id: str, name: str) -
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestExplorerSettings:
     def test_get_settings_empty(self, test_db: Session, test_org_id, authenticated_user_id):
         test_set = _create_explorer_set(test_db, test_org_id, authenticated_user_id)

--- a/tests/backend/services/explorer/test_suggestions.py
+++ b/tests/backend/services/explorer/test_suggestions.py
@@ -58,7 +58,6 @@ async def _collect(stream):
 
 
 @pytest.mark.integration
-@pytest.mark.service
 @pytest.mark.asyncio
 class TestInvokeEndpointForSuggestionsStream:
     """Test the NDJSON stream that generates outputs for non-persisted suggestions."""
@@ -194,7 +193,6 @@ class TestInvokeEndpointForSuggestionsStream:
 
 
 @pytest.mark.integration
-@pytest.mark.service
 @pytest.mark.asyncio
 class TestEvaluateSuggestionsStream:
     """Test the NDJSON stream that evaluates non-persisted suggestion outputs."""
@@ -331,7 +329,6 @@ async def _fake_suggestion_stream(items):
 
 
 @pytest.mark.integration
-@pytest.mark.service
 @pytest.mark.asyncio
 class TestSuggestionPipelineStream:
     """Test the unified generate → embed → invoke → evaluate NDJSON stream."""

--- a/tests/backend/services/explorer/test_tests.py
+++ b/tests/backend/services/explorer/test_tests.py
@@ -108,7 +108,6 @@ def explorer_and_regular_test_sets(test_db: Session, test_org_id, authenticated_
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestExplorerTreeNodes:
     """Test get_tree_nodes - returns all nodes including topic markers."""
 
@@ -164,7 +163,6 @@ class TestExplorerTreeNodes:
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestExplorerTreeTests:
     """Test get_tree_tests - returns only test nodes (no topic markers)."""
 
@@ -219,7 +217,6 @@ class TestExplorerTreeTests:
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestExplorerTreeTopics:
     """Test get_tree_topics - returns TopicNode objects."""
 
@@ -267,7 +264,6 @@ class TestExplorerTreeTopics:
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestGetExplorerTestSets:
     """Test get_explorer_test_sets - returns test sets flagged as Explorer-owned."""
 
@@ -401,7 +397,6 @@ class TestGetExplorerTestSets:
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestCreateExplorerTestSet:
     """Test create_explorer_test_set - creates a test set for adaptive testing."""
 
@@ -457,7 +452,6 @@ class TestCreateExplorerTestSet:
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestDeleteExplorerTestSet:
     """Test delete_explorer_test_set - removes adaptive test sets only."""
 
@@ -656,7 +650,6 @@ class TestBulkDeleteExplorerTestSets:
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestCreateTestNode:
     """Test create_test_node - creates test nodes in a test set."""
 
@@ -829,7 +822,6 @@ class TestCreateTestNode:
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestUpdateTestNode:
     """Test update_test_node - updates test nodes in a test set."""
 
@@ -964,7 +956,6 @@ class TestUpdateTestNode:
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestDeleteTestNode:
     """Test delete_test_node - deletes test nodes from a test set."""
 
@@ -1086,7 +1077,6 @@ class TestDeleteTestNode:
 # ============================================================================
 
 
-@pytest.mark.service
 class TestImportExplorerTestSetFromSource:
     """Test import_explorer_test_set_from_source."""
 
@@ -1234,7 +1224,6 @@ class TestImportExplorerTestSetFromSource:
 # ============================================================================
 
 
-@pytest.mark.service
 class TestExportRegularTestSetFromExplorer:
     """Test export_regular_test_set_from_explorer."""
 

--- a/tests/backend/services/explorer/test_topics.py
+++ b/tests/backend/services/explorer/test_topics.py
@@ -115,7 +115,6 @@ def deep_topic_test_set(test_db: Session, test_org_id, authenticated_user_id):
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestCreateTopicNode:
     """Test create_topic_node - creates topic markers in a test set."""
 
@@ -262,7 +261,6 @@ class TestCreateTopicNode:
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestRemoveTopicNode:
     """Test remove_topic_node - removes topics and ensures topic markers are deleted."""
 
@@ -460,7 +458,6 @@ class TestRemoveTopicNode:
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestUpdateTopicNode:
     """Test update_topic_node - renames topics in a test set."""
 

--- a/tests/backend/services/garak/test_importer.py
+++ b/tests/backend/services/garak/test_importer.py
@@ -14,7 +14,6 @@ fake = Faker()
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestProbeSelectionDataclass:
     """Tests for ProbeSelection dataclass."""
 
@@ -41,7 +40,6 @@ class TestProbeSelectionDataclass:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakImporterInit:
     """Tests for GarakImporter initialization."""
 
@@ -59,7 +57,6 @@ class TestGarakImporterInit:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakImporterMetadataBuilding:
     """Tests for metadata building methods."""
 
@@ -147,7 +144,6 @@ class TestGarakImporterMetadataBuilding:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakImporterNameGeneration:
     """Tests for name generation methods."""
 
@@ -217,7 +213,6 @@ class TestGarakImporterNameGeneration:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakImporterProbeRetrieval:
     """Tests for probe info retrieval."""
 
@@ -274,7 +269,6 @@ class TestGarakImporterProbeRetrieval:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakImporterPreview:
     """Tests for import preview."""
 
@@ -360,7 +354,6 @@ class TestGarakImporterPreview:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakImporterMetricCreation:
     """Tests for metric creation/lookup."""
 
@@ -380,7 +373,6 @@ class TestGarakImporterMetricCreation:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakImporterTagRequirements:
     """Tests for _tag_garak_requirements idempotency."""
 

--- a/tests/backend/services/garak/test_probes.py
+++ b/tests/backend/services/garak/test_probes.py
@@ -16,7 +16,6 @@ from rhesis.backend.app.services.garak.probes.service import _get_enumeration_lo
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakProbeInfoDataclass:
     """Tests for GarakProbeInfo dataclass."""
 
@@ -56,7 +55,6 @@ class TestGarakProbeInfoDataclass:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakModuleInfoDataclass:
     """Tests for GarakModuleInfo dataclass."""
 
@@ -92,7 +90,6 @@ class TestGarakModuleInfoDataclass:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakProbeServiceInit:
     """Tests for GarakProbeService initialization."""
 
@@ -195,7 +192,6 @@ class TestGarakProbeServiceInit:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakProbeServiceProbeChecking:
     """Tests for probe class checking."""
 
@@ -233,7 +229,6 @@ class TestGarakProbeServiceProbeChecking:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakProbeServiceEnumeration:
     """Tests for probe enumeration."""
 
@@ -315,7 +310,6 @@ class TestGarakProbeServiceEnumeration:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakProbeServiceExtraction:
     """Tests for probe extraction."""
 
@@ -368,7 +362,6 @@ class TestGarakProbeServiceExtraction:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakProbeServiceHelpers:
     """Tests for helper methods."""
 
@@ -408,7 +401,6 @@ class TestGarakProbeServiceHelpers:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGeneratorPlaceholder:
     """Tests for the generator placeholder constant."""
 
@@ -418,7 +410,6 @@ class TestGeneratorPlaceholder:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakProbeServiceGetProbe:
     """Tests for get_probe/get_probes_for_module cache-preferring lookups."""
 
@@ -482,7 +473,6 @@ class TestGarakProbeServiceGetProbe:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakProbeServiceEnumerateCachedConcurrency:
     """Regression test for a cache-stampede bug: enumerate_probe_modules_cached
     offloads the cold-cache "enumerate + populate" path to a worker thread so

--- a/tests/backend/services/garak/test_sync.py
+++ b/tests/backend/services/garak/test_sync.py
@@ -17,7 +17,6 @@ fake = Faker()
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestSyncResultDataclass:
     """Tests for SyncResult dataclass."""
 
@@ -39,7 +38,6 @@ class TestSyncResultDataclass:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakSyncServiceInit:
     """Tests for GarakSyncService initialization."""
 
@@ -52,7 +50,6 @@ class TestGarakSyncServiceInit:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakSyncServiceCanSync:
     """Tests for can_sync method."""
 
@@ -130,7 +127,6 @@ class TestGarakSyncServiceCanSync:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakSyncServiceSoftDeleteContract:
     """A soft-deleted test set must not be treated as syncable, and must not
     crash any of the four lookups with an unhandled ItemDeletedException."""
@@ -187,7 +183,6 @@ class TestGarakSyncServiceSoftDeleteContract:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakSyncServiceProbeIds:
     """Tests for probe ID extraction."""
 
@@ -295,7 +290,6 @@ class TestGarakSyncServiceProbeIds:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakSyncServiceSyncTestSet:
     """Tests for sync_test_set method."""
 
@@ -333,7 +327,6 @@ class TestGarakSyncServiceSyncTestSet:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakSyncServiceLegacySyncSafety:
     """Regression tests for a critical PR review finding: preloaded probe data
     that resolves to zero probes for a non-empty legacy module list must never
@@ -404,7 +397,6 @@ class TestGarakSyncServiceLegacySyncSafety:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakSyncServiceSyncPreview:
     """Tests for get_sync_preview method."""
 
@@ -541,7 +533,6 @@ class TestGarakSyncServiceSyncPreview:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakSyncServiceGetProbe:
     """Tests for _get_probe helper method."""
 
@@ -598,7 +589,6 @@ class TestGarakSyncServiceGetProbe:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakSyncServiceResolveSyncTarget:
     """Tests for resolve_sync_target.
 

--- a/tests/backend/services/garak/test_taxonomy.py
+++ b/tests/backend/services/garak/test_taxonomy.py
@@ -11,7 +11,6 @@ from rhesis.backend.app.services.garak.taxonomy import (
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakMapping:
     """Tests for the GarakMapping dataclass."""
 
@@ -31,7 +30,6 @@ class TestGarakMapping:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakTaxonomyMappings:
     """Tests for module mappings."""
 
@@ -114,7 +112,6 @@ class TestGarakTaxonomyMappings:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakTaxonomyDefaultMapping:
     """Tests for default mapping requirement."""
 
@@ -137,7 +134,6 @@ class TestGarakTaxonomyDefaultMapping:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakTaxonomyHelpers:
     """Tests for taxonomy get_mapping and MODULE_MAPPINGS access."""
 
@@ -173,7 +169,6 @@ class TestGarakTaxonomyHelpers:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakTaxonomyConsistency:
     """Tests for taxonomy consistency."""
 
@@ -214,7 +209,6 @@ class TestGarakTaxonomyConsistency:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGarakTaxonomyV013Modules:
     """Tests for garak v0.13.3 taxonomy additions and renames."""
 
@@ -356,7 +350,6 @@ class TestGarakTaxonomyV013Modules:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestResolveRequirement:
     """Tests for resolve_requirement tag-to-requirement resolution."""
 

--- a/tests/backend/services/test_async_service.py
+++ b/tests/backend/services/test_async_service.py
@@ -34,7 +34,6 @@ def service():
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestAsyncServiceExecuteWithFallback:
     """Tests for the execute_with_fallback method."""
 
@@ -99,7 +98,6 @@ class TestAsyncServiceExecuteWithFallback:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestAsyncServiceBatchExecute:
     """Tests for the batch_execute method."""
 
@@ -129,7 +127,6 @@ class TestAsyncServiceBatchExecute:
 
 
 @pytest.mark.integration
-@pytest.mark.services
 class TestAsyncServiceIntegration:
     """Integration tests for the AsyncService base class."""
 

--- a/tests/backend/services/test_confluence_rest.py
+++ b/tests/backend/services/test_confluence_rest.py
@@ -9,7 +9,6 @@ from rhesis.backend.app.services.tool.rest.confluence import ConfluenceRestClien
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestConfluenceInit:
     def test_base_url_trailing_slash_stripped(self):
         client = ConfluenceRestClient(
@@ -22,7 +21,6 @@ class TestConfluenceInit:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 @pytest.mark.asyncio
 class TestConfluenceHealthCheck:
     def _client(self):

--- a/tests/backend/services/test_document_handler.py
+++ b/tests/backend/services/test_document_handler.py
@@ -39,7 +39,6 @@ class DocumentHandlerTestMixin(DocumentHandlerTestMixin):
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestDocumentHandlerInitialization(DocumentHandlerTestMixin, BaseDocumentHandlerTests):
     """Test DocumentHandler initialization and configuration."""
 
@@ -84,7 +83,6 @@ class TestDocumentHandlerInitialization(DocumentHandlerTestMixin, BaseDocumentHa
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestDocumentHandlerValidation(DocumentHandlerTestMixin, BaseDocumentHandlerTests):
     """Test document validation methods."""
 
@@ -173,7 +171,6 @@ class TestDocumentHandlerValidation(DocumentHandlerTestMixin, BaseDocumentHandle
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestDocumentHandlerFileOperations(DocumentHandlerTestMixin, BaseDocumentHandlerTests):
     """Test document file operations."""
 
@@ -224,7 +221,6 @@ class TestDocumentHandlerFileOperations(DocumentHandlerTestMixin, BaseDocumentHa
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestDocumentHandlerMetadataExtraction(DocumentHandlerTestMixin, BaseDocumentHandlerTests):
     """Test metadata extraction methods."""
 
@@ -326,7 +322,6 @@ class TestDocumentHandlerMetadataExtraction(DocumentHandlerTestMixin, BaseDocume
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestDocumentHandlerIntegration(DocumentHandlerTestMixin, BaseDocumentHandlerTests):
     """Integration tests for DocumentHandler with real file operations."""
 
@@ -451,7 +446,6 @@ class TestDocumentHandlerIntegration(DocumentHandlerTestMixin, BaseDocumentHandl
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestDocumentHandlerEdgeCases(DocumentHandlerTestMixin, BaseDocumentHandlerTests):
     """Test edge cases and error scenarios for DocumentHandler."""
 

--- a/tests/backend/services/test_embedding_generator.py
+++ b/tests/backend/services/test_embedding_generator.py
@@ -146,7 +146,6 @@ def test_entity(
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestEmbeddingGenerator:
     """Test EmbeddingGenerator functionality."""
 

--- a/tests/backend/services/test_embedding_service.py
+++ b/tests/backend/services/test_embedding_service.py
@@ -152,7 +152,6 @@ def user_with_embedding_model(test_db: Session, db_user, embedding_model):
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestEmbeddingService:
     """Test EmbeddingService async/sync orchestration."""
 
@@ -410,7 +409,6 @@ class TestEmbeddingService:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestEmbeddingServiceIntegration:
     """Integration tests for EmbeddingService with real generator."""
 

--- a/tests/backend/services/test_github_rest.py
+++ b/tests/backend/services/test_github_rest.py
@@ -13,7 +13,6 @@ from rhesis.backend.app.services.tool.rest.github import (
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestParseGithubUrl:
     """Test _parse_github_url for the supported URL shapes."""
 
@@ -50,7 +49,6 @@ class TestParseGithubUrl:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestDecode:
     """Test _decode base64 handling."""
 
@@ -68,7 +66,6 @@ class TestDecode:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 @pytest.mark.asyncio
 class TestGithubHealthCheck:
     async def test_authenticated(self):
@@ -111,7 +108,6 @@ class TestGithubHealthCheck:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 @pytest.mark.asyncio
 class TestGithubFetch:
     """Test fetch / fetch_all for files, directories, and errors."""

--- a/tests/backend/services/test_jira_rest.py
+++ b/tests/backend/services/test_jira_rest.py
@@ -13,7 +13,6 @@ from rhesis.backend.app.services.tool.rest.notion import NotionRestClient
 
 
 @pytest.mark.unit
-@pytest.mark.services
 @pytest.mark.asyncio
 class TestCreateJiraTicketFromTask:
     """Test create_jira_ticket_from_task REST function."""
@@ -141,7 +140,6 @@ class TestCreateJiraTicketFromTask:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 @pytest.mark.asyncio
 class TestJiraRestClient:
     """Test JiraRestClient.create_issue error handling."""

--- a/tests/backend/services/test_mcp_service.py
+++ b/tests/backend/services/test_mcp_service.py
@@ -53,7 +53,6 @@ def _make_ctx(org_id="test-org-id", user_id="test-user-id", db=None):
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestHandleMCPException:
     """Test exception handling and HTTP exception mapping"""
 
@@ -170,7 +169,6 @@ class TestHandleMCPException:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestGetMCPClientByToolId:
     """Test client creation from tool ID"""
 
@@ -265,7 +263,6 @@ class TestGetMCPClientByToolId:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestGetMCPClientFromParams:
     """Test client creation from parameters"""
 
@@ -322,7 +319,6 @@ class TestGetMCPClientFromParams:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 @pytest.mark.asyncio
 class TestQueryMCP:
     """Test query_mcp function"""

--- a/tests/backend/services/test_notion_rest.py
+++ b/tests/backend/services/test_notion_rest.py
@@ -9,7 +9,6 @@ from rhesis.backend.app.services.tool.rest.notion import NotionRestClient
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestExtractPageId:
     """Test _extract_page_id URL/ID normalization and validation."""
 
@@ -48,7 +47,6 @@ class TestExtractPageId:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestBlocksToMarkdown:
     """Test _blocks_to_markdown rendering."""
 
@@ -106,7 +104,6 @@ class TestBlocksToMarkdown:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 @pytest.mark.asyncio
 class TestNotionHealthCheck:
     """Test health_check credential verification."""
@@ -132,7 +129,6 @@ class TestNotionHealthCheck:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 @pytest.mark.asyncio
 class TestNotionRequestBlocks:
     """Test _request_blocks HTTP status mapping."""
@@ -159,7 +155,6 @@ class TestNotionRequestBlocks:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 @pytest.mark.asyncio
 class TestNotionFetch:
     """Test fetch / fetch_all end-to-end with a mocked HTTP client."""

--- a/tests/backend/services/test_organization.py
+++ b/tests/backend/services/test_organization.py
@@ -20,7 +20,6 @@ from rhesis.backend.app.services import organization as organization_service
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestLoadInitialData:
     """Test load_initial_data function."""
 
@@ -523,7 +522,6 @@ class TestLoadInitialData:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestRollbackInitialData:
     """Test rollback_initial_data function."""
 

--- a/tests/backend/services/test_recycle.py
+++ b/tests/backend/services/test_recycle.py
@@ -59,7 +59,6 @@ def db_soft_deleted_test_run_with_results(
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestRecycleService:
     """🧪 Test recycle service operations"""
 

--- a/tests/backend/services/test_rest_config.py
+++ b/tests/backend/services/test_rest_config.py
@@ -16,7 +16,6 @@ from rhesis.backend.app.utils.database_exceptions import ItemDeletedException
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestBuildClient:
     """Test build_client provider → client resolution."""
 
@@ -64,7 +63,6 @@ class TestBuildClient:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestGetRestClient:
     """Test get_rest_client DB → client resolution and error handling."""
 

--- a/tests/backend/services/test_rest_health.py
+++ b/tests/backend/services/test_rest_health.py
@@ -14,7 +14,6 @@ _OK = {"is_authenticated": "Yes", "message": "Connected"}
 
 
 @pytest.mark.unit
-@pytest.mark.services
 @pytest.mark.asyncio
 class TestRunRestHealthCheck:
     """Test both the tool_id path and the provider_type_id + credentials path."""

--- a/tests/backend/services/test_storage_integration.py
+++ b/tests/backend/services/test_storage_integration.py
@@ -62,7 +62,6 @@ class StorageIntegrationTestMixin(StorageIntegrationTestMixin):
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestStorageServiceIntegration(StorageIntegrationTestMixin, BaseStorageIntegrationTests):
     """Integration tests for StorageService with real file operations."""
 
@@ -234,7 +233,6 @@ class TestStorageServiceIntegration(StorageIntegrationTestMixin, BaseStorageInte
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestDocumentHandlerIntegration(StorageIntegrationTestMixin, BaseStorageIntegrationTests):
     """Integration tests for DocumentHandler with real storage operations."""
 
@@ -408,7 +406,6 @@ class TestDocumentHandlerIntegration(StorageIntegrationTestMixin, BaseStorageInt
 
 
 @pytest.mark.integration
-@pytest.mark.service
 class TestStorageServiceEnvironmentConfigurations(
     StorageIntegrationTestMixin, BaseStorageIntegrationTests
 ):

--- a/tests/backend/services/test_storage_service.py
+++ b/tests/backend/services/test_storage_service.py
@@ -41,7 +41,6 @@ class StorageServiceTestMixin(StorageServiceTestMixin):
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestStorageServiceInitialization(StorageServiceTestMixin, BaseStorageServiceTests):
     """Test StorageService initialization and configuration."""
 
@@ -119,7 +118,6 @@ class TestStorageServiceInitialization(StorageServiceTestMixin, BaseStorageServi
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestStorageServiceFilePaths(StorageServiceTestMixin, BaseStorageServiceTests):
     """Test file path generation methods."""
 
@@ -150,7 +148,6 @@ class TestStorageServiceFilePaths(StorageServiceTestMixin, BaseStorageServiceTes
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestStorageServiceFileOperations(StorageServiceTestMixin, BaseStorageServiceTests):
     """Test file operations with mocked file system."""
 
@@ -280,7 +277,6 @@ class TestStorageServiceFileOperations(StorageServiceTestMixin, BaseStorageServi
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestStorageServiceEdgeCases(StorageServiceTestMixin, BaseStorageServiceTests):
     """Test edge cases and error scenarios for StorageService."""
 
@@ -430,7 +426,6 @@ class TestStorageServiceEdgeCases(StorageServiceTestMixin, BaseStorageServiceTes
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestStorageServicePathBuilders:
     """Tests for domain-scoped path builder methods."""
 

--- a/tests/backend/services/test_test.py
+++ b/tests/backend/services/test_test.py
@@ -49,7 +49,6 @@ def create_bulk_test_data(**overrides):
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestBulkCreateTests:
     """Test bulk_create_tests function."""
 
@@ -413,7 +412,6 @@ class TestBulkCreateTests:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestTestSetAssociationsInTestService:
     """Test test set association functions in test service."""
 

--- a/tests/backend/services/test_test_execution.py
+++ b/tests/backend/services/test_test_execution.py
@@ -79,7 +79,6 @@ def create_test_with_id_request_data(test_id: str, **overrides):
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestExecuteTestInPlace:
     """Test execute_test_in_place function with various scenarios."""
 
@@ -546,7 +545,6 @@ class TestExecuteTestInPlace:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestCreateInplaceTest:
     """Test _create_inplace_test helper function."""
 
@@ -679,7 +677,6 @@ class TestCreateInplaceTest:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestExecutionHelpers:
     """Test helper functions for single-turn and multi-turn execution."""
 
@@ -832,7 +829,6 @@ class TestExecutionHelpers:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestEdgeCases:
     """Test edge cases and error handling."""
 

--- a/tests/backend/services/test_test_generation_pipeline.py
+++ b/tests/backend/services/test_test_generation_pipeline.py
@@ -99,7 +99,6 @@ async def _collect_ndjson(async_gen):
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestFetchDbContext:
     def test_returns_requirements_and_prompt(self):
         mock_db = MagicMock()
@@ -194,7 +193,6 @@ class TestFetchDbContext:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestRenderConfigPrompt:
     def test_renders_template_with_requirements(self):
         ctx = _db_context()
@@ -218,7 +216,6 @@ class TestRenderConfigPrompt:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 @pytest.mark.asyncio
 class TestStreamConfig:
     async def test_yields_config_items_from_all_dimensions(self):
@@ -354,7 +351,6 @@ def _config_response_json(**overrides):
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestIncrementalConfigParser:
     def test_single_chunk_attributes_each_array(self):
         """Non-streaming models may deliver the full JSON in one chunk."""
@@ -407,7 +403,6 @@ class TestIncrementalConfigParser:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 class TestIncrementalJsonArrayParser:
     def test_nested_arrays_do_not_break_parsing(self):
         """Objects containing nested arrays must not prematurely close the top-level array."""
@@ -456,7 +451,6 @@ class TestIncrementalJsonArrayParser:
 
 
 @pytest.mark.unit
-@pytest.mark.services
 @pytest.mark.asyncio
 class TestPipelineStream:
     async def test_single_turn_pipeline(self):

--- a/tests/backend/services/test_test_interpretation_fixtures.py
+++ b/tests/backend/services/test_test_interpretation_fixtures.py
@@ -20,7 +20,7 @@ from rhesis.backend.app.services.test_interpretation import (
     interpret_test_configuration,
 )
 
-pytestmark = [pytest.mark.integration, pytest.mark.ai, pytest.mark.slow]
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
 
 # One intent, phrased the three ways authors actually phrase it. These must be indistinguishable

--- a/tests/backend/services/test_test_set.py
+++ b/tests/backend/services/test_test_set.py
@@ -58,7 +58,6 @@ def create_endpoint_data(**overrides):
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestTestSetAssociations:
     """Test test set association operations."""
 
@@ -200,7 +199,6 @@ class TestTestSetAssociations:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestTestSetExecution:
     """Test test set execution operations."""
 
@@ -587,7 +585,6 @@ class TestTestSetExecution:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestTestSetGeneration:
     """Test test set generation with custom names."""
 
@@ -654,7 +651,6 @@ class TestTestSetGeneration:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestBulkCreateEnforcesUniformTestType:
     def test_prompt_only_test_rejected_for_multi_turn_set(self):
         with pytest.raises(ValidationError, match="does not match test set type"):
@@ -783,7 +779,6 @@ class TestBulkCreateEnforcesUniformTestType:
 
 
 @pytest.mark.unit
-@pytest.mark.service
 class TestGetTestSetsExcludesExplorer:
     """test_set_crud.get_test_sets must omit explorer sets (general test set list API)."""
 

--- a/tests/backend/services/test_transaction_management.py
+++ b/tests/backend/services/test_transaction_management.py
@@ -32,8 +32,6 @@ from rhesis.backend.app.services import test_set as test_set_service
 
 
 @pytest.mark.unit
-@pytest.mark.services
-@pytest.mark.transaction
 class TestServiceTransactionManagement:
     """🔄 Test automatic transaction management in service functions"""
 

--- a/tests/backend/utils/test_crud_utils.py
+++ b/tests/backend/utils/test_crud_utils.py
@@ -66,7 +66,6 @@ def create_requirement_data(**overrides):
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestGetOrCreateEntity:
     """Test get_or_create_entity function."""
 
@@ -201,7 +200,6 @@ class TestGetOrCreateEntity:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestGetOrCreateSpecializedFunctions:
     """Test specialized get_or_create functions."""
 

--- a/tests/backend/utils/test_get_items_detail_pagination_split.py
+++ b/tests/backend/utils/test_get_items_detail_pagination_split.py
@@ -35,7 +35,6 @@ def _create_categories(db: Session, org_id: str, suffixes: list) -> list:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestGetItemsDetailPaginationSplit:
     def test_preserves_sort_order_across_pages(self, test_db: Session, test_org_id):
         created = _create_categories(

--- a/tests/backend/utils/test_model_utils.py
+++ b/tests/backend/utils/test_model_utils.py
@@ -15,7 +15,6 @@ from rhesis.backend.app.utils.query_utils import QueryBuilder
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestQueryBuilder:
     """Test QueryBuilder class."""
 

--- a/tests/backend/utils/test_project_querybuilder.py
+++ b/tests/backend/utils/test_project_querybuilder.py
@@ -57,7 +57,6 @@ def test_project2(test_db: Session, test_org_id):
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestHasProjectId:
     """Unit tests for the has_project_id() helper."""
 
@@ -84,7 +83,6 @@ class TestHasProjectId:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestQueryBuilderProjectFilter:
     """Tests for QueryBuilder.with_project_filter()."""
 
@@ -182,7 +180,6 @@ class TestQueryBuilderProjectFilter:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestValidateSameProject:
     """Unit tests for validate_same_project()."""
 

--- a/tests/backend/utils/test_query_builder_load.py
+++ b/tests/backend/utils/test_query_builder_load.py
@@ -44,7 +44,6 @@ def _is_loaded(instance, attr_name: str) -> bool:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestIncludeConstruction:
     def test_rejects_non_relationship_attribute(self):
         """A plain column has no .uselist to dispatch joinedload/selectinload on."""
@@ -58,7 +57,6 @@ class TestIncludeConstruction:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestWithRelatedColumnScoping:
     def test_scopes_columns_on_eager_loaded_relationship(
         self, test_db: Session, test_org_id, test_test, test_requirement
@@ -146,7 +144,6 @@ class TestWithRelatedColumnScoping:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestMetricRequirementNestedM2MLoads:
     """Regression coverage for the N+1 gap in nested many-to-many collections.
 
@@ -277,7 +274,6 @@ class TestMetricRequirementNestedM2MLoads:
 
 
 @pytest.mark.unit
-@pytest.mark.crud
 class TestODataAnyNavigationFilter:
     """Regression coverage for OData $filter expressions that navigate a
     many-to-many relationship with `any(...)`, e.g. the frontend's

--- a/tests/backend/utils/test_scope_listeners.py
+++ b/tests/backend/utils/test_scope_listeners.py
@@ -63,7 +63,6 @@ def test_org2_id(test_db: Session):
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestScopeContextVar:
     """Unit tests for the RequestScope ContextVar helpers."""
 
@@ -101,7 +100,6 @@ class TestScopeContextVar:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestAutoFilterNoOp:
     """Auto-filter is a no-op when scope is unbound (isolate_request_scope resets to None)."""
 
@@ -124,7 +122,6 @@ class TestAutoFilterNoOp:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestAutoFilterWhenBound:
     """Auto-filter applies WHERE clauses when scope IS bound."""
 
@@ -254,7 +251,6 @@ class TestAutoFilterWhenBound:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestBypassFiltering:
     """bypass_tenant_filter() suppresses the listener."""
 
@@ -285,7 +281,6 @@ class TestBypassFiltering:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestAutoStamp:
     """Auto-stamp fills identity columns from the ambient scope on INSERT."""
 
@@ -348,7 +343,6 @@ class TestAutoStamp:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestProjectFailClosed:
     """Project auto-filter is fail-closed: no active project => org-level rows only."""
 
@@ -452,7 +446,6 @@ class TestProjectFailClosed:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestExemptModels:
     """User, Organization bypass auto-filter."""
 
@@ -470,7 +463,6 @@ class TestExemptModels:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestKillSwitch:
     """RHESIS_DISABLE_SCOPE_LISTENER=1 - verifies env-var check at query time."""
 
@@ -502,7 +494,6 @@ class TestKillSwitch:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestBulkInsertGap:
     """
     Explicit assertion that bulk_insert_mappings bypasses auto-stamp.
@@ -536,7 +527,6 @@ class TestBulkInsertGap:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestSessionInfoScope:
     """
     Regression guard for the async-safe scope path.

--- a/tests/backend/utils/test_soft_delete_crud.py
+++ b/tests/backend/utils/test_soft_delete_crud.py
@@ -29,7 +29,6 @@ from tests.backend.routes.fixtures.data_factories import (
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestSoftDeletion:
     """Test soft deletion functionality in CRUD utilities."""
 
@@ -321,7 +320,6 @@ class TestSoftDeletion:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestSoftDeleteContext:
     """Test the without_soft_delete_filter context manager."""
 
@@ -388,7 +386,6 @@ class TestSoftDeleteContext:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestBaseModelSoftDeleteMethods:
     """Test soft delete methods on the Base model."""
 

--- a/tests/backend/utils/test_soft_delete_querybuilder.py
+++ b/tests/backend/utils/test_soft_delete_querybuilder.py
@@ -26,7 +26,6 @@ from tests.backend.routes.fixtures.data_factories import (
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestQueryBuilderSoftDelete:
     """Test QueryBuilder soft deletion methods."""
 
@@ -317,7 +316,6 @@ class TestQueryBuilderSoftDelete:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestQueryBuilderWithEventListener:
     """Test QueryBuilder interaction with soft delete event listener."""
 
@@ -410,7 +408,6 @@ class TestQueryBuilderWithEventListener:
 
 
 @pytest.mark.unit
-@pytest.mark.utils
 class TestQueryBuilderEdgeCases:
     """Test edge cases and error conditions for QueryBuilder soft deletion."""
 

--- a/tests/backend/utils/test_transaction_management.py
+++ b/tests/backend/utils/test_transaction_management.py
@@ -32,8 +32,6 @@ from tests.backend.routes.fixtures.data_factories import (
 
 
 @pytest.mark.unit
-@pytest.mark.utils
-@pytest.mark.transaction
 class TestCRUDUtilsTransactionManagement:
     """🔄 Test automatic transaction management in CRUD utilities"""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,17 +7,6 @@ that applies to all test modules across the entire monorepo.
 
 import pytest
 
-
-def pytest_configure(config):
-    """🔧 Configure pytest markers for better test organization"""
-    config.addinivalue_line("markers", "unit: fast tests with mocked dependencies")
-    config.addinivalue_line("markers", "integration: tests with real external services")
-    config.addinivalue_line("markers", "slow: tests that take >5 seconds")
-    config.addinivalue_line("markers", "ai: tests involving AI model calls")
-    config.addinivalue_line("markers", "critical: core functionality tests")
-    config.addinivalue_line("markers", "security: security and vulnerability tests")
-
-
 # 🎭 Global fixtures that can be used across all components
 
 @pytest.fixture

--- a/tests/polyphemus/test_stress.py
+++ b/tests/polyphemus/test_stress.py
@@ -24,7 +24,7 @@ from rhesis.polyphemus.services.services import (
     generate_text_via_vertex_endpoint,
 )
 
-pytestmark = [pytest.mark.slow, pytest.mark.performance]
+pytestmark = [pytest.mark.slow]
 
 _CONFIGURED_MODELS = {
     "polyphemus-default": "projects/p/locations/us-central1/endpoints/default",

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -15,22 +15,11 @@ filterwarnings =
     ignore:transaction already deassociated from connection:sqlalchemy.exc.SAWarning
     ignore:cannot collect test class.*because it has a __init__ constructor:pytest.PytestCollectionWarning
 
-# Common markers used across components
+# Markers shared across components. Declarative only — no tooling selects on
+# them; they exist so `-m` is available when a suite gets big enough to need it.
 markers =
     unit: fast tests with mocked dependencies
     integration: tests with real external services
     slow: tests that take >5 seconds
-    ai: tests involving AI model calls
-    critical: core functionality tests
     security: security and vulnerability tests
-    performance: performance and load testing
-    service: tests for service layer functions
-    services: tests for service layer functions (alternative naming)
-    utils: tests for utility functions
-    crud: tests for CRUD operations
-    database: tests that require database connectivity
-    transaction: tests for transaction management
-    tasks: tests for background tasks
-    auth: tests for authentication and authorization
-    routes: tests for API route endpoints
     ee: tests that require the EE package (rhesis-backend-ee) to be installed


### PR DESCRIPTION
## Purpose

The backend suite declared 17 pytest markers and applied them 1252 times, but nothing selected on any of them. CI and both Makefile targets filter by path, never with `-m`. Of the 17, eleven were never referenced by any tooling, script, fixture or doc — and the nine "area" markers (`service`, `services`, `routes`, `utils`, `crud`, `transaction`, `database`, `tasks`, `auth`) only restated the directory a test already lives in, so a path argument selects exactly the same set.

The taxonomy was also drifting. `service` (87 uses) and `services` (30) were competing spellings for the same thing, blessed as "alternative naming" in the config. `tasks` had one use, left over from the `tasks` → `jobs` rename. `auth` had one use, in a directory that otherwise never used it. And markers were declared in three places that disagreed: `tests/pytest.ini` listed all 17, while `apps/backend/pyproject.toml` and a `pytest_configure` hook in `tests/conftest.py` each listed a different subset of 6 — so which markers were even registered depended on how you invoked pytest.

This collapses the set to the five that carry information a path does not, reconciles the config sites, and fixes the dead code found alongside them. Markers stay declarative: nothing selects on them, they are just available if a suite later grows into needing `-m`.

## What Changed

- **Markers collapsed to five**: `unit`, `integration`, `slow`, `security`, `ee`. Removed 253 decorators and `pytestmark` entries for the other twelve.
- **Config reconciled**: `tests/pytest.ini` and `apps/backend/pyproject.toml` now declare an identical set, so it no longer matters which one pytest picks as the configfile. Removed the duplicate declarations from `tests/conftest.py` — a third source of truth for the same list.
- **Dead `--ignore` removed**: CI and both Makefile targets passed `--ignore=../../tests/backend/integration`, but that directory does not exist, so the flag never excluded anything. Removing it changes nothing about what runs; the command just stops claiming otherwise.
- **Dead `skip_if_slow` fixture removed** from `tests/backend/routes/conftest.py`. No test requested it, and `--runslow` was never registered via `pytest_addoption`, so `config.getoption` always fell back to its default and the fixture could only ever skip.
- **Docs corrected**: `tests/backend/README.md` documented `api` and `celery` markers that never existed at all, and gave a `-m api` run example that collected nothing. `tests/README.md` now also records that only the winning configfile's `addopts` and `pythonpath` apply.
- **`tests/polyphemus/test_stress.py`** loses its `performance` marker. `tests/pytest.ini` is the shared root config for that suite too, so leaving the marker there would have created a new unknown-marker warning.

## Additional Context

No behavior change to what CI runs. Nothing read a removed marker: the only programmatic marker consumer was the dead `skip_if_slow` fixture, and the one remaining reference (`tests/backend/routes/conftest.py:130`) just lists marker names for diagnostics and is not tied to any specific marker.

`--strict-markers` was deliberately **not** added, and CI still selects by path rather than by `-m`. Note that `--strict-markers` would not have caught the stale `api`/`celery` names anyway — it validates markers applied in code, not names passed to `-m`, which silently deselect everything and exit 0.

Two pre-existing issues are documented but intentionally left alone, since fixing them needs a full suite run to verify:

- `apps/backend/pyproject.toml`'s `addopts = "-p no:plugins"` (the deepeval-plugin workaround) is silently discarded in CI and `make test`, because passing a path under `tests/` makes `tests/pytest.ini` the configfile and only its settings apply.
- Roughly half of backend tests carry no marker at all, so `-m unit` runs well short of the whole fast suite. This is now stated in `tests/README.md` rather than left as a trap.

Also out of scope: `tests/sdk/pytest.ini` still registers seven markers while the SDK suite only uses `unit` and `integration`.

## Testing

Not verified by a suite run — `tests/backend/conftest.py:17` calls `ensure_test_containers()` at import time, so even `--collect-only` starts Postgres and Redis. CI covers it.

What was verified locally:

- Every one of the 78 changed Python files was `ast.parse`d before being written, then `py_compile`d afterwards.
- Marker registration confirmed against real pytest — `uv run pytest ../../tests/backend --markers` from `apps/backend` lists exactly the five, and both configfiles now agree.
- `grep` confirms no `pytest.mark.<removed>` remains anywhere under `tests/`, and that only the five surviving markers are used.
- Ruff was diffed before and after across all changed files: one new error (a now-unused `import pytest` in `tests/backend/routes/test_home.py`), fixed, zero remaining. The 133 pre-existing errors in those files are untouched — `ruff format` was deliberately not run, as it wanted to reformat 22 files for unrelated reasons.
