### PR TITLE
Fix Java SDK execute test failing on a missing model credential

### DIFF
--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -66,6 +66,24 @@ x-java-backend-config: &java-backend-config
   QUICK_START: "true"
   BACKEND_ENV: local
   ENABLE_RHESIS_KEY: "true"
+  # Without these the backend is a misconfigured deployment: DEFAULT_EXECUTION_MODEL and
+  # DEFAULT_EVALUATION_MODEL both default to rhesis/rhesis, and the execute endpoint
+  # pre-flight-validates them by constructing the model, which RhesisLLM.__init__ refuses
+  # to do with no key. That surfaces as a 500 on testExecuteTestSet -- correctly, since a
+  # server that cannot build its own default model is a server error.
+  #
+  # The Java repo's own compose omits these too, and gets away with it only because it
+  # pins ghcr.io/rhesis-ai/backend:latest, which is rebuilt on v* tags and so predates
+  # the change that stopped swallowing the construction failure (#2643, post-v0.14.0).
+  # Running this checkout's backend is the whole point of this profile, so it has to be
+  # configured like a real deployment instead.
+  #
+  # Construction opens no connection and this profile runs no Celery worker, so the model
+  # is never actually invoked -- the key only has to exist. Base URL points at this
+  # backend rather than the public API so that if something ever does invoke it, the call
+  # fails locally instead of reaching production with a bogus token.
+  RHESIS_API_KEY: rh-local-token
+  RHESIS_BASE_URL: "http://localhost:8080"
 
 services:
   # ==========================================================================

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -79,11 +79,17 @@ x-java-backend-config: &java-backend-config
   # configured like a real deployment instead.
   #
   # Construction opens no connection and this profile runs no Celery worker, so the model
-  # is never actually invoked -- the key only has to exist. Base URL points at this
-  # backend rather than the public API so that if something ever does invoke it, the call
-  # fails locally instead of reaching production with a bogus token.
+  # is never actually invoked -- the key only has to exist.
+  #
+  # Base URL is a dead port rather than either plausible alternative. The default is
+  # https://api.rhesis.ai, so leaving it unset would send an accidental invocation to
+  # production with a bogus token. Pointing it at this backend is worse still: RhesisLLM
+  # posts to services/generate/content, which this backend serves, and that route resolves
+  # the generation model -- rhesis/rhesis again, at the same base URL. That is a closed
+  # loop, one HTTP hop per level, not a fast failure. Nothing listens on port 1, so an
+  # invocation dies on connection-refused instead.
   RHESIS_API_KEY: rh-local-token
-  RHESIS_BASE_URL: "http://localhost:8080"
+  RHESIS_BASE_URL: "http://127.0.0.1:1"
 
 services:
   # ==========================================================================


### PR DESCRIPTION
## What

`TestRunIntegrationTest.testExecuteTestSet` fails with a 500 in the `[Test] Java SDK` workflow. Adds `RHESIS_API_KEY` and `RHESIS_BASE_URL` to the `java` compose profile's backend.

## Why

`POST /test_sets/{id}/execute/{endpoint_id}` pre-flight-validates the evaluation and execution models by constructing them. Both default to `rhesis/rhesis`, and `RhesisLLM.__init__` raises `RHESIS_API_KEY is not set`. The backend could not build its own default model — the 500 is correct behaviour for that; the deployment is what was wrong.

The Java repo's own compose omits the key too, but pins `ghcr.io/rhesis-ai/backend:latest`, which is rebuilt only on `v*` tags. That image predates #2643 (post-v0.14.0), which stopped swallowing the construction failure and returning the bare provider string. Running *this checkout's* backend is the whole point of this profile, so it has to be configured like a real deployment.

Not caused by #2662 — this workflow has never passed (0 successes in 8 runs since it was added on 2026-08-31), failing identically on `main` and on unrelated branches.

## Verification

Brought the profile up locally and confirmed causality in the same container:

- key unset → `ensure_language_model('rhesis/rhesis')` raises the original `ValueError`
- key set → model constructs, and `POST /test_sets/{id}/execute/{endpoint_id}` returns **200** with a real submission payload
- zero occurrences of the error in backend logs

`RHESIS_BASE_URL` points at a dead port (127.0.0.1:1). Unset it defaults to `https://api.rhesis.ai`, sending an accidental invocation to production; pointing it at this backend instead creates a closed loop, since `RhesisLLM` posts to `services/generate/content`, which this backend serves and which re-resolves the same model. A dead port fails on connection-refused in 0.00s. Nothing invokes it today: construction opens no connection and the profile runs no Celery worker.

## Considered and rejected

Retyping the construction failure so the pre-flight validators return a 400 instead of a 500. Two existing tests defend the current behaviour deliberately (`test_validate_execution_model_generic_error`, `test_raises_when_construction_fails`), and the 400 copy — "check your model settings in the Models page" — would misdirect: the model that fails is the *deployment default*, which an API caller cannot fix. A 500 is right for a server misconfiguration, and it is already logged with a traceback and an `error_id`.

## Follow-ups (not in this PR)

- This check had never been green and `main` has no branch protection, so it carried no signal and #2662 merged straight past it. Staying advisory (not a required check) for now — decided. Its value from here is that green is the baseline, so a future red is a real signal rather than background noise.
- A backend startup *warning* when `DEFAULT_*_MODEL` cannot be constructed would surface any misconfigured deployment at boot rather than on first execute.

## Test plan

- [x] Verified locally end to end (see above)
- [ ] CI: `[Test] Java SDK` goes green — this PR is the first chance to confirm `testExecuteTestSet` asserts nothing beyond a 200

