### PR TITLE
Give server-rendered navigations immediate feedback

### DIFF
--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -56,20 +56,17 @@ const nextConfig = {
   // Source maps: enable in prod for debugging, faster option in dev
   productionBrowserSourceMaps: isProd,
 
-  // Next.js already modularizes the app's own barrel imports for the heavy
-  // libraries (@mui/material, @mui/icons-material, lucide-react, date-fns,
-  // recharts, …) via its default optimizePackageImports list. But that default
-  // does NOT reach the barrel imports inside our transpilePackages workspace
-  // package @rhesis/ee-frontend, so its `import { X } from '@mui/material'`
-  // still pulls in the full CJS barrel. Under Turbopack that barrel eagerly
-  // evaluates @mui/material/useMediaQuery, whose CJS→ESM interop of
-  // `unstable_createUseMediaQuery` breaks in MUI v7.3.x — crashing the whole
-  // app at module-eval time (see mui/material-ui#46688). Listing the packages
-  // explicitly forces the barrel-to-deep-import rewrite for the transpiled EE
-  // sources too, sidestepping the eager useMediaQuery evaluation.
-  experimental: {
-    optimizePackageImports: ['@mui/material', '@mui/icons-material'],
-  },
+  // No experimental.optimizePackageImports entry here on purpose: @mui/material
+  // and @mui/icons-material are already in Next's default list, and Next unions
+  // the user's list with that default (`new Set([...userProvided, ...defaults])`
+  // in next/dist/server/config.js), so naming them changes nothing. The list is
+  // keyed on package name, so it never "reaches into" transpilePackages either.
+  //
+  // The crash this used to claim to fix (mui/material-ui#46688,
+  // `unstable_createUseMediaQuery is not a function`) is not an interop problem:
+  // @mui/material/useMediaQuery calls a 'use client' export at module-evaluation
+  // time, which fails whenever the module lands in the RSC server graph. That is
+  // fixed by patches/@mui+material+7.3.5.patch, which defers the call.
 
   // Environment variables available to the client
   // NEXT_PUBLIC_ prefix guarantees availability in client components

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rhesis-app",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rhesis-app",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "hasInstallScript": true,
       "dependencies": {
         "@emotion/react": "^11",
@@ -37,6 +37,7 @@
         "markdown-to-jsx": "^9.7.1",
         "next": "^16.2.11",
         "next-auth": "5.0.0-beta.32",
+        "nextjs-toploader": "^3.9.17",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "react-mentions": "^4.4.10",
@@ -9881,6 +9882,24 @@
         }
       }
     },
