### PR TITLE
Add timeouts to outbound HTTP calls and enforce with ruff S113

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/github.py
+++ b/apps/backend/src/rhesis/backend/app/services/github.py
@@ -10,6 +10,11 @@ import requests
 from pathspec import PathSpec
 from pathspec.patterns import GitWildMatchPattern
 
+# read_repo_contents runs on a sync route, so it holds an anyio threadpool slot for
+# the whole download. Without a timeout an unresponsive GitHub holds it forever and
+# enough of those starve every sync route in the process.
+_GITHUB_TIMEOUT_SECONDS = 30
+
 
 def parse_github_url(github_url):
     """Parse GitHub URL into components"""
@@ -53,13 +58,13 @@ def download_github_repo(github_url, local_path):
 
     # Get the tree using GitHub API
     api_url = f"https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}?recursive=1"
-    response = requests.get(api_url)
+    response = requests.get(api_url, timeout=_GITHUB_TIMEOUT_SECONDS)
     if response.status_code == 404 and branch == "main":
         # Fallback to master if main doesn't exist
         branch = "master"
         base_url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}"
         api_url = f"https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}?recursive=1"
-        response = requests.get(api_url)
+        response = requests.get(api_url, timeout=_GITHUB_TIMEOUT_SECONDS)
 
     response.raise_for_status()
 
@@ -84,7 +89,7 @@ def download_github_repo(github_url, local_path):
         # Download file content
         file_url = f"{base_url}/{item['path']}"
         print(f"Downloading: {file_url}")  # Debug line
-        response = requests.get(file_url)
+        response = requests.get(file_url, timeout=_GITHUB_TIMEOUT_SECONDS)
         if response.status_code == 200:
             file_path.write_bytes(response.content)
             downloaded_files += 1

--- a/apps/chatbot/test_rate_limiting.py
+++ b/apps/chatbot/test_rate_limiting.py
@@ -15,6 +15,7 @@ import requests
 
 BASE_URL = "http://localhost:8085"
 API_KEY = "test-secret-key-12345"
+REQUEST_TIMEOUT = 30
 
 
 def test_public_access():
@@ -27,6 +28,7 @@ def test_public_access():
         f"{BASE_URL}/chat",
         json={"message": "What is term life insurance?"},
         headers={"Content-Type": "application/json"},
+        timeout=REQUEST_TIMEOUT,
     )
 
     print(f"Status Code: {response.status_code}")
@@ -39,7 +41,7 @@ def test_public_access():
         print(f"❌ FAILED - {response.text}")
 
     # Check root endpoint to verify tier
-    info_response = requests.get(f"{BASE_URL}/")
+    info_response = requests.get(f"{BASE_URL}/", timeout=REQUEST_TIMEOUT)
     info_data = info_response.json()
     print(f"\nAuthentication tier: {info_data['authentication']['tier']}")
     print(
@@ -63,7 +65,10 @@ def test_authenticated_access_user1():
     }
 
     response = requests.post(
-        f"{BASE_URL}/chat", json={"message": "What is whole life insurance?"}, headers=headers
+        f"{BASE_URL}/chat",
+        json={"message": "What is whole life insurance?"},
+        headers=headers,
+        timeout=REQUEST_TIMEOUT,
     )
 
     print(f"Status Code: {response.status_code}")
@@ -76,7 +81,7 @@ def test_authenticated_access_user1():
         print(f"❌ FAILED - {response.text}")
 
     # Check root endpoint to verify tier
-    info_response = requests.get(f"{BASE_URL}/", headers=headers)
+    info_response = requests.get(f"{BASE_URL}/", headers=headers, timeout=REQUEST_TIMEOUT)
     info_data = info_response.json()
     print(f"\nAuthentication tier: {info_data['authentication']['tier']}")
     print(
@@ -100,7 +105,10 @@ def test_authenticated_access_user2():
     }
 
     response = requests.post(
-        f"{BASE_URL}/chat", json={"message": "What is auto insurance?"}, headers=headers
+        f"{BASE_URL}/chat",
+        json={"message": "What is auto insurance?"},
+        headers=headers,
+        timeout=REQUEST_TIMEOUT,
     )
 
     print(f"Status Code: {response.status_code}")
@@ -127,7 +135,12 @@ def test_invalid_api_key():
         "X-Organization-ID": "org-456",
     }
 
-    response = requests.post(f"{BASE_URL}/chat", json={"message": "Test message"}, headers=headers)
+    response = requests.post(
+        f"{BASE_URL}/chat",
+        json={"message": "Test message"},
+        headers=headers,
+        timeout=REQUEST_TIMEOUT,
+    )
 
     print(f"Status Code: {response.status_code}")
     if response.status_code == 401:
