### PR TITLE
Align usage limits with published pricing, enforce custom enterprise caps, and surface plan state

### DIFF
--- a/apps/backend/src/rhesis/backend/app/auth/terms.py
+++ b/apps/backend/src/rhesis/backend/app/auth/terms.py
@@ -10,16 +10,36 @@ only an explicit accept or a version bump matters.
 
 Bump ``CURRENT_TERMS_VERSION`` (and ``CURRENT_TERMS_EFFECTIVE_DATE``) when
 publishing new terms; users with an older accepted version must
-re-accept before continuing.
+re-accept before continuing. ``TermsAcceptanceGate`` on the frontend reads
+``has_prior_acceptance`` and shows such a user "Updated Terms" rather than
+first-run copy, so a bump needs no frontend change.
+
+**Do not bump this ahead of the terms themselves being published.** The
+consent dialog links to rhesis.ai for the document, so a version live here
+before the page is live means users accepting a version number whose text
+they cannot yet read -- and the acceptance record would point at the wrong
+document.
 """
 
 from datetime import date, datetime, timezone
 
 from rhesis.backend.app.models.user import User
 
-# Active T&C version (effective 2025-09-01).
-CURRENT_TERMS_VERSION = "1.0"
-CURRENT_TERMS_EFFECTIVE_DATE = date(2025, 9, 1)
+# Active T&C version.
+#
+# 2.0 replaces the public preview terms with the commercial SaaS terms and
+# conditions, published at rhesis.ai/terms-conditions/saas. A major bump
+# because it is a different document rather than an amendment: the preview
+# terms said of themselves that they would be replaced once a commercial
+# offering existed, and Free is now designated a Free Trial Phase under
+# Section 14 rather than being uncovered. Everyone carrying 1.0 -- including
+# the users the ``b5c6d7e8f9a0`` backfill set to that baseline -- is prompted
+# to re-accept on their next request.
+#
+# The version is ours, not the document's: the SaaS terms are issued as an
+# appendix and carry no version of their own.
+CURRENT_TERMS_VERSION = "2.0"
+CURRENT_TERMS_EFFECTIVE_DATE = date(2026, 9, 1)
 
 
 def _user_terms(user: User) -> dict:

--- a/apps/backend/src/rhesis/backend/app/quota/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/quota/__init__.py
@@ -22,12 +22,15 @@ one blocking rule instead of each re-deriving it.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional, Protocol, Union
 
 from rhesis.backend.app.config.settings import get_application_settings
 from rhesis.backend.app.models.organization import Organization
+
+logger = logging.getLogger(__name__)
 
 
 class QuotaResource(str, Enum):
@@ -178,6 +181,26 @@ class QuotaPolicy:
             return limit
         return limit * (100 + self.overage_tolerance_percent) // 100
 
+    def with_limit_overrides(self, overrides: dict[QuotaResource, int | None]) -> "QuotaPolicy":
+        """Return a copy with *overrides* applied on top of :attr:`limits`.
+
+        A **per-resource** merge, not a replacement: a resource absent from
+        *overrides* keeps this policy's limit. That is what makes a partial
+        override meaningful -- a bespoke deal that caps one resource must not
+        silently unmeter the other six by omitting them.
+
+        The overage policy is deliberately not overridable. A negotiated cap
+        changes *what* the ceiling is, not whether the tier gets a grace band
+        before hitting it.
+        """
+        if not overrides:
+            return self
+        return QuotaPolicy(
+            limits={**self.limits, **overrides},
+            overage=self.overage,
+            overage_tolerance_percent=self.overage_tolerance_percent,
+        )
+
 
 def limits_to_wire(limits: dict[QuotaResource, int | None]) -> dict[str, int | None]:
     """Convert a ``QuotaResource``-keyed limits dict to string keys for the wire.
@@ -187,6 +210,68 @@ def limits_to_wire(limits: dict[QuotaResource, int | None]) -> dict[str, int | N
     ``GET /features`` response -- both need the same enum-to-string shape.
     """
     return {str(k): v for k, v in limits.items()}
+
+
+def limits_from_wire(raw: object) -> dict[QuotaResource, int | None]:
+    """Parse a wire limits mapping into ``QuotaResource`` keys, skipping junk.
+
+    The inverse of :func:`limits_to_wire`, for a limits map that arrived as
+    *data at request time* -- currently the ``lic.custom_limits`` claim of a
+    signed license token, carrying a bespoke deal's negotiated caps.
+
+    Deliberately lenient where the tier-YAML parser
+    (``ee.licensing.tiers._parse_limits``) is strict, and the difference is
+    the source, not the shape:
+
+    - The YAML is authored by us, read once at startup, and validated there,
+      so a bad key is a deploy-time bug worth refusing to boot over.
+    - A token is validated by signature, not by schema, and is read on the
+      request path. Raising here would turn one malformed claim into a 500 on
+      every request for that org.
+
+    So an unknown resource name, a non-integer, a ``bool`` (which passes
+    ``isinstance(v, int)``), or a negative number is dropped with a warning
+    and the tier default applies to that resource instead. That fails toward
+    *not* enforcing an override we could not read, which for the enterprise
+    tier this exists to serve means staying unlimited -- lenient toward the
+    customer, and visible in the logs, rather than blocking work at a ceiling
+    nobody can explain.
+
+    Returns a **partial** map: only the resources *raw* actually names, so it
+    is safe to merge via :meth:`QuotaPolicy.with_limit_overrides`. A non-mapping
+    *raw* (including ``None``) yields an empty dict.
+    """
+    if not isinstance(raw, dict):
+        if raw is not None:
+            logger.warning("Ignoring non-mapping limits claim (got %s)", type(raw).__name__)
+        return {}
+
+    parsed: dict[QuotaResource, int | None] = {}
+    for key, value in raw.items():
+        try:
+            resource = QuotaResource(key)
+        except ValueError:
+            logger.warning("Ignoring unknown resource %r in limits claim", key)
+            continue
+
+        if value is None:
+            parsed[resource] = None
+            continue
+        # bool must be rejected explicitly: it passes isinstance(v, int).
+        if isinstance(value, bool) or not isinstance(value, int):
+            logger.warning(
+                "Ignoring non-integer limit for %r in limits claim: %r (%s)",
+                key,
+                value,
+                type(value).__name__,
+            )
+            continue
+        if value < 0:
+            logger.warning("Ignoring negative limit for %r in limits claim: %r", key, value)
+            continue
+        parsed[resource] = value
+
+    return parsed
 
 
 class QuotaProvider(Protocol):
@@ -297,6 +382,7 @@ __all__ = [
     "QuotaResource",
     "QuotaResourceLike",
     "UNLIMITED_LIMITS",
+    "limits_from_wire",
     "limits_to_wire",
     "resource_label",
 ]

--- a/apps/backend/src/rhesis/backend/app/quota/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/quota/__init__.py
@@ -112,11 +112,15 @@ class OveragePolicy(str, Enum):
 # malformed. Exported (not underscore-prefixed) so both consumers -- and a
 # test asserting the YAML's "community" entry matches -- can reference the
 # same numbers instead of duplicating them.
+#
+# Published on the pricing page as the Free plan -- see the header comment in
+# ee/.../licensing/tier_config.yaml. These must stay equal to that file's
+# `community` entry (asserted by tests/backend/ee/licensing/test_tiers.py).
 FREE_TIER_LIMITS: dict[QuotaResource, int | None] = {
     QuotaResource.TEST_EXECUTIONS: 500,
     QuotaResource.TRACING_SPANS: 50_000,
     QuotaResource.TEST_GENERATION: 100,
-    QuotaResource.MODEL_TOKENS: 5_000_000,
+    QuotaResource.MODEL_TOKENS: 1_000_000,
     QuotaResource.SEATS: 3,
     QuotaResource.PROJECTS: 3,
     QuotaResource.ENDPOINTS: 3,

--- a/apps/backend/src/rhesis/backend/app/routers/usage.py
+++ b/apps/backend/src/rhesis/backend/app/routers/usage.py
@@ -42,6 +42,15 @@ class UsageResourceItem(BaseModel):
 class UsageResponse(BaseModel):
     resources: Dict[str, UsageResourceItem] = Field(default_factory=dict)
     edition: str
+    #: Whether the org holds an *active* paid license. Distinct from
+    #: ``edition``, which keeps naming a lapsed tier so the UI can say which
+    #: license expired: a canceled enterprise license reports
+    #: ``edition="enterprise", licensed=False`` while resolving to community
+    #: limits. Without this flag a client can only read the edition, and would
+    #: show such an org as Enterprise while it is being held to free-tier
+    #: ceilings -- with no upgrade path offered, because it does not look
+    #: like a free org.
+    licensed: bool = False
 
 
 class UsageHistoryPoint(BaseModel):

--- a/apps/backend/src/rhesis/backend/app/services/usage.py
+++ b/apps/backend/src/rhesis/backend/app/services/usage.py
@@ -240,7 +240,14 @@ def get_usage_summary(
     period_start: Optional[date] = None,
 ) -> dict:
     """Return ``{resources: {<resource>: {used, limit, ceiling, period_start, period_end,
-    kind}}, edition}``.
+    kind}}, edition, licensed}``.
+
+    ``edition`` and ``licensed`` are reported separately because a lapsed
+    license keeps its edition name: a canceled enterprise license resolves to
+    community *limits* but still reports ``edition="enterprise"``, so that the
+    UI can name which license expired. A client reading only ``edition`` would
+    present such an org as Enterprise while it is held to free-tier ceilings,
+    and would withhold the upgrade path because it does not look free.
 
     Flow resources report cumulative usage from the ``usage`` table for the
     requested billing period (the current one by default). ``kind``
@@ -311,8 +318,10 @@ def get_usage_summary(
             "kind": STOCK_KIND if counter is not None else FLOW_KIND,
         }
 
-    edition = str(FeatureRegistry.license_info(org=org).get("edition", "community"))
-    return {"resources": resources, "edition": edition}
+    license_info = FeatureRegistry.license_info(org=org)
+    edition = str(license_info.get("edition", "community"))
+    licensed = bool(license_info.get("licensed", False))
+    return {"resources": resources, "edition": edition, "licensed": licensed}
 
 
 def _recent_period_starts(months: int, today: Optional[date] = None) -> list[date]:

--- a/apps/frontend/src/__tests__/components/navigation/Sidebar.test.tsx
+++ b/apps/frontend/src/__tests__/components/navigation/Sidebar.test.tsx
@@ -69,10 +69,14 @@ const mockUsageResources: {
     }
   >;
 } = { current: {} };