+    "node_modules/nextjs-toploader": {
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/nextjs-toploader/-/nextjs-toploader-3.9.17.tgz",
+      "integrity": "sha512-9OF0KSSLtoSAuNg2LZ3aTl4hR9mBDj5L9s9DZiFCbMlXehyICGjkIz5dVGzuATU2bheJZoBdFgq9w07AKSuQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "nprogress": "^0.2.0",
+        "prop-types": "^15.8.1"
+      },
+      "funding": {
+        "url": "https://buymeacoffee.com/thesgj"
+      },
+      "peerDependencies": {
+        "next": ">= 6.0.0",
+        "react": ">= 16.0.0",
+        "react-dom": ">= 16.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "dev": true,
@@ -9913,6 +9932,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
+      "license": "MIT"
     },
     "node_modules/nwsapi": {
       "version": "2.2.22",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev --webpack -H 0.0.0.0 -p ${PORT:-3000}",
     "dev:turbo": "next dev --turbo -H 0.0.0.0 -p ${PORT:-3000}",
     "build": "npm run clean && next build --webpack",
-    "postinstall": "patch-package",
+    "postinstall": "patch-package --error-on-fail",
     "start": "next start -p ${PORT}",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx && npm --prefix ../../ee/frontend run lint",
     "lint:errors": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0 && npm --prefix ../../ee/frontend run lint",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -62,6 +62,7 @@
     "markdown-to-jsx": "^9.7.1",
     "next": "^16.2.11",
     "next-auth": "5.0.0-beta.32",
+    "nextjs-toploader": "^3.9.17",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-mentions": "^4.4.10",

--- a/apps/frontend/scripts/generate-templates.js
+++ b/apps/frontend/scripts/generate-templates.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
+const prettier = require('prettier');
 
 // Read the YAML file
 const yamlPath = path.join(__dirname, '../src/config/test-templates.yml');
@@ -73,18 +74,29 @@ ${templatesCode}
 `;
 };
 
-// Generate and write the file
-try {
+// Generate and write the file.
+// The output is checked in, so it has to be formatted the way Prettier would
+// leave it. Writing it raw makes `prettier --check` fail and shows every
+// `prebuild` run as a large content-identical diff in git.
+async function main() {
   const generatedContent = generateTypeScriptFile(config.templates);
   const outputPath = path.join(
     __dirname,
     '../src/config/test-templates.generated.ts'
   );
 
-  fs.writeFileSync(outputPath, generatedContent, 'utf8');
+  const prettierConfig = await prettier.resolveConfig(outputPath);
+  const formatted = await prettier.format(generatedContent, {
+    ...prettierConfig,
+    filepath: outputPath,
+  });
+
+  fs.writeFileSync(outputPath, formatted, 'utf8');
   console.log('Successfully generated test-templates.generated.ts');
   console.log(`Generated ${config.templates.length} templates`);
-} catch (error) {
+}
+
+main().catch(error => {
   console.error('Error generating templates:', error);
   process.exit(1);
-}
+});

--- a/apps/frontend/src/app/(protected)/architect/loading.tsx
+++ b/apps/frontend/src/app/(protected)/architect/loading.tsx
@@ -1,0 +1,5 @@
+import PageLoadingState from '@/components/common/PageLoadingState';
+
+export default function ArchitectLoading() {
+  return <PageLoadingState />;
+}

--- a/apps/frontend/src/app/(protected)/architect/loading.tsx
+++ b/apps/frontend/src/app/(protected)/architect/loading.tsx
@@ -1,5 +1,13 @@
+import DelayedReveal from '@/components/loading/DelayedReveal';
 import PageLoadingState from '@/components/common/PageLoadingState';
 
+// Architect is full-bleed, so a centered spinner fits better than the
+// PageLayout-shaped skeletons. DelayedReveal gives it the same hold, so a
+// fast navigation shows only the top progress bar.
 export default function ArchitectLoading() {
-  return <PageLoadingState />;
+  return (
+    <DelayedReveal sx={{ height: '100%' }}>
+      <PageLoadingState />
+    </DelayedReveal>
+  );
 }

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/loading.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/loading.tsx
@@ -1,0 +1,5 @@
+import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
+
+export default function ExperimentDetailLoading() {
+  return <PageDetailSkeleton />;
+}

--- a/apps/frontend/src/app/(protected)/jobs/[identifier]/loading.tsx
+++ b/apps/frontend/src/app/(protected)/jobs/[identifier]/loading.tsx
@@ -1,0 +1,5 @@
+import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
+
+export default function JobDetailLoading() {
+  return <PageDetailSkeleton />;
+}

--- a/apps/frontend/src/app/(protected)/knowledge/[identifier]/loading.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/[identifier]/loading.tsx
@@ -1,0 +1,5 @@
+import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
+
+export default function KnowledgeDetailLoading() {
+  return <PageDetailSkeleton />;
+}

--- a/apps/frontend/src/app/(protected)/loading.tsx
+++ b/apps/frontend/src/app/(protected)/loading.tsx
@@ -1,0 +1,5 @@
+import PageListSkeleton from '@/components/loading/PageListSkeleton';
+
+export default function ProtectedLoading() {
+  return <PageListSkeleton />;
+}

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/loading.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/loading.tsx
@@ -1,0 +1,5 @@
+import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
+
+export default function MetricDetailLoading() {
+  return <PageDetailSkeleton />;
+}

--- a/apps/frontend/src/app/(protected)/requirements/[identifier]/loading.tsx
+++ b/apps/frontend/src/app/(protected)/requirements/[identifier]/loading.tsx
@@ -1,0 +1,5 @@
+import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
+
+export default function RequirementDetailLoading() {
+  return <PageDetailSkeleton />;
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/loading.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/loading.tsx
@@ -1,0 +1,5 @@
+import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
+
+export default function TestRunDetailLoading() {
+  return <PageDetailSkeleton />;
+}

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/loading.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/loading.tsx
@@ -1,0 +1,5 @@
+import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
+
+export default function TestSetDetailLoading() {
+  return <PageDetailSkeleton />;
+}

--- a/apps/frontend/src/app/(protected)/test-sets/loading.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/loading.tsx
@@ -1,0 +1,7 @@
+import PageListSkeleton from '@/components/loading/PageListSkeleton';
+
+// Test Sets shows 4 header FABs (import, security scan, generate, create) for a
+// fully-permissioned user; the catch-all skeleton's default of 2 undercounts it.
+export default function TestSetsLoading() {
+  return <PageListSkeleton actionCount={4} />;
+}

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/loading.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/loading.tsx
@@ -1,0 +1,5 @@
+import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
+
+export default function TestDetailLoading() {
+  return <PageDetailSkeleton />;
+}

--- a/apps/frontend/src/app/(protected)/traces/[identifier]/loading.tsx
+++ b/apps/frontend/src/app/(protected)/traces/[identifier]/loading.tsx
@@ -1,0 +1,5 @@
+import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
+
+export default function TraceDetailLoading() {
+  return <PageDetailSkeleton />;
+}

--- a/apps/frontend/src/components/common/Fab.tsx
+++ b/apps/frontend/src/components/common/Fab.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Box, CircularProgress, Fab as MuiFab, Tooltip } from '@mui/material';
 import type { BoxProps } from '@mui/material/Box';
 import type { FabProps as MuiFabProps } from '@mui/material/Fab';
-import { ELEVATION, FAB_GROUP_GAP } from '@/styles/theme';
+import { ELEVATION, FAB_GROUP_GAP, FAB_SIZE } from '@/styles/theme';
 
 export { FAB_GROUP_GAP };
 export { default as FabAddIcon } from './FabAddIcon';
@@ -29,11 +29,12 @@ const fabIconSlotSx = {
 export const fabButtonSx = {
   bgcolor: 'primary.main',
   color: 'primary.contrastText',
-  width: 56,
-  height: 56,
-  minWidth: 56,
-  minHeight: 56,
-  padding: '12px',
+  width: FAB_SIZE,
+  height: FAB_SIZE,
+  minWidth: FAB_SIZE,
+  minHeight: FAB_SIZE,
+  // 1.5 spacing units = 12px, the Figma FAB inset around a 32px icon slot.
+  padding: 1.5,
   boxSizing: 'border-box',
   boxShadow: ELEVATION.xs,
   '&:hover': {

--- a/apps/frontend/src/components/common/GridToolbar.tsx
+++ b/apps/frontend/src/components/common/GridToolbar.tsx
@@ -5,7 +5,11 @@ import Box from '@mui/material/Box';
 import { SxProps, Theme } from '@mui/material/styles';
 import { FilterButton } from '@/components/common/FilterButton';
 import { SearchPill } from '@/components/common/SearchPill';
-import { BORDER_RADIUS } from '@/styles/theme';
+import {
+  BORDER_RADIUS,
+  GRID_CARD_INSET,
+  GRID_TOOLBAR_MIN_HEIGHT,
+} from '@/styles/theme';
 
 export interface ToolbarPillTab {
   label: string;
@@ -187,9 +191,9 @@ export function PrimarySegmentedPills({
 
 /** Toolbar row inside a linked-data card (Figma 1435:46915) — below a card header. */
 export const linkedGridToolbarSx: SxProps<Theme> = {
-  px: '30px',
+  px: GRID_CARD_INSET,
   pt: 0,
-  pb: '30px',
+  pb: GRID_CARD_INSET,
   minHeight: 'auto',
   borderBottom: 'none',
 };
@@ -201,7 +205,7 @@ export const sectionCardGridBleedSx: SxProps<Theme> = {
 };
 
 /** Shared 30px horizontal inset for grids/tables embedded in a bleeded section card. */
-export const SECTION_CARD_GRID_INSET_PX = '30px';
+export const SECTION_CARD_GRID_INSET_PX = GRID_CARD_INSET;
 
 /** Table horizontal padding inside a bleeded section-card grid area. */
 export const sectionCardGridTableInsetSx: SxProps<Theme> = {
@@ -285,9 +289,9 @@ export function GridToolbar({
     display: 'flex',
     alignItems: 'center',
     gap: 1.5,
-    px: '30px',
-    py: '30px',
-    minHeight: 52,
+    px: GRID_CARD_INSET,
+    py: GRID_CARD_INSET,
+    minHeight: GRID_TOOLBAR_MIN_HEIGHT,
   };
 
   return (

--- a/apps/frontend/src/components/layout/LayoutContent.tsx
+++ b/apps/frontend/src/components/layout/LayoutContent.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { Box, useTheme } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
+import NextTopLoader from 'nextjs-toploader';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SessionProvider } from 'next-auth/react';
@@ -130,6 +131,11 @@ export function LayoutContent({
       <SessionGuard>
         <AppRouterCacheProvider options={{ enableCssLayer: true }}>
           <CssBaseline />
+          <NextTopLoader
+            color={theme.palette.primary.main}
+            showSpinner={false}
+            shadow={false}
+          />
           <QueryClientProvider client={queryClient}>
             <QuickStartProvider value={initialQuickStart}>
               <ActiveProjectProvider

--- a/apps/frontend/src/components/loading/DelayedReveal.tsx
+++ b/apps/frontend/src/components/loading/DelayedReveal.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+/**
+ * Suspense fallbacks are held invisible for this long before fading in.
+ *
+ * A skeleton predicts the shape of content that hasn't arrived. When the
+ * prediction is wrong the swap reads as a glitch, and the worst case is a
+ * page whose list is empty: a six-row table dissolves into an onboarding
+ * card. Empty pages are also the fastest ones, since there is no data to
+ * fetch or serialize, so they are exactly the pages that resolve inside this
+ * window and never show a skeleton at all.
+ *
+ * `nextjs-toploader` covers the window: the progress bar starts on click, so
+ * a navigation shorter than the delay still gives immediate feedback.
+ *
+ * Suspense unmounts the fallback as soon as the page resolves, so a page
+ * that settles before the delay elapses paints nothing in between.
+ *
+ * 500ms sits between the ~300ms floor below which users don't perceive a
+ * delay and the 1s mark where they notice one (Nielsen's response-time
+ * limits), and is meant to clear a backend round trip for an empty list.
+ * TanStack Router defaults the same knob (`defaultPendingMs`) to 1000ms;
+ * raise this if empty pages still flash a skeleton in production.
+ *
+ * The complementary half of this pattern, a minimum display duration
+ * (TanStack's `pendingMinMs`), is deliberately absent: React owns when it
+ * unmounts a `loading.tsx` fallback, so honouring a minimum would mean
+ * hand-rolled Suspense boundaries and client timers on every route. The fade
+ * below softens that case instead, since a fallback unmounted mid-fade never
+ * reached full opacity.
+ */
+export const SKELETON_DELAY_MS = 500;
+
+/** Fade length once the delay has elapsed. Short enough to feel immediate. */
+export const SKELETON_FADE_MS = 150;
+
+export const delayedRevealSx = {
+  opacity: 0,
+  '@keyframes delayed-reveal': {
+    from: { opacity: 0 },
+    to: { opacity: 1 },
+  },
+  animation: `delayed-reveal ${SKELETON_FADE_MS}ms ease-out ${SKELETON_DELAY_MS}ms forwards`,
+  // The hold is timing rather than motion, so keep it under reduced motion
+  // and collapse only the fade.
+  '@media (prefers-reduced-motion: reduce)': {
+    animationDuration: '1ms',
+  },
+};
+
+export interface DelayedRevealProps {
+  children: React.ReactNode;
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * Wraps a loading fallback so it stays invisible for `SKELETON_DELAY_MS`.
+ * Both page skeletons apply `delayedRevealSx` themselves; use this for
+ * fallbacks that don't, such as a bare `PageLoadingState`.
+ */
+export default function DelayedReveal({ children, sx }: DelayedRevealProps) {
+  return (
+    <Box
+      sx={[delayedRevealSx, ...(Array.isArray(sx) ? sx : sx ? [sx] : [])]}
+      role="status"
+      aria-label="Loading"
+    >
+      {children}
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
@@ -2,10 +2,13 @@
 
 import Box from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
+import type { Theme } from '@mui/material/styles';
 import {
   BORDER_RADIUS,
   ELEVATION,
   FAB_GROUP_GAP,
+  FAB_SIZE,
+  GRID_CARD_INSET,
   SECTION_GRID,
 } from '@/styles/theme-constants';
 import { delayedRevealSx } from './DelayedReveal';
@@ -22,8 +25,60 @@ import { skeletonTextSx } from './skeletonText';
  * (DetailTabPanel `pt: 5`) and `SECTION_GRID` field spacing.
  */
 
-const HEADER_ROW_HEIGHT = 56;
-const TAB_UNDERLINE_HEIGHT = 3;
+/** Page header, mirroring `PageLayout`. */
+const HEADER = {
+  /** `minHeight` of the title row. */
+  rowHeight: 56,
+  /** Gap between the title and the action cluster. */
+  titleGap: '16px',
+  /** Vertical gap between the breadcrumbs and the title block. */
+  stackGap: '20px',
+  /** Bottom margin of the whole header block, in MUI spacing units. */
+  marginBottom: 5,
+  titleWidth: 280,
+  descriptionWidth: 460,
+} as const;
+
+/** Breadcrumb trail, mirroring `PageBreadcrumbs` in PageLayout. */
+const BREADCRUMB = {
+  /** Gap between crumbs. */
+  gap: '10px',
+  /** Gap between a crumb's label and its separator. */
+  itemGap: '6px',
+  separatorSize: 6,
+  firstWidth: 72,
+  restWidth: 108,
+} as const;
+
+/** Tab bar, mirroring `DetailTabNav`. */
+const TABS = {
+  /** Gap between tabs; DetailTabNav's default `tabGap`. */
+  gap: '50px',
+  /** Gap between a label and its underline. */
+  labelGap: '8px',
+  /** Height of the active tab's underline. */
+  underlineHeight: 3,
+  /** The underline is a solid bar in the real nav; dim it so it reads as a placeholder. */
+  underlineOpacity: 0.35,
+} as const;
+
+/** Section cards inside the tab panel. */
+const SECTION = {
+  /** Inset matching a SectionCard's padding. */
+  inset: GRID_CARD_INSET,
+  /** Gap between stacked cards, in MUI spacing units. */
+  gap: 3,
+  /** Inset DetailTabPanel puts above the panel body, in MUI spacing units. */
+  panelTop: 5,
+  /** Gap below a card heading, in MUI spacing units. */
+  headingGap: 3,
+  fieldLabelWidth: 96,
+  fieldValueWidth: '72%',
+} as const;
+
+/** Card border, matching the grid card and SectionCard. */
+const cardBorder = (theme: Theme) =>
+  `1px solid ${theme.palette.greyscale.border}`;
 
 /** Tab label widths — detail pages run 3-5 tabs (Overview, Test Sets, …). */
 const TAB_WIDTHS = [78, 96, 132, 62];
@@ -59,22 +114,37 @@ export default function PageDetailSkeleton({
     >
       {/* PageLayout header: breadcrumbs, then title/description block, mb: 5 */}
       <Box
-        sx={{ display: 'flex', flexDirection: 'column', gap: '20px', mb: 5 }}
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: HEADER.stackGap,
+          mb: HEADER.marginBottom,
+        }}
         aria-hidden
       >
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', gap: BREADCRUMB.gap }}
+        >
           {crumbKeys.map((key, idx) => (
             <Box
               key={key}
-              sx={{ display: 'flex', alignItems: 'center', gap: '6px' }}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: BREADCRUMB.itemGap,
+              }}
             >
               <Skeleton
                 variant="text"
-                width={idx === 0 ? 72 : 108}
+                width={idx === 0 ? BREADCRUMB.firstWidth : BREADCRUMB.restWidth}
                 sx={skeletonTextSx('bodyMReg')}
               />
               {idx < crumbKeys.length - 1 && (
-                <Skeleton variant="circular" width={6} height={6} />
+                <Skeleton
+                  variant="circular"
+                  width={BREADCRUMB.separatorSize}
+                  height={BREADCRUMB.separatorSize}
+                />
               )}
             </Box>
           ))}
@@ -86,19 +156,23 @@ export default function PageDetailSkeleton({
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'space-between',
-              gap: '16px',
-              minHeight: HEADER_ROW_HEIGHT,
+              gap: HEADER.titleGap,
+              minHeight: HEADER.rowHeight,
             }}
           >
-            <Skeleton variant="text" width={280} sx={skeletonTextSx('h4')} />
+            <Skeleton
+              variant="text"
+              width={HEADER.titleWidth}
+              sx={skeletonTextSx('h4')}
+            />
             {actionCount > 0 && (
               <Box sx={{ display: 'flex', gap: FAB_GROUP_GAP, flexShrink: 0 }}>
                 {fabKeys.map(key => (
                   <Skeleton
                     key={key}
                     variant="circular"
-                    width={56}
-                    height={56}
+                    width={FAB_SIZE}
+                    height={FAB_SIZE}
                   />
                 ))}
               </Box>
@@ -106,26 +180,30 @@ export default function PageDetailSkeleton({
           </Box>
           <Skeleton
             variant="text"
-            width={460}
+            width={HEADER.descriptionWidth}
             sx={skeletonTextSx('bodyLReg')}
           />
         </Box>
       </Box>
 
       {/* DetailTabNav: 18px labels at 50px gaps, active tab underlined */}
-      <Box sx={{ display: 'flex', gap: '50px' }} aria-hidden>
+      <Box sx={{ display: 'flex', gap: TABS.gap }} aria-hidden>
         {TAB_WIDTHS.map((width, idx) => (
           <Box
             key={width}
-            sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: TABS.labelGap,
+            }}
           >
             <Skeleton variant="text" width={width} sx={skeletonTextSx('h6')} />
             <Box
               sx={{
-                height: TAB_UNDERLINE_HEIGHT,
+                height: TABS.underlineHeight,
                 borderRadius: BORDER_RADIUS.xs,
                 bgcolor: idx === 0 ? 'primary.main' : 'transparent',
-                opacity: idx === 0 ? 0.35 : 0,
+                opacity: idx === 0 ? TABS.underlineOpacity : 0,
               }}
             />
           </Box>
@@ -134,7 +212,12 @@ export default function PageDetailSkeleton({
 
       {/* Tab panel content: DetailTabPanel applies pt: 5 */}
       <Box
-        sx={{ pt: 5, display: 'flex', flexDirection: 'column', gap: 3 }}
+        sx={{
+          pt: SECTION.panelTop,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: SECTION.gap,
+        }}
         aria-hidden
       >
         {SECTIONS.map(section => (
@@ -143,15 +226,15 @@ export default function PageDetailSkeleton({
             sx={{
               borderRadius: BORDER_RADIUS.md,
               boxShadow: ELEVATION.xs,
-              border: theme => `1px solid ${theme.palette.greyscale.border}`,
+              border: cardBorder,
               bgcolor: 'background.paper',
-              p: '30px',
+              p: SECTION.inset,
             }}
           >
             <Skeleton
               variant="text"
               width={section.heading}
-              sx={{ ...skeletonTextSx('h6'), mb: 3 }}
+              sx={{ ...skeletonTextSx('h6'), mb: SECTION.headingGap }}
             />
             <Box
               sx={{
@@ -168,12 +251,12 @@ export default function PageDetailSkeleton({
                 <Box key={key}>
                   <Skeleton
                     variant="text"
-                    width={96}
+                    width={SECTION.fieldLabelWidth}
                     sx={skeletonTextSx('bodySReg')}
                   />
                   <Skeleton
                     variant="text"
-                    width="72%"
+                    width={SECTION.fieldValueWidth}
                     sx={skeletonTextSx('bodyLReg')}
                   />
                 </Box>

--- a/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
@@ -9,6 +9,7 @@ import {
   SECTION_GRID,
 } from '@/styles/theme-constants';
 import { delayedRevealSx } from './DelayedReveal';
+import { skeletonTextSx } from './skeletonText';
 
 /**
  * Loading placeholder for entity detail pages: `PageLayout` header
@@ -70,7 +71,7 @@ export default function PageDetailSkeleton({
               <Skeleton
                 variant="text"
                 width={idx === 0 ? 72 : 108}
-                sx={{ fontSize: '0.875rem' }}
+                sx={skeletonTextSx('bodyMReg')}
               />
               {idx < crumbKeys.length - 1 && (
                 <Skeleton variant="circular" width={6} height={6} />
@@ -89,11 +90,7 @@ export default function PageDetailSkeleton({
               minHeight: HEADER_ROW_HEIGHT,
             }}
           >
-            <Skeleton
-              variant="text"
-              width={280}
-              sx={{ fontSize: '2.125rem' }}
-            />
+            <Skeleton variant="text" width={280} sx={skeletonTextSx('h4')} />
             {actionCount > 0 && (
               <Box sx={{ display: 'flex', gap: FAB_GROUP_GAP, flexShrink: 0 }}>
                 {fabKeys.map(key => (
@@ -107,7 +104,11 @@ export default function PageDetailSkeleton({
               </Box>
             )}
           </Box>
-          <Skeleton variant="text" width={460} sx={{ fontSize: '1rem' }} />
+          <Skeleton
+            variant="text"
+            width={460}
+            sx={skeletonTextSx('bodyLReg')}
+          />
         </Box>
       </Box>
 
@@ -118,11 +119,7 @@ export default function PageDetailSkeleton({
             key={width}
             sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}
           >
-            <Skeleton
-              variant="text"
-              width={width}
-              sx={{ fontSize: '1.125rem' }}
-            />
+            <Skeleton variant="text" width={width} sx={skeletonTextSx('h6')} />
             <Box
               sx={{
                 height: TAB_UNDERLINE_HEIGHT,
@@ -154,7 +151,7 @@ export default function PageDetailSkeleton({
             <Skeleton
               variant="text"
               width={section.heading}
-              sx={{ fontSize: '1.25rem', mb: 3 }}
+              sx={{ ...skeletonTextSx('h6'), mb: 3 }}
             />
             <Box
               sx={{
@@ -172,12 +169,12 @@ export default function PageDetailSkeleton({
                   <Skeleton
                     variant="text"
                     width={96}
-                    sx={{ fontSize: '0.75rem' }}
+                    sx={skeletonTextSx('bodySReg')}
                   />
                   <Skeleton
                     variant="text"
                     width="72%"
-                    sx={{ fontSize: '1rem' }}
+                    sx={skeletonTextSx('bodyLReg')}
                   />
                 </Box>
               ))}

--- a/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
+import {
+  BORDER_RADIUS,
+  ELEVATION,
+  FAB_GROUP_GAP,
+  SECTION_GRID,
+} from '@/styles/theme-constants';
+
+/**
+ * Loading placeholder for entity detail pages: `PageLayout` header
+ * (breadcrumbs, title, description, FAB cluster) above a `DetailTabNav` bar
+ * and section cards.
+ *
+ * Geometry follows the real components: 10px breadcrumb gap and 20px header
+ * stack (PageLayout), 56px FABs at `FAB_GROUP_GAP` (Fab.tsx), 50px tab gap
+ * with an active-tab underline (DetailTabNav), 40px panel inset
+ * (DetailTabPanel `pt: 5`) and `SECTION_GRID` field spacing.
+ */
+
+const HEADER_ROW_HEIGHT = 56;
+const TAB_UNDERLINE_HEIGHT = 3;
+
+/** Tab label widths — detail pages run 3-5 tabs (Overview, Test Sets, …). */
+const TAB_WIDTHS = [78, 96, 132, 62];
+
+/** Section cards, each with a heading and a 2-column field grid. */
+const SECTIONS = [
+  { key: 'primary', heading: 150, fields: 6 },
+  { key: 'secondary', heading: 190, fields: 4 },
+];
+
+export interface PageDetailSkeletonProps {
+  /** FAB placeholders in the header, matching the page's action cluster. */
+  actionCount?: number;
+  /** Breadcrumb segments before the current page. */
+  breadcrumbCount?: number;
+}
+
+export default function PageDetailSkeleton({
+  actionCount = 2,
+  breadcrumbCount = 2,
+}: PageDetailSkeletonProps = {}) {
+  const fabKeys = Array.from({ length: actionCount }, (_, i) => `fab-${i}`);
+  const crumbKeys = Array.from(
+    { length: breadcrumbCount },
+    (_, i) => `crumb-${i}`
+  );
+
+  return (
+    <Box sx={{ width: '100%' }} role="status" aria-label="Loading page">
+      {/* PageLayout header: breadcrumbs, then title/description block, mb: 5 */}
+      <Box
+        sx={{ display: 'flex', flexDirection: 'column', gap: '20px', mb: 5 }}
+        aria-hidden
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          {crumbKeys.map((key, idx) => (
+            <Box
+              key={key}
+              sx={{ display: 'flex', alignItems: 'center', gap: '6px' }}
+            >
+              <Skeleton
+                variant="text"
+                width={idx === 0 ? 72 : 108}
+                sx={{ fontSize: '0.875rem' }}
+              />
+              {idx < crumbKeys.length - 1 && (
+                <Skeleton variant="circular" width={6} height={6} />
+              )}
+            </Box>
+          ))}
+        </Box>
+
+        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: '16px',
+              minHeight: HEADER_ROW_HEIGHT,
+            }}
+          >
+            <Skeleton
+              variant="text"
+              width={280}
+              sx={{ fontSize: '2.125rem' }}
+            />
+            {actionCount > 0 && (
+              <Box sx={{ display: 'flex', gap: FAB_GROUP_GAP, flexShrink: 0 }}>
+                {fabKeys.map(key => (
+                  <Skeleton
+                    key={key}
+                    variant="circular"
+                    width={56}
+                    height={56}
+                  />
+                ))}
+              </Box>
+            )}
+          </Box>
+          <Skeleton variant="text" width={460} sx={{ fontSize: '1rem' }} />
+        </Box>
+      </Box>
+
+      {/* DetailTabNav: 18px labels at 50px gaps, active tab underlined */}
+      <Box sx={{ display: 'flex', gap: '50px' }} aria-hidden>
+        {TAB_WIDTHS.map((width, idx) => (
+          <Box
+            key={width}
+            sx={{ display: 'flex', flexDirection: 'column', gap: '8px' }}
+          >
+            <Skeleton
+              variant="text"
+              width={width}
+              sx={{ fontSize: '1.125rem' }}
+            />
+            <Box
+              sx={{
+                height: TAB_UNDERLINE_HEIGHT,
+                borderRadius: BORDER_RADIUS.xs,
+                bgcolor: idx === 0 ? 'primary.main' : 'transparent',
+                opacity: idx === 0 ? 0.35 : 0,
+              }}
+            />
+          </Box>
+        ))}
+      </Box>
+
+      {/* Tab panel content: DetailTabPanel applies pt: 5 */}
+      <Box
+        sx={{ pt: 5, display: 'flex', flexDirection: 'column', gap: 3 }}
+        aria-hidden
+      >
+        {SECTIONS.map(section => (
+          <Box
+            key={section.key}
+            sx={{
+              borderRadius: BORDER_RADIUS.md,
+              boxShadow: ELEVATION.xs,
+              border: theme => `1px solid ${theme.palette.greyscale.border}`,
+              bgcolor: 'background.paper',
+              p: '30px',
+            }}
+          >
+            <Skeleton
+              variant="text"
+              width={section.heading}
+              sx={{ fontSize: '1.25rem', mb: 3 }}
+            />
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+                columnGap: SECTION_GRID.columnSpacing,
+                rowGap: SECTION_GRID.rowSpacing,
+              }}
+            >
+              {Array.from(
+                { length: section.fields },
+                (_, i) => `${section.key}-field-${i}`
+              ).map(key => (
+                <Box key={key}>
+                  <Skeleton
+                    variant="text"
+                    width={96}
+                    sx={{ fontSize: '0.75rem' }}
+                  />
+                  <Skeleton
+                    variant="text"
+                    width="72%"
+                    sx={{ fontSize: '1rem' }}
+                  />
+                </Box>
+              ))}
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
@@ -8,6 +8,7 @@ import {
   FAB_GROUP_GAP,
   SECTION_GRID,
 } from '@/styles/theme-constants';
+import { delayedRevealSx } from './DelayedReveal';
 
 /**
  * Loading placeholder for entity detail pages: `PageLayout` header
@@ -50,7 +51,11 @@ export default function PageDetailSkeleton({
   );
 
   return (
-    <Box sx={{ width: '100%' }} role="status" aria-label="Loading page">
+    <Box
+      sx={{ width: '100%', ...delayedRevealSx }}
+      role="status"
+      aria-label="Loading page"
+    >
       {/* PageLayout header: breadcrumbs, then title/description block, mb: 5 */}
       <Box
         sx={{ display: 'flex', flexDirection: 'column', gap: '20px', mb: 5 }}

--- a/apps/frontend/src/components/loading/PageListSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageListSkeleton.tsx
@@ -8,6 +8,7 @@ import {
   FAB_GROUP_GAP,
 } from '@/styles/theme-constants';
 import { delayedRevealSx } from './DelayedReveal';
+import { skeletonTextSx } from './skeletonText';
 
 /**
  * Loading placeholder for the standard list page: `PageLayout` header (title,
@@ -79,7 +80,7 @@ export default function PageListSkeleton({
             minHeight: HEADER_ROW_HEIGHT,
           }}
         >
-          <Skeleton variant="text" width={180} sx={{ fontSize: '2.125rem' }} />
+          <Skeleton variant="text" width={180} sx={skeletonTextSx('h4')} />
           {actionCount > 0 && (
             <Box
               sx={{ display: 'flex', gap: FAB_GROUP_GAP, flexShrink: 0 }}
@@ -91,7 +92,7 @@ export default function PageListSkeleton({
             </Box>
           )}
         </Box>
-        <Skeleton variant="text" width={420} sx={{ fontSize: '1rem' }} />
+        <Skeleton variant="text" width={420} sx={skeletonTextSx('bodyLReg')} />
       </Box>
 
       {/* Grid card — mirrors GRID_PAPER_SX */}
@@ -129,7 +130,10 @@ export default function PageListSkeleton({
               variant="rounded"
               width={240}
               height={38}
-              sx={{ borderRadius: '30px', flexShrink: 0 }}
+              sx={{
+                borderRadius: '30px', // Intentional: matches SearchPill's elongated pill
+                flexShrink: 0,
+              }}
             />
             {/* Centered pill tabs */}
             <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
@@ -153,7 +157,7 @@ export default function PageListSkeleton({
                   key={width}
                   variant="text"
                   width={width}
-                  sx={{ fontSize: '0.875rem' }}
+                  sx={skeletonTextSx('bodyMReg')}
                 />
               ))}
             </Box>
@@ -184,7 +188,7 @@ export default function PageListSkeleton({
               <Skeleton
                 variant="text"
                 width={col.header}
-                sx={{ fontSize: '0.875rem' }}
+                sx={skeletonTextSx('bodyMReg')}
               />
             </Box>
           ))}
@@ -225,7 +229,7 @@ export default function PageListSkeleton({
                   <Skeleton
                     variant="text"
                     width={col.cell}
-                    sx={{ fontSize: '0.875rem' }}
+                    sx={skeletonTextSx('bodyMReg')}
                   />
                 )}
               </Box>
@@ -246,7 +250,7 @@ export default function PageListSkeleton({
           }}
         >
           <Skeleton variant="circular" width={32} height={32} />
-          <Skeleton variant="text" width={64} sx={{ fontSize: '0.875rem' }} />
+          <Skeleton variant="text" width={64} sx={skeletonTextSx('bodyMReg')} />
           <Skeleton variant="circular" width={32} height={32} />
         </Box>
       </Box>

--- a/apps/frontend/src/components/loading/PageListSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageListSkeleton.tsx
@@ -1,0 +1,250 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
+import {
+  BORDER_RADIUS,
+  ELEVATION,
+  FAB_GROUP_GAP,
+} from '@/styles/theme-constants';
+
+/**
+ * Loading placeholder for the standard list page: `PageLayout` header (title,
+ * description, FAB cluster) above a grid card holding `GridToolbar`, column
+ * headers, rows and the pagination footer.
+ *
+ * Geometry is copied from the real components so the swap to content doesn't
+ * shift anything: 56px FABs at `FAB_GROUP_GAP` (Fab.tsx), 30px toolbar inset
+ * and 36/38px controls (GridToolbar, FilterButton, SearchPill), 30px column
+ * inset (BaseDataGrid `theme.spacing(3.75)`), and the card's own border,
+ * radius and elevation (`GRID_PAPER_SX`). Those tokens are re-declared rather
+ * than imported from BaseDataGrid because importing it would pull
+ * @mui/x-data-grid into the loading chunk, which defeats the point.
+ */
+
+const HEADER_ROW_HEIGHT = 56;
+const DATA_ROW_HEIGHT = 52;
+const FOOTER_HEIGHT = 56;
+
+/** Column widths approximating a typical entity grid: wide first column, then
+ *  chip columns, then metadata. `chip` cells render pill shapes because those
+ *  columns hold `GridBadge`/`Chip` renderers rather than plain text. */
+const COLUMNS = [
+  { key: 'primary', width: '17%', header: 64, cell: '86%', kind: 'text' },
+  { key: 'chip-a', width: '11%', header: 84, cell: 72, kind: 'chip' },
+  { key: 'chip-b', width: '13%', header: 52, cell: 104, kind: 'chip' },
+  { key: 'chip-c', width: '12%', header: 68, cell: 82, kind: 'chip' },
+  { key: 'type', width: '10%', header: 72, cell: 70, kind: 'text' },
+  { key: 'created', width: '13%', header: 60, cell: 116, kind: 'text' },
+  { key: 'meta-a', width: '9%', header: 76, cell: 24, kind: 'text' },
+  { key: 'meta-b', width: '9%', header: 48, cell: 24, kind: 'text' },
+  { key: 'actions', width: '6%', header: 56, cell: 24, kind: 'text' },
+] as const;
+
+/** Text links in the toolbar's right slot (Select / Columns / Density / Export). */
+const TOOLBAR_ACTIONS = [76, 62, 56, 50];
+
+export interface PageListSkeletonProps {
+  /** FAB placeholders in the header, matching the page's action cluster. */
+  actionCount?: number;
+  /** Placeholder data rows. */
+  rows?: number;
+  /** Render the search + filter + tabs toolbar row. */
+  showToolbar?: boolean;
+}
+
+export default function PageListSkeleton({
+  actionCount = 2,
+  rows = 6,
+  showToolbar = true,
+}: PageListSkeletonProps = {}) {
+  const rowKeys = Array.from({ length: rows }, (_, i) => `row-${i}`);
+  const fabKeys = Array.from({ length: actionCount }, (_, i) => `fab-${i}`);
+
+  return (
+    <Box sx={{ width: '100%' }} role="status" aria-label="Loading page">
+      {/* PageLayout header: title row (minHeight 56) then description, mb: 5 */}
+      <Box sx={{ display: 'flex', flexDirection: 'column', mb: 5 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '16px',
+            minHeight: HEADER_ROW_HEIGHT,
+          }}
+        >
+          <Skeleton variant="text" width={180} sx={{ fontSize: '2.125rem' }} />
+          {actionCount > 0 && (
+            <Box
+              sx={{ display: 'flex', gap: FAB_GROUP_GAP, flexShrink: 0 }}
+              aria-hidden
+            >
+              {fabKeys.map(key => (
+                <Skeleton key={key} variant="circular" width={56} height={56} />
+              ))}
+            </Box>
+          )}
+        </Box>
+        <Skeleton variant="text" width={420} sx={{ fontSize: '1rem' }} />
+      </Box>
+
+      {/* Grid card — mirrors GRID_PAPER_SX */}
+      <Box
+        sx={{
+          width: '100%',
+          borderRadius: BORDER_RADIUS.md,
+          boxShadow: ELEVATION.xs,
+          border: theme => `1px solid ${theme.palette.greyscale.border}`,
+          overflow: 'hidden',
+          bgcolor: 'background.paper',
+        }}
+        aria-hidden
+      >
+        {showToolbar && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.5,
+              px: '30px',
+              py: '30px',
+              minHeight: 52,
+            }}
+          >
+            {/* FilterButton: 36px square, radius sm */}
+            <Skeleton
+              variant="rounded"
+              width={36}
+              height={36}
+              sx={{ borderRadius: BORDER_RADIUS.sm, flexShrink: 0 }}
+            />
+            {/* SearchPill: 240x38, elongated pill */}
+            <Skeleton
+              variant="rounded"
+              width={240}
+              height={38}
+              sx={{ borderRadius: '30px', flexShrink: 0 }}
+            />
+            {/* Centered pill tabs */}
+            <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
+              <Skeleton
+                variant="rounded"
+                width={248}
+                height={38}
+                sx={{ borderRadius: BORDER_RADIUS.pill }}
+              />
+            </Box>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.5,
+                flexShrink: 0,
+              }}
+            >
+              {TOOLBAR_ACTIONS.map(width => (
+                <Skeleton
+                  key={width}
+                  variant="text"
+                  width={width}
+                  sx={{ fontSize: '0.875rem' }}
+                />
+              ))}
+            </Box>
+          </Box>
+        )}
+
+        {/* Column headers: 56px, paper background, bottom divider */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            height: HEADER_ROW_HEIGHT,
+            borderTop: theme => `1px solid ${theme.palette.greyscale.border}`,
+            borderBottom: theme =>
+              `1px solid ${theme.palette.greyscale.border}`,
+          }}
+        >
+          {COLUMNS.map((col, idx) => (
+            <Box
+              key={col.key}
+              sx={{
+                width: col.width,
+                flexShrink: 0,
+                pl: idx === 0 ? '30px' : 0,
+                pr: idx === COLUMNS.length - 1 ? '30px' : 2,
+              }}
+            >
+              <Skeleton
+                variant="text"
+                width={col.header}
+                sx={{ fontSize: '0.875rem' }}
+              />
+            </Box>
+          ))}
+        </Box>
+
+        {/* Data rows: 52px, divider between */}
+        {rowKeys.map((rowKey, rowIdx) => (
+          <Box
+            key={rowKey}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              height: DATA_ROW_HEIGHT,
+              ...(rowIdx < rowKeys.length - 1 && {
+                borderBottom: theme =>
+                  `1px solid ${theme.palette.greyscale.border}`,
+              }),
+            }}
+          >
+            {COLUMNS.map((col, idx) => (
+              <Box
+                key={col.key}
+                sx={{
+                  width: col.width,
+                  flexShrink: 0,
+                  pl: idx === 0 ? '30px' : 0,
+                  pr: idx === COLUMNS.length - 1 ? '30px' : 2,
+                }}
+              >
+                {col.kind === 'chip' ? (
+                  <Skeleton
+                    variant="rounded"
+                    width={col.cell}
+                    height={24}
+                    sx={{ borderRadius: BORDER_RADIUS.pill }}
+                  />
+                ) : (
+                  <Skeleton
+                    variant="text"
+                    width={col.cell}
+                    sx={{ fontSize: '0.875rem' }}
+                  />
+                )}
+              </Box>
+            ))}
+          </Box>
+        ))}
+
+        {/* Pagination footer: right-aligned prev/next + range label */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'flex-end',
+            gap: 1.5,
+            height: FOOTER_HEIGHT,
+            px: '30px',
+            borderTop: theme => `1px solid ${theme.palette.greyscale.border}`,
+          }}
+        >
+          <Skeleton variant="circular" width={32} height={32} />
+          <Skeleton variant="text" width={64} sx={{ fontSize: '0.875rem' }} />
+          <Skeleton variant="circular" width={32} height={32} />
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/loading/PageListSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageListSkeleton.tsx
@@ -2,10 +2,14 @@
 
 import Box from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
+import type { Theme } from '@mui/material/styles';
 import {
   BORDER_RADIUS,
   ELEVATION,
   FAB_GROUP_GAP,
+  FAB_SIZE,
+  GRID_CARD_INSET,
+  GRID_TOOLBAR_MIN_HEIGHT,
 } from '@/styles/theme-constants';
 import { delayedRevealSx } from './DelayedReveal';
 import { skeletonTextSx } from './skeletonText';
@@ -15,18 +19,47 @@ import { skeletonTextSx } from './skeletonText';
  * description, FAB cluster) above a grid card holding `GridToolbar`, column
  * headers, rows and the pagination footer.
  *
- * Geometry is copied from the real components so the swap to content doesn't
- * shift anything: 56px FABs at `FAB_GROUP_GAP` (Fab.tsx), 30px toolbar inset
- * and 36/38px controls (GridToolbar, FilterButton, SearchPill), 30px column
- * inset (BaseDataGrid `theme.spacing(3.75)`), and the card's own border,
- * radius and elevation (`GRID_PAPER_SX`). Those tokens are re-declared rather
- * than imported from BaseDataGrid because importing it would pull
- * @mui/x-data-grid into the loading chunk, which defeats the point.
+ * Shared geometry comes from `theme-constants` so this cannot drift from the
+ * components it stands in for. The card's border, radius and elevation mirror
+ * BaseDataGrid's `GRID_PAPER_SX`, which is re-declared here rather than
+ * imported because importing BaseDataGrid would pull @mui/x-data-grid into the
+ * loading chunk and defeat the point of a lightweight fallback.
  */
 
-const HEADER_ROW_HEIGHT = 56;
-const DATA_ROW_HEIGHT = 52;
-const FOOTER_HEIGHT = 56;
+/** Page header, mirroring `PageLayout`. */
+const HEADER = {
+  /** `minHeight` of the title row. */
+  rowHeight: 56,
+  /** Gap between the title and the action cluster. */
+  titleGap: '16px',
+  /** Bottom margin of the whole header block, in MUI spacing units. */
+  marginBottom: 5,
+  titleWidth: 180,
+  descriptionWidth: 420,
+} as const;
+
+/** Toolbar controls, mirroring `GridToolbar`, `FilterButton` and `SearchPill`. */
+const TOOLBAR = {
+  /** Gap between controls, in MUI spacing units. */
+  gap: 1.5,
+  filterButtonSize: 36,
+  searchWidth: 240,
+  controlHeight: 38,
+  pillTabsWidth: 248,
+} as const;
+
+/** Grid rows and footer, mirroring BaseDataGrid's styled DataGrid. */
+const GRID = {
+  headerHeight: 56,
+  rowHeight: 52,
+  footerHeight: 56,
+  /** Height of a `GridBadge`/`Chip` inside a cell. */
+  chipHeight: 24,
+  paginationButtonSize: 32,
+  paginationLabelWidth: 64,
+  /** Trailing padding on non-edge cells, in MUI spacing units. */
+  cellGap: 2,
+} as const;
 
 /** Column widths approximating a typical entity grid: wide first column, then
  *  chip columns, then metadata. `chip` cells render pill shapes because those
@@ -46,6 +79,9 @@ const COLUMNS = [
 /** Text links in the toolbar's right slot (Select / Columns / Density / Export). */
 const TOOLBAR_ACTIONS = [76, 62, 56, 50];
 
+/** Row and cell separator, matching BaseDataGrid's cell borders. */
+const divider = (theme: Theme) => `1px solid ${theme.palette.greyscale.border}`;
+
 export interface PageListSkeletonProps {
   /** FAB placeholders in the header, matching the page's action cluster. */
   actionCount?: number;
@@ -63,36 +99,60 @@ export default function PageListSkeleton({
   const rowKeys = Array.from({ length: rows }, (_, i) => `row-${i}`);
   const fabKeys = Array.from({ length: actionCount }, (_, i) => `fab-${i}`);
 
+  /** Edge cells carry the card inset; the rest carry a trailing gap. */
+  const cellInsetSx = (idx: number) => ({
+    pl: idx === 0 ? GRID_CARD_INSET : 0,
+    pr: idx === COLUMNS.length - 1 ? GRID_CARD_INSET : GRID.cellGap,
+  });
+
   return (
     <Box
       sx={{ width: '100%', ...delayedRevealSx }}
       role="status"
       aria-label="Loading page"
     >
-      {/* PageLayout header: title row (minHeight 56) then description, mb: 5 */}
-      <Box sx={{ display: 'flex', flexDirection: 'column', mb: 5 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          mb: HEADER.marginBottom,
+        }}
+      >
         <Box
           sx={{
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
-            gap: '16px',
-            minHeight: HEADER_ROW_HEIGHT,
+            gap: HEADER.titleGap,
+            minHeight: HEADER.rowHeight,
           }}
         >
-          <Skeleton variant="text" width={180} sx={skeletonTextSx('h4')} />
+          <Skeleton
+            variant="text"
+            width={HEADER.titleWidth}
+            sx={skeletonTextSx('h4')}
+          />
           {actionCount > 0 && (
             <Box
               sx={{ display: 'flex', gap: FAB_GROUP_GAP, flexShrink: 0 }}
               aria-hidden
             >
               {fabKeys.map(key => (
-                <Skeleton key={key} variant="circular" width={56} height={56} />
+                <Skeleton
+                  key={key}
+                  variant="circular"
+                  width={FAB_SIZE}
+                  height={FAB_SIZE}
+                />
               ))}
             </Box>
           )}
         </Box>
-        <Skeleton variant="text" width={420} sx={skeletonTextSx('bodyLReg')} />
+        <Skeleton
+          variant="text"
+          width={HEADER.descriptionWidth}
+          sx={skeletonTextSx('bodyLReg')}
+        />
       </Box>
 
       {/* Grid card — mirrors GRID_PAPER_SX */}
@@ -101,7 +161,7 @@ export default function PageListSkeleton({
           width: '100%',
           borderRadius: BORDER_RADIUS.md,
           boxShadow: ELEVATION.xs,
-          border: theme => `1px solid ${theme.palette.greyscale.border}`,
+          border: divider,
           overflow: 'hidden',
           bgcolor: 'background.paper',
         }}
@@ -112,35 +172,33 @@ export default function PageListSkeleton({
             sx={{
               display: 'flex',
               alignItems: 'center',
-              gap: 1.5,
-              px: '30px',
-              py: '30px',
-              minHeight: 52,
+              gap: TOOLBAR.gap,
+              px: GRID_CARD_INSET,
+              py: GRID_CARD_INSET,
+              minHeight: GRID_TOOLBAR_MIN_HEIGHT,
             }}
           >
-            {/* FilterButton: 36px square, radius sm */}
             <Skeleton
               variant="rounded"
-              width={36}
-              height={36}
+              width={TOOLBAR.filterButtonSize}
+              height={TOOLBAR.filterButtonSize}
               sx={{ borderRadius: BORDER_RADIUS.sm, flexShrink: 0 }}
             />
-            {/* SearchPill: 240x38, elongated pill */}
             <Skeleton
               variant="rounded"
-              width={240}
-              height={38}
+              width={TOOLBAR.searchWidth}
+              height={TOOLBAR.controlHeight}
               sx={{
                 borderRadius: '30px', // Intentional: matches SearchPill's elongated pill
                 flexShrink: 0,
               }}
             />
-            {/* Centered pill tabs */}
+            {/* Pill tabs sit centred, as ToolbarPillTabs does */}
             <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
               <Skeleton
                 variant="rounded"
-                width={248}
-                height={38}
+                width={TOOLBAR.pillTabsWidth}
+                height={TOOLBAR.controlHeight}
                 sx={{ borderRadius: BORDER_RADIUS.pill }}
               />
             </Box>
@@ -148,7 +206,7 @@ export default function PageListSkeleton({
               sx={{
                 display: 'flex',
                 alignItems: 'center',
-                gap: 1.5,
+                gap: TOOLBAR.gap,
                 flexShrink: 0,
               }}
             >
@@ -164,26 +222,19 @@ export default function PageListSkeleton({
           </Box>
         )}
 
-        {/* Column headers: 56px, paper background, bottom divider */}
         <Box
           sx={{
             display: 'flex',
             alignItems: 'center',
-            height: HEADER_ROW_HEIGHT,
-            borderTop: theme => `1px solid ${theme.palette.greyscale.border}`,
-            borderBottom: theme =>
-              `1px solid ${theme.palette.greyscale.border}`,
+            height: GRID.headerHeight,
+            borderTop: divider,
+            borderBottom: divider,
           }}
         >
           {COLUMNS.map((col, idx) => (
             <Box
               key={col.key}
-              sx={{
-                width: col.width,
-                flexShrink: 0,
-                pl: idx === 0 ? '30px' : 0,
-                pr: idx === COLUMNS.length - 1 ? '30px' : 2,
-              }}
+              sx={{ width: col.width, flexShrink: 0, ...cellInsetSx(idx) }}
             >
               <Skeleton
                 variant="text"
@@ -194,35 +245,26 @@ export default function PageListSkeleton({
           ))}
         </Box>
 
-        {/* Data rows: 52px, divider between */}
         {rowKeys.map((rowKey, rowIdx) => (
           <Box
             key={rowKey}
             sx={{
               display: 'flex',
               alignItems: 'center',
-              height: DATA_ROW_HEIGHT,
-              ...(rowIdx < rowKeys.length - 1 && {
-                borderBottom: theme =>
-                  `1px solid ${theme.palette.greyscale.border}`,
-              }),
+              height: GRID.rowHeight,
+              ...(rowIdx < rowKeys.length - 1 && { borderBottom: divider }),
             }}
           >
             {COLUMNS.map((col, idx) => (
               <Box
                 key={col.key}
-                sx={{
-                  width: col.width,
-                  flexShrink: 0,
-                  pl: idx === 0 ? '30px' : 0,
-                  pr: idx === COLUMNS.length - 1 ? '30px' : 2,
-                }}
+                sx={{ width: col.width, flexShrink: 0, ...cellInsetSx(idx) }}
               >
                 {col.kind === 'chip' ? (
                   <Skeleton
                     variant="rounded"
                     width={col.cell}
-                    height={24}
+                    height={GRID.chipHeight}
                     sx={{ borderRadius: BORDER_RADIUS.pill }}
                   />
                 ) : (
@@ -237,21 +279,32 @@ export default function PageListSkeleton({
           </Box>
         ))}
 
-        {/* Pagination footer: right-aligned prev/next + range label */}
         <Box
           sx={{
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'flex-end',
-            gap: 1.5,
-            height: FOOTER_HEIGHT,
-            px: '30px',
-            borderTop: theme => `1px solid ${theme.palette.greyscale.border}`,
+            gap: TOOLBAR.gap,
+            height: GRID.footerHeight,
+            px: GRID_CARD_INSET,
+            borderTop: divider,
           }}
         >
-          <Skeleton variant="circular" width={32} height={32} />
-          <Skeleton variant="text" width={64} sx={skeletonTextSx('bodyMReg')} />
-          <Skeleton variant="circular" width={32} height={32} />
+          <Skeleton
+            variant="circular"
+            width={GRID.paginationButtonSize}
+            height={GRID.paginationButtonSize}
+          />
+          <Skeleton
+            variant="text"
+            width={GRID.paginationLabelWidth}
+            sx={skeletonTextSx('bodyMReg')}
+          />
+          <Skeleton
+            variant="circular"
+            width={GRID.paginationButtonSize}
+            height={GRID.paginationButtonSize}
+          />
         </Box>
       </Box>
     </Box>

--- a/apps/frontend/src/components/loading/PageListSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageListSkeleton.tsx
@@ -7,6 +7,7 @@ import {
   ELEVATION,
   FAB_GROUP_GAP,
 } from '@/styles/theme-constants';
+import { delayedRevealSx } from './DelayedReveal';
 
 /**
  * Loading placeholder for the standard list page: `PageLayout` header (title,
@@ -62,7 +63,11 @@ export default function PageListSkeleton({
   const fabKeys = Array.from({ length: actionCount }, (_, i) => `fab-${i}`);
 
   return (
-    <Box sx={{ width: '100%' }} role="status" aria-label="Loading page">
+    <Box
+      sx={{ width: '100%', ...delayedRevealSx }}
+      role="status"
+      aria-label="Loading page"
+    >
       {/* PageLayout header: title row (minHeight 56) then description, mb: 5 */}
       <Box sx={{ display: 'flex', flexDirection: 'column', mb: 5 }}>
         <Box

--- a/apps/frontend/src/components/loading/skeletonText.ts
+++ b/apps/frontend/src/components/loading/skeletonText.ts
@@ -1,0 +1,20 @@
+import type { Theme } from '@mui/material/styles';
+
+/** Typography variants the page skeletons stand in for. */
+export type SkeletonTextVariant =
+  | 'h4'
+  | 'h6'
+  | 'bodyLReg'
+  | 'bodyMReg'
+  | 'bodySReg';
+
+/**
+ * Sizes a `variant="text"` Skeleton to the typography variant it replaces.
+ *
+ * MUI derives a text skeleton's height from its font size, so reading that
+ * size off the theme keeps each placeholder line the same height as the real
+ * text that lands in its place, and keeps it in step when a variant changes.
+ */
+export const skeletonTextSx = (variant: SkeletonTextVariant) => ({
+  fontSize: (theme: Theme) => theme.typography[variant].fontSize,
+});

--- a/apps/frontend/src/styles/theme-constants.ts
+++ b/apps/frontend/src/styles/theme-constants.ts
@@ -46,6 +46,19 @@ export const BACKDROP_COLORS = {
 /** Horizontal gap between FAB buttons in a page-header action group (Figma) */
 export const FAB_GROUP_GAP = '20px';
 
+/** Diameter of a page-header FAB (Figma). Shared by `Fab` and its skeleton. */
+export const FAB_SIZE = 56;
+
+/**
+ * Inset for everything inside a grid card: the toolbar, the first and last
+ * column, and the pagination footer (Figma). BaseDataGrid expresses the same
+ * value as `theme.spacing(3.75)`.
+ */
+export const GRID_CARD_INSET = '30px';
+
+/** Minimum height of a grid-card toolbar row (Figma). */
+export const GRID_TOOLBAR_MIN_HEIGHT = 52;
+
 /** MUI spacing units for section-level Grid containers (EditableSection, SectionCard). */
 export const SECTION_GRID = {
   columnSpacing: 4,

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -12,6 +12,9 @@ import {
   BACKDROP_COLORS,
   ELEVATION,
   FAB_GROUP_GAP,
+  FAB_SIZE,
+  GRID_CARD_INSET,
+  GRID_TOOLBAR_MIN_HEIGHT,
 } from './theme-constants';
 import {
   contrastTextFor,
@@ -21,7 +24,16 @@ import {
   deriveBrandSurfaces,
   deriveSecondaryAccents,
 } from './brand-palette';
-export { GREYSCALE, BORDER_RADIUS, BACKDROP_COLORS, ELEVATION, FAB_GROUP_GAP };
+export {
+  GREYSCALE,
+  BORDER_RADIUS,
+  BACKDROP_COLORS,
+  ELEVATION,
+  FAB_GROUP_GAP,
+  FAB_SIZE,
+  GRID_CARD_INSET,
+  GRID_TOOLBAR_MIN_HEIGHT,
+};
 
 /** Deployment brand overrides (`BRAND_PRIMARY_COLOR`, `BRAND_SECONDARY_COLOR`, `BRAND_FONT_FAMILY`). */
 export interface BrandColors {

--- a/ee/frontend/src/api-clients/components/ApiClientsList.tsx
+++ b/ee/frontend/src/api-clients/components/ApiClientsList.tsx
@@ -20,26 +20,24 @@
  */
 
 import * as React from 'react';
-import {
-  Box,
-  Button,
-  Chip,
-  CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  IconButton,
-  Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Tooltip,
-} from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Tooltip from '@mui/material/Tooltip';
 import {
   Refresh as RotateIcon,
   Block as DisableIcon,

--- a/ee/frontend/src/api-clients/components/ApiClientsSection.tsx
+++ b/ee/frontend/src/api-clients/components/ApiClientsSection.tsx
@@ -13,14 +13,12 @@
  */
 
 import * as React from 'react';
-import {
-  Alert,
-  Box,
-  Button,
-  CircularProgress,
-  Stack,
-  Typography,
-} from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import { Add as AddIcon } from '@mui/icons-material';
 import { SectionCard } from '@/components/common/SectionCard';
 import SectionEmptyState from '@/components/common/SectionEmptyState';

--- a/ee/frontend/src/api-clients/components/ClientSecretDisplayDrawer.tsx
+++ b/ee/frontend/src/api-clients/components/ClientSecretDisplayDrawer.tsx
@@ -19,18 +19,16 @@
  */
 
 import * as React from 'react';
-import {
-  Alert,
-  Box,
-  Button,
-  Checkbox,
-  Drawer,
-  FormControlLabel,
-  IconButton,
-  Stack,
-  Tooltip,
-  Typography,
-} from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import Drawer from '@mui/material/Drawer';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import { ContentCopy as CopyIcon } from '@mui/icons-material';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { BACKDROP_COLORS } from '@/styles/theme';

--- a/ee/frontend/src/api-clients/components/CreateApiClientDrawer.tsx
+++ b/ee/frontend/src/api-clients/components/CreateApiClientDrawer.tsx
@@ -32,20 +32,18 @@
  */
 
 import * as React from 'react';
-import {
-  Alert,
-  Box,
-  Checkbox,
-  FormControl,
-  FormControlLabel,
-  FormGroup,
-  FormHelperText,
-  InputLabel,
-  MenuItem,
-  Select,
-  Stack,
-  TextField,
-} from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Checkbox from '@mui/material/Checkbox';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+import FormHelperText from '@mui/material/FormHelperText';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
 import BaseDrawer from '@/components/common/BaseDrawer';
 import { V1_SUPPORTED_SCOPES, type AuthClientCreateRequest } from '../types';
 

--- a/ee/frontend/src/api-clients/register.tsx
+++ b/ee/frontend/src/api-clients/register.tsx
@@ -18,7 +18,9 @@
  */
 
 import * as React from 'react';
-import { Alert, Box, CircularProgress } from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import { FeatureName } from '@/constants/features';
 import { FeatureGate, useFeatureWarning } from '@/contexts/FeaturesContext';
 import { registerOrgSettingsTab } from '@/lib/extension-registries';

--- a/ee/frontend/src/rbac/components/OrgRoleChip.tsx
+++ b/ee/frontend/src/rbac/components/OrgRoleChip.tsx
@@ -1,14 +1,11 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import {
-  Chip,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
-  Skeleton,
-  Typography,
-} from '@mui/material';
+import Chip from '@mui/material/Chip';
+import MenuItem from '@mui/material/MenuItem';
+import Select, { type SelectChangeEvent } from '@mui/material/Select';
+import Skeleton from '@mui/material/Skeleton';
+import Typography from '@mui/material/Typography';
 import { can, useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { useFeature } from '@/contexts/FeaturesContext';

--- a/ee/frontend/src/rbac/components/PermissionGroupControl.tsx
+++ b/ee/frontend/src/rbac/components/PermissionGroupControl.tsx
@@ -1,18 +1,15 @@
 'use client';
 
 import React, { useState } from 'react';
-import {
-  alpha,
-  Box,
-  Checkbox,
-  Collapse,
-  FormControlLabel,
-  IconButton,
-  ToggleButton,
-  ToggleButtonGroup,
-  Typography,
-} from '@mui/material';
-import type { Theme } from '@mui/material/styles';
+import { alpha, type Theme } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Checkbox from '@mui/material/Checkbox';
+import Collapse from '@mui/material/Collapse';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import IconButton from '@mui/material/IconButton';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Typography from '@mui/material/Typography';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { BORDER_RADIUS } from '@/styles/theme-constants';
 import {

--- a/ee/frontend/src/rbac/components/ProjectRoleChip.tsx
+++ b/ee/frontend/src/rbac/components/ProjectRoleChip.tsx
@@ -1,14 +1,11 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import {
-  Chip,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
-  Skeleton,
-  Typography,
-} from '@mui/material';
+import Chip from '@mui/material/Chip';
+import MenuItem from '@mui/material/MenuItem';
+import Select, { type SelectChangeEvent } from '@mui/material/Select';
+import Skeleton from '@mui/material/Skeleton';
+import Typography from '@mui/material/Typography';
 import { can, useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { useFeature } from '@/contexts/FeaturesContext';

--- a/ee/frontend/src/rbac/components/RoleEditorDrawer.tsx
+++ b/ee/frontend/src/rbac/components/RoleEditorDrawer.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { Alert, Box, Link, Stack, TextField, Typography } from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 import BaseDrawer from '@/components/common/BaseDrawer';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import {

--- a/ee/frontend/src/rbac/components/RoleSelectField.tsx
+++ b/ee/frontend/src/rbac/components/RoleSelectField.tsx
@@ -1,14 +1,12 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
-import {
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  Skeleton,
-  Typography,
-} from '@mui/material';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Skeleton from '@mui/material/Skeleton';
+import Typography from '@mui/material/Typography';
 import { drawerOutlinedFieldSx } from '@/components/common/drawerFormFieldSx';
 import { fetchRoles } from '../api/role-cache';
 import {

--- a/ee/frontend/src/rbac/components/RolesTab.tsx
+++ b/ee/frontend/src/rbac/components/RolesTab.tsx
@@ -1,21 +1,19 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import {
-  Box,
-  Button,
-  Chip,
-  CircularProgress,
-  IconButton,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Tooltip,
-  Typography,
-} from '@mui/material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import type { SxProps, Theme } from '@mui/material/styles';
 import AddIcon from '@mui/icons-material/Add';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';

--- a/ee/frontend/src/rbac/components/TokenScopeField.tsx
+++ b/ee/frontend/src/rbac/components/TokenScopeField.tsx
@@ -1,21 +1,18 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
-import {
-  alpha,
-  Box,
-  Chip,
-  FormControl,
-  FormControlLabel,
-  InputLabel,
-  MenuItem,
-  Radio,
-  RadioGroup,
-  Select,
-  Stack,
-  Typography,
-} from '@mui/material';
-import type { Theme } from '@mui/material/styles';
+import { alpha, type Theme } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import Select from '@mui/material/Select';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import LockIcon from '@mui/icons-material/Lock';
 import { drawerOutlinedFieldSx } from '@/components/common/drawerFormFieldSx';

--- a/ee/frontend/src/rbac/register.tsx
+++ b/ee/frontend/src/rbac/register.tsx
@@ -12,7 +12,8 @@
  */
 
 import * as React from 'react';
-import { Box, CircularProgress } from '@mui/material';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import { FeatureName } from '@/constants/features';
 import { FeatureGate } from '@/contexts/FeaturesContext';
 import {

--- a/ee/frontend/src/rbac/role-display.ts
+++ b/ee/frontend/src/rbac/role-display.ts
@@ -15,8 +15,7 @@
  * Custom roles use level 50 by default (below Member).
  */
 
-import { alpha } from '@mui/material';
-import type { Theme } from '@mui/material/styles';
+import { alpha, type Theme } from '@mui/material/styles';
 import type { RoleRead } from './types';
 
 /**

--- a/ee/frontend/src/sso/components/SSOConfigForm.tsx
+++ b/ee/frontend/src/sso/components/SSOConfigForm.tsx
@@ -1,22 +1,20 @@
 'use client';
 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import {
-  Box,
-  TextField,
-  Button,
-  Alert,
-  CircularProgress,
-  Grid,
-  Switch,
-  FormControlLabel,
-  Chip,
-  IconButton,
-  Tooltip,
-  Typography,
-  Divider,
-  Collapse,
-} from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Collapse from '@mui/material/Collapse';
+import Divider from '@mui/material/Divider';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import {
   Save as SaveIcon,
   Delete as DeleteIcon,

--- a/ee/frontend/src/sso/register.tsx
+++ b/ee/frontend/src/sso/register.tsx
@@ -21,7 +21,9 @@
  */
 
 import * as React from 'react';
-import { Alert, Box, CircularProgress } from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import { FeatureName } from '@/constants/features';
 import { FeatureGate, useFeatureWarning } from '@/contexts/FeaturesContext';
 import { registerOrgSettingsTab } from '@/lib/extension-registries';


### PR DESCRIPTION
## Problem

Since large parts of the app moved to server-side rendering, clicking a link gives no feedback
until the server finishes rendering. The click lands, nothing happens, then the new page appears.
There were no `loading.tsx` files anywhere and no navigation indicator, so every navigation felt
like a dead click.

During client-side navigation Next.js does not re-run layouts, only `page.tsx`, so the wait is
whatever the page's own server fetches take.

## What changed

**Navigation progress bar.** `nextjs-toploader` renders a thin primary-coloured bar as soon as a
navigation starts. This covers every route with no per-page work and is the main feedback
mechanism.

**Route loading skeletons.** `loading.tsx` wraps `page.tsx` in a Suspense boundary so a placeholder
paints while the page's server fetches run. Two shared skeletons cover the dominant page shapes.
Their geometry is copied from the real components (`PageLayout`, `GridToolbar`, `BaseDataGrid`,
`DetailTabNav`, `Fab`) so the swap to content does not shift layout: 56px FABs at `FAB_GROUP_GAP`,
30px toolbar and column insets, 52px rows, and pill shapes in the columns that hold chips.

The catch-all under `(protected)` serves every list page. Detail routes override it with the detail
shape, `architect` uses a centred spinner because it is full-bleed, and `test-sets` bumps the FAB
count to 4.

**Skeletons are delayed by 500ms.** A skeleton predicts the shape of content that has not arrived,
and the prediction is worst on a page whose list is empty: six rows of fake table dissolve into an
onboarding card. Empty pages are also the fastest, since there is no data to fetch, so they are
exactly the pages that never needed a skeleton. Every fallback is held invisible for 500ms and then
fades in, and the progress bar covers that window.

This is the delayed-indicator pattern that TanStack Router ships as `defaultPendingMs` and Ant
Design as `Spin`'s `delay` prop. 500ms sits between the ~300ms floor below which a delay is
imperceptible and the 1s mark where users notice one. The pattern's other half, a minimum display
duration, is deliberately absent: React owns when it unmounts a `loading.tsx` fallback, so
honouring a minimum would need hand-rolled Suspense boundaries and client timers on every route.
The fade covers that case instead, since a fallback unmounted mid-fade never reaches full opacity.

**EE components use MUI deep imports.** Barrel imports pull the full CJS barrel, which eagerly
evaluates `useMediaQuery`, and Next's barrel optimiser does not reach `transpilePackages` sources.
Not load-bearing (the underlying crash is fixed by `patches/@mui+material+7.3.5.patch`), just the
packaging MUI recommends. Drops out cleanly if you would rather keep this PR narrower.

**Installs now fail when a patch does not apply.** `patch-package` only exits non-zero in CI;
locally it warns and exits 0. That is how `patches/@mui+material+7.3.5.patch` went missing during
this branch, taking the whole app down with
`unstable_createUseMediaQuery is not a function` while the install that broke it looked clean. The
patch defers a client-only call out of module evaluation so `@mui/material` can be evaluated in the
RSC server graph. `--error-on-fail` applies the CI behaviour everywhere; verified against a
deliberately unappliable patch, exit 0 before and exit 1 after.

## Deliberately not included: streaming the protected layout

An earlier version of this branch moved the protected layout's features, permissions and terms
fetches into a Suspense-wrapped server component, with a fallback that mounted
`ProtectedLayoutClient` seeded with `null`. It has been dropped after review.

The fallback duplicated the entire provider tree *and* `{children}`. Those providers all fetch when
their seed is null (`FeaturesProvider` only passes `initialData` for a non-null seed,
`NotificationsProvider` fetches its summary on mount, `WebSocketProvider` mints a token per connect,
`TermsAcceptanceGate` fetches when unseeded), so if the client hydrates the fallback before the
boundary resolves, all of that runs twice, and the page subtree sits in both branches.

Whether it double-runs is timing dependent, and the bad case is a slow server, which is exactly the
case the change was meant to improve. Next.js also does not re-run layouts on client-side
navigation, so the change only ever affected cold loads, not the sidebar-click case this PR is
about. Narrow benefit, real cost.

Doing it properly means passing the promises into a stably mounted `ProtectedLayoutClient` and
unwrapping them with React 19's `use()`, so the providers mount once and stream their data in. That
changes the provider seeding contract and belongs in its own PR.

## Testing

- `next build --webpack` passes on the rebased branch
- `tsc --noEmit`, `eslint` and `prettier --check` pass
- Exercised in the browser against a local dev server, including the delay behaviour

Reviewers may want to look at the delay specifically, since its whole value is timing. Throttling to
Slow 3G and navigating between two list pages shows the skeleton fading in rather than appearing
hard; navigating to an entity with no rows should show the progress bar and nothing else.

## Notes

Three papercuts found along the way and fixed here rather than left behind:

- `postinstall` now runs `patch-package --error-on-fail` (see above).
- The `experimental.optimizePackageImports` entry for the MUI packages was a no-op, since both are
  already in Next's default list and Next unions the two. Removed, with a note on why there is
  deliberately no entry.
- `scripts/generate-templates.js` wrote its output unformatted, so every `prebuild` de-formatted the
  checked-in `test-templates.generated.ts` with a ~250 line content-identical diff. It now runs the
  output through Prettier and is verified idempotent.
