### PR TITLE
Fix backend endpoints missing eager loads for derived/related fields

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/metric.py
+++ b/apps/backend/src/rhesis/backend/app/crud/metric.py
@@ -379,6 +379,7 @@ def get_metric_requirements(
     return (
         QueryBuilder(db, models.Requirement)
         .with_related(include(models.Requirement.user))
+        .with_default_derived_field_loads()
         .with_organization_filter(organization_id)
         .with_custom_filter(
             lambda q: q.join(models.requirement_metric_association).filter(
@@ -425,6 +426,7 @@ def get_requirement_metrics(
     return (
         QueryBuilder(db, models.Metric)
         .with_related(include(models.Metric.metric_type), include(models.Metric.backend_type))
+        .with_default_derived_field_loads()
         .with_organization_filter(organization_id)
         .with_custom_filter(
             lambda q: q.join(models.requirement_metric_association).filter(

--- a/apps/backend/src/rhesis/backend/app/crud/project.py
+++ b/apps/backend/src/rhesis/backend/app/crud/project.py
@@ -204,10 +204,11 @@ def get_project_members(
 def get_my_projects(db: Session, user_id: uuid.UUID, organization_id: str) -> List[models.Project]:
     """Return all ACTIVE, non-deleted projects the given user is a member of."""
     from rhesis.backend.app.models.project_membership import ProjectMembership
+    from rhesis.backend.app.utils.derived_field_loads import derived_field_load_options
 
     return (
         db.query(models.Project)
-        .options(include(models.Project.owner))
+        .options(include(models.Project.owner), *derived_field_load_options(models.Project))
         .join(ProjectMembership, ProjectMembership.project_id == models.Project.id)
         .filter(
             ProjectMembership.user_id == user_id,

--- a/apps/backend/src/rhesis/backend/app/crud/prompt.py
+++ b/apps/backend/src/rhesis/backend/app/crud/prompt.py
@@ -14,6 +14,7 @@ from rhesis.backend.app.utils.crud_utils import (
     create_item,
     delete_item,
     get_item,
+    get_item_detail,
     get_items,
     get_items_detail,
     update_item,
@@ -87,7 +88,9 @@ def delete_prompt(
 def get_prompt_template(
     db: Session, prompt_template_id: uuid.UUID, organization_id: str, user_id: str
 ) -> Optional[models.PromptTemplate]:
-    return get_item(db, models.PromptTemplate, prompt_template_id, organization_id, user_id)
+    return get_item_detail(
+        db, models.PromptTemplate, prompt_template_id, organization_id, user_id
+    )
 
 
 def get_prompt_templates(

--- a/apps/backend/src/rhesis/backend/app/crud/prompt.py
+++ b/apps/backend/src/rhesis/backend/app/crud/prompt.py
@@ -88,9 +88,7 @@ def delete_prompt(
 def get_prompt_template(
     db: Session, prompt_template_id: uuid.UUID, organization_id: str, user_id: str
 ) -> Optional[models.PromptTemplate]:
-    return get_item_detail(
-        db, models.PromptTemplate, prompt_template_id, organization_id, user_id
-    )
+    return get_item_detail(db, models.PromptTemplate, prompt_template_id, organization_id, user_id)
 
 
 def get_prompt_templates(

--- a/apps/backend/src/rhesis/backend/app/crud/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/crud/telemetry.py
@@ -38,6 +38,8 @@ class TraceRow(NamedTuple):
     trace: models.Trace
     span_count: int
     total: int
+    tags_count: int
+    comments_count: int
 
 
 # ============================================================================
@@ -334,8 +336,33 @@ def query_traces(
     #    Uses a window function so pagination total comes from the same query.
     total_col = func.count().over().label("total_count")
 
+    # -- Columns 4/5: tags_count/comments_count — correlated counts, same
+    #    style as span_count_col, so the list view doesn't need to eager-load
+    #    the full tag/comment rows just to know how many there are.
+    tags_count_col = (
+        select(func.count(models.TaggedItem.id))
+        .where(
+            and_(
+                models.TaggedItem.entity_id == models.Trace.id,
+                models.TaggedItem.entity_type == models.Trace.__name__,
+            )
+        )
+        .scalar_subquery()
+    )
+    comments_count_col = (
+        select(func.count(models.Comment.id))
+        .where(
+            and_(
+                models.Comment.entity_id == models.Trace.id,
+                models.Comment.entity_type == models.Trace.__name__,
+                models.Comment.deleted_at.is_(None),
+            )
+        )
+        .scalar_subquery()
+    )
+
     query = (
-        db.query(models.Trace, span_count_col, total_col)
+        db.query(models.Trace, span_count_col, total_col, tags_count_col, comments_count_col)
         .filter(models.Trace.organization_id == org_uuid)
         .options(
             joinedload(models.Trace.test_result)
@@ -477,7 +504,10 @@ def query_traces(
         query = query.filter(models.Trace.trace_metrics_status_id.in_(matching_status_ids))
 
     results = query.order_by(desc(models.Trace.start_time)).limit(limit).offset(offset).all()
-    return [TraceRow(trace=r[0], span_count=r[1], total=r[2]) for r in results]
+    return [
+        TraceRow(trace=r[0], span_count=r[1], total=r[2], tags_count=r[3], comments_count=r[4])
+        for r in results
+    ]
 
 
 def get_unprocessed_traces(

--- a/apps/backend/src/rhesis/backend/app/crud/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/crud/telemetry.py
@@ -336,15 +336,13 @@ def query_traces(
     #    Uses a window function so pagination total comes from the same query.
     total_col = func.count().over().label("total_count")
 
-    # -- Columns 4/5: tags_count/comments_count — correlated counts, same
-    #    style as span_count_col, so the list view doesn't need to eager-load
-    #    the full tag/comment rows just to know how many there are.
     tags_count_col = (
         select(func.count(models.TaggedItem.id))
         .where(
             and_(
                 models.TaggedItem.entity_id == models.Trace.id,
                 models.TaggedItem.entity_type == models.Trace.__name__,
+                models.TaggedItem.deleted_at.is_(None),
             )
         )
         .scalar_subquery()

--- a/apps/backend/src/rhesis/backend/app/crud/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/crud/test_set.py
@@ -159,6 +159,7 @@ def get_test_set_by_nano_id_or_slug(
         QueryBuilder(db, models.TestSet)
         .with_deleted()
         .with_related(*_TEST_SET_RELATED_FIELDS)
+        .with_default_derived_field_loads()
         .with_organization_filter(organization_id)
         .with_visibility_filter(user_id)
         .with_custom_filter(
@@ -234,6 +235,7 @@ def get_test_sets_for_test(
     query_builder = (
         QueryBuilder(db, models.TestSet)
         .with_related(*_TEST_SET_RELATED_FIELDS)
+        .with_default_derived_field_loads()
         .with_organization_filter(organization_id)
         .with_visibility_filter(user_id)
         .with_custom_filter(
@@ -298,6 +300,7 @@ def get_test_set_tests(
             include(models.Test.category),
             include(models.Test.status),
         )
+        .with_default_derived_field_loads()
         .with_visibility_filter()
         .with_custom_filter(
             lambda q: q.join(models.test.test_test_set_association).filter(

--- a/apps/backend/src/rhesis/backend/app/models/mixins.py
+++ b/apps/backend/src/rhesis/backend/app/models/mixins.py
@@ -17,14 +17,9 @@ def safe_relationship(default_factory=list):
     After delete_item() commits, the RLS session variable
     (app.current_organization) may no longer be set on the DB connection.
     Any lazy-load of a relationship during response serialization would
-    then fail with DetachedInstanceError. This decorator catches only that
+    then fail with DetachedInstanceError. This decorator catches that
     case and returns a safe default so the response can still be
     serialized.
-
-    Deliberately NOT a broad SQLAlchemyError catch: that used to also
-    swallow raiseload/InvalidRequestError from a missing eager-load,
-    which made the tests/backend/conftest.py raiseload trip-wire blind to
-    any caller of this property. A missing eager-load should fail loudly.
     """
 
     def decorator(method):

--- a/apps/backend/src/rhesis/backend/app/models/mixins.py
+++ b/apps/backend/src/rhesis/backend/app/models/mixins.py
@@ -3,7 +3,6 @@ import logging
 from typing import Any
 
 from sqlalchemy import Column, ForeignKey, and_, event
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, declared_attr, object_session, relationship
 from sqlalchemy.orm.exc import DetachedInstanceError
 
@@ -18,8 +17,14 @@ def safe_relationship(default_factory=list):
     After delete_item() commits, the RLS session variable
     (app.current_organization) may no longer be set on the DB connection.
     Any lazy-load of a relationship during response serialization would
-    then fail.  This decorator catches those errors and returns a safe
-    default so the response can still be serialized.
+    then fail with DetachedInstanceError. This decorator catches only that
+    case and returns a safe default so the response can still be
+    serialized.
+
+    Deliberately NOT a broad SQLAlchemyError catch: that used to also
+    swallow raiseload/InvalidRequestError from a missing eager-load,
+    which made the tests/backend/conftest.py raiseload trip-wire blind to
+    any caller of this property. A missing eager-load should fail loudly.
     """
 
     def decorator(method):
@@ -27,7 +32,7 @@ def safe_relationship(default_factory=list):
         def wrapper(self):
             try:
                 return method(self)
-            except (DetachedInstanceError, SQLAlchemyError) as exc:
+            except DetachedInstanceError as exc:
                 logger.warning(
                     "Suppressed lazy-load error on %s.%s: %s",
                     type(self).__name__,

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -451,6 +451,8 @@ def list_traces(
                 has_reviews=has_reviews,
                 last_review=trace.last_review,
                 matches_review=trace.matches_review,
+                tags_count=row.tags_count,
+                comments_count=row.comments_count,
             )
             summaries.append(summary)
 

--- a/apps/backend/src/rhesis/backend/app/routers/test.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test.py
@@ -367,8 +367,6 @@ def interpret_test(
     matches the current wording.
     """
     organization_id, user_id = tenant_context
-    # get_test_detail, not get_test: ensure_contract reads test.requirement/
-    # category/topic below, none of which get_test eager-loads.
     db_test = test_crud.get_test_detail(
         db, test_id=test_id, organization_id=organization_id, user_id=user_id
     )

--- a/apps/backend/src/rhesis/backend/app/routers/test.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test.py
@@ -367,7 +367,9 @@ def interpret_test(
     matches the current wording.
     """
     organization_id, user_id = tenant_context
-    db_test = test_crud.get_test(
+    # get_test_detail, not get_test: ensure_contract reads test.requirement/
+    # category/topic below, none of which get_test eager-loads.
+    db_test = test_crud.get_test_detail(
         db, test_id=test_id, organization_id=organization_id, user_id=user_id
     )
     if db_test is None:

--- a/apps/backend/src/rhesis/backend/app/routers/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_run.py
@@ -554,6 +554,8 @@ def get_test_run_traces(
             test_run_id=str(trace.test_run_id) if trace.test_run_id else None,
             test_result_id=str(trace.test_result_id) if trace.test_result_id else None,
             test_id=str(trace.test_id) if trace.test_id else None,
+            tags_count=row.tags_count,
+            comments_count=row.comments_count,
         )
         summaries.append(summary)
 

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -696,10 +696,6 @@ def delete_item(
     """
     from rhesis.backend.app.services import cascade as cascade_service
 
-    # get_item_detail, not get_item: the deleted item is returned straight to
-    # the response model, and some entities (e.g. PromptTemplate, TestSet)
-    # declare tags/counts on their write schema, not just the *Detail read
-    # schema -- an un-eager-loaded relationship there fails serialization.
     item = get_item_detail(db, model, item_id, organization_id, user_id)
 
     if not item:

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -696,7 +696,11 @@ def delete_item(
     """
     from rhesis.backend.app.services import cascade as cascade_service
 
-    item = get_item(db, model, item_id, organization_id, user_id)
+    # get_item_detail, not get_item: the deleted item is returned straight to
+    # the response model, and some entities (e.g. PromptTemplate, TestSet)
+    # declare tags/counts on their write schema, not just the *Detail read
+    # schema -- an un-eager-loaded relationship there fails serialization.
+    item = get_item_detail(db, model, item_id, organization_id, user_id)
 
     if not item:
         return None

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/invocation.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/invocation.py
@@ -74,7 +74,9 @@ async def resolve_contract_lazy(
         with get_db_with_tenant_variables(
             ctx.organization_id, ctx.user_id or "", ctx.project_id or ""
         ) as db:
-            test = test_crud.get_test(db, UUID(test_id), ctx.organization_id, ctx.user_id)
+            # get_test_detail, not get_test: resolve_multi_turn_contract -> ensure_contract
+            # reads test.requirement/category/topic below.
+            test = test_crud.get_test_detail(db, UUID(test_id), ctx.organization_id, ctx.user_id)
             if test is None:
                 return None, False
             return resolve_multi_turn_contract(db, test, ctx.user_id)

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/invocation.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/invocation.py
@@ -65,8 +65,9 @@ async def resolve_contract_lazy(
     from uuid import UUID
 
     def _resolve():
-        from rhesis.backend.app.crud import test as test_crud
         from rhesis.backend.app.database import get_db_with_tenant_variables
+        from rhesis.backend.app.utils.crud_utils import get_item_detail
+        from rhesis.backend.app.utils.query_utils import include
         from rhesis.backend.jobs.execution.executors.output_providers import (
             resolve_multi_turn_contract,
         )
@@ -74,7 +75,18 @@ async def resolve_contract_lazy(
         with get_db_with_tenant_variables(
             ctx.organization_id, ctx.user_id or "", ctx.project_id or ""
         ) as db:
-            test = test_crud.get_test_detail(db, UUID(test_id), ctx.organization_id, ctx.user_id)
+            test = get_item_detail(
+                db,
+                Test,
+                UUID(test_id),
+                ctx.organization_id,
+                ctx.user_id,
+                related_fields=(
+                    include(Test.requirement),
+                    include(Test.category),
+                    include(Test.topic),
+                ),
+            )
             if test is None:
                 return None, False
             return resolve_multi_turn_contract(db, test, ctx.user_id)

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/invocation.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/invocation.py
@@ -74,8 +74,6 @@ async def resolve_contract_lazy(
         with get_db_with_tenant_variables(
             ctx.organization_id, ctx.user_id or "", ctx.project_id or ""
         ) as db:
-            # get_test_detail, not get_test: resolve_multi_turn_contract -> ensure_contract
-            # reads test.requirement/category/topic below.
             test = test_crud.get_test_detail(db, UUID(test_id), ctx.organization_id, ctx.user_id)
             if test is None:
                 return None, False

--- a/apps/backend/src/rhesis/backend/jobs/execution/executors/data.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/executors/data.py
@@ -39,7 +39,9 @@ def get_test_and_prompt(
     from rhesis.backend.app.utils.database_exceptions import ItemDeletedException
     from rhesis.backend.jobs.execution.modes import get_test_type
 
-    # Get the test. Reads test.prompt below for single-turn tests -- eager-load it explicitly.
+    # Get the test. Reads test.prompt below for single-turn tests, and a
+    # multi-turn test flows into ensure_contract() (via resolve_multi_turn_contract),
+    # which reads test.requirement/category/topic -- eager-load all four explicitly.
     # Raised as ValueError (not ItemDeletedException) so every failure mode of
     # this function shares one exception type -- callers only catch/re-raise
     # generically, so this is purely about message clarity ("deleted" vs
@@ -50,7 +52,12 @@ def get_test_and_prompt(
             Test,
             UUID(test_id),
             organization_id=organization_id,
-            related_fields=(include(Test.prompt),),
+            related_fields=(
+                include(Test.prompt),
+                include(Test.requirement),
+                include(Test.category),
+                include(Test.topic),
+            ),
         )
     except ItemDeletedException:
         raise ValueError(f"Test with ID {test_id} has been deleted")

--- a/apps/backend/src/rhesis/backend/jobs/execution/executors/data.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/executors/data.py
@@ -39,9 +39,7 @@ def get_test_and_prompt(
     from rhesis.backend.app.utils.database_exceptions import ItemDeletedException
     from rhesis.backend.jobs.execution.modes import get_test_type
 
-    # Get the test. Reads test.prompt below for single-turn tests, and a
-    # multi-turn test flows into ensure_contract() (via resolve_multi_turn_contract),
-    # which reads test.requirement/category/topic -- eager-load all four explicitly.
+    # Get the test. Reads test.prompt below for single-turn tests -- eager-load it explicitly.
     # Raised as ValueError (not ItemDeletedException) so every failure mode of
     # this function shares one exception type -- callers only catch/re-raise
     # generically, so this is purely about message clarity ("deleted" vs

--- a/tests/backend/jobs/test_batch_contract_resolution.py
+++ b/tests/backend/jobs/test_batch_contract_resolution.py
@@ -46,8 +46,8 @@ class TestResolveContractLazy:
         with (
             patch("rhesis.backend.app.database.get_db_with_tenant_variables") as mock_get_db,
             patch(
-                "rhesis.backend.app.crud.test.get_test", return_value=fresh_test
-            ) as mock_get_test,
+                "rhesis.backend.app.crud.test.get_test_detail", return_value=fresh_test
+            ) as mock_get_test_detail,
             patch(
                 _RESOLVE_MULTI_TURN_CONTRACT,
                 return_value=({"prohibited_behavior": ["X"]}, True),
@@ -61,7 +61,7 @@ class TestResolveContractLazy:
                 ctx, "3a51f7ae-f7b2-4ff4-8454-9e8f4826afa1"
             )
 
-        mock_get_test.assert_called_once()
+        mock_get_test_detail.assert_called_once()
         mock_resolve.assert_called_once_with(mock_db, fresh_test, ctx.user_id)
         assert contract == {"prohibited_behavior": ["X"]}
         assert usable is True
@@ -73,7 +73,7 @@ class TestResolveContractLazy:
 
         with (
             patch("rhesis.backend.app.database.get_db_with_tenant_variables") as mock_get_db,
-            patch("rhesis.backend.app.crud.test.get_test", return_value=None),
+            patch("rhesis.backend.app.crud.test.get_test_detail", return_value=None),
         ):
             mock_get_db.return_value.__enter__.return_value = MagicMock()
             mock_get_db.return_value.__exit__.return_value = False
@@ -131,7 +131,7 @@ class TestRunMultiTurnContractThreading:
             patch(
                 _RESOLVE_MULTI_TURN_CONTRACT, return_value=({"prohibited_behavior": ["X"]}, True)
             ),
-            patch("rhesis.backend.app.crud.test.get_test", return_value=test),
+            patch("rhesis.backend.app.crud.test.get_test_detail", return_value=test),
             patch("rhesis.backend.app.database.get_db_with_tenant_variables") as mock_get_db,
             patch("rhesis.backend.jobs.execution.penelope_target.BackendEndpointTarget"),
         ):
@@ -161,7 +161,7 @@ class TestRunMultiTurnContractThreading:
 
         with (
             patch(_RESOLVE_MULTI_TURN_CONTRACT, return_value=(None, False)),
-            patch("rhesis.backend.app.crud.test.get_test", return_value=test),
+            patch("rhesis.backend.app.crud.test.get_test_detail", return_value=test),
             patch("rhesis.backend.app.database.get_db_with_tenant_variables") as mock_get_db,
             patch("rhesis.backend.jobs.execution.penelope_target.BackendEndpointTarget"),
         ):

--- a/tests/backend/jobs/test_batch_contract_resolution.py
+++ b/tests/backend/jobs/test_batch_contract_resolution.py
@@ -46,8 +46,8 @@ class TestResolveContractLazy:
         with (
             patch("rhesis.backend.app.database.get_db_with_tenant_variables") as mock_get_db,
             patch(
-                "rhesis.backend.app.crud.test.get_test_detail", return_value=fresh_test
-            ) as mock_get_test_detail,
+                "rhesis.backend.app.utils.crud_utils.get_item_detail", return_value=fresh_test
+            ) as mock_get_item_detail,
             patch(
                 _RESOLVE_MULTI_TURN_CONTRACT,
                 return_value=({"prohibited_behavior": ["X"]}, True),
@@ -61,7 +61,7 @@ class TestResolveContractLazy:
                 ctx, "3a51f7ae-f7b2-4ff4-8454-9e8f4826afa1"
             )
 
-        mock_get_test_detail.assert_called_once()
+        mock_get_item_detail.assert_called_once()
         mock_resolve.assert_called_once_with(mock_db, fresh_test, ctx.user_id)
         assert contract == {"prohibited_behavior": ["X"]}
         assert usable is True
@@ -73,7 +73,7 @@ class TestResolveContractLazy:
 
         with (
             patch("rhesis.backend.app.database.get_db_with_tenant_variables") as mock_get_db,
-            patch("rhesis.backend.app.crud.test.get_test_detail", return_value=None),
+            patch("rhesis.backend.app.utils.crud_utils.get_item_detail", return_value=None),
         ):
             mock_get_db.return_value.__enter__.return_value = MagicMock()
             mock_get_db.return_value.__exit__.return_value = False
@@ -131,7 +131,7 @@ class TestRunMultiTurnContractThreading:
             patch(
                 _RESOLVE_MULTI_TURN_CONTRACT, return_value=({"prohibited_behavior": ["X"]}, True)
             ),
-            patch("rhesis.backend.app.crud.test.get_test_detail", return_value=test),
+            patch("rhesis.backend.app.utils.crud_utils.get_item_detail", return_value=test),
             patch("rhesis.backend.app.database.get_db_with_tenant_variables") as mock_get_db,
             patch("rhesis.backend.jobs.execution.penelope_target.BackendEndpointTarget"),
         ):
@@ -161,7 +161,7 @@ class TestRunMultiTurnContractThreading:
 
         with (
             patch(_RESOLVE_MULTI_TURN_CONTRACT, return_value=(None, False)),
-            patch("rhesis.backend.app.crud.test.get_test_detail", return_value=test),
+            patch("rhesis.backend.app.utils.crud_utils.get_item_detail", return_value=test),
             patch("rhesis.backend.app.database.get_db_with_tenant_variables") as mock_get_db,
             patch("rhesis.backend.jobs.execution.penelope_target.BackendEndpointTarget"),
         ):


### PR DESCRIPTION
## Purpose

Several backend read paths fetch a model without eager-loading fields that get read later (during response serialization, `ensure_contract`, or after a lazy-load-hostile `delete_item()` commit), causing `raiseload`/`DetachedInstanceError` failures. A bug in `safe_relationship`'s error handling was also masking these failures from the raiseload trip-wire in `tests/backend/conftest.py`, letting them go undetected.

## What Changed

- `safe_relationship` now only catches `DetachedInstanceError`, not the broad `SQLAlchemyError` — the old catch-all was silently swallowing raiseload errors from missing eager-loads, hiding them from the trip-wire test fixture.
- `delete_item()` and `interpret_test()` now fetch via `get_item_detail()`/`get_test_detail()` instead of `get_item()`/`get_test()`, since both read relationships on the item after fetching it.
- Added `with_default_derived_field_loads()` (or `derived_field_load_options()`) to the `Requirement`, `Metric`, `Project`, and `TestSet` list queries th were missing it, so derived fields don't lazy-load during serialization.
- `query_traces()` now populates `tags_count`/`comments_count` on `TraceSummary` via correlated count subqueries (same pattern as the existing `span_count` column) — the schema already declared these fields, but the query never populated them. Wired through in the `telemetry` and `test_run` routers.

## Additional Context

Related to the ongoing eager-load/N+1 audit across CRUD entities.

## Testing

- Backend test suite (raiseload trip-wire in `tests/backend/conftest.py` should now catch missing eager-loads instead of silently passing).
- Manually verify: deleting a prompt template/test set, calling `interpret_test`, listing projects/metrics/test sets, and loading the telemetry trace list (tag/comme counts show correctly).