+const mockUsagePlan: {
+  current: { edition: string; licensed: boolean | null };
+} = { current: { edition: 'community', licensed: false } };
 jest.mock('@/contexts/UsageContext', () => ({
   useUsage: () => ({
     resources: mockUsageResources.current,
-    edition: 'community',
+    edition: mockUsagePlan.current.edition,
+    licensed: mockUsagePlan.current.licensed,
     loading: false,
     error: null,
   }),

--- a/apps/frontend/src/__tests__/components/navigation/Sidebar.test.tsx
+++ b/apps/frontend/src/__tests__/components/navigation/Sidebar.test.tsx
@@ -122,6 +122,62 @@ describe('Sidebar', () => {
     mockRouterPush.mockClear();
     mockUnreadBySection.current = {};
     mockUsageResources.current = {};
+    mockUsagePlan.current = { edition: 'community', licensed: false };
+  });
+
+  describe('plan row in the footer card', () => {
+    /** The footer card the plan row heads, keyed off a link it always has. */
+    function footerCard(container: HTMLElement): HTMLElement {
+      const starLink = screen.getByText('Star Rhesis');
+      const card = starLink.closest('div')?.parentElement;
+      if (!card) throw new Error('footer card not found');
+      expect(container).toContainElement(card);
+      return card;
+    }
+
+    const footerNav: NavigationItem[] = [
+      { kind: 'divider' },
+      {
+        kind: 'link',
+        title: 'Star Rhesis',
+        href: 'https://github.com/rhesis-ai/rhesis',
+        external: true,
+      },
+      { kind: 'action', title: 'Support', action: 'support' },
+    ];
+
+    it('sits above Star Rhesis', () => {
+      setupMocks({ navigation: footerNav });
+      const { container } = render(<Sidebar />);
+
+      const card = footerCard(container);
+      const plan = screen.getByText('community');
+      const star = screen.getByText('Star Rhesis');
+
+      expect(card).toContainElement(plan);
+      // Ordered comparison rather than an index: DOCUMENT_POSITION_FOLLOWING
+      // says "star comes after plan" without depending on the card's exact
+      // nesting, which the styling wrappers can change.
+      expect(
+        plan.compareDocumentPosition(star) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    });
+
+    it('names an active paid plan', () => {
+      mockUsagePlan.current = { edition: 'enterprise', licensed: true };
+      setupMocks({ navigation: footerNav });
+      render(<Sidebar />);
+
+      expect(screen.getByText('enterprise')).toBeInTheDocument();
+    });
+
+    it('marks a lapsed paid plan inactive', () => {
+      mockUsagePlan.current = { edition: 'enterprise', licensed: false };
+      setupMocks({ navigation: footerNav });
+      render(<Sidebar />);
+
+      expect(screen.getByText('enterprise (inactive)')).toBeInTheDocument();
+    });
   });
 
   it('renders without crashing', () => {

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/constants/quota';
 import {
   classifyZone,
-  isCommunityEdition,
+  isUnlicensedPlan,
   zoneColor,
   type QuotaZone,
 } from '@/utils/quota';
@@ -234,7 +234,8 @@ function ResourceList({
 export default function UsageOverviewTab() {
   const [periodStart, setPeriodStart] = React.useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = React.useState(false);
-  const { resources, edition, loading, error } = useUsageForPeriod(periodStart);
+  const { resources, edition, licensed, loading, error } =
+    useUsageForPeriod(periodStart);
 
   // The period is the only filter here, so an active one is a count of 1.
   // Passing the number matters: given only the boolean, FilterButton draws
@@ -243,8 +244,8 @@ export default function UsageOverviewTab() {
 
   const headerActions = (
     <Stack direction="row" spacing={1.5} alignItems="center">
-      {edition && <PlanChip edition={edition} />}
-      {edition && isCommunityEdition(edition) && <UpgradeLink />}
+      {edition && <PlanChip edition={edition} licensed={licensed} />}
+      {isUnlicensedPlan(edition, licensed) && <UpgradeLink />}
       <FilterButton
         onClick={() => setDrawerOpen(true)}
         hasActiveFilters={activeFilterCount > 0}

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
@@ -43,6 +43,7 @@ beforeEach(() => {
   mockUseUsage.mockReturnValue({
     resources: USAGE_RESOURCES,
     edition: 'community',
+    licensed: false,
     loading: false,
     error: null,
   });
@@ -103,7 +104,7 @@ describe('UsageOverviewTab', () => {
 
     expect(screen.getByText('community')).toBeInTheDocument();
     const upgradeLink = screen.getByRole('link', { name: 'Upgrade' });
-    expect(upgradeLink).toHaveAttribute('href', 'https://rhesis.ai/editions');
+    expect(upgradeLink).toHaveAttribute('href', 'https://rhesis.ai/pricing');
     expect(upgradeLink).toHaveAttribute('target', '_blank');
     expect(upgradeLink).toHaveAttribute('rel', 'noopener noreferrer');
   });
@@ -165,6 +166,7 @@ describe('UsageOverviewTab', () => {
         },
       },
       edition: 'community',
+      licensed: false,
       loading: false,
       error: null,
     });
@@ -178,6 +180,7 @@ describe('UsageOverviewTab', () => {
     mockUseUsage.mockReturnValue({
       resources: USAGE_RESOURCES,
       edition: 'enterprise',
+      licensed: true,
       loading: false,
       error: null,
     });
@@ -188,5 +191,23 @@ describe('UsageOverviewTab', () => {
     expect(
       screen.queryByRole('link', { name: 'Upgrade' })
     ).not.toBeInTheDocument();
+  });
+
+  it('marks a lapsed paid plan inactive and offers the upgrade', () => {
+    // A canceled licence is held to community limits while still reporting
+    // its edition, so this page would otherwise show "enterprise" beside
+    // free-tier ceilings and no way to act on it.
+    mockUseUsage.mockReturnValue({
+      resources: USAGE_RESOURCES,
+      edition: 'enterprise',
+      licensed: false,
+      loading: false,
+      error: null,
+    });
+
+    render(<UsageOverviewTab />);
+
+    expect(screen.getByText('enterprise (inactive)')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Upgrade' })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/auth/QuotaBanner.tsx
+++ b/apps/frontend/src/components/auth/QuotaBanner.tsx
@@ -16,11 +16,7 @@ import { useUsage } from '@/contexts/UsageContext';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { UPGRADE_URL, type QuotaResource } from '@/constants/quota';
-import {
-  findWorstResource,
-  isCommunityEdition,
-  quotaCopy,
-} from '@/utils/quota';
+import { findWorstResource, isUnlicensedPlan, quotaCopy } from '@/utils/quota';
 
 /**
  * Org-wide quota banner. `usage:read` (the same capability `GET /usage`
@@ -32,7 +28,7 @@ import {
  */
 export default function QuotaBanner() {
   const theme = useTheme();
-  const { resources, edition, loading } = useUsage();
+  const { resources, edition, licensed, loading } = useUsage();
   const canManageOrg = useCan(Capability.Organization.UPDATE);
   const [dismissedFor, setDismissedFor] = useState<QuotaResource | null>(null);
 
@@ -53,8 +49,7 @@ export default function QuotaBanner() {
   // Never reached with `limit === null` -- `findWorstResource` only flags
   // resources whose zone isn't `healthy`, which requires a non-null limit.
   const limit = item.limit ?? 0;
-  const canUpgrade =
-    canManageOrg && edition !== null && isCommunityEdition(edition);
+  const canUpgrade = canManageOrg && isUnlicensedPlan(edition, licensed);
   const { sentence } = quotaCopy({
     resource: worst.resource,
     kind: item.kind,

--- a/apps/frontend/src/components/auth/__tests__/QuotaBanner.test.tsx
+++ b/apps/frontend/src/components/auth/__tests__/QuotaBanner.test.tsx
@@ -38,12 +38,19 @@ function item(
 
 function mockUsage(
   resources: Record<string, UsageResourceItem>,
-  options: { loading?: boolean; edition?: string | null } = {}
+  options: {
+    loading?: boolean;
+    edition?: string | null;
+    licensed?: boolean | null;
+  } = {}
 ) {
-  const { loading = false, edition = 'community' } = options;
+  // `licensed: false` alongside the community default, matching what the
+  // backend actually sends for a free org.
+  const { loading = false, edition = 'community', licensed = false } = options;
   (useUsage as jest.Mock).mockReturnValue({
     resources,
     edition,
+    licensed,
     loading,
     error: null,
   });
@@ -144,7 +151,34 @@ describe('QuotaBanner', () => {
   it('does not offer to upgrade a paying org', () => {
     mockUsage(
       { [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) },
-      { edition: 'pro' }
+      { edition: 'pro', licensed: true }
+    );
+    render(<QuotaBanner />);
+    expect(
+      screen.queryByRole('link', { name: /upgrade plan/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('offers to upgrade an org whose paid licence has lapsed', () => {
+    // The backend holds a canceled licence to community limits while still
+    // reporting its old edition, so gating the CTA on the edition name left
+    // exactly this org blocked at free-tier ceilings with no way forward.
+    mockUsage(
+      { [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) },
+      { edition: 'enterprise', licensed: false }
+    );
+    render(<QuotaBanner />);
+    expect(
+      screen.getByRole('link', { name: /upgrade plan/i })
+    ).toBeInTheDocument();
+  });
+
+  it('offers nothing while licence status is still unknown', () => {
+    // A response from a backend predating `licensed`. Must not read as
+    // unlicensed and prompt a paying customer to upgrade.
+    mockUsage(
+      { [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) },
+      { edition: 'enterprise', licensed: null }
     );
     render(<QuotaBanner />);
     expect(

--- a/apps/frontend/src/components/common/QuotaChips.tsx
+++ b/apps/frontend/src/components/common/QuotaChips.tsx
@@ -9,14 +9,34 @@ import { isCommunityEdition } from '@/utils/quota';
 /** Plan pill (e.g. "community", "enterprise"). Shared by the usage page
  * and the org-menu usage block so the two never drift on styling. Lower
  * case, no "plan" suffix -- the org-menu block is space-constrained, and
- * the chip already reads as a plan in context. */
-export function PlanChip({ edition }: { edition: string }) {
-  const label = edition.toLowerCase();
+ * the chip already reads as a plan in context.
+ *
+ * A paid plan whose licence is no longer active is marked "inactive" rather
+ * than shown as though it were still in force. The backend holds such an org
+ * to community limits while still reporting its old edition, so a plain
+ * "enterprise" pill next to free-tier numbers is the one reading that leaves
+ * an admin with no idea why their ceilings dropped.
+ *
+ * `licensed` is optional and defaults to "unknown" (`null`), which renders
+ * exactly as before -- callers without the flag cannot accidentally label a
+ * live plan inactive. */
+export function PlanChip({
+  edition,
+  licensed = null,
+}: {
+  edition: string;
+  licensed?: boolean | null;
+}) {
+  const isFreeTier = isCommunityEdition(edition);
+  const isLapsed = licensed === false && !isFreeTier;
+  const label = isLapsed
+    ? `${edition.toLowerCase()} (inactive)`
+    : edition.toLowerCase();
   return (
     <Chip
       label={label}
       size="small"
-      color={isCommunityEdition(edition) ? 'default' : 'primary'}
+      color={isLapsed ? 'warning' : isFreeTier ? 'default' : 'primary'}
       sx={{ borderRadius: BORDER_RADIUS.pill, fontWeight: 600 }}
     />
   );

--- a/apps/frontend/src/components/common/__tests__/QuotaChips.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/QuotaChips.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { PlanChip, UpgradeLink } from '@/components/common/QuotaChips';
+import { UPGRADE_URL } from '@/constants/quota';
+
+describe('PlanChip', () => {
+  it('names the plan in lower case', () => {
+    render(<PlanChip edition="Enterprise" licensed={true} />);
+    expect(screen.getByText('enterprise')).toBeInTheDocument();
+  });
+
+  it('marks a lapsed paid plan inactive', () => {
+    // The backend keeps reporting the old edition for a canceled licence while
+    // holding the org to community limits. A plain "enterprise" pill next to
+    // free-tier numbers is what left admins with no idea why their ceilings
+    // dropped, so the chip has to say it.
+    render(<PlanChip edition="enterprise" licensed={false} />);
+    expect(screen.getByText('enterprise (inactive)')).toBeInTheDocument();
+  });
+
+  it('does not mark the free tier inactive', () => {
+    // Community is unlicensed by definition -- "community (inactive)" would be
+    // telling a free org that something it never had has expired.
+    render(<PlanChip edition="community" licensed={false} />);
+    expect(screen.getByText('community')).toBeInTheDocument();
+  });
+
+  it('renders plainly when licence status is unknown', () => {
+    // Default for callers that have no flag, and for a backend predating it.
+    render(<PlanChip edition="enterprise" />);
+    expect(screen.getByText('enterprise')).toBeInTheDocument();
+  });
+});
+
+describe('UpgradeLink', () => {
+  it('points at the published pricing page in a new tab', () => {
+    render(<UpgradeLink />);
+    const link = screen.getByRole('link', { name: /upgrade/i });
+    expect(link).toHaveAttribute('href', UPGRADE_URL);
+    expect(link).toHaveAttribute('href', 'https://rhesis.ai/pricing');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+});

--- a/apps/frontend/src/components/navigation/NavLinkItem.tsx
+++ b/apps/frontend/src/components/navigation/NavLinkItem.tsx
@@ -11,7 +11,11 @@ import {
   type NavigationLinkItem,
   type NavigationActionItem,
 } from '@/types/navigation';
-import { collapsedNavItemSx } from './sidebar-utils';
+import {
+  collapsedNavItemSx,
+  NAV_CARD_ICON_SIZE,
+  NAV_CARD_ROW_SX,
+} from './sidebar-utils';
 
 interface NavLinkItemProps {
   item: NavigationLinkItem | NavigationActionItem;
@@ -25,8 +29,7 @@ export function NavLinkItem({ item, collapsed, onAction }: NavLinkItemProps) {
   const sharedSx: SxProps<Theme> = {
     display: 'flex',
     alignItems: 'center',
-    gap: '10px',
-    px: '14px',
+    ...NAV_CARD_ROW_SX,
     py: '8px',
     borderRadius: BORDER_RADIUS.sm,
     textDecoration: 'none',
@@ -34,7 +37,12 @@ export function NavLinkItem({ item, collapsed, onAction }: NavLinkItemProps) {
     '&:hover': {
       bgcolor: (theme: Theme) => theme.palette.greyscale.surface1,
     },
-    transition: 'background-color 0.15s ease',
+    // `duration.shortest` is the theme's own 150ms -- the value this used to
+    // spell out as '0.15s'.
+    transition: (theme: Theme) =>
+      theme.transitions.create('background-color', {
+        duration: theme.transitions.duration.shortest,
+      }),
     ...(collapsed ? collapsedNavItemSx : {}),
   };
 
@@ -44,7 +52,7 @@ export function NavLinkItem({ item, collapsed, onAction }: NavLinkItemProps) {
         display: 'flex',
         flexShrink: 0,
         color: (theme: Theme) => theme.palette.greyscale.body,
-        '& svg': { width: 24, height: 24 },
+        '& svg': { width: NAV_CARD_ICON_SIZE, height: NAV_CARD_ICON_SIZE },
       }}
     >
       {item.icon}

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -35,7 +35,7 @@ import {
 } from '@/constants/quota';
 import {
   flaggedResources,
-  isCommunityEdition,
+  isUnlicensedPlan,
   quotaCopy,
   usageMenuRows,
   usageRowFillPercent,
@@ -303,12 +303,11 @@ export function Sidebar() {
   // keeps this quiet until there is real data, not a permission check.
   // "Can upgrade" is a narrower, separate question: Organization.UPDATE
   // (the same owner/admin gate as Org Settings), not Usage.READ.
-  const { resources: usageResources, edition } = useUsage();
+  const { resources: usageResources, edition, licensed } = useUsage();
   const flaggedUsage = flaggedResources(usageResources);
   const flaggedCount = flaggedUsage.length;
   const canManageOrg = useCan(Capability.Organization.UPDATE);
-  const canUpgrade =
-    canManageOrg && edition !== null && isCommunityEdition(edition);
+  const canUpgrade = canManageOrg && isUnlicensedPlan(edition, licensed);
 
   // The badge answers "how many"; the sentence (only rendered as a tooltip
   // here, in full in the org-menu block below) answers "how bad" -- no
@@ -428,7 +427,7 @@ export function Sidebar() {
               >
                 {usagePeriodLabel ?? 'Current usage'}
               </Typography>
-              {edition && <PlanChip edition={edition} />}
+              {edition && <PlanChip edition={edition} licensed={licensed} />}
             </Box>
             {usageRows.map(row => (
               <UsageMenuRow key={row.resource} {...row} />

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -63,6 +63,7 @@ import {
 } from './sidebar-utils';
 import { NavItem } from './NavItem';
 import { NavLinkItem } from './NavLinkItem';
+import { SidebarPlanRow } from './SidebarPlanRow';
 import { NavSection } from './NavSection';
 import ProjectSwitcherDrawer from './ProjectSwitcherDrawer';
 import SupportDrawer from './SupportDrawer';
@@ -845,7 +846,8 @@ export function Sidebar() {
           pt: '20px',
         }}
       >
-        {/* White rounded card for external footer links (Star Rhesis, Support) */}
+        {/* White rounded card for external footer links (Star Rhesis, Support),
+            headed by the current plan */}
         {footerGroup && footerGroup.items.length > 0 && !collapsed && (
           <Box
             sx={{
@@ -857,6 +859,7 @@ export function Sidebar() {
               flexDirection: 'column',
             }}
           >
+            <SidebarPlanRow edition={edition} licensed={licensed} />
             {footerGroup.items.map(item => (
               <NavLinkItem
                 key={`footer-${item.title}`}

--- a/apps/frontend/src/components/navigation/SidebarPlanRow.tsx
+++ b/apps/frontend/src/components/navigation/SidebarPlanRow.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import NextLink from 'next/link';
+import { PlanChip } from '@/components/common/QuotaChips';
+import { BORDER_RADIUS } from '@/styles/theme';
+import { NAV_CARD_STATUS_ROW_SX } from './sidebar-utils';
+
+/** Where the row goes: the plan lives next to the usage it governs, and this
+ * is the one page that shows both. Internal, and readable by every org member
+ * (`usage:read` is not admin-only), so the row never links somewhere the
+ * clicker cannot follow. */
+const USAGE_HREF = '/organizations/usage';
+
+interface SidebarPlanRowProps {
+  /** Licence edition from `GET /usage`, or `null` while it loads. */
+  edition: string | null;
+  /** Whether that licence is currently active. `null`/`undefined` when not
+   * yet known — see `isUnlicensedPlan` in `utils/quota.ts`. */
+  licensed?: boolean | null;
+}
+
+/**
+ * The org's current plan, as the first row of the sidebar's footer card.
+ *
+ * Deliberately holds no opinion about the plan itself. Naming the edition,
+ * marking a lapsed licence "inactive", and colouring a paid plan apart from a
+ * free one are all :component:`PlanChip`'s job, and it already does them for
+ * the usage page and the org-menu block. Re-deriving any of that here would
+ * let the sidebar and the usage page disagree about the same licence.
+ *
+ * The layout mirrors the org-menu usage block in `Sidebar.tsx`, which pairs a
+ * caption with the same chip — so the two plan readouts in this sidebar are
+ * one pattern, not two.
+ *
+ * Renders nothing until `edition` is known: a plan must not flicker from a
+ * placeholder to the real value.
+ */
+export function SidebarPlanRow({ edition, licensed }: SidebarPlanRowProps) {
+  if (!edition) return null;
+
+  return (
+    <Box
+      component={NextLink}
+      href={USAGE_HREF}
+      aria-label="Current plan — view usage"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        ...NAV_CARD_STATUS_ROW_SX,
+        borderRadius: BORDER_RADIUS.sm,
+        textDecoration: 'none',
+        // Separates status from the actions below it. The card draws no
+        // dividers between its own links, so without this the plan reads as a
+        // third thing you could click to do something.
+        borderBottom: theme => `1px solid ${theme.palette.greyscale.border}`,
+        '&:hover': {
+          bgcolor: theme => theme.palette.greyscale.surface1,
+        },
+        transition: theme =>
+          theme.transitions.create('background-color', {
+            duration: theme.transitions.duration.shortest,
+          }),
+      }}
+    >
+      <Typography variant="caption">Plan</Typography>
+      <PlanChip edition={edition} licensed={licensed} />
+    </Box>
+  );
+}
+
+export default SidebarPlanRow;

--- a/apps/frontend/src/components/navigation/__tests__/SidebarPlanRow.test.tsx
+++ b/apps/frontend/src/components/navigation/__tests__/SidebarPlanRow.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SidebarPlanRow } from '../SidebarPlanRow';
+
+/**
+ * The row's own job is placement and delegation: show up once the plan is
+ * known, link to usage, and hand the edition and licence status to `PlanChip`.
+ *
+ * How a plan is *named* and *coloured* — the "(inactive)" marker, paid vs free
+ * — belongs to `PlanChip` and is covered in `QuotaChips.test.tsx`. Asserting it
+ * again here would duplicate that contract and make a deliberate copy change
+ * fail in two places.
+ */
+describe('SidebarPlanRow', () => {
+  it('renders nothing until the edition is known', () => {
+    // A plan must not flicker from a placeholder to the real value.
+    const { container } = render(<SidebarPlanRow edition={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('labels the row and links to the usage page', () => {
+    render(<SidebarPlanRow edition="team" licensed={true} />);
+
+    expect(screen.getByText('Plan')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      '/organizations/usage'
+    );
+  });
+
+  it('shows the plan through PlanChip rather than its own label', () => {
+    render(<SidebarPlanRow edition="Enterprise" licensed={true} />);
+
+    // Lower-cased is PlanChip's formatting, which is the point: the row does
+    // not format the edition itself.
+    expect(screen.getByText('enterprise')).toBeInTheDocument();
+  });
+
+  it('passes licence status through, so a lapsed plan is marked', () => {
+    // Not a re-test of the chip's copy -- it proves `licensed` actually reaches
+    // it. Dropping the prop would leave a lapsed plan looking active here while
+    // the usage page called it inactive.
+    render(<SidebarPlanRow edition="enterprise" licensed={false} />);
+
+    expect(screen.getByText('enterprise (inactive)')).toBeInTheDocument();
+  });
+
+  it('does not mark a plan inactive when licence status is unknown', () => {
+    render(<SidebarPlanRow edition="enterprise" />);
+
+    expect(screen.getByText('enterprise')).toBeInTheDocument();
+    expect(screen.queryByText(/inactive/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/navigation/sidebar-utils.ts
+++ b/apps/frontend/src/components/navigation/sidebar-utils.ts
@@ -25,6 +25,38 @@ export const collapsedNavItemSx = {
 };
 
 /**
+ * Horizontal geometry every row inside a sidebar card shares: the side padding
+ * and the icon-to-label gap.
+ *
+ * Named rather than repeated inline because it is an *alignment contract*, not
+ * two loose numbers -- the plan row and the link rows below it stack in one
+ * card, and their icons and labels have to sit on the same two columns. Typed
+ * out separately in each component, they drift the moment one is nudged.
+ *
+ * Figma values, which is why they are px and not `theme.spacing` units: 14 and
+ * 10 are not multiples of the 8px spacing step, so a spacing unit would round
+ * them and shift the whole card.
+ */
+export const NAV_CARD_ROW_SX = {
+  px: '14px',
+  gap: '10px',
+} as const;
+
+/** Icon box for a full-height card row (`NavLinkItem`). */
+export const NAV_CARD_ICON_SIZE = 24;
+
+/**
+ * A card row that reports state rather than offering an action -- currently
+ * the plan row heading the footer card. Tighter vertically so it reads as a
+ * status line above the actions instead of a third thing to click, while
+ * keeping their horizontal alignment.
+ */
+export const NAV_CARD_STATUS_ROW_SX = {
+  ...NAV_CARD_ROW_SX,
+  py: '6px',
+} as const;
+
+/**
  * The count-badge pill: a small filled number shown beside something that has
  * a count -- a nav item's unread notifications, the brand row's flagged
  * quota resources, the org and user menu rows.

--- a/apps/frontend/src/constants/quota.ts
+++ b/apps/frontend/src/constants/quota.ts
@@ -63,10 +63,15 @@ export const QUOTA_RESOURCE_ORDER: readonly QuotaResource[] = [
  */
 export const WARNING_THRESHOLD = 0.8;
 
-/** Where every "Upgrade" affordance in the app links to. The page publishes
- * the same per-tier limits this app enforces, so it is the one place a reader
- * who just hit a ceiling can see what a higher tier would give them.
+/** The public pricing page: where every "Upgrade" affordance links, and every
+ * "Learn about Enterprise" prompt on an EE feature's empty state. The page
+ * publishes the same per-tier limits and capabilities this app enforces, so it
+ * is the one place a reader who just hit a ceiling -- or found a feature
+ * gated -- can see what a higher tier would give them.
  *
- * `/editions` 301s here, but link to the destination directly -- an upgrade
- * prompt is the wrong place to spend a redirect. */
+ * One constant rather than a URL per call site: this moved once already
+ * (`/editions` -> `/pricing`, which still 301s) and the three EE empty states
+ * had each hardcoded the old path, so the move had to be made in four places.
+ * Link to the destination directly; an upgrade prompt is the wrong place to
+ * spend a redirect. */
 export const UPGRADE_URL = 'https://rhesis.ai/pricing';

--- a/apps/frontend/src/constants/quota.ts
+++ b/apps/frontend/src/constants/quota.ts
@@ -63,5 +63,10 @@ export const QUOTA_RESOURCE_ORDER: readonly QuotaResource[] = [
  */
 export const WARNING_THRESHOLD = 0.8;
 
-/** Where every "Upgrade" affordance in the app links to. */
-export const UPGRADE_URL = 'https://rhesis.ai/editions';
+/** Where every "Upgrade" affordance in the app links to. The page publishes
+ * the same per-tier limits this app enforces, so it is the one place a reader
+ * who just hit a ceiling can see what a higher tier would give them.
+ *
+ * `/editions` 301s here, but link to the destination directly -- an upgrade
+ * prompt is the wrong place to spend a redirect. */
+export const UPGRADE_URL = 'https://rhesis.ai/pricing';

--- a/apps/frontend/src/contexts/UsageContext.tsx
+++ b/apps/frontend/src/contexts/UsageContext.tsx
@@ -38,6 +38,15 @@ import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
 export interface UsageState {
   resources: Readonly<Record<string, UsageResourceItem>>;
   edition: string | null;
+  /**
+   * Whether the org holds an active paid license. `null` while loading or on
+   * error, matching `edition`.
+   *
+   * Carried separately from `edition` because a lapsed plan keeps its edition
+   * name -- see `isUnlicensedPlan` in `utils/quota.ts`, which is what upgrade
+   * affordances should gate on.
+   */
+  licensed: boolean | null;
   loading: boolean;
   error: Error | null;
 }
@@ -45,6 +54,7 @@ export interface UsageState {
 const DEFAULT_STATE: UsageState = {
   resources: {},
   edition: null,
+  licensed: null,
   loading: true,
   error: null,
 };
@@ -83,6 +93,7 @@ export function UsageProvider({
       return {
         resources: {},
         edition: null,
+        licensed: null,
         loading: false,
         error: error instanceof Error ? error : new Error(String(error)),
       };
@@ -90,6 +101,10 @@ export function UsageProvider({
     return {
       resources: data.resources,
       edition: data.edition,
+      // `?? null` rather than `?? false`: a response predating this field is
+      // "unknown", not "unlicensed". Defaulting to false would offer an
+      // upgrade to every paying org against an older backend.
+      licensed: data.licensed ?? null,
       loading: false,
       error: null,
     };

--- a/apps/frontend/src/hooks/useQuotaGate.tsx
+++ b/apps/frontend/src/hooks/useQuotaGate.tsx
@@ -22,8 +22,8 @@ import { Capability } from '@/constants/capabilities';
 import type { QuotaResource } from '@/constants/quota';
 import { useResourceUsage, useUsage } from '@/contexts/UsageContext';
 import {
-  isCommunityEdition,
   isKnownQuotaResource,
+  isUnlicensedPlan,
   parseQuotaError,
   quotaCopy,
 } from '@/utils/quota';
@@ -132,12 +132,16 @@ export function useQuotaMessageFor(
 }
 
 /** Whether this reader can act on an upgrade: someone who can manage the org
- * (the same owner/admin gate as Org Settings) on a community-edition org.
- * Deliberately not `usage:read`, which every member holds. */
+ * (the same owner/admin gate as Org Settings) whose org has no active paid
+ * license. Deliberately not `usage:read`, which every member holds.
+ *
+ * Gates on licence status rather than the edition name so a lapsed paid org --
+ * held to community limits but still reporting its old edition -- is offered
+ * the upgrade too. See `isUnlicensedPlan`. */
 export function useCanUpgrade(): boolean {
   const canManageOrg = useCan(Capability.Organization.UPDATE);
-  const { edition } = useUsage();
-  return canManageOrg && edition !== null && isCommunityEdition(edition);
+  const { edition, licensed } = useUsage();
+  return canManageOrg && isUnlicensedPlan(edition, licensed);
 }
 
 export interface QuotaErrorResult {

--- a/apps/frontend/src/hooks/useUsageForPeriod.ts
+++ b/apps/frontend/src/hooks/useUsageForPeriod.ts
@@ -18,6 +18,7 @@ import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
 const LOADING_STATE: UsageState = {
   resources: {},
   edition: null,
+  licensed: null,
   loading: true,
   error: null,
 };
@@ -44,6 +45,7 @@ export function useUsageForPeriod(periodStart: string | null): UsageState {
       return {
         resources: {},
         edition: null,
+        licensed: null,
         loading: false,
         error: error instanceof Error ? error : new Error(String(error)),
       };
@@ -52,6 +54,7 @@ export function useUsageForPeriod(periodStart: string | null): UsageState {
     return {
       resources: data.resources,
       edition: data.edition,
+      licensed: data.licensed ?? null,
       loading: false,
       error: null,
     };

--- a/apps/frontend/src/utils/__tests__/quota.test.ts
+++ b/apps/frontend/src/utils/__tests__/quota.test.ts
@@ -2,7 +2,9 @@ import {
   classifyZone,
   flaggedResources,
   findWorstResource,
+  isCommunityEdition,
   isKnownQuotaResource,
+  isUnlicensedPlan,
   parseQuotaError,
   quotaCopy,
   usageMenuRows,
@@ -300,6 +302,48 @@ describe('isKnownQuotaResource', () => {
 
   it('rejects one it does not', () => {
     expect(isKnownQuotaResource('some_future_resource')).toBe(false);
+  });
+});
+
+describe('isCommunityEdition', () => {
+  it('matches the free tier regardless of case', () => {
+    expect(isCommunityEdition('community')).toBe(true);
+    expect(isCommunityEdition('COMMUNITY')).toBe(true);
+  });
+
+  it('does not match a paid edition', () => {
+    expect(isCommunityEdition('enterprise')).toBe(false);
+  });
+});
+
+describe('isUnlicensedPlan', () => {
+  it('offers an upgrade to a free org', () => {
+    expect(isUnlicensedPlan('community', false)).toBe(true);
+  });
+
+  it('does not offer one to an org on an active paid licence', () => {
+    expect(isUnlicensedPlan('team', true)).toBe(false);
+    expect(isUnlicensedPlan('enterprise', true)).toBe(false);
+  });
+
+  it('offers one to a paid org whose licence has lapsed', () => {
+    // The case the old edition-string check got wrong. A canceled licence
+    // resolves to community limits on the backend but keeps reporting its
+    // edition, so this org hits free-tier ceilings while not looking free --
+    // and was shown no upgrade path at the moment it most needed one.
+    expect(isUnlicensedPlan('enterprise', false)).toBe(true);
+    expect(isUnlicensedPlan('team', false)).toBe(true);
+  });
+
+  it.each([
+    ['loading', null, null],
+    ['edition loaded, licence unknown', 'enterprise', null],
+    ['licence field absent', 'enterprise', undefined],
+  ])('offers nothing when %s', (_case, edition, licensed) => {
+    // Never prompt a paying customer to upgrade on missing data.
+    expect(
+      isUnlicensedPlan(edition as string | null, licensed as boolean | null)
+    ).toBe(false);
   });
 });
 

--- a/apps/frontend/src/utils/api-client/usage-client.ts
+++ b/apps/frontend/src/utils/api-client/usage-client.ts
@@ -24,6 +24,16 @@ export interface UsageResourceItem {
 export interface UsageResponse {
   resources: Record<string, UsageResourceItem>;
   edition: string;
+  /**
+   * Whether the org holds an *active* paid license.
+   *
+   * Separate from `edition`, which keeps naming a lapsed tier so the UI can
+   * say which license expired: a canceled enterprise license reports
+   * `edition: "enterprise"` with `licensed: false`, while the backend holds it
+   * to community limits. Gate upgrade affordances on this, not on the edition
+   * string -- see `isUnlicensedPlan` in `utils/quota.ts`.
+   */
+  licensed: boolean;
 }
 
 export interface UsageHistoryPoint {

--- a/apps/frontend/src/utils/quota.ts
+++ b/apps/frontend/src/utils/quota.ts
@@ -16,8 +16,41 @@ import type { UsageResourceItem } from '@/utils/api-client/usage-client';
 
 const COMMUNITY_EDITION = 'community';
 
+/** Whether *edition* names the free tier. Answers "what plan is this", which
+ * is a display question -- for "should this org be offered an upgrade", use
+ * {@link isUnlicensedPlan}: a lapsed paid plan is not the community edition
+ * but is held to community limits. */
 export function isCommunityEdition(edition: string): boolean {
   return edition.toLowerCase() === COMMUNITY_EDITION;
+}
+
+/**
+ * Whether the org has no active paid license, and should therefore be shown
+ * an upgrade path.
+ *
+ * This is the question every upgrade affordance is really asking, and it is
+ * deliberately *not* `isCommunityEdition(edition)`, which is what it used to
+ * be. The backend reports edition and licence status separately, because a
+ * lapsed licence keeps its edition name so the UI can say which one expired:
+ * a canceled enterprise licence resolves to community *limits* while still
+ * reporting `edition: "enterprise"`.
+ *
+ * Gating on the edition string stranded exactly that org. It gets free-tier
+ * ceilings and 402s at 500 test runs, but does not look like a free org, so
+ * every upgrade link, banner CTA and `canUpgrade` recourse line was withheld
+ * -- the one state where the reader most needs to be told what to do.
+ *
+ * Requires a positive `licensed === false`, so anything unknown -- a loading
+ * provider (`null`), or a response from a backend predating the field
+ * (`undefined`) -- reads as "no opinion" and shows nothing, rather than
+ * flashing an upgrade prompt at a paying customer.
+ */
+export function isUnlicensedPlan(
+  edition: string | null,
+  licensed: boolean | null | undefined
+): boolean {
+  if (edition === null) return false;
+  return licensed === false;
 }
 
 /** Narrows a wire-value string (e.g. `parseQuotaError(err).resource`) to

--- a/ee/backend/src/rhesis/backend/ee/licensing/cli.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/cli.py
@@ -456,7 +456,12 @@ def _build_parser() -> argparse.ArgumentParser:
             "--limits",
             default=None,
             metavar="JSON",
-            help='JSON limits override, e.g. \'{"seats": 200}\' (merged with tier defaults).',
+            help=(
+                'JSON per-resource limit override, e.g. \'{"test_executions": 500000}\'. '
+                "Overlaid on the tier's live limits at enforcement time; resources left "
+                "out keep following the published tier. Use null for unlimited. This is "
+                'how a "custom" enterprise cap is set.'
+            ),
         )
 
     # --- mint ---

--- a/ee/backend/src/rhesis/backend/ee/licensing/entitlements.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/entitlements.py
@@ -101,7 +101,23 @@ LIC_EDITION = "edition"
 LIC_STATUS = "status"
 LIC_ALL_FEATURES = "all_features"
 LIC_FEATURES = "features"
+#: Tier limits as they stood when the token was minted. A snapshot for audit
+#: and diagnostics -- NOT enforced. Enforcement resolves limits from the live
+#: tier catalog (``tier_config.yaml``) so a published pricing change applies
+#: without re-minting every customer's token. See :data:`LIC_CUSTOM_LIMITS`
+#: for the part that does override.
 LIC_LIMITS = "limits"
+#: Bespoke per-org limit overrides, present only when explicitly minted
+#: (``mint_token(custom_limits=...)`` / ``rhesis-license --limits``). Overlaid
+#: per-resource on the tier's catalog limits by
+#: :class:`~rhesis.backend.ee.licensing.quota_provider.ConfigQuotaProvider`.
+#:
+#: Deliberately separate from :data:`LIC_LIMITS` rather than merged into it:
+#: because that claim is a full tier snapshot, a merged override is
+#: indistinguishable from "the tier looked like this at mint time", and
+#: enforcing it would pin every org to its mint-time numbers and silently
+#: ignore later pricing changes.
+LIC_CUSTOM_LIMITS = "custom_limits"
 
 # --- Environment variable names --------------------------------------------
 ENV_TIER_CONFIG = "RHESIS_TIER_CONFIG"
@@ -130,7 +146,8 @@ class Entitlements:
           "status": "active|past_due|canceled",
           "all_features": true,
           "features": ["sso", "api_clients"],
-          "limits": {"seats": 50}
+          "limits": {"seats": 50},
+          "custom_limits": {"test_executions": 500000}
         }
 
     ``sub`` and ``expires_at`` come from the standard JWT top-level claims.
@@ -156,14 +173,20 @@ class Entitlements:
     """UTC expiry derived from the ``exp`` JWT claim; ``None`` if absent."""
 
     limits: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
-    """Arbitrary limit map (e.g. ``{"seats": 50}``). Always a read-only mapping —
-    see :meth:`__post_init__`."""
+    """Tier limits as of minting (e.g. ``{"seats": 50}``) — a snapshot, not
+    enforced. See :data:`LIC_LIMITS`. Always a read-only mapping, see
+    :meth:`__post_init__`."""
+
+    custom_limits: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+    """Bespoke per-org limit overrides, empty unless explicitly minted. These
+    *are* enforced, overlaid on the tier catalog. See :data:`LIC_CUSTOM_LIMITS`.
+    Always a read-only mapping, see :meth:`__post_init__`."""
 
     jti: Optional[str] = None
     """JWT ID for audit logging and future revocation support."""
 
     def __post_init__(self) -> None:
-        """Coerce ``limits`` to a read-only mapping.
+        """Coerce the limit mappings to read-only.
 
         ``Entitlements`` is frozen, but that only blocks attribute
         *reassignment* — it does nothing to stop in-place mutation of a
@@ -174,8 +197,10 @@ class Entitlements:
         using the same token. Wrapping in ``MappingProxyType`` makes that a
         ``TypeError`` instead of a silent cross-request leak.
         """
-        if not isinstance(self.limits, MappingProxyType):
-            object.__setattr__(self, "limits", MappingProxyType(dict(self.limits)))
+        for attr in ("limits", "custom_limits"):
+            value = getattr(self, attr)
+            if not isinstance(value, MappingProxyType):
+                object.__setattr__(self, attr, MappingProxyType(dict(value)))
 
     def is_expired(self) -> bool:
         """Return ``True`` if the license has passed its expiry window.
@@ -230,6 +255,7 @@ __all__ = [
     "LIC_ALL_FEATURES",
     "LIC_EDITION",
     "LIC_FEATURES",
+    "LIC_CUSTOM_LIMITS",
     "LIC_LIMITS",
     "LIC_STATUS",
     "REQUIRED_CLAIMS",

--- a/ee/backend/src/rhesis/backend/ee/licensing/mint.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/mint.py
@@ -54,8 +54,8 @@ from rhesis.backend.ee.licensing.entitlements import (
     CLAIM_SUBJECT,
     ENV_LICENSE_PRIVATE_KEY,
     LIC_ALL_FEATURES,
+    LIC_CUSTOM_LIMITS,
     LIC_FEATURES,
-    LIC_LIMITS,
     LICENSE_ALGORITHM,
     LICENSE_AUDIENCE,
     LICENSE_ISSUER,
@@ -152,8 +152,13 @@ def mint_token(
     :param custom_features: When set, overrides the tier-default feature list
         (a sorted list of :class:`~rhesis.backend.app.features.FeatureName`
         string values). Use for one-off bespoke deals.
-    :param custom_limits: When set, overrides or extends the tier-default
-        limits dict (e.g. ``{"seats": 200}``).
+    :param custom_limits: Bespoke per-resource limit overrides for this org
+        (e.g. ``{"seats": 200}``), written to the ``custom_limits`` claim.
+        Overlaid per-resource on the tier's *live* catalog limits at
+        enforcement time, so resources left out keep tracking the published
+        tier and a later pricing change still reaches this customer. Use
+        ``None`` as a value to make one resource unlimited. This is the
+        mechanism behind the pricing page's "custom" enterprise limits.
     :returns: Signed JWT string.
     :raises RuntimeError: if the private key is unavailable or invalid, or if
         *edition* is not a sellable tier.
@@ -175,9 +180,11 @@ def mint_token(
         lic_claim[LIC_ALL_FEATURES] = False
 
     if custom_limits is not None:
-        merged = dict(lic_claim.get(LIC_LIMITS) or {})
-        merged.update(custom_limits)
-        lic_claim[LIC_LIMITS] = merged
+        # Its own claim, deliberately not merged into LIC_LIMITS -- that one is
+        # a full tier snapshot, so a merged override could not be told apart
+        # from the tier's own numbers, and enforcing it would pin this org to
+        # its mint-time limits for good. See LIC_CUSTOM_LIMITS.
+        lic_claim[LIC_CUSTOM_LIMITS] = dict(custom_limits)
 
     payload: dict[str, Any] = {
         CLAIM_ISSUER: LICENSE_ISSUER,

--- a/ee/backend/src/rhesis/backend/ee/licensing/provider.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/provider.py
@@ -80,7 +80,27 @@ class SignedTokenLicenseProvider:
         return entitlements.allows(feature.name.value)
 
     def info(self, org: Optional[Organization] = None) -> dict:
-        """Return opaque license metadata for the ``GET /features`` response."""
+        """Return opaque license metadata for the ``GET /features`` response.
+
+        ``custom_limits`` carries the token's ``lic.custom_limits`` claim
+        verbatim (wire form: string resource names). It is present only for a
+        licensed, active org whose token actually carries the claim --
+        :class:`~rhesis.backend.ee.licensing.quota_provider.ConfigQuotaProvider`
+        reads it to overlay a bespoke deal's negotiated caps on the tier
+        defaults. This is the same channel it already resolves ``edition``
+        through, which is equally enforcement-critical.
+
+        The mint-time ``limits`` snapshot is deliberately *not* exposed: it is
+        for audit only, and handing it to the quota provider would pin the org
+        to its mint-time numbers (see :data:`~rhesis.backend.ee.licensing.entitlements.LIC_LIMITS`).
+
+        Note this does *not* widen the ``GET /features`` payload:
+        ``routers/features.py`` builds its ``LicenseInfo`` from ``edition``
+        and ``licensed`` only, and reports limits separately from
+        :meth:`~rhesis.backend.app.quota.QuotaRegistry.get_limits` -- which
+        resolves through the quota provider, so the overlay is reflected there
+        already.
+        """
         if org is None:
             return self._unlicensed_info(LicenseEdition.COMMUNITY)
 
@@ -93,7 +113,13 @@ class SignedTokenLicenseProvider:
         if not entitlements.is_active():
             return self._unlicensed_info(entitlements.edition)
 
-        return {"edition": entitlements.edition.value, "licensed": True}
+        info: dict = {"edition": entitlements.edition.value, "licensed": True}
+        # Omitted rather than sent as {} when the token carries no override, so
+        # "no custom limits" and "an empty override map" are the same thing on
+        # the consuming side instead of two cases it has to distinguish.
+        if entitlements.custom_limits:
+            info["custom_limits"] = dict(entitlements.custom_limits)
+        return info
 
     # ------------------------------------------------------------------ #
     # Internal helpers

--- a/ee/backend/src/rhesis/backend/ee/licensing/quota_provider.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/quota_provider.py
@@ -5,6 +5,24 @@ is present.  Resolves the organization's edition from the license
 provider, then looks up the limits and overage policy defined in the
 YAML-loaded tier catalog.  Unlicensed orgs get the community (free-tier)
 entry.
+
+On top of that tier baseline, any bespoke per-org overrides carried in the
+license token's ``custom_limits`` claim are applied per-resource. That is the
+mechanism behind the pricing page's "custom" enterprise limits: the
+``enterprise`` tier is ``null`` (unlimited) across the board in the catalog,
+and a negotiated cap is minted into the customer's own token rather than
+written into a catalog every org shares.
+
+Two properties of that split are worth stating, because both are load-bearing:
+
+- **Absent means unlimited, not zero.** A resource the token does not name
+  keeps its catalog limit, which for ``enterprise`` is unlimited. So every
+  enterprise license minted before this claim existed keeps behaving exactly
+  as it did, with nothing to re-mint.
+- **The catalog stays live.** Overrides are read from ``custom_limits``, never
+  from the mint-time ``limits`` snapshot, so changing a published tier number
+  takes effect for everyone on that tier without re-issuing tokens. Only the
+  resources actually negotiated are pinned.
 """
 
 from __future__ import annotations
@@ -13,8 +31,8 @@ import logging
 from typing import Optional
 
 from rhesis.backend.app.models.organization import Organization
-from rhesis.backend.app.quota import QuotaPolicy
-from rhesis.backend.ee.licensing.entitlements import LicenseEdition
+from rhesis.backend.app.quota import QuotaPolicy, limits_from_wire
+from rhesis.backend.ee.licensing.entitlements import LIC_CUSTOM_LIMITS, LicenseEdition
 from rhesis.backend.ee.licensing.tiers import resolve_policy
 
 logger = logging.getLogger(__name__)
@@ -25,17 +43,41 @@ class ConfigQuotaProvider:
 
     For each organization, it determines the edition from the license
     provider's entitlements, then returns the limits and overage policy
-    defined in the config for that edition.
+    defined in the config for that edition, with any bespoke per-org
+    overrides from the license token overlaid on top.
     """
 
-    def _resolve_edition(self, org: Optional[Organization]) -> Optional[LicenseEdition]:
-        """Determine the org's edition from the license provider."""
+    def _license_info(self, org: Optional[Organization]) -> dict:
+        """Return the installed license provider's info dict for *org*.
+
+        Read once per :meth:`get_policy` call and passed down, rather than
+        resolved separately for the edition and the overrides -- two lookups
+        could disagree if the license changed between them, and would verify
+        the same token twice.
+        """
         if org is None:
-            return None
+            return {}
 
         from rhesis.backend.app.features import FeatureRegistry
 
-        info = FeatureRegistry.license_info(org)
+        return FeatureRegistry.license_info(org)
+
+    def _resolve_edition(self, org: Optional[Organization], info: dict) -> Optional[LicenseEdition]:
+        """Determine the org's edition from the license provider.
+
+        Returns ``None`` (meaning community limits) unless the org holds an
+        *active* license. ``info`` keeps reporting the lapsed edition so the UI
+        can say which license expired, but granting that tier's limits on the
+        strength of the name alone would leave a canceled or past-due
+        enterprise org on unlimited quota indefinitely -- billing status is
+        exactly the thing that is supposed to end that.
+        """
+        if org is None:
+            return None
+
+        if not info.get("licensed"):
+            return None
+
         edition_str = info.get("edition")
         if edition_str is None:
             return None
@@ -54,8 +96,22 @@ class ConfigQuotaProvider:
         return edition
 
     def get_policy(self, org: Optional[Organization] = None) -> QuotaPolicy:
-        edition = self._resolve_edition(org)
-        return resolve_policy(edition)
+        info = self._license_info(org)
+        edition = self._resolve_edition(org, info)
+        policy = resolve_policy(edition)
+
+        overrides = limits_from_wire(info.get(LIC_CUSTOM_LIMITS))
+        if not overrides:
+            return policy
+
+        logger.info(
+            "Applying %d custom limit override(s) for org %s (edition=%s): %s",
+            len(overrides),
+            getattr(org, "id", None),
+            edition.value if edition else None,
+            {r.value: v for r, v in overrides.items()},
+        )
+        return policy.with_limit_overrides(overrides)
 
 
 __all__ = ["ConfigQuotaProvider"]

--- a/ee/backend/src/rhesis/backend/ee/licensing/quota_provider.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/quota_provider.py
@@ -104,13 +104,22 @@ class ConfigQuotaProvider:
         if not overrides:
             return policy
 
-        logger.info(
-            "Applying %d custom limit override(s) for org %s (edition=%s): %s",
-            len(overrides),
-            getattr(org, "id", None),
-            edition.value if edition else None,
-            {r.value: v for r, v in overrides.items()},
-        )
+        # DEBUG, and resource names without their values. This runs on the
+        # request path -- every quota gate and every hosted-model call resolves
+        # a policy -- so INFO here is one line per request for the orgs that
+        # have overrides. The values are also a customer's negotiated caps,
+        # which is contract detail that should not be sitting in log storage;
+        # the names alone are enough to answer "did an override apply, and to
+        # what" when debugging, and the effective numbers are already visible
+        # on `GET /usage`.
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Applied %d custom limit override(s) for org %s (edition=%s) on: %s",
+                len(overrides),
+                getattr(org, "id", None),
+                edition.value if edition else None,
+                ", ".join(sorted(r.value for r in overrides)),
+            )
         return policy.with_limit_overrides(overrides)
 
 

--- a/ee/backend/src/rhesis/backend/ee/licensing/tier_config.yaml
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tier_config.yaml
@@ -5,6 +5,18 @@
 # null = unlimited.  Unlicensed orgs resolve to the `community` entry.
 # Override at runtime via RHESIS_TIER_CONFIG env var pointing to a
 # different YAML file (e.g. mounted from a K8s ConfigMap).
+#
+# The `community` and `team` numbers below are PUBLISHED on the pricing
+# page (rhesis-ai/website, src/data/pricing.ts -> PLAN_LIMITS, pinned as
+# literals in src/data/pricing.test.ts) and are part of the terms of
+# service. Change them in both repos together, or not at all -- a number
+# advertised here that the backend does not enforce is a promise we break,
+# and the reverse blocks a customer at a ceiling they were never told about.
+#
+# `enterprise` is null (unlimited) because the page says "custom": the
+# negotiated cap is minted per-org into the license token's
+# `lic.custom_limits` claim and overlaid on this tier by
+# ConfigQuotaProvider. See quota_provider.py.
 
 community:
   all_features: false
@@ -13,7 +25,7 @@ community:
     test_executions: 500
     tracing_spans: 50000
     test_generation: 100
-    model_tokens: 5000000
+    model_tokens: 1000000
     seats: 3
     projects: 3
     endpoints: 3
@@ -26,9 +38,9 @@ team:
     - rbac
   limits:
     test_executions: 100000
-    tracing_spans: 5000000
+    tracing_spans: 1000000
     test_generation: 50000
-    model_tokens: 250000000
+    model_tokens: 25000000
     seats: null
     projects: null
     endpoints: null

--- a/ee/backend/src/rhesis/backend/ee/licensing/verify.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/verify.py
@@ -34,6 +34,7 @@ from rhesis.backend.ee.licensing.entitlements import (
     CLAIM_LICENSE,
     CLAIM_SUBJECT,
     LIC_ALL_FEATURES,
+    LIC_CUSTOM_LIMITS,
     LIC_EDITION,
     LIC_FEATURES,
     LIC_LIMITS,
@@ -121,6 +122,32 @@ def _parse_token(raw_token: str) -> Optional[Entitlements]:
     return _payload_to_entitlements(payload)
 
 
+def _mapping_claim(lic: dict, key: str) -> dict:
+    """Read *key* from *lic* as a dict, treating anything else as absent.
+
+    Guards the limit claims specifically. ``dict(...)`` on a non-mapping raises
+    ``ValueError``/``TypeError``, which the caller's except-clause turns into a
+    rejected token -- so one malformed limits claim would cost the org its whole
+    license, including every EE feature, not just the limits it got wrong.
+
+    A limits claim is signed by us, so junk there is a minting bug on our side.
+    Dropping just that claim leaves the customer on their paid tier with the
+    override ignored and a warning in the logs, which beats silently demoting
+    them to community over a field that only ever *narrows* what they get.
+    """
+    value = lic.get(key)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        logger.warning(
+            "Ignoring malformed %r claim in license token: expected a mapping, got %s",
+            key,
+            type(value).__name__,
+        )
+        return {}
+    return dict(value)
+
+
 def _payload_to_entitlements(payload: dict) -> Optional[Entitlements]:
     """Map a decoded JWT payload dict to :class:`Entitlements`, or ``None`` on error."""
     try:
@@ -138,7 +165,8 @@ def _payload_to_entitlements(payload: dict) -> Optional[Entitlements]:
             all_features=bool(lic.get(LIC_ALL_FEATURES, False)),
             features=frozenset(str(f) for f in lic.get(LIC_FEATURES, [])),
             expires_at=expires_at,
-            limits=dict(lic.get(LIC_LIMITS) or {}),
+            limits=_mapping_claim(lic, LIC_LIMITS),
+            custom_limits=_mapping_claim(lic, LIC_CUSTOM_LIMITS),
             jti=payload.get(CLAIM_JWT_ID),
         )
     except (KeyError, TypeError, ValueError) as exc:

--- a/ee/backend/src/rhesis/backend/ee/licensing/verify.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/verify.py
@@ -148,6 +148,54 @@ def _mapping_claim(lic: dict, key: str) -> dict:
     return dict(value)
 
 
+def _all_features_claim(lic: dict) -> bool:
+    """Read ``all_features`` strictly: only a literal ``True`` grants everything.
+
+    This claim is a blanket grant over every registered EE feature, so it is the
+    single most valuable bit in the token and must not be reachable by accident.
+    A plain ``bool(...)`` coercion would read the *string* ``"false"`` as
+    ``True`` -- every non-empty string is truthy in Python -- and hand out the
+    full feature set to a token that says the opposite.
+
+    The tier-YAML loader already refuses a non-bool here for exactly this reason
+    (see ``tiers._parse_all_features``); this keeps the token side to the same
+    standard, so the two halves of the same decision cannot disagree. Anything
+    that is not a real bool is treated as ``False`` and logged: unlike the YAML,
+    a token is read on the request path, where raising would 500 the request
+    rather than merely denying an upgrade nobody was entitled to.
+    """
+    value = lic.get(LIC_ALL_FEATURES, False)
+    if isinstance(value, bool):
+        return value
+    logger.warning(
+        "Ignoring non-boolean %r claim in license token: %r (%s); treating as false",
+        LIC_ALL_FEATURES,
+        value,
+        type(value).__name__,
+    )
+    return False
+
+
+def _features_claim(lic: dict) -> frozenset[str]:
+    """Read ``features`` as a list of names, treating any other shape as empty.
+
+    Iterating the claim blindly is what makes a malformed one dangerous rather
+    than merely wrong: a bare string ``"sso"`` iterates per character, and a
+    ``{"sso": true}`` mapping iterates its *keys* -- which yields a real ``sso``
+    grant from a claim that was never a feature list. Require a sequence.
+    """
+    value = lic.get(LIC_FEATURES, [])
+    if not isinstance(value, (list, tuple)):
+        if value is not None:
+            logger.warning(
+                "Ignoring malformed %r claim in license token: expected a list, got %s",
+                LIC_FEATURES,
+                type(value).__name__,
+            )
+        return frozenset()
+    return frozenset(str(f) for f in value)
+
+
 def _payload_to_entitlements(payload: dict) -> Optional[Entitlements]:
     """Map a decoded JWT payload dict to :class:`Entitlements`, or ``None`` on error."""
     try:
@@ -162,8 +210,8 @@ def _payload_to_entitlements(payload: dict) -> Optional[Entitlements]:
             sub=str(payload[CLAIM_SUBJECT]),
             edition=LicenseEdition(lic.get(LIC_EDITION)),
             status=LicenseStatus(lic.get(LIC_STATUS)),
-            all_features=bool(lic.get(LIC_ALL_FEATURES, False)),
-            features=frozenset(str(f) for f in lic.get(LIC_FEATURES, [])),
+            all_features=_all_features_claim(lic),
+            features=_features_claim(lic),
             expires_at=expires_at,
             limits=_mapping_claim(lic, LIC_LIMITS),
             custom_limits=_mapping_claim(lic, LIC_CUSTOM_LIMITS),

--- a/ee/frontend/src/__tests__/EnterpriseEmptyStateLinks.test.tsx
+++ b/ee/frontend/src/__tests__/EnterpriseEmptyStateLinks.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { UPGRADE_URL } from '@/constants/quota';
+import RolesEmptyState from '../rbac/components/RolesEmptyState';
+import SSOEmptyState from '../sso/components/SSOEmptyState';
+import ApiClientsEmptyState from '../api-clients/components/ApiClientsEmptyState';
+
+/**
+ * Every "Learn about Enterprise" prompt must resolve its destination from the
+ * shared `UPGRADE_URL`, never from its own string.
+ *
+ * These three each hardcoded `https://rhesis.ai/editions`, so when the page
+ * moved to `/pricing` the change had to be found in four separate files — and
+ * three of them are EE, which a core-only search misses. Asserting against the
+ * constant means a re-hardcoded URL fails here instead of quietly pointing a
+ * gated customer at a redirect, or eventually a 404.
+ */
+const EMPTY_STATES = [
+  ['Roles', RolesEmptyState],
+  ['SSO', SSOEmptyState],
+  ['API Clients', ApiClientsEmptyState],
+] as const;
+
+describe('Enterprise empty-state upgrade links', () => {
+  let openSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+  });
+
+  it.each(EMPTY_STATES)(
+    '%s sends the reader to the shared pricing URL',
+    async (_name, Component) => {
+      render(<Component />);
+
+      await userEvent.click(
+        screen.getByRole('button', { name: /learn about enterprise/i })
+      );
+
+      expect(openSpy).toHaveBeenCalledWith(
+        UPGRADE_URL,
+        '_blank',
+        'noopener,noreferrer'
+      );
+    }
+  );
+
+  it('has no empty state pointing at the retired /editions path', () => {
+    // Guards the migration itself: `/editions` only 301s to `/pricing`, and an
+    // upgrade prompt is the wrong place to spend a redirect.
+    expect(UPGRADE_URL).toBe('https://rhesis.ai/pricing');
+    expect(UPGRADE_URL).not.toContain('/editions');
+  });
+});

--- a/ee/frontend/src/api-clients/components/ApiClientsEmptyState.tsx
+++ b/ee/frontend/src/api-clients/components/ApiClientsEmptyState.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { UPGRADE_URL } from '@/constants/quota';
 import ApiIcon from '@mui/icons-material/Api';
 
 export default function ApiClientsEmptyState() {
@@ -13,13 +14,7 @@ export default function ApiClientsEmptyState() {
       title="API Clients are an Enterprise feature"
       description="Issue scoped OAuth client credentials for machine-to-machine access to your organization's data."
       actionLabel="Learn about Enterprise"
-      onAction={() =>
-        window.open(
-          'https://rhesis.ai/editions',
-          '_blank',
-          'noopener,noreferrer'
-        )
-      }
+      onAction={() => window.open(UPGRADE_URL, '_blank', 'noopener,noreferrer')}
     />
   );
 }

--- a/ee/frontend/src/rbac/components/RolesEmptyState.tsx
+++ b/ee/frontend/src/rbac/components/RolesEmptyState.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { UPGRADE_URL } from '@/constants/quota';
 import SecurityIcon from '@mui/icons-material/Security';
 
 export default function RolesEmptyState() {
@@ -13,13 +14,7 @@ export default function RolesEmptyState() {
       title="Roles are an Enterprise feature"
       description="Fine-grained role-based access control lets you define custom roles, assign them to team members, and control who can do what across your organization."
       actionLabel="Learn about Enterprise"
-      onAction={() =>
-        window.open(
-          'https://rhesis.ai/editions',
-          '_blank',
-          'noopener,noreferrer'
-        )
-      }
+      onAction={() => window.open(UPGRADE_URL, '_blank', 'noopener,noreferrer')}
     />
   );
 }

--- a/ee/frontend/src/sso/components/SSOEmptyState.tsx
+++ b/ee/frontend/src/sso/components/SSOEmptyState.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { UPGRADE_URL } from '@/constants/quota';
 import VerifiedUserIcon from '@mui/icons-material/VerifiedUser';
 
 export default function SSOEmptyState() {
@@ -13,13 +14,7 @@ export default function SSOEmptyState() {
       title="Single Sign-On is an Enterprise feature"
       description="Let your team sign in with your identity provider (SAML, OIDC) instead of managing separate passwords."
       actionLabel="Learn about Enterprise"
-      onAction={() =>
-        window.open(
-          'https://rhesis.ai/editions',
-          '_blank',
-          'noopener,noreferrer'
-        )
-      }
+      onAction={() => window.open(UPGRADE_URL, '_blank', 'noopener,noreferrer')}
     />
   );
 }

--- a/tests/backend/auth/test_terms.py
+++ b/tests/backend/auth/test_terms.py
@@ -28,6 +28,38 @@ def test_user_has_accepted_current_terms_false_for_outdated_version():
     assert user_has_prior_terms_acceptance(user) is True
 
 
+def test_backfilled_baseline_users_must_re_accept():
+    """The population this bump exists for.
+
+    Every user onboarded before terms tracking carries ``"1.0"``, written once
+    by the ``b5c6d7e8f9a0`` backfill. Version 2.0 replaces the public preview
+    terms with the commercial SaaS terms -- a different document, not an
+    amendment -- so that whole population has to be prompted again. A bump that
+    left them reading as current would silently hold them to terms they never
+    saw.
+
+    ``user_has_prior_terms_acceptance`` staying true is what makes the frontend
+    gate say "Updated Terms" rather than showing them first-run copy.
+    """
+    backfill_baseline = "1.0"
+    assert CURRENT_TERMS_VERSION != backfill_baseline, (
+        "CURRENT_TERMS_VERSION is back at the backfill baseline, so no "
+        "pre-existing user would be asked to re-accept."
+    )
+
+    user = User(
+        email="a@example.com",
+        user_settings={
+            "terms": {
+                "accepted_at": datetime.now(timezone.utc).isoformat(),
+                "version": backfill_baseline,
+            }
+        },
+    )
+    assert user_has_accepted_current_terms(user) is False
+    assert user_has_prior_terms_acceptance(user) is True
+
+
 def test_record_terms_acceptance_sets_current_version():
     user = User(email="a@example.com")
     record_terms_acceptance(user)

--- a/tests/backend/ee/licensing/conftest.py
+++ b/tests/backend/ee/licensing/conftest.py
@@ -29,6 +29,7 @@ from rhesis.backend.ee.licensing.entitlements import (
     CLAIM_LICENSE,
     CLAIM_SUBJECT,
     LIC_ALL_FEATURES,
+    LIC_CUSTOM_LIMITS,
     LIC_EDITION,
     LIC_FEATURES,
     LIC_LIMITS,
@@ -69,6 +70,7 @@ def mint_token(ed25519_keypair):
         all_features: bool = True,
         features: Optional[list] = None,
         limits: Optional[dict] = None,
+        custom_limits: Optional[dict] = None,
         exp: Optional[int] = None,
         iss: str = LICENSE_ISSUER,
         aud: str = LICENSE_AUDIENCE,
@@ -77,6 +79,17 @@ def mint_token(ed25519_keypair):
         extra_claims: Optional[dict[str, Any]] = None,
     ) -> str:
         now = int(time.time())
+        lic: dict[str, Any] = {
+            LIC_EDITION: edition,
+            LIC_STATUS: status,
+            LIC_ALL_FEATURES: all_features,
+            LIC_FEATURES: features or [],
+            LIC_LIMITS: limits or {},
+        }
+        # Only set when asked, so the default token looks like the ones already
+        # in the wild -- no custom_limits claim at all.
+        if custom_limits is not None:
+            lic[LIC_CUSTOM_LIMITS] = custom_limits
         payload: dict[str, Any] = {
             CLAIM_ISSUER: iss,
             CLAIM_AUDIENCE: aud,
@@ -84,13 +97,7 @@ def mint_token(ed25519_keypair):
             CLAIM_ISSUED_AT: now,
             CLAIM_EXPIRY: exp if exp is not None else now + 3600,
             CLAIM_JWT_ID: jti,
-            CLAIM_LICENSE: {
-                LIC_EDITION: edition,
-                LIC_STATUS: status,
-                LIC_ALL_FEATURES: all_features,
-                LIC_FEATURES: features or [],
-                LIC_LIMITS: limits or {},
-            },
+            CLAIM_LICENSE: lic,
         }
         if extra_claims:
             payload.update(extra_claims)

--- a/tests/backend/ee/licensing/test_licensing_loopholes.py
+++ b/tests/backend/ee/licensing/test_licensing_loopholes.py
@@ -1,0 +1,647 @@
+"""Adversarial tests for the licensing and quota system.
+
+Everything here asks one question: **can a customer end up with more than they
+paid for?** Either more features, a higher tier, or a higher (or absent) usage
+ceiling. Each test states the escalation it is trying to achieve, so a failure
+reads as "this attack now works" rather than "an assertion changed".
+
+The threat model, stated explicitly because it decides what is in scope:
+
+- A customer controls their own API requests and request bodies, and anything
+  the API lets them write. They do **not** hold the license signing key.
+- ``organization.license`` is server-side state. It is not in the Organization
+  Pydantic schema, so it cannot be set over the wire -- that exclusion is
+  itself load-bearing and is asserted here (see
+  :class:`TestLicenseColumnIsNotClientWritable`), because adding the field to
+  the schema later would hand customers the ability to install their own token.
+- So the realistic attacks are: present a token we did not sign, replay a token
+  we signed for someone else, or exploit a *logic* gap that turns a valid
+  low-tier license into a high-tier one.
+
+Fail-closed is the invariant throughout: anything we cannot verify resolves to
+``community`` limits and no features, never to unlimited.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from rhesis.backend.app.features import Feature, FeatureName, FeatureRegistry
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.ee.licensing.entitlements import (
+    CLAIM_AUDIENCE,
+    CLAIM_EXPIRY,
+    CLAIM_ISSUED_AT,
+    CLAIM_ISSUER,
+    CLAIM_JWT_ID,
+    CLAIM_LICENSE,
+    CLAIM_SUBJECT,
+    LIC_ALL_FEATURES,
+    LIC_CUSTOM_LIMITS,
+    LIC_EDITION,
+    LIC_FEATURES,
+    LIC_LIMITS,
+    LIC_STATUS,
+    LICENSE_AUDIENCE,
+    LICENSE_ISSUER,
+    LicenseEdition,
+)
+from rhesis.backend.ee.licensing.provider import SignedTokenLicenseProvider
+from rhesis.backend.ee.licensing.quota_provider import ConfigQuotaProvider
+from rhesis.backend.ee.licensing.tiers import resolve_limits, resolve_tier
+from rhesis.backend.ee.licensing.verify import _parse_token, verify_token
+
+pytestmark = pytest.mark.skipif(
+    not pytest.importorskip(
+        "rhesis.backend.ee",
+        reason="EE package not installed",
+    ),
+    reason="EE package not installed",
+)
+
+_VICTIM_ORG = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+_OTHER_ORG = "11111111-2222-3333-4444-555555555555"
+
+_SSO = Feature(name=FeatureName.SSO, display_name="SSO")
+
+_COMMUNITY_LIMITS = resolve_limits(LicenseEdition.COMMUNITY)
+_ENTERPRISE_LIMITS = resolve_tier(LicenseEdition.ENTERPRISE).limits
+
+
+def _make_org(org_id: str = _VICTIM_ORG, license_token: str | None = None) -> MagicMock:
+    org = MagicMock()
+    org.id = UUID(org_id)
+    org.license = license_token
+    return org
+
+
+def _lic_claim(
+    edition: str = "enterprise",
+    status: str = "active",
+    all_features: Any = True,
+    features: Optional[list] = None,
+    limits: Optional[dict] = None,
+    custom_limits: Optional[dict] = None,
+) -> dict:
+    claim: dict[str, Any] = {
+        LIC_EDITION: edition,
+        LIC_STATUS: status,
+        LIC_ALL_FEATURES: all_features,
+        LIC_FEATURES: features if features is not None else [],
+        LIC_LIMITS: limits or {},
+    }
+    if custom_limits is not None:
+        claim[LIC_CUSTOM_LIMITS] = custom_limits
+    return claim
+
+
+def _payload(sub: str = _VICTIM_ORG, exp_offset: int = 3600, **claim_kwargs) -> dict:
+    now = int(time.time())
+    return {
+        CLAIM_ISSUER: LICENSE_ISSUER,
+        CLAIM_AUDIENCE: LICENSE_AUDIENCE,
+        CLAIM_SUBJECT: sub,
+        CLAIM_ISSUED_AT: now,
+        CLAIM_EXPIRY: now + exp_offset,
+        CLAIM_JWT_ID: "loophole-test",
+        CLAIM_LICENSE: _lic_claim(**claim_kwargs),
+    }
+
+
+def _b64url(raw: bytes) -> str:
+    """Base64url with padding stripped, as JWT requires."""
+    import base64
+
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _hs256_token(payload: dict, secret: bytes) -> str:
+    """Hand-build an HS256 JWT, bypassing PyJWT's encode-side key guard."""
+    import hashlib
+    import hmac
+    import json
+
+    signing_input = ".".join(
+        (
+            _b64url(json.dumps({"alg": "HS256", "typ": "JWT"}).encode()),
+            _b64url(json.dumps(payload).encode()),
+        )
+    )
+    signature = hmac.new(secret, signing_input.encode(), hashlib.sha256).digest()
+    return f"{signing_input}.{_b64url(signature)}"
+
+
+@pytest.fixture
+def attacker_key():
+    """A keypair we never registered as trusted -- stands in for any key a
+    customer could generate themselves."""
+    return Ed25519PrivateKey.generate()
+
+
+@pytest.fixture
+def provider():
+    return SignedTokenLicenseProvider()
+
+
+@pytest.fixture
+def quota_provider():
+    return ConfigQuotaProvider()
+
+
+@pytest.fixture
+def licensed_registry():
+    """Install the real EE license provider so quota resolution reads real tokens."""
+    saved = FeatureRegistry._license
+    FeatureRegistry.set_license_provider(SignedTokenLicenseProvider())
+    yield
+    FeatureRegistry._license = saved
+
+
+@pytest.fixture(autouse=True)
+def _no_env_license():
+    """Neutralize RHESIS_LICENSE for every test here.
+
+    A blanket env token grants its tier to *every* org, so leaving one set would
+    mask exactly the per-org checks these tests exist to exercise.
+    """
+    with patch.dict("os.environ", {"RHESIS_LICENSE": ""}):
+        yield
+
+
+def _limits_for(quota_provider, org) -> dict:
+    return quota_provider.get_policy(org).limits
+
+
+# ---------------------------------------------------------------------------
+# 1. Tokens we did not sign
+# ---------------------------------------------------------------------------
+
+
+class TestForgedTokens:
+    """Escalation attempt: mint your own enterprise license.
+
+    Each token here claims ``edition: enterprise`` with ``all_features``. All of
+    them must resolve to no features and community limits.
+    """
+
+    def _assert_rejected(self, token, provider, quota_provider):
+        org = _make_org(license_token=token)
+        assert verify_token(token) is None
+        assert provider.allows_feature(_SSO, org) is False
+        assert provider.info(org) == {"edition": "community", "licensed": False}
+        assert _limits_for(quota_provider, org) == _COMMUNITY_LIMITS
+
+    def test_unsigned_alg_none_token_is_rejected(self, provider, quota_provider):
+        """The classic: strip the signature and set ``alg: none``.
+
+        Blocked because ``jwt.decode`` pins ``algorithms=["EdDSA"]``.
+        """
+        token = jwt.encode(_payload(), key="", algorithm="none")
+        self._assert_rejected(token, provider, quota_provider)
+
+    def test_hmac_algorithm_confusion_is_rejected(self, ed25519_keypair, provider, quota_provider):
+        """Algorithm confusion: re-sign with HS256 using the *public* key as the
+        HMAC secret.
+
+        The public key is not secret, so against a verifier that trusts the
+        token's own ``alg`` header this forges anything. Built by hand rather
+        than with ``jwt.encode``, which refuses an asymmetric key as an HMAC
+        secret -- that guard protects our own signing code, not us from an
+        attacker who is not using PyJWT.
+        """
+        _, public_key = ed25519_keypair
+        secret = public_key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
+        token = _hs256_token(_payload(), secret)
+        self._assert_rejected(token, provider, quota_provider)
+
+    def test_token_signed_by_an_untrusted_key_is_rejected(
+        self, attacker_key, provider, quota_provider
+    ):
+        """Correct algorithm, correct claim shape, wrong signing key."""
+        token = jwt.encode(_payload(), key=attacker_key, algorithm="EdDSA")
+        self._assert_rejected(token, provider, quota_provider)
+
+    def test_forged_token_with_a_trusted_kid_is_rejected(
+        self, attacker_key, provider, quota_provider
+    ):
+        """Claiming a trusted ``kid`` must not select a key that then verifies a
+        signature made with a different one. ``kid`` picks the candidate key; it
+        never substitutes for the signature check.
+        """
+        token = jwt.encode(
+            _payload(), key=attacker_key, algorithm="EdDSA", headers={"kid": "test-v1"}
+        )
+        self._assert_rejected(token, provider, quota_provider)
+
+    def test_tampered_payload_with_a_valid_signature_is_rejected(
+        self, mint_token, provider, quota_provider
+    ):
+        """Swap the payload of a legitimately signed community token for an
+        enterprise one, keeping the original signature."""
+        import base64
+        import json
+
+        legit = mint_token(sub=_VICTIM_ORG, edition="community", all_features=False)
+        header_b64, _payload_b64, signature_b64 = legit.split(".")
+
+        def _b64(raw: bytes) -> str:
+            return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+        forged_payload = _b64(json.dumps(_payload()).encode())
+        token = f"{header_b64}.{forged_payload}.{signature_b64}"
+        self._assert_rejected(token, provider, quota_provider)
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {CLAIM_ISSUER: "attacker-issuer"},
+            {CLAIM_AUDIENCE: "attacker-audience"},
+        ],
+        ids=["wrong-issuer", "wrong-audience"],
+    )
+    def test_wrong_issuer_or_audience_is_rejected(
+        self, ed25519_keypair, provider, quota_provider, overrides
+    ):
+        """Even signed by the real key, a token issued for something else must
+        not be accepted here."""
+        private_key, _ = ed25519_keypair
+        payload = {**_payload(), **overrides}
+        token = jwt.encode(payload, key=private_key, algorithm="EdDSA", headers={"kid": "test-v1"})
+        self._assert_rejected(token, provider, quota_provider)
+
+    @pytest.mark.parametrize("drop", [CLAIM_SUBJECT, CLAIM_EXPIRY], ids=["no-sub", "no-exp"])
+    def test_missing_required_claims_are_rejected(
+        self, ed25519_keypair, provider, quota_provider, drop
+    ):
+        """A token with no ``sub`` would otherwise have nothing to bind it to an
+        org; one with no ``exp`` would never expire."""
+        private_key, _ = ed25519_keypair
+        payload = {k: v for k, v in _payload().items() if k != drop}
+        token = jwt.encode(payload, key=private_key, algorithm="EdDSA", headers={"kid": "test-v1"})
+        self._assert_rejected(token, provider, quota_provider)
+
+
+# ---------------------------------------------------------------------------
+# 2. Replaying tokens we did sign, for someone else
+# ---------------------------------------------------------------------------
+
+
+class TestTokenReplay:
+    """Escalation attempt: obtain a real enterprise token and use it as your own."""
+
+    def test_another_orgs_token_does_not_apply_to_you(
+        self, mint_token, provider, quota_provider, licensed_registry
+    ):
+        token = mint_token(sub=_OTHER_ORG, edition="enterprise")
+        org = _make_org(_VICTIM_ORG, license_token=token)
+
+        # The token itself is perfectly valid -- it just is not ours.
+        assert verify_token(token) is not None
+        assert provider.allows_feature(_SSO, org) is False
+        assert _limits_for(quota_provider, org) == _COMMUNITY_LIMITS
+
+    def test_blanket_token_in_the_org_column_does_not_apply(
+        self, mint_token, provider, quota_provider, licensed_registry
+    ):
+        """A blanket ``sub:"*"`` license is an operator-level, single-tenant
+        deployment mechanism, honoured only from the ``RHESIS_LICENSE`` env var.
+
+        If the org column accepted it too, any customer who ever saw a blanket
+        token (a self-hosted licensee, say) could paste it into a cloud tenant
+        and self-upgrade. The column path requires ``sub == org.id``, and ``"*"``
+        is not a UUID.
+        """
+        token = mint_token(sub="*", edition="enterprise")
+        org = _make_org(_VICTIM_ORG, license_token=token)
+
+        assert verify_token(token) is not None
+        assert provider.allows_feature(_SSO, org) is False
+        assert _limits_for(quota_provider, org) == _COMMUNITY_LIMITS
+
+    def test_expired_enterprise_token_gives_community_quota(
+        self, mint_token, quota_provider, licensed_registry
+    ):
+        token = mint_token(sub=_VICTIM_ORG, edition="enterprise", exp=int(time.time()) - 3600)
+        org = _make_org(license_token=token)
+        assert _limits_for(quota_provider, org) == _COMMUNITY_LIMITS
+
+    @pytest.mark.parametrize("status", ["canceled", "unknown", "not-a-status"])
+    def test_revoked_license_gives_community_quota_not_its_old_tier(
+        self, mint_token, quota_provider, licensed_registry, status
+    ):
+        """Stopping payment must stop the allowance.
+
+        ``info()`` deliberately keeps reporting the lapsed edition so the UI can
+        name what expired, which makes it tempting to resolve limits from that
+        name -- and that left a canceled enterprise org on unlimited quota
+        indefinitely.
+        """
+        token = mint_token(sub=_VICTIM_ORG, edition="enterprise", status=status)
+        org = _make_org(license_token=token)
+        limits = _limits_for(quota_provider, org)
+
+        assert limits == _COMMUNITY_LIMITS
+        assert limits != _ENTERPRISE_LIMITS
+        assert limits[QuotaResource.TEST_EXECUTIONS] is not None
+
+
+# ---------------------------------------------------------------------------
+# 3. Tier escalation through claim values
+# ---------------------------------------------------------------------------
+
+
+class TestEditionEscalation:
+    """Escalation attempt: name a tier that resolves to more than it should.
+
+    These all require our signing key, so they are defense-in-depth against a
+    minting mistake rather than a customer-reachable attack. They matter because
+    the failure mode is silent and generous.
+    """
+
+    @pytest.mark.parametrize(
+        "edition",
+        ["ENTERPRISE", "Enterprise", " enterprise", "enterprise ", "unknown", "", "nope"],
+    )
+    def test_unrecognized_edition_falls_back_to_community_not_unlimited(
+        self, mint_token, quota_provider, licensed_registry, edition
+    ):
+        """``LicenseEdition._missing_`` coerces anything unrecognized to
+        ``UNKNOWN``, which must resolve to community limits.
+
+        The dangerous alternative is an empty limits dict: every consumer reads a
+        missing resource as *unlimited*, so a typo'd edition would hand out
+        unmetered access rather than the free tier.
+        """
+        token = mint_token(sub=_VICTIM_ORG, edition=edition, all_features=False)
+        org = _make_org(license_token=token)
+        limits = _limits_for(quota_provider, org)
+
+        assert limits == _COMMUNITY_LIMITS
+        assert all(limits[r] is not None for r in (QuotaResource.TEST_EXECUTIONS,))
+
+    def test_unknown_edition_never_resolves_to_the_internal_master_tier(
+        self, mint_token, quota_provider, licensed_registry
+    ):
+        """``master`` is an internal all-features, all-unlimited tier. No
+        fallback path may land on it."""
+        token = mint_token(sub=_VICTIM_ORG, edition="mastr", all_features=False)
+        org = _make_org(license_token=token)
+        assert _limits_for(quota_provider, org) != resolve_tier(LicenseEdition.MASTER).limits
+
+    def test_missing_edition_claim_falls_back_to_community(
+        self, ed25519_keypair, quota_provider, licensed_registry
+    ):
+        private_key, _ = ed25519_keypair
+        payload = _payload(all_features=False)
+        del payload[CLAIM_LICENSE][LIC_EDITION]
+        token = jwt.encode(payload, key=private_key, algorithm="EdDSA", headers={"kid": "test-v1"})
+        org = _make_org(license_token=token)
+        assert _limits_for(quota_provider, org) == _COMMUNITY_LIMITS
+
+
+class TestFeatureClaimCoercion:
+    """Escalation attempt: get ``allows_feature`` to say yes without a grant."""
+
+    @pytest.mark.parametrize(
+        "all_features",
+        [False, None, 0, "", "false", "no", "0", [], {}],
+        ids=[
+            "false",
+            "none",
+            "zero",
+            "empty-string",
+            "string-false",
+            "string-no",
+            "string-zero",
+            "empty-list",
+            "empty-dict",
+        ],
+    )
+    def test_only_a_real_true_unlocks_every_feature(self, mint_token, provider, all_features):
+        """``all_features`` is a blanket grant over every registered EE feature,
+        so it must be read strictly.
+
+        ``bool("false")`` is ``True`` in Python, so a plain ``bool()`` coercion
+        turns the *string* ``"false"`` into a full grant -- the exact trap the
+        tier-YAML loader already guards against in ``_parse_all_features``. This
+        pins the token side to the same standard: only a literal JSON ``true``
+        counts.
+        """
+        token = mint_token(sub=_VICTIM_ORG, edition="team", all_features=all_features, features=[])
+        org = _make_org(license_token=token)
+        assert provider.allows_feature(_SSO, org) is False
+
+    def test_a_real_true_still_unlocks_features(self, mint_token, provider):
+        """The guard above must not break the legitimate grant."""
+        token = mint_token(sub=_VICTIM_ORG, edition="enterprise", all_features=True)
+        org = _make_org(license_token=token)
+        assert provider.allows_feature(_SSO, org) is True
+
+    @pytest.mark.parametrize(
+        "features",
+        ["sso", {"sso": True}, None],
+        ids=["bare-string", "dict", "null"],
+    )
+    def test_a_malformed_feature_list_grants_nothing(self, mint_token, provider, features):
+        """A bare string would iterate per character, and a dict per key. Neither
+        should accidentally yield a grant, and neither should raise."""
+        token = mint_token(sub=_VICTIM_ORG, edition="team", all_features=False, features=features)
+        org = _make_org(license_token=token)
+        assert provider.allows_feature(_SSO, org) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. Quota escalation through the custom_limits overlay
+# ---------------------------------------------------------------------------
+
+
+class TestCustomLimitEscalation:
+    """Escalation attempt: use the bespoke-limits overlay to unmeter yourself.
+
+    The overlay exists so a negotiated enterprise cap can be enforced. The risk
+    it introduces is the opposite of its purpose: an override that fails to
+    parse must not become "no limit".
+    """
+
+    @pytest.mark.parametrize(
+        "junk",
+        [
+            {"test_executions": "unlimited"},
+            {"test_executions": True},
+            {"test_executions": -1},
+            {"not_a_resource": 999},
+            {"test_executions": 1.5},
+            "not-a-mapping",
+            [],
+        ],
+        ids=[
+            "string",
+            "bool",
+            "negative",
+            "unknown-key",
+            "float",
+            "non-mapping",
+            "list",
+        ],
+    )
+    def test_an_unparseable_override_keeps_the_tier_limit(
+        self, mint_token, quota_provider, licensed_registry, junk
+    ):
+        """Falls back to the tier's own number, never to ``None``.
+
+        ``None`` means unlimited to every consumer, so "we could not read the
+        override" must not be spelled the same way as "this org has no ceiling".
+        """
+        token = mint_token(sub=_VICTIM_ORG, edition="team", custom_limits=junk)
+        org = _make_org(license_token=token)
+        limits = _limits_for(quota_provider, org)
+
+        assert limits == resolve_tier(LicenseEdition.TEAM).limits
+        assert limits[QuotaResource.TEST_EXECUTIONS] is not None
+
+    def test_a_malformed_override_does_not_cost_the_org_its_license(
+        self, mint_token, provider, licensed_registry
+    ):
+        """The other direction of the same failure: a non-mapping claim used to
+        raise inside entitlement parsing, rejecting the whole token and silently
+        demoting a paying enterprise org to community."""
+        token = mint_token(sub=_VICTIM_ORG, edition="enterprise", custom_limits="not-a-mapping")
+        org = _make_org(license_token=token)
+
+        assert provider.allows_feature(_SSO, org) is True
+        assert provider.info(org)["edition"] == "enterprise"
+
+    def test_another_orgs_override_does_not_apply_to_you(
+        self, mint_token, quota_provider, licensed_registry
+    ):
+        token = mint_token(
+            sub=_OTHER_ORG,
+            edition="enterprise",
+            custom_limits={"test_executions": 10_000_000},
+        )
+        org = _make_org(_VICTIM_ORG, license_token=token)
+        assert _limits_for(quota_provider, org) == _COMMUNITY_LIMITS
+
+    def test_an_override_on_a_revoked_license_does_not_apply(
+        self, mint_token, quota_provider, licensed_registry
+    ):
+        """A canceled license must not keep its bespoke allowances."""
+        token = mint_token(
+            sub=_VICTIM_ORG,
+            edition="enterprise",
+            status="canceled",
+            custom_limits={"test_executions": 10_000_000},
+        )
+        org = _make_org(license_token=token)
+        limits = _limits_for(quota_provider, org)
+
+        assert limits == _COMMUNITY_LIMITS
+        assert (
+            limits[QuotaResource.TEST_EXECUTIONS]
+            == _COMMUNITY_LIMITS[QuotaResource.TEST_EXECUTIONS]
+        )
+
+    def test_the_mint_time_snapshot_cannot_raise_a_limit(
+        self, mint_token, quota_provider, licensed_registry
+    ):
+        """``lic.limits`` is an audit snapshot and must never be enforced.
+
+        If it were, a token minted under older, more generous pricing would keep
+        overriding the catalog for good -- and a published limit *reduction*
+        would silently miss every existing customer.
+        """
+        inflated = {r.value: 10_000_000 for r in QuotaResource}
+        token = mint_token(sub=_VICTIM_ORG, edition="team", limits=inflated)
+        org = _make_org(license_token=token)
+
+        assert _limits_for(quota_provider, org) == resolve_tier(LicenseEdition.TEAM).limits
+
+    def test_an_override_cannot_change_the_overage_policy(
+        self, mint_token, quota_provider, licensed_registry
+    ):
+        """Community is a hard block at the limit. An override must not turn that
+        into a soft tier with a grace band on top of the free allowance."""
+        token = mint_token(
+            sub=_VICTIM_ORG, edition="community", custom_limits={"test_executions": 500}
+        )
+        org = _make_org(license_token=token)
+        policy = quota_provider.get_policy(org)
+
+        # Unlicensed/community resolution ignores the token entirely, so the
+        # community hard policy stands and the ceiling equals the limit.
+        assert policy.ceiling_for(500) == 500
+
+
+# ---------------------------------------------------------------------------
+# 5. Ways to end up unlimited without a license at all
+# ---------------------------------------------------------------------------
+
+
+class TestNoLicenseIsNeverUnlimited:
+    """The fail-open cases. Each asserts a *finite* free-tier ceiling."""
+
+    @pytest.mark.parametrize(
+        "license_value",
+        [None, "", "   ", "not-a-jwt", "a.b.c", "null", "{}"],
+        ids=["none", "empty", "whitespace", "garbage", "three-parts", "null", "braces"],
+    )
+    def test_absent_or_junk_license_resolves_to_finite_community_limits(
+        self, quota_provider, licensed_registry, license_value
+    ):
+        org = _make_org(license_token=license_value)
+        limits = _limits_for(quota_provider, org)
+
+        assert limits == _COMMUNITY_LIMITS
+        for resource in (
+            QuotaResource.TEST_EXECUTIONS,
+            QuotaResource.TRACING_SPANS,
+            QuotaResource.SEATS,
+        ):
+            assert limits[resource] is not None, f"{resource.value} must be metered"
+
+    def test_no_public_keys_fails_closed(self, mint_token, provider, quota_provider):
+        """If key loading breaks, verification must deny rather than skip.
+
+        A verifier that treats "no keys" as "nothing to check" would hand every
+        org whatever its token claims.
+        """
+        token = mint_token(sub=_VICTIM_ORG, edition="enterprise")
+        org = _make_org(license_token=token)
+
+        _parse_token.cache_clear()
+        with patch("rhesis.backend.ee.licensing.verify.get_public_keys", return_value={}):
+            assert verify_token(token) is None
+            assert provider.allows_feature(_SSO, org) is False
+            assert _limits_for(quota_provider, org) == _COMMUNITY_LIMITS
+        _parse_token.cache_clear()
+
+
+class TestLicenseColumnIsNotClientWritable:
+    """The assumption the whole threat model rests on.
+
+    Every test above assumes a customer cannot install a token of their choosing.
+    That holds only because ``license`` is absent from the Organization request
+    schemas. Adding it -- easy to do by widening a base schema -- would let a
+    customer install any token they have seen, so it is asserted rather than
+    trusted.
+    """
+
+    def test_license_is_not_an_accepted_organization_input_field(self):
+        from rhesis.backend.app import schemas
+
+        for schema_name in ("OrganizationCreate", "OrganizationUpdate", "OrganizationBase"):
+            schema = getattr(schemas, schema_name, None)
+            if schema is None:
+                continue
+            assert "license" not in schema.model_fields, (
+                f"{schema_name} accepts a client-supplied 'license'. That lets an "
+                f"organization install its own license token and pick its own tier."
+            )

--- a/tests/backend/ee/licensing/test_mint.py
+++ b/tests/backend/ee/licensing/test_mint.py
@@ -212,7 +212,7 @@ class TestMintTokenOverrides:
         assert ent.allows("sso") is True
         assert ent.allows("api_clients") is True
 
-    def test_custom_limits_merge_with_tier_defaults(self, private_key_env):
+    def test_custom_limits_land_in_their_own_claim(self, private_key_env):
         from rhesis.backend.ee.licensing.mint import mint_token
 
         ent = verify_token(
@@ -224,22 +224,43 @@ class TestMintTokenOverrides:
             )
         )
         assert ent is not None
-        assert ent.limits["seats"] == 200
-        assert ent.limits["extra_quota"] == 50
+        assert ent.custom_limits["seats"] == 200
+        assert ent.custom_limits["extra_quota"] == 50
 
-    def test_custom_limits_override_tier_seat_count(self, private_key_env):
+    def test_custom_limits_leave_the_tier_snapshot_alone(self, private_key_env):
+        """The ``limits`` snapshot must keep reporting the tier, not the override.
+
+        The two claims answer different questions -- "what did this tier look
+        like when minted" vs "what was negotiated for this org" -- and only the
+        second is enforced. Merging the override into the snapshot is what would
+        make a bespoke cap indistinguishable from the tier's own number, and pin
+        the org to its mint-time limits for every other resource.
+        """
         from rhesis.backend.ee.licensing.mint import mint_token
+        from rhesis.backend.ee.licensing.tiers import resolve_tier
+
+        seats = str(QuotaResource.SEATS)
+        tier_seats = resolve_tier(LicenseEdition.TEAM).limits[QuotaResource.SEATS]
 
         ent = verify_token(
             mint_token(
                 self.ORG_ID,
                 LicenseEdition.TEAM,
                 kid="test-v1",
-                custom_limits={str(QuotaResource.SEATS): 99},
+                custom_limits={seats: 99},
             )
         )
         assert ent is not None
-        assert ent.limits[str(QuotaResource.SEATS)] == 99
+        assert ent.custom_limits[seats] == 99
+        assert ent.limits[seats] == tier_seats
+
+    def test_no_custom_limits_means_an_empty_override_map(self, private_key_env):
+        """Absent is the common case and must not read as "capped at nothing"."""
+        from rhesis.backend.ee.licensing.mint import mint_token
+
+        ent = verify_token(mint_token(self.ORG_ID, LicenseEdition.ENTERPRISE, kid="test-v1"))
+        assert ent is not None
+        assert dict(ent.custom_limits) == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/ee/licensing/test_quota_provider.py
+++ b/tests/backend/ee/licensing/test_quota_provider.py
@@ -1,0 +1,258 @@
+"""Unit tests for :class:`~rhesis.backend.ee.licensing.quota_provider.ConfigQuotaProvider`.
+
+Two things are under test here, and the second is the reason this file exists:
+
+1. The tier baseline — an org's edition resolves to its ``tier_config.yaml`` limits.
+2. The bespoke overlay — a license token's ``custom_limits`` claim overrides
+   individual resources on top of that baseline. This is what backs the pricing
+   page's "custom" enterprise limits, and it has to hold two properties that are
+   easy to break: an override must not leak into resources it does not name, and
+   the mint-time ``limits`` snapshot must never be treated as an override (which
+   would pin every org to the numbers its token was minted with).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from rhesis.backend.app.features import FeatureRegistry
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.ee.licensing.entitlements import LicenseEdition
+from rhesis.backend.ee.licensing.provider import SignedTokenLicenseProvider
+from rhesis.backend.ee.licensing.quota_provider import ConfigQuotaProvider
+from rhesis.backend.ee.licensing.tiers import resolve_limits, resolve_tier
+
+pytestmark = pytest.mark.skipif(
+    not pytest.importorskip(
+        "rhesis.backend.ee",
+        reason="EE package not installed",
+    ),
+    reason="EE package not installed",
+)
+
+_ORG_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+# Every resource the catalog meters, so a test can assert an override touched
+# exactly one of them and left the rest alone.
+_ALL_RESOURCES = tuple(QuotaResource)
+
+
+def _make_org(license_token: str | None = None) -> MagicMock:
+    org = MagicMock()
+    org.id = UUID(_ORG_UUID)
+    org.license = license_token
+    return org
+
+
+@pytest.fixture
+def provider():
+    return ConfigQuotaProvider()
+
+
+@pytest.fixture
+def licensed_registry():
+    """Install the real EE license provider, so info() comes from a real token.
+
+    The overlay is only meaningful end to end: the claim has to survive minting,
+    signature verification, and the provider's ``info()`` before the quota
+    provider ever sees it. Stubbing ``license_info`` would skip exactly the wiring
+    this file is here to cover.
+    """
+    saved = FeatureRegistry._license
+    FeatureRegistry.set_license_provider(SignedTokenLicenseProvider())
+    yield
+    FeatureRegistry._license = saved
+
+
+def _policy_for(provider, mint_token, licensed_registry, **mint_kwargs):
+    """Resolve a policy for an org holding a token minted with *mint_kwargs*."""
+    token = mint_token(sub=_ORG_UUID, **mint_kwargs)
+    org = _make_org(license_token=token)
+    with patch.dict("os.environ", {"RHESIS_LICENSE": ""}):
+        return provider.get_policy(org)
+
+
+class TestTierBaseline:
+    def test_unlicensed_org_gets_community_limits(self, provider):
+        """No token at all -- the free tier, not unlimited."""
+        org = _make_org(license_token=None)
+        with patch.dict("os.environ", {"RHESIS_LICENSE": ""}):
+            policy = provider.get_policy(org)
+        assert policy.limits == resolve_limits(LicenseEdition.COMMUNITY)
+
+    def test_no_org_gets_community_limits(self, provider):
+        assert provider.get_policy(None).limits == resolve_limits(LicenseEdition.COMMUNITY)
+
+    @pytest.mark.parametrize("edition", [LicenseEdition.TEAM, LicenseEdition.ENTERPRISE])
+    def test_licensed_org_gets_its_tier(self, provider, mint_token, licensed_registry, edition):
+        policy = _policy_for(provider, mint_token, licensed_registry, edition=edition.value)
+        assert policy.limits == resolve_tier(edition).limits
+
+    def test_enterprise_is_unlimited_without_an_override(
+        self, provider, mint_token, licensed_registry
+    ):
+        """The default enterprise posture, and what every already-minted
+        enterprise token keeps doing after this change."""
+        policy = _policy_for(provider, mint_token, licensed_registry, edition="enterprise")
+        assert all(policy.limits[r] is None for r in _ALL_RESOURCES)
+
+    @pytest.mark.parametrize("status", ["canceled", "bogus-status"])
+    def test_revoked_license_drops_to_community_limits(
+        self, provider, mint_token, licensed_registry, status
+    ):
+        """Billing status has to actually end the paid allowance.
+
+        ``info()`` still reports ``edition: enterprise`` for a revoked license so
+        the UI can name what expired. Resolving limits from that name alone left
+        a canceled enterprise org on unlimited quota indefinitely. An
+        unrecognized status counts as revoked, matching ``ACTIVE_STATUSES``.
+        """
+        policy = _policy_for(
+            provider,
+            mint_token,
+            licensed_registry,
+            edition="enterprise",
+            status=status,
+        )
+        assert policy.limits == resolve_limits(LicenseEdition.COMMUNITY)
+
+    def test_past_due_keeps_its_tier(self, provider, mint_token, licensed_registry):
+        """Deliberate, per ``ACTIVE_STATUSES``: a temporary payment problem must
+        not cut a paying customer off mid-work. Only an explicit cancellation
+        (or an unknown status) revokes the allowance."""
+        policy = _policy_for(
+            provider,
+            mint_token,
+            licensed_registry,
+            edition="team",
+            status="past_due",
+        )
+        assert policy.limits == resolve_tier(LicenseEdition.TEAM).limits
+
+
+class TestCustomLimitOverlay:
+    def test_override_caps_a_single_enterprise_resource(
+        self, provider, mint_token, licensed_registry
+    ):
+        """The "custom" enterprise case: one negotiated cap, everything else
+        still unlimited."""
+        policy = _policy_for(
+            provider,
+            mint_token,
+            licensed_registry,
+            edition="enterprise",
+            custom_limits={"test_executions": 500_000},
+        )
+        assert policy.limits[QuotaResource.TEST_EXECUTIONS] == 500_000
+        others = [r for r in _ALL_RESOURCES if r is not QuotaResource.TEST_EXECUTIONS]
+        assert all(policy.limits[r] is None for r in others)
+
+    def test_override_can_raise_a_team_limit(self, provider, mint_token, licensed_registry):
+        tier_seats = resolve_tier(LicenseEdition.TEAM).limits[QuotaResource.SEATS]
+        policy = _policy_for(
+            provider,
+            mint_token,
+            licensed_registry,
+            edition="team",
+            custom_limits={"test_executions": 5_000_000},
+        )
+        assert policy.limits[QuotaResource.TEST_EXECUTIONS] == 5_000_000
+        # Untouched resources still track the published tier.
+        assert policy.limits[QuotaResource.SEATS] == tier_seats
+        assert (
+            policy.limits[QuotaResource.TRACING_SPANS]
+            == resolve_tier(LicenseEdition.TEAM).limits[QuotaResource.TRACING_SPANS]
+        )
+
+    def test_explicit_null_override_means_unlimited(self, provider, mint_token, licensed_registry):
+        policy = _policy_for(
+            provider,
+            mint_token,
+            licensed_registry,
+            edition="team",
+            custom_limits={"test_executions": None},
+        )
+        assert policy.limits[QuotaResource.TEST_EXECUTIONS] is None
+
+    def test_override_preserves_the_tier_overage_policy(
+        self, provider, mint_token, licensed_registry
+    ):
+        """A negotiated cap changes the ceiling, not whether there is a grace band."""
+        tier = resolve_tier(LicenseEdition.TEAM)
+        policy = _policy_for(
+            provider,
+            mint_token,
+            licensed_registry,
+            edition="team",
+            custom_limits={"test_executions": 1_000},
+        )
+        assert policy.overage is tier.overage
+        assert policy.overage_tolerance_percent == tier.overage_tolerance_percent
+
+    def test_mint_time_limits_snapshot_is_never_an_override(
+        self, provider, mint_token, licensed_registry
+    ):
+        """The regression this design exists to prevent.
+
+        ``lic.limits`` is a snapshot of the tier as it stood at minting. If it
+        were enforced, a token minted under older pricing would keep overriding
+        the catalog forever, and every published limit change would silently
+        miss existing customers. Here the token claims numbers unlike the live
+        team tier; the live tier must win.
+        """
+        tier_limits = resolve_tier(LicenseEdition.TEAM).limits
+        stale = {r.value: 42 for r in _ALL_RESOURCES}
+
+        policy = _policy_for(
+            provider,
+            mint_token,
+            licensed_registry,
+            edition="team",
+            limits=stale,
+        )
+        assert policy.limits == tier_limits
+        assert 42 not in policy.limits.values()
+
+    @pytest.mark.parametrize(
+        "junk",
+        [
+            {"not_a_resource": 10},
+            {"seats": "many"},
+            {"seats": True},
+            {"seats": -1},
+            "not-a-mapping",
+        ],
+        ids=["unknown-key", "string", "bool", "negative", "non-mapping"],
+    )
+    def test_unreadable_override_falls_back_to_the_tier(
+        self, provider, mint_token, licensed_registry, junk
+    ):
+        """A token is signed, not schema-checked, and is read on the request
+        path -- so junk is dropped and the tier applies, rather than 500ing
+        every request for that org."""
+        policy = _policy_for(
+            provider,
+            mint_token,
+            licensed_registry,
+            edition="team",
+            custom_limits=junk,
+        )
+        assert policy.limits == resolve_tier(LicenseEdition.TEAM).limits
+
+    def test_override_is_ignored_for_an_inactive_license(
+        self, provider, mint_token, licensed_registry
+    ):
+        """A canceled license falls back to community, and must not carry its
+        bespoke enterprise allowances along with it."""
+        policy = _policy_for(
+            provider,
+            mint_token,
+            licensed_registry,
+            edition="enterprise",
+            status="canceled",
+            custom_limits={"test_executions": 5_000_000},
+        )
+        assert policy.limits == resolve_limits(LicenseEdition.COMMUNITY)

--- a/tests/backend/ee/licensing/test_tiers.py
+++ b/tests/backend/ee/licensing/test_tiers.py
@@ -105,6 +105,71 @@ class TestCatalogShape:
         import EE), so drift between them would only show up here."""
         assert bundled_catalog[LicenseEdition.COMMUNITY].limits == FREE_TIER_LIMITS
 
+    def test_published_limits_match_the_pricing_page(self, bundled_catalog):
+        """These numbers are advertised publicly, so they are a promise, not a default.
+
+        Pinned as literals here and again in the website repo
+        (``src/data/pricing.test.ts``), deliberately duplicated across the two
+        repos because neither build can see the other. The pricing page presents
+        them as terms of service: a number published there but not enforced here
+        is a promise we break, and a lower number enforced here than published
+        there blocks a customer at a ceiling they were never told about.
+
+        Change these together with ``src/data/pricing.ts`` -> ``PLAN_LIMITS``,
+        or not at all.
+        """
+        assert bundled_catalog[LicenseEdition.COMMUNITY].limits == {
+            QuotaResource.TEST_EXECUTIONS: 500,
+            QuotaResource.TRACING_SPANS: 50_000,
+            QuotaResource.TEST_GENERATION: 100,
+            QuotaResource.MODEL_TOKENS: 1_000_000,
+            QuotaResource.SEATS: 3,
+            QuotaResource.PROJECTS: 3,
+            QuotaResource.ENDPOINTS: 3,
+        }
+        assert bundled_catalog[LicenseEdition.COMMUNITY].retention_days == 14
+
+        assert bundled_catalog[LicenseEdition.TEAM].limits == {
+            QuotaResource.TEST_EXECUTIONS: 100_000,
+            QuotaResource.TRACING_SPANS: 1_000_000,
+            QuotaResource.TEST_GENERATION: 50_000,
+            QuotaResource.MODEL_TOKENS: 25_000_000,
+            QuotaResource.SEATS: None,
+            QuotaResource.PROJECTS: None,
+            QuotaResource.ENDPOINTS: None,
+        }
+        assert bundled_catalog[LicenseEdition.TEAM].retention_days == 90
+
+    def test_enterprise_publishes_custom_via_unlimited_defaults(self, bundled_catalog):
+        """The page says "custom" for enterprise, which is the absence of a
+        catalog number, not a number of its own.
+
+        A negotiated cap is minted per-org into the token's ``custom_limits``
+        claim and overlaid on this tier (see ``quota_provider.py``). Putting a
+        finite default here instead would silently cap every enterprise customer
+        at whatever one contract happened to negotiate.
+        """
+        limits = bundled_catalog[LicenseEdition.ENTERPRISE].limits
+        assert set(limits) == set(QuotaResource)
+        assert all(value is None for value in limits.values())
+
+    def test_no_tier_advertises_less_than_the_free_tier(self, bundled_catalog):
+        """Team must never get a smaller allowance than community. Mirrors the
+        website's own "never advertises a smaller allowance on a bigger plan"
+        check, so an edit that inverts two tiers fails on this side too."""
+        free = bundled_catalog[LicenseEdition.COMMUNITY].limits
+        team = bundled_catalog[LicenseEdition.TEAM].limits
+        for resource in QuotaResource:
+            free_limit, team_limit = free[resource], team[resource]
+            if team_limit is None:
+                continue  # unlimited beats any finite free-tier number
+            assert free_limit is not None, (
+                f"{resource.value}: free is unlimited but team is capped at {team_limit}"
+            )
+            assert team_limit > free_limit, (
+                f"{resource.value}: team ({team_limit}) must exceed free ({free_limit})"
+            )
+
     def test_limit_keys_are_quota_resources(self):
         """All limit keys in every tier spec are QuotaResource members."""
         for edition, spec in EDITION_ENTITLEMENTS.items():

--- a/tests/backend/routes/test_usage.py
+++ b/tests/backend/routes/test_usage.py
@@ -28,9 +28,14 @@ class TestUsageEndpoint:
         response = authenticated_client.get("/usage")
         body = response.json()
 
-        assert set(body.keys()) == {"resources", "edition"}
+        assert set(body.keys()) == {"resources", "edition", "licensed"}
         assert isinstance(body["resources"], dict)
         assert isinstance(body["edition"], str)
+        # Reported separately from `edition`, which keeps naming a lapsed tier.
+        # The frontend gates its upgrade affordances on this, so a client can
+        # tell "free org" from "paid org whose licence expired" -- the latter is
+        # held to community limits while still reporting its old edition.
+        assert isinstance(body["licensed"], bool)
 
     def test_includes_every_quota_resource(self, authenticated_client: TestClient):
         response = authenticated_client.get("/usage")


### PR DESCRIPTION
Makes backend quota enforcement match what the pricing page publishes, since
those numbers become terms of service. Pairs with
[website#94](https://github.com/rhesis-ai/website/pull/94).

## Three limits did not match

Enforcement is live (`usageQuotasEnabled: true` in dev/stg/prd, no
`RHESIS_TIER_CONFIG` override in the charts, so the bundled catalog is what
runs), which made these a promise we were not keeping:

| | enforced before | published, now enforced |
|---|---|---|
| free `model_tokens` | 5,000,000 | **1,000,000** |
| team `tracing_spans` | 5,000,000 | **1,000,000** |
| team `model_tokens` | 250,000,000 | **25,000,000** |

The other 13 values already agreed. Both published tiers are now pinned as
literals, mirroring the website's own pinned test, plus a check that team never
gets a smaller allowance than free. Neither build can see the other, so the
duplication is deliberate: an edit on one side fails on both.

## "Custom" enterprise limits now have a mechanism

The page advertises "custom" for enterprise and nothing behind it worked.
`mint_token(custom_limits=...)` and the CLI's `--limits` wrote a claim into the
signed JWT that **no code ever read back** — `LicenseProvider.info()` returned
only `{edition, licensed}`, so a negotiated cap was signed and discarded.

Adds a dedicated `custom_limits` claim, overlaid per-resource on the tier
catalog by `ConfigQuotaProvider`.

It has to be a *new* claim, not the existing `limits`, because that one is a
full snapshot of the tier as of minting. Enforcing it would pin every org to its
mint-time numbers and silently ignore later published changes — a team token
minted today carries the old 250,000,000 and would have overridden the catalog
for good. `limits` stays audit-only.

Both consequences of the per-key merge are deliberate:

- **Absent means unlimited, not zero.** A resource the token does not name keeps
  its catalog limit, which for enterprise is `null`. **Every enterprise license
  already minted keeps behaving exactly as before — nothing to re-mint.**
- **The catalog stays live.** Only negotiated resources are pinned, so a
  published tier change still reaches existing customers.

## Four bugs found along the way

1. **A canceled license kept its old tier's limits** — a lapsed enterprise org
   stayed on unlimited quota indefinitely. `info()` still reports the lapsed
   edition for the UI, but quota resolution now requires an active license.
   `past_due` keeps its tier, per `ACTIVE_STATUSES`.
2. **A malformed limits claim cost an org its whole license** — a non-mapping
   value raised inside entitlement parsing, rejecting the token and demoting a
   paying org to community, losing every EE feature over one bad field.
3. **`all_features` was read with `bool()`, and `bool("false")` is `True`** — a
   token claiming `all_features: "false"` unlocked every EE feature. The
   tier-YAML loader already guards this exact trap in `_parse_all_features`; the
   token side, the more exposed of the two, did not.
4. **A `{"sso": true}` features claim iterated its keys**, producing a real `sso`
   grant from something that was never a feature list.

3 and 4 need our signing key, so neither is customer-reachable — but both fail
silently in the customer's favour, which is the wrong direction for the claims
that decide entitlement.

## Adversarial test suite

`tests/backend/ee/licensing/test_licensing_loopholes.py`, 58 tests, each naming
the escalation it attempts so a failure reads as "this attack now works":

- **Forged tokens** — `alg:none`, HS256 confusion using the public key as the
  HMAC secret (hand-built, since PyJWT refuses to *encode* that), untrusted
  signing key, tampered payload with a valid signature, forged token claiming a
  trusted `kid`, wrong `iss`/`aud`, missing `sub`/`exp`.
- **Replay** — another org's enterprise token; a blanket `sub:"*"` token pasted
  into the org column (honored only from env, so a self-hosted licensee cannot
  self-upgrade a cloud tenant); expired; revoked.
- **Edition escalation** — `"ENTERPRISE"`, `" enterprise"`, `""`, junk all land
  on community, never on an empty limits dict that every consumer reads as
  *unlimited*, and never on the internal `master` tier.
- **Quota escalation** — no unparseable `custom_limits` value becomes
  `None`/unlimited; the mint-time snapshot cannot raise a ceiling; an override
  on a revoked license does not apply.
- **Fail-open surfaces** — absent/empty/garbage license and zero public keys all
  give finite community limits.

It also asserts `license` is absent from the Organization request schemas. The
threat model rests on a customer being unable to install a token of their
choosing, and widening a base schema would quietly hand them that.

## Frontend: the lapsed-licence gap this opened

Making a canceled licence resolve to community limits exposed a hole on the
client. Every upgrade affordance was gated on `isCommunityEdition(edition)`, in
five places — but a lapsed enterprise org reports `edition: "enterprise"` while
being held to free-tier ceilings. It would hit 402s at 500 test runs looking
like an Enterprise customer, so the upgrade link, the banner CTA and the
`canUpgrade` recourse copy were all withheld, at the one moment the reader most
needs to be told what to do.

`edition` alone cannot answer "should this org be offered an upgrade", so:

- **`GET /usage` now reports `licensed`** alongside `edition`. The value was
  already computed there; only half of it was being passed on.
- **`isUnlicensedPlan(edition, licensed)`** replaces the edition-string check at
  the four upgrade gates. It requires a positive `false`, so a loading provider
  (`null`) or a backend predating the field (`undefined`) shows nothing rather
  than prompting a paying customer. An earlier version keyed on `=== null` and
  let `undefined` through — the tests caught it.
- **`PlanChip` marks a lapsed paid plan "inactive"** instead of rendering it as
  though still in force. A plain "enterprise" pill beside free-tier numbers is
  what left an admin unable to explain why their ceilings dropped. Community is
  never marked inactive — it never held a licence to lose.
- **`UPGRADE_URL` → `rhesis.ai/pricing`**, the page these limits are published
  on. `/editions` 301s there, but an upgrade prompt is the wrong place to spend
  a redirect. (Depends on website#94 for the destination; harmless before it.)

Nothing was needed for the limit changes themselves — the frontend reads limits
from the API, and `ceiling` derives from the resolved policy, so the
`custom_limits` overlay flows through on its own. The mixed enterprise state the
overlay makes newly reachable (one resource capped, the rest unlimited) already
rendered correctly.

## Frontend: current plan in the sidebar

A plan row above Star Rhesis, so the plan is visible without opening the org
menu, linking to the usage page. It holds no opinion about the plan itself —
naming the edition, marking a lapse and colouring paid apart from free are all
`PlanChip`'s job already. The layout mirrors the org-menu usage block in the
same file, so the two plan readouts are one pattern rather than two.

Row geometry moved into `NAV_CARD_ROW_SX` / `NAV_CARD_STATUS_ROW_SX`, with
`NavLinkItem` pointed at the same constants: the plan row and the link rows
stack in one card and their labels must sit on the same column, which typed
separately in two files drifts the moment one is nudged.

## Not addressed, flagged for a decision

- **A blanket `RHESIS_LICENSE` in cloud would grant every org that tier.** By
  design for single-tenant; there is no guard against it being set in a
  multi-tenant deployment. Worth a startup assertion if cloud should never have
  one.
- **`jti` revocation is not implemented.** Clearing `organization.license` works,
  but a leaked token stays valid until `exp` (default 365 days).

## Checks

**Backend** — 2097 tests pass across EE, quota and security suites (195 in
licensing alone). Ruff clean, no new lint errors. Community boundary intact:
core gains only `limits_from_wire` and `QuotaPolicy.with_limit_overrides`, no EE
imports.

**Frontend** — 221 tests pass across the quota, usage and navigation suites.
`tsc --noEmit` clean, eslint clean, and `scripts/check-hardcoded-styles.js`
clean on all changed files.

Each commit was verified to stand on its own, not just the final state: the
licence-status commit was checked out into a scratch worktree and typechecked
and tested there (142 passing) to prove it carries no forward reference to the
plan row that lands after it.

Not verified in a browser — the plan row's divider and chip weight are
judgement calls worth eyeballing before merge.

## Terms re-consent

`CURRENT_TERMS_VERSION` goes 1.0 → 2.0, so everyone is prompted to accept
again. A major bump because the commercial SaaS terms are a different document,
not an amendment: the preview terms said of themselves they would be replaced
once a commercial offering existed, and Free is now designated a Free Trial
Phase under Section 14 instead of being uncovered by any terms at all.

That reaches every pre-existing user, since the `b5c6d7e8f9a0` backfill wrote
1.0 for all of them. They see the gate's "Updated Terms" copy rather than
first-run copy, because `has_prior_acceptance` stays true — the frontend already
branches on it, so nothing there changes. A test pins that population
specifically, against the actual backfill baseline rather than an arbitrary old
version, so reverting the bump fails loudly instead of silently leaving everyone
un-prompted.

## Deploy order: website#94 goes live FIRST

**Corrected — this was stated the other way round earlier in this description,
and that was wrong.** The terms bump is what makes the order strict.

The consent dialog links to `rhesis.ai/terms-conditions`, a hub page. Until
website#94 is live, the only cloud document reachable from it is the *public
preview* terms. Deploying this PR first would prompt users to accept "2.0"
while the text they can actually read is 1.0 — an acceptance record pointing at
the wrong document, which is exactly what re-consent exists to avoid.

The limits go the other way and are safe in either order: with the page live
first it publishes 1M / 1M / 25M while the backend still allows the old, more
generous figures, so we honour more than we advertise until this deploys.

If this PR needs to land first for some other reason, the terms bump is its own
commit (`7e19fdff3`) and can be lifted onto a follow-up that ships after the
website. Nothing else here depends on it.