@@ -144,7 +157,7 @@ def test_rate_limit_info():
     print("=" * 60)
 
     # Public rate limit info
-    public_response = requests.get(f"{BASE_URL}/")
+    public_response = requests.get(f"{BASE_URL}/", timeout=REQUEST_TIMEOUT)
     public_data = public_response.json()
 
     print("\nPublic Access:")
@@ -157,7 +170,7 @@ def test_rate_limit_info():
         "X-User-ID": "user-123",
         "X-Organization-ID": "org-456",
     }
-    auth_response = requests.get(f"{BASE_URL}/", headers=auth_headers)
+    auth_response = requests.get(f"{BASE_URL}/", headers=auth_headers, timeout=REQUEST_TIMEOUT)
     auth_data = auth_response.json()
 
     print("\nAuthenticated Access:")
@@ -175,7 +188,7 @@ def main():
 
     try:
         # Test health endpoint first
-        health = requests.get(f"{BASE_URL}/health")
+        health = requests.get(f"{BASE_URL}/health", timeout=REQUEST_TIMEOUT)
         if health.status_code == 200:
             print("✅ Service is healthy")
         else:

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,6 +17,9 @@ select = [
     "RUF013",
     # noqa directives for violations that no longer happen.
     "RUF100",
+    # bandit: HTTP calls with no timeout. `requests` defaults to waiting forever, so one
+    # unresponsive upstream holds a worker thread or a Celery task for good.
+    "S113",
     # mccabe: cyclomatic complexity ceiling, see [lint.mccabe] below.
     "C90",
     # pylint: function size ceilings, see [lint.pylint] below. C901 counts paths

--- a/sdk/src/rhesis/sdk/clients/api.py
+++ b/sdk/src/rhesis/sdk/clients/api.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
-from rhesis.sdk.config import get_api_key, get_base_url
+from rhesis.sdk.config import DEFAULT_API_TIMEOUT, get_api_key, get_base_url
 
 
 class HTTPStatus:
@@ -126,7 +126,12 @@ class APIClient:
         if url_params is not None:
             url = f"{url}/{url_params}"
         response = requests.request(
-            method=method.value, url=url, headers=self.headers, json=data, params=params
+            method=method.value,
+            url=url,
+            headers=self.headers,
+            json=data,
+            params=params,
+            timeout=DEFAULT_API_TIMEOUT,
         )
         response.raise_for_status()
         return response.json()
@@ -150,7 +155,9 @@ class APIClient:
         url = self.get_url(endpoint.value)
         # Auth-only headers; Content-Type is set by requests for multipart
         headers = {"Authorization": f"Bearer {self.api_key}"}
-        response = requests.post(url=url, headers=headers, files=files, params=params)
+        response = requests.post(
+            url=url, headers=headers, files=files, params=params, timeout=DEFAULT_API_TIMEOUT
+        )
         response.raise_for_status()
         return response.json()
 
@@ -174,6 +181,8 @@ class APIClient:
         if url_params is not None:
             url = f"{url}/{url_params}"
         headers = {"Authorization": f"Bearer {self.api_key}"}
-        response = requests.request(method=method.value, url=url, headers=headers)
+        response = requests.request(
+            method=method.value, url=url, headers=headers, timeout=DEFAULT_API_TIMEOUT
+        )
         response.raise_for_status()
         return response

--- a/sdk/src/rhesis/sdk/config.py
+++ b/sdk/src/rhesis/sdk/config.py
@@ -6,6 +6,10 @@ DEFAULT_BASE_URL = "https://api.rhesis.ai"
 
 DEFAULT_LLM_TIMEOUT = 300
 
+# Backend REST calls, not model calls. `requests` applies this per socket operation,
+# so a slow-but-progressing download is not cut off — only a stalled one.
+DEFAULT_API_TIMEOUT = 30
+
 # Module level variables
 api_key: Optional[str] = None
 base_url: Optional[str] = None

--- a/sdk/src/rhesis/sdk/connector/types.py
+++ b/sdk/src/rhesis/sdk/connector/types.py
@@ -9,6 +9,10 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
     import aiohttp
 
+# urlopen defaults to no timeout at all, so a stalled storage host would hang the
+# caller indefinitely. Applies per socket operation, not to the whole download.
+_READ_TIMEOUT_SECONDS = 60
+
 
 class FileReference(BaseModel):
     """A reference to a file stored in object storage.
@@ -51,7 +55,7 @@ class FileReference(BaseModel):
             )
         import urllib.request
 
-        with urllib.request.urlopen(self.signed_url) as resp:
+        with urllib.request.urlopen(self.signed_url, timeout=_READ_TIMEOUT_SECONDS) as resp:
             return resp.read()
 
     async def aread_bytes(self, session: Optional["aiohttp.ClientSession"] = None) -> bytes:

--- a/sdk/src/rhesis/sdk/entities/experiment.py
+++ b/sdk/src/rhesis/sdk/entities/experiment.py
@@ -11,6 +11,7 @@ import logging
 from typing import Any, ClassVar, Optional
 
 from rhesis.sdk.clients import APIClient, Endpoints, Methods
+from rhesis.sdk.config import DEFAULT_API_TIMEOUT
 from rhesis.sdk.entities.base_collection import BaseCollection
 from rhesis.sdk.entities.base_entity import BaseEntity, handle_http_errors
 
@@ -63,7 +64,7 @@ class Experiment(BaseEntity):
         import requests as _requests
 
         url = client.get_url(f"projects/{project_id}/experiments")
-        resp = _requests.post(url, headers=client.headers, json=data)
+        resp = _requests.post(url, headers=client.headers, json=data, timeout=DEFAULT_API_TIMEOUT)
         resp.raise_for_status()
         return resp.json()
 
@@ -175,6 +176,7 @@ class Experiment(BaseEntity):
                 "experiment_id": str(self.id),
                 "version": self.latest_version,
             },
+            timeout=DEFAULT_API_TIMEOUT,
         )
         resp.raise_for_status()
 

--- a/sdk/src/rhesis/sdk/parameters/_facade.py
+++ b/sdk/src/rhesis/sdk/parameters/_facade.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import requests
 
-from rhesis.sdk.config import get_api_key, get_base_url
+from rhesis.sdk.config import DEFAULT_API_TIMEOUT, get_api_key, get_base_url
 from rhesis.sdk.models.parameters import (
     ParameterSchema,
     ProjectEnvironments,
@@ -139,7 +139,11 @@ class Parameters:
         base = get_base_url().rstrip("/")
         api_key = get_api_key()
         url = f"{base}/projects/{pid}/parameters/schema"
-        resp = requests.get(url, headers={"Authorization": f"Bearer {api_key}"})
+        resp = requests.get(
+            url,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=DEFAULT_API_TIMEOUT,
+        )
         resp.raise_for_status()
         return ParameterSchema.model_validate(resp.json())
 
@@ -155,7 +159,11 @@ class Parameters:
         base = get_base_url().rstrip("/")
         api_key = get_api_key()
         url = f"{base}/projects/{pid}/parameters/environments"
-        resp = requests.get(url, headers={"Authorization": f"Bearer {api_key}"})
+        resp = requests.get(
+            url,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=DEFAULT_API_TIMEOUT,
+        )
         resp.raise_for_status()
         return ProjectEnvironments.model_validate(resp.json())
 
@@ -181,6 +189,7 @@ class Parameters:
             url,
             headers={"Authorization": f"Bearer {api_key}"},
             json=schema.model_dump(mode="json"),
+            timeout=DEFAULT_API_TIMEOUT,
         )
         resp.raise_for_status()
 
@@ -208,6 +217,7 @@ class Parameters:
                 "experiment_id": str(experiment_id),
                 "version": version,
             },
+            timeout=DEFAULT_API_TIMEOUT,
         )
         resp.raise_for_status()
 
@@ -245,6 +255,7 @@ class Parameters:
             url,
             headers={"Authorization": f"Bearer {api_key}"},
             params=params,
+            timeout=DEFAULT_API_TIMEOUT,
         )
         resp.raise_for_status()
         return ResolveResponse.model_validate(resp.json())

--- a/tests/sdk/connector/test_file_reference.py
+++ b/tests/sdk/connector/test_file_reference.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from rhesis.sdk.connector.types import FileReference
+from rhesis.sdk.connector.types import _READ_TIMEOUT_SECONDS, FileReference
 
 
 def _make_ref(signed_url: str | None = "https://example.test/file") -> FileReference:
@@ -36,7 +36,9 @@ class TestReadBytesSync:
         with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
             result = ref.read_bytes()
 
-        mock_open.assert_called_once_with("https://example.test/file")
+        mock_open.assert_called_once_with(
+            "https://example.test/file", timeout=_READ_TIMEOUT_SECONDS
+        )
         assert result == b"hello bytes"
 
     def test_raises_when_signed_url_missing(self):

--- a/tests/sdk/entities/test_base_collection.py
+++ b/tests/sdk/entities/test_base_collection.py
@@ -6,6 +6,7 @@ import pytest
 from requests.exceptions import HTTPError
 
 from rhesis.sdk.clients import HTTPStatus
+from rhesis.sdk.config import DEFAULT_API_TIMEOUT
 from rhesis.sdk.entities.base_collection import BaseCollection
 from rhesis.sdk.entities.base_entity import BaseEntity
 
@@ -42,6 +43,7 @@ def test_all(mock_request):
         },
         json=None,
         params=None,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
 
@@ -58,6 +60,7 @@ def test_exists(mock_request):
         },
         json=None,
         params=None,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
     """Test exists method returns False for nonexistent entity."""
@@ -99,4 +102,5 @@ def test_pull_with_name(mock_request):
         },
         json=None,
         params={"$filter": "tolower(name) eq 'test-entity'"},
+        timeout=DEFAULT_API_TIMEOUT,
     )

--- a/tests/sdk/entities/test_base_entity.py
+++ b/tests/sdk/entities/test_base_entity.py
@@ -8,6 +8,7 @@ import pytest
 from requests.exceptions import HTTPError
 
 from rhesis.sdk.clients import HTTPStatus
+from rhesis.sdk.config import DEFAULT_API_TIMEOUT
 from rhesis.sdk.entities.base_entity import BaseEntity, handle_http_errors
 from rhesis.sdk.errors import RhesisAPIError
 
@@ -52,6 +53,7 @@ def test_delete_by_id(mock_request, test_entity):
         },
         json=None,
         params=None,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
     # Mock not found error response
@@ -81,6 +83,7 @@ def test_push_with_id(mock_request, test_entity):
         },
         json={"name": "Test", "description": "Test"},
         params=None,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
 
@@ -96,6 +99,7 @@ def test_push_without_id(mock_request, test_entity_without_id):
         },
         json={"name": "Test", "description": "Test"},
         params=None,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
 
@@ -116,6 +120,7 @@ def test_pull_by_id(mock_request, test_entity):
         },
         json=None,
         params=None,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
 

--- a/tests/sdk/entities/test_file.py
+++ b/tests/sdk/entities/test_file.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from rhesis.sdk.config import DEFAULT_API_TIMEOUT
 from rhesis.sdk.entities.file import File
 from rhesis.sdk.entities.test import Test
 from rhesis.sdk.entities.test_result import TestResult
@@ -199,6 +200,7 @@ def test_file_download_writes_to_disk(mock_request, tmp_path):
         method="GET",
         url="http://test:8000/files/file-001/content",
         headers={"Authorization": "Bearer rh-test-token"},
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
 
@@ -230,6 +232,7 @@ def test_file_delete(mock_request):
         },
         json=None,
         params=None,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
 
@@ -302,6 +305,7 @@ def test_test_get_files(mock_request):
         },
         json=None,
         params=None,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
 
@@ -382,6 +386,7 @@ def test_test_result_get_files(mock_request):
         },
         json=None,
         params=None,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
 

--- a/tests/sdk/entities/test_insights.py
+++ b/tests/sdk/entities/test_insights.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from rhesis.sdk.config import DEFAULT_API_TIMEOUT
 from rhesis.sdk.entities import Insights
 from rhesis.sdk.entities.test_result import TestResults
 from rhesis.sdk.entities.test_run import TestRun, TestRuns
@@ -55,6 +56,7 @@ def test_insights_get_sends_entity_group_by_measures_and_filters(mock_request, i
             "group_by": ["requirement"],
             "measures": ["count", "pass_rate"],
         },
+        timeout=DEFAULT_API_TIMEOUT,
     )
     assert result.rows[0]["requirement"] == "refund"
 
@@ -90,6 +92,7 @@ def test_insights_ids_hits_ids_endpoint_with_outcome(mock_request, insights_ids_
         },
         json=None,
         params={"entity": "test_result", "test_run_ids": ["run-1"], "outcome": "fail"},
+        timeout=DEFAULT_API_TIMEOUT,
     )
     assert result.ids == ["test-1", "test-2"]
 

--- a/tests/sdk/entities/test_test_configuration.py
+++ b/tests/sdk/entities/test_test_configuration.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from rhesis.sdk.config import DEFAULT_API_TIMEOUT
 from rhesis.sdk.entities.test_configuration import TestConfiguration
 
 os.environ["RHESIS_BASE_URL"] = "http://test:8000"
@@ -68,6 +69,7 @@ def test_get_test_runs(mock_request, test_configuration):
         },
         json=None,
         params={"$filter": "test_configuration_id eq 'config-567'"},
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
     # Verify the result

--- a/tests/sdk/entities/test_test_result.py
+++ b/tests/sdk/entities/test_test_result.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from rhesis.sdk.config import DEFAULT_API_TIMEOUT
 from rhesis.sdk.entities.status import Status
 from rhesis.sdk.entities.test_result import TestResult
 
@@ -82,6 +83,7 @@ def test_pull_test_result_with_nested_status(mock_request, test_result_data):
         },
         json=None,
         params=None,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
     # Verify the result has nested status

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -4,6 +4,7 @@ import pytest
 import requests
 
 from rhesis.sdk.clients import APIClient, Endpoints, Methods
+from rhesis.sdk.config import DEFAULT_API_TIMEOUT
 
 
 @pytest.fixture
@@ -71,6 +72,7 @@ def test_send_request_get(mock_request):
         headers=client.headers,
         json=None,
         params=None,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
     # Verify the response
@@ -97,6 +99,7 @@ def test_send_request_post_with_data(mock_request):
         headers=client.headers,
         json=data,
         params=None,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
     # Verify the response
@@ -123,6 +126,7 @@ def test_send_request_with_params(mock_request):
         headers=client.headers,
         json=None,
         params=params,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
     # Verify the response
@@ -148,6 +152,7 @@ def test_send_request_with_url_params(mock_request):
         headers=client.headers,
         json=None,
         params=None,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
     # Verify the response
@@ -177,6 +182,7 @@ def test_send_request_put_with_all_params(mock_request):
         headers=client.headers,
         json=data,
         params=params,
+        timeout=DEFAULT_API_TIMEOUT,
     )
 
     # Verify the response


### PR DESCRIPTION
## Purpose

`requests` has no default timeout — a call without one waits forever. Repo-wide, only 3 of 30 `requests.*` calls passed a timeout, so an unresponsive upstream could hold a caller indefinitely with no error and no recovery.

The worst case was `apps/backend/src/rhesis/backend/app/services/github.py`. It is reached from `GET /services/github/contents`, which is declared `def`, so FastAPI runs it in the anyio threadpool. It then downloads a repository file by file in a loop, one timeout-less request per file. A single unresponsive file was enough to hold a threadpool slot for good, and enough of those starve every sync route in the process.

## What Changed

- **SDK** — added `DEFAULT_API_TIMEOUT = 30` in `config.py` for backend REST calls (the LLM path keeps its own longer `DEFAULT_LLM_TIMEOUT`), and applied it across `clients/api.py`, `parameters/_facade.py` and `entities/experiment.py`.
- **SDK** — `connector/types.py` also called `urllib.request.urlopen()` with no timeout. Ruff's `S113` only understands `requests` and `httpx`, so it does not flag this, but `urlopen` defaults to no timeout at all — the most unbounded case in the repo. Now bounded at 60s. Left `aiohttp.ClientSession()` in the same file alone; aiohttp already defaults to a 5-minute total timeout.
- **Backend** — the three `requests.get` calls in the GitHub service now pass a 30s timeout.
- **Chatbot** — the manual rate-limit script's 10 calls now pass a timeout.
- **Guardrail** — enabled ruff `S113` so this cannot come back. The lint workflow already runs `make lint` for `apps/backend`, `sdk` and `penelope`, and its backend filter watches `ruff.toml`, so the rule is enforced on every PR touching those.

All 22 pre-existing `S113` violations are fixed; the rule reports zero across the entire repo, including the directories CI does not yet lint.

## Additional Context

- `requests` applies its timeout per socket operation rather than to the whole call, so a slow-but-progressing download is not cut off — only a stalled one. That is why one value works for both API calls and file downloads.
- 21 `assert_called_once_with` blocks across 8 SDK test files pinned the exact kwargs of `requests.request`, so they all needed the new argument. Worth noting separately: asserting transport details that precisely means any change to how the SDK makes HTTP calls breaks a fifth of the entity tests. Not addressed here.
- `ee/backend`, `apps/worker`, `apps/chatbot`, `scripts` and `tests/` are not in the lint workflow's Python matrix, so `S113` is not enforced there. They are clean today, but nothing will catch a regression. Widening that matrix is a separate change.

## Testing

- `make lint` passes in `apps/backend`, `sdk` and `penelope` — the exact command CI runs.
- `uvx ruff check --select S113` reports zero repo-wide.
- Full SDK suite: **2920 passed, 17 skipped** (skips pre-existing — missing `rhesis.backend` module and deliberate skips).
- No backend test exercises `services/github.py` — nothing imports the module or references `read_repo_contents` / `download_github_repo`, so there was no coverage to run there before or after. The backend change is three added `timeout=` kwargs.
