### PR TITLE
Match loading skeletons to each page's real shape

### DIFF
--- a/apps/frontend/src/app/(protected)/insights/loading.tsx
+++ b/apps/frontend/src/app/(protected)/insights/loading.tsx
@@ -1,0 +1,7 @@
+import PageDashboardSkeleton from '@/components/loading/PageDashboardSkeleton';
+
+// Insights is a dashboard: filter bar, pass-rate summary, requirement
+// breakdown and per-requirement rows. Neither list shape fits it.
+export default function InsightsLoading() {
+  return <PageDashboardSkeleton actionCount={2} />;
+}

--- a/apps/frontend/src/app/(protected)/metrics/loading.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/loading.tsx
@@ -1,0 +1,7 @@
+import PageCardGridSkeleton from '@/components/loading/PageCardGridSkeleton';
+
+// metrics renders a grid of EntityCards, not a DataGrid, so the catch-all
+// table skeleton would be the wrong shape here.
+export default function MetricsLoading() {
+  return <PageCardGridSkeleton actionCount={1} />;
+}

--- a/apps/frontend/src/app/(protected)/models/loading.tsx
+++ b/apps/frontend/src/app/(protected)/models/loading.tsx
@@ -1,0 +1,7 @@
+import PageCardGridSkeleton from '@/components/loading/PageCardGridSkeleton';
+
+// models renders a grid of EntityCards, not a DataGrid, so the catch-all
+// table skeleton would be the wrong shape here.
+export default function ModelsLoading() {
+  return <PageCardGridSkeleton actionCount={2} />;
+}

--- a/apps/frontend/src/app/(protected)/organizations/settings/loading.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/settings/loading.tsx
@@ -1,6 +1,7 @@
 import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
 
-// Organization settings is a tabbed section page with no header FABs.
+// Organization settings is a tabbed section page with a 2-item breadcrumb
+// trail and no header FABs.
 export default function OrganizationSettingsLoading() {
-  return <PageDetailSkeleton actionCount={0} breadcrumbCount={0} />;
+  return <PageDetailSkeleton actionCount={0} breadcrumbCount={2} />;
 }

--- a/apps/frontend/src/app/(protected)/organizations/settings/loading.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/settings/loading.tsx
@@ -1,0 +1,6 @@
+import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
+
+// Organization settings is a tabbed section page with no header FABs.
+export default function OrganizationSettingsLoading() {
+  return <PageDetailSkeleton actionCount={0} breadcrumbCount={0} />;
+}

--- a/apps/frontend/src/app/(protected)/organizations/usage/loading.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/loading.tsx
@@ -1,6 +1,7 @@
 import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
 
-// Usage is a tabbed section page with no header FABs.
+// Usage is a tabbed section page with a 2-item breadcrumb trail and no
+// header FABs.
 export default function UsageLoading() {
-  return <PageDetailSkeleton actionCount={0} breadcrumbCount={0} />;
+  return <PageDetailSkeleton actionCount={0} breadcrumbCount={2} />;
 }

--- a/apps/frontend/src/app/(protected)/organizations/usage/loading.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/loading.tsx
@@ -1,0 +1,6 @@
+import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
+
+// Usage is a tabbed section page with no header FABs.
+export default function UsageLoading() {
+  return <PageDetailSkeleton actionCount={0} breadcrumbCount={0} />;
+}

--- a/apps/frontend/src/app/(protected)/playground/loading.tsx
+++ b/apps/frontend/src/app/(protected)/playground/loading.tsx
@@ -1,0 +1,16 @@
+import PageLoadingState from '@/components/common/PageLoadingState';
+import DelayedReveal from '@/components/loading/DelayedReveal';
+import SkeletonPageHeader from '@/components/loading/SkeletonPageHeader';
+
+// Playground is a chat interface, so its body has no predictable shape to
+// skeleton: a spinner is the honest placeholder there. It does render a
+// PageLayout header with two FABs though, unlike architect, so the header is
+// worth drawing.
+export default function PlaygroundLoading() {
+  return (
+    <DelayedReveal>
+      <SkeletonPageHeader actionCount={2} />
+      <PageLoadingState />
+    </DelayedReveal>
+  );
+}

--- a/apps/frontend/src/app/(protected)/projects/loading.tsx
+++ b/apps/frontend/src/app/(protected)/projects/loading.tsx
@@ -1,0 +1,7 @@
+import PageCardGridSkeleton from '@/components/loading/PageCardGridSkeleton';
+
+// projects renders a grid of EntityCards, not a DataGrid, so the catch-all
+// table skeleton would be the wrong shape here.
+export default function ProjectsLoading() {
+  return <PageCardGridSkeleton actionCount={1} />;
+}

--- a/apps/frontend/src/app/(protected)/requirements/loading.tsx
+++ b/apps/frontend/src/app/(protected)/requirements/loading.tsx
@@ -1,0 +1,7 @@
+import PageCardGridSkeleton from '@/components/loading/PageCardGridSkeleton';
+
+// requirements renders a grid of EntityCards, not a DataGrid, so the catch-all
+// table skeleton would be the wrong shape here.
+export default function RequirementsLoading() {
+  return <PageCardGridSkeleton actionCount={1} />;
+}

--- a/apps/frontend/src/app/(protected)/settings/loading.tsx
+++ b/apps/frontend/src/app/(protected)/settings/loading.tsx
@@ -1,9 +1,9 @@
 import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
 
-// Settings stacks section cards straight under the header: no tab bar,
-// no breadcrumbs and no header FABs.
+// Settings renders a 1-item breadcrumb trail and stacks section cards straight
+// under the header: no tab bar and no header FABs.
 export default function SettingsLoading() {
   return (
-    <PageDetailSkeleton actionCount={0} breadcrumbCount={0} showTabs={false} />
+    <PageDetailSkeleton actionCount={0} breadcrumbCount={1} showTabs={false} />
   );
 }

--- a/apps/frontend/src/app/(protected)/settings/loading.tsx
+++ b/apps/frontend/src/app/(protected)/settings/loading.tsx
@@ -1,0 +1,9 @@
+import PageDetailSkeleton from '@/components/loading/PageDetailSkeleton';
+
+// Settings stacks section cards straight under the header: no tab bar,
+// no breadcrumbs and no header FABs.
+export default function SettingsLoading() {
+  return (
+    <PageDetailSkeleton actionCount={0} breadcrumbCount={0} showTabs={false} />
+  );
+}

--- a/apps/frontend/src/app/(protected)/tools/loading.tsx
+++ b/apps/frontend/src/app/(protected)/tools/loading.tsx
@@ -1,7 +1,8 @@
 import PageCardGridSkeleton from '@/components/loading/PageCardGridSkeleton';
 
-// tools renders a grid of EntityCards, not a DataGrid, so the catch-all
-// table skeleton would be the wrong shape here.
+// tools renders a grid of EntityCards, not a DataGrid. It is also the one card
+// directory whose toolbar has no centred pill tabs, so the skeleton omits them
+// rather than showing tabs that vanish when content arrives.
 export default function ToolsLoading() {
-  return <PageCardGridSkeleton actionCount={1} />;
+  return <PageCardGridSkeleton actionCount={1} showTabs={false} />;
 }

--- a/apps/frontend/src/app/(protected)/tools/loading.tsx
+++ b/apps/frontend/src/app/(protected)/tools/loading.tsx
@@ -1,0 +1,7 @@
+import PageCardGridSkeleton from '@/components/loading/PageCardGridSkeleton';
+
+// tools renders a grid of EntityCards, not a DataGrid, so the catch-all
+// table skeleton would be the wrong shape here.
+export default function ToolsLoading() {
+  return <PageCardGridSkeleton actionCount={1} />;
+}

--- a/apps/frontend/src/components/loading/DelayedReveal.tsx
+++ b/apps/frontend/src/components/loading/DelayedReveal.tsx
@@ -57,16 +57,22 @@ export interface DelayedRevealProps {
 }
 
 /**
- * Wraps a loading fallback so it stays invisible for `SKELETON_DELAY_MS`.
- * Both page skeletons apply `delayedRevealSx` themselves; use this for
- * fallbacks that don't, such as a bare `PageLoadingState`.
+ * Wraps a loading fallback so it stays invisible for `SKELETON_DELAY_MS`, and
+ * announces it as a full-width status region.
+ *
+ * Every page skeleton roots itself here, so the delay and the accessibility
+ * attributes are declared once. `delayedRevealSx` is exported separately for a
+ * fallback that needs to apply the hold to its own container.
  */
 export default function DelayedReveal({ children, sx }: DelayedRevealProps) {
   return (
     <Box
-      sx={[delayedRevealSx, ...(Array.isArray(sx) ? sx : sx ? [sx] : [])]}
+      sx={[
+        { width: '100%', ...delayedRevealSx },
+        ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+      ]}
       role="status"
-      aria-label="Loading"
+      aria-label="Loading page"
     >
       {children}
     </Box>

--- a/apps/frontend/src/components/loading/PageCardGridSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageCardGridSkeleton.tsx
@@ -2,15 +2,12 @@
 
 import Box from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
-import type { Theme } from '@mui/material/styles';
-import {
-  BORDER_RADIUS,
-  ELEVATION,
-  GRID_CARD_INSET,
-} from '@/styles/theme-constants';
-import { delayedRevealSx } from './DelayedReveal';
+import { BORDER_RADIUS, GRID_CARD_INSET } from '@/styles/theme-constants';
+import DelayedReveal from './DelayedReveal';
 import SkeletonPageHeader from './SkeletonPageHeader';
+import { skeletonSurfaceSx } from './skeletonSurface';
 import { skeletonTextSx } from './skeletonText';
+import SkeletonToolbar from './SkeletonToolbar';
 
 /**
  * Loading placeholder for card-directory pages: metrics, requirements, models,
@@ -22,6 +19,15 @@ import { skeletonTextSx } from './skeletonText';
  * declare, and `EntityCard`'s own inset, radius, elevation and internal stack.
  */
 
+/** Borderless toolbar above the cards. Only the gap and margin differ from
+ *  the grid-card toolbar; the controls live in SkeletonToolbar. */
+const DIRECTORY_TOOLBAR = {
+  /** `directoryToolbarSx` spaces its controls 20px apart, not by spacing units. */
+  gap: '20px',
+  /** Bottom margin, in MUI spacing units. */
+  marginBottom: 3,
+} as const;
+
 /** Card directory grid, mirroring the container in MetricsDirectoryTab,
  *  RequirementsClient, ToolsPageClient, ModelsPageClient and
  *  ProjectsClientWrapper, which all declare it identically. */
@@ -31,18 +37,6 @@ const CARD_GRID = {
   gap: 3,
   /** Bottom margin below the grid, in MUI spacing units. */
   marginBottom: 4,
-} as const;
-
-/** Borderless toolbar above the cards, mirroring `directoryToolbarSx`. */
-const TOOLBAR = {
-  /** Gap between controls. */
-  gap: '20px',
-  /** Bottom margin, in MUI spacing units. */
-  marginBottom: 3,
-  filterButtonSize: 36,
-  searchWidth: 240,
-  controlHeight: 38,
-  pillTabsWidth: 248,
 } as const;
 
 /** EntityCard internals: title row, clamped description, footer meta. */
@@ -63,10 +57,6 @@ const CARD = {
   chipHeight: 24,
   chipWidths: [64, 88, 52],
 } as const;
-
-/** Card border, matching EntityCard. */
-const cardBorder = (theme: Theme) =>
-  `1px solid ${theme.palette.greyscale.border}`;
 
 export interface PageCardGridSkeletonProps {
   /** FAB placeholders in the header, matching the page's action cluster. */
@@ -89,47 +79,14 @@ export default function PageCardGridSkeleton({
   );
 
   return (
-    <Box
-      sx={{ width: '100%', ...delayedRevealSx }}
-      role="status"
-      aria-label="Loading page"
-    >
+    <DelayedReveal>
       <SkeletonPageHeader actionCount={actionCount} />
 
       {showToolbar && (
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: TOOLBAR.gap,
-            mb: TOOLBAR.marginBottom,
-          }}
-          aria-hidden
-        >
-          <Skeleton
-            variant="rounded"
-            width={TOOLBAR.filterButtonSize}
-            height={TOOLBAR.filterButtonSize}
-            sx={{ borderRadius: BORDER_RADIUS.sm, flexShrink: 0 }}
-          />
-          <Skeleton
-            variant="rounded"
-            width={TOOLBAR.searchWidth}
-            height={TOOLBAR.controlHeight}
-            sx={{
-              borderRadius: '30px', // Intentional: matches SearchPill's elongated pill
-              flexShrink: 0,
-            }}
-          />
-          <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
-            <Skeleton
-              variant="rounded"
-              width={TOOLBAR.pillTabsWidth}
-              height={TOOLBAR.controlHeight}
-              sx={{ borderRadius: BORDER_RADIUS.pill }}
-            />
-          </Box>
-        </Box>
+        <SkeletonToolbar
+          gap={DIRECTORY_TOOLBAR.gap}
+          sx={{ mb: DIRECTORY_TOOLBAR.marginBottom }}
+        />
       )}
 
       <Box
@@ -148,10 +105,7 @@ export default function PageCardGridSkeleton({
               display: 'flex',
               flexDirection: 'column',
               gap: CARD.gap,
-              border: cardBorder,
-              borderRadius: BORDER_RADIUS.md,
-              boxShadow: ELEVATION.xs,
-              bgcolor: 'background.paper',
+              ...skeletonSurfaceSx,
               p: GRID_CARD_INSET,
             }}
           >
@@ -224,6 +178,6 @@ export default function PageCardGridSkeleton({
           </Box>
         ))}
       </Box>
-    </Box>
+    </DelayedReveal>
   );
 }

--- a/apps/frontend/src/components/loading/PageCardGridSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageCardGridSkeleton.tsx
@@ -65,12 +65,18 @@ export interface PageCardGridSkeletonProps {
   cards?: number;
   /** Render the filter + search + tabs toolbar row. */
   showToolbar?: boolean;
+  /**
+   * Render the centred pill tabs in the toolbar. Tools passes false because it
+   * is the one card directory that gives GridToolbar no `middleContent`.
+   */
+  showTabs?: boolean;
 }
 
 export default function PageCardGridSkeleton({
   actionCount = 2,
   cards = 6,
   showToolbar = true,
+  showTabs = true,
 }: PageCardGridSkeletonProps = {}) {
   const cardKeys = Array.from({ length: cards }, (_, i) => `card-${i}`);
   const descriptionKeys = Array.from(
@@ -85,6 +91,7 @@ export default function PageCardGridSkeleton({
       {showToolbar && (
         <SkeletonToolbar
           gap={DIRECTORY_TOOLBAR.gap}
+          showTabs={showTabs}
           sx={{ mb: DIRECTORY_TOOLBAR.marginBottom }}
         />
       )}

--- a/apps/frontend/src/components/loading/PageCardGridSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageCardGridSkeleton.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
+import type { Theme } from '@mui/material/styles';
+import {
+  BORDER_RADIUS,
+  ELEVATION,
+  GRID_CARD_INSET,
+} from '@/styles/theme-constants';
+import { delayedRevealSx } from './DelayedReveal';
+import SkeletonPageHeader from './SkeletonPageHeader';
+import { skeletonTextSx } from './skeletonText';
+
+/**
+ * Loading placeholder for card-directory pages: metrics, requirements, models,
+ * tools and projects. These render a responsive grid of `EntityCard`s rather
+ * than a DataGrid, so the table skeleton is the wrong shape for them.
+ *
+ * Geometry mirrors those pages: the borderless `directoryToolbarSx` toolbar,
+ * the identical `xs: 1fr / sm: 1fr 1fr / md: repeat(3, 1fr)` grid they each
+ * declare, and `EntityCard`'s own inset, radius, elevation and internal stack.
+ */
+
+/** Card directory grid, mirroring the container in MetricsDirectoryTab,
+ *  RequirementsClient, ToolsPageClient, ModelsPageClient and
+ *  ProjectsClientWrapper, which all declare it identically. */
+const CARD_GRID = {
+  columns: { xs: '1fr', sm: '1fr 1fr', md: 'repeat(3, 1fr)' },
+  /** Gap between cards, in MUI spacing units. */
+  gap: 3,
+  /** Bottom margin below the grid, in MUI spacing units. */
+  marginBottom: 4,
+} as const;
+
+/** Borderless toolbar above the cards, mirroring `directoryToolbarSx`. */
+const TOOLBAR = {
+  /** Gap between controls. */
+  gap: '20px',
+  /** Bottom margin, in MUI spacing units. */
+  marginBottom: 3,
+  filterButtonSize: 36,
+  searchWidth: 240,
+  controlHeight: 38,
+  pillTabsWidth: 248,
+} as const;
+
+/** EntityCard internals: title row, clamped description, footer meta. */
+const CARD = {
+  /** Vertical gap between the card's sections. */
+  gap: '20px',
+  /** Gap inside the title block. */
+  titleGap: '10px',
+  iconSize: 24,
+  titleWidth: '62%',
+  /** Description is clamped to 3 lines at 22px, so it reserves 66px. */
+  descriptionLines: 3,
+  descriptionLineHeight: 22,
+  /** Avatar in the footer meta row. */
+  avatarSize: 24,
+  avatarLabelWidth: 96,
+  /** Chip row under the divider. */
+  chipHeight: 24,
+  chipWidths: [64, 88, 52],
+} as const;
+
+/** Card border, matching EntityCard. */
+const cardBorder = (theme: Theme) =>
+  `1px solid ${theme.palette.greyscale.border}`;
+
+export interface PageCardGridSkeletonProps {
+  /** FAB placeholders in the header, matching the page's action cluster. */
+  actionCount?: number;
+  /** Card placeholders. Default fills two rows at desktop width. */
+  cards?: number;
+  /** Render the filter + search + tabs toolbar row. */
+  showToolbar?: boolean;
+}
+
+export default function PageCardGridSkeleton({
+  actionCount = 2,
+  cards = 6,
+  showToolbar = true,
+}: PageCardGridSkeletonProps = {}) {
+  const cardKeys = Array.from({ length: cards }, (_, i) => `card-${i}`);
+  const descriptionKeys = Array.from(
+    { length: CARD.descriptionLines },
+    (_, i) => `line-${i}`
+  );
+
+  return (
+    <Box
+      sx={{ width: '100%', ...delayedRevealSx }}
+      role="status"
+      aria-label="Loading page"
+    >
+      <SkeletonPageHeader actionCount={actionCount} />
+
+      {showToolbar && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: TOOLBAR.gap,
+            mb: TOOLBAR.marginBottom,
+          }}
+          aria-hidden
+        >
+          <Skeleton
+            variant="rounded"
+            width={TOOLBAR.filterButtonSize}
+            height={TOOLBAR.filterButtonSize}
+            sx={{ borderRadius: BORDER_RADIUS.sm, flexShrink: 0 }}
+          />
+          <Skeleton
+            variant="rounded"
+            width={TOOLBAR.searchWidth}
+            height={TOOLBAR.controlHeight}
+            sx={{
+              borderRadius: '30px', // Intentional: matches SearchPill's elongated pill
+              flexShrink: 0,
+            }}
+          />
+          <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
+            <Skeleton
+              variant="rounded"
+              width={TOOLBAR.pillTabsWidth}
+              height={TOOLBAR.controlHeight}
+              sx={{ borderRadius: BORDER_RADIUS.pill }}
+            />
+          </Box>
+        </Box>
+      )}
+
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: CARD_GRID.columns,
+          gap: CARD_GRID.gap,
+          mb: CARD_GRID.marginBottom,
+        }}
+        aria-hidden
+      >
+        {cardKeys.map(cardKey => (
+          <Box
+            key={cardKey}
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: CARD.gap,
+              border: cardBorder,
+              borderRadius: BORDER_RADIUS.md,
+              boxShadow: ELEVATION.xs,
+              bgcolor: 'background.paper',
+              p: GRID_CARD_INSET,
+            }}
+          >
+            {/* Title row: icon plus name */}
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: CARD.titleGap,
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: CARD.titleGap,
+                }}
+              >
+                <Skeleton
+                  variant="circular"
+                  width={CARD.iconSize}
+                  height={CARD.iconSize}
+                />
+                <Skeleton
+                  variant="text"
+                  width={CARD.titleWidth}
+                  sx={skeletonTextSx('h6')}
+                />
+              </Box>
+            </Box>
+
+            {/* Description, clamped to 3 lines in the real card */}
+            <Box>
+              {descriptionKeys.map((lineKey, idx) => (
+                <Skeleton
+                  key={lineKey}
+                  variant="text"
+                  width={idx === CARD.descriptionLines - 1 ? '55%' : '100%'}
+                  height={CARD.descriptionLineHeight}
+                />
+              ))}
+            </Box>
+
+            {/* Footer meta: avatar plus name */}
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
+              <Skeleton
+                variant="circular"
+                width={CARD.avatarSize}
+                height={CARD.avatarSize}
+              />
+              <Skeleton
+                variant="text"
+                width={CARD.avatarLabelWidth}
+                sx={skeletonTextSx('bodyMReg')}
+              />
+            </Box>
+
+            {/* Chip section */}
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+              {CARD.chipWidths.map(width => (
+                <Skeleton
+                  key={width}
+                  variant="rounded"
+                  width={width}
+                  height={CARD.chipHeight}
+                  sx={{ borderRadius: BORDER_RADIUS.pill }}
+                />
+              ))}
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/loading/PageDashboardSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageDashboardSkeleton.tsx
@@ -18,12 +18,12 @@ import SkeletonToolbar from './SkeletonToolbar';
  * `RequirementInsightsView`.
  */
 
-/** Compact filter bar, mirroring `TestResultsFilters` in its compact variant.
- *  The controls themselves live in SkeletonToolbar. */
+/** Filter bar, mirroring `TestResultsFilters`. It renders only the filter
+ *  button and the search pill: its `middleContent` is conditional on active
+ *  filters and it passes no `rightContent` at all. */
 const FILTERS = {
-  /** The compact bar spaces its controls 20px apart, not by spacing units. */
+  /** The bar spaces its controls 20px apart, not by spacing units. */
   gap: '20px',
-  chipWidths: [104, 132, 88],
 } as const;
 
 /** Pass-rate summary, mirroring `InsightsSummaryBar`. */
@@ -79,12 +79,7 @@ export default function PageDashboardSkeleton({
         aria-hidden
       >
         {/* Compact filter bar */}
-        <SkeletonToolbar
-          gap={FILTERS.gap}
-          showTabs={false}
-          rightSlot="chips"
-          chipWidths={FILTERS.chipWidths}
-        />
+        <SkeletonToolbar gap={FILTERS.gap} showTabs={false} />
 
         {/* Pass-rate summary bar */}
         <Box

--- a/apps/frontend/src/components/loading/PageDashboardSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageDashboardSkeleton.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
+import type { Theme } from '@mui/material/styles';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
+import { delayedRevealSx } from './DelayedReveal';
+import SkeletonPageHeader from './SkeletonPageHeader';
+import { skeletonTextSx } from './skeletonText';
+
+/**
+ * Loading placeholder for the insights dashboard, which is neither a table nor
+ * a card directory: a compact filter bar, a pass-rate summary bar, a
+ * three-column requirement breakdown, then a stack of per-requirement rows.
+ *
+ * Geometry mirrors `InsightsPage`, `InsightsSummaryBar` and
+ * `RequirementInsightsView`.
+ */
+
+/** Compact filter bar, mirroring `TestResultsFilters` in its compact variant. */
+const FILTERS = {
+  gap: '20px',
+  filterButtonSize: 36,
+  searchWidth: 240,
+  controlHeight: 38,
+  chipWidths: [104, 132, 88],
+} as const;
+
+/** Pass-rate summary, mirroring `InsightsSummaryBar`. */
+const SUMMARY = {
+  /** Container padding, in MUI spacing units. */
+  paddingX: 1.75,
+  paddingY: 1.25,
+  /** Container radius, in MUI spacing units. */
+  radius: 1.5,
+  labelWidth: 280,
+  /** Height of the LinearProgress under the label. */
+  barHeight: 4,
+} as const;
+
+/** Requirement breakdown, mirroring `RequirementInsightsView`. */
+const BREAKDOWN = {
+  columns: { xs: '1fr', md: '1fr 1fr 1fr' },
+  /** Gap between the view's stacked sections, in MUI spacing units. */
+  sectionGap: 3,
+  /** Gap between the requirement rows, in MUI spacing units. */
+  rowGap: 1.5,
+  columnHeadingWidth: 128,
+  columnLines: 4,
+  rowHeight: 56,
+  rows: 5,
+} as const;
+
+const panelBorder = (theme: Theme) =>
+  `1px solid ${theme.palette.greyscale.border}`;
+
+export interface PageDashboardSkeletonProps {
+  /** FAB placeholders in the header, matching the page's action cluster. */
+  actionCount?: number;
+}
+
+export default function PageDashboardSkeleton({
+  actionCount = 2,
+}: PageDashboardSkeletonProps = {}) {
+  const columnKeys = ['passed', 'failed', 'pending'];
+  const rowKeys = Array.from({ length: BREAKDOWN.rows }, (_, i) => `row-${i}`);
+  const lineKeys = Array.from(
+    { length: BREAKDOWN.columnLines },
+    (_, i) => `line-${i}`
+  );
+
+  return (
+    <Box
+      sx={{ width: '100%', ...delayedRevealSx }}
+      role="status"
+      aria-label="Loading page"
+    >
+      <SkeletonPageHeader actionCount={actionCount} />
+
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: BREAKDOWN.sectionGap,
+        }}
+        aria-hidden
+      >
+        {/* Compact filter bar */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: FILTERS.gap }}>
+          <Skeleton
+            variant="rounded"
+            width={FILTERS.filterButtonSize}
+            height={FILTERS.filterButtonSize}
+            sx={{ borderRadius: BORDER_RADIUS.sm, flexShrink: 0 }}
+          />
+          <Skeleton
+            variant="rounded"
+            width={FILTERS.searchWidth}
+            height={FILTERS.controlHeight}
+            sx={{
+              borderRadius: '30px', // Intentional: matches SearchPill's elongated pill
+              flexShrink: 0,
+            }}
+          />
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            {FILTERS.chipWidths.map(width => (
+              <Skeleton
+                key={width}
+                variant="rounded"
+                width={width}
+                height={FILTERS.controlHeight}
+                sx={{ borderRadius: BORDER_RADIUS.pill }}
+              />
+            ))}
+          </Box>
+        </Box>
+
+        {/* Pass-rate summary bar */}
+        <Box
+          sx={{
+            px: SUMMARY.paddingX,
+            py: SUMMARY.paddingY,
+            borderRadius: SUMMARY.radius,
+            border: panelBorder,
+            bgcolor: 'background.paper',
+          }}
+        >
+          <Skeleton
+            variant="text"
+            width={SUMMARY.labelWidth}
+            sx={skeletonTextSx('bodyMReg')}
+          />
+          <Skeleton
+            variant="rounded"
+            width="100%"
+            height={SUMMARY.barHeight}
+            sx={{ borderRadius: BORDER_RADIUS.pill }}
+          />
+        </Box>
+
+        {/* Three-column requirement breakdown */}
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: BREAKDOWN.columns,
+            gap: BREAKDOWN.sectionGap,
+          }}
+        >
+          {columnKeys.map(columnKey => (
+            <Box
+              key={columnKey}
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 1,
+                border: panelBorder,
+                borderRadius: BORDER_RADIUS.md,
+                bgcolor: 'background.paper',
+                p: 2,
+              }}
+            >
+              <Skeleton
+                variant="text"
+                width={BREAKDOWN.columnHeadingWidth}
+                sx={skeletonTextSx('bodyMReg')}
+              />
+              {lineKeys.map((lineKey, idx) => (
+                <Skeleton
+                  key={lineKey}
+                  variant="text"
+                  width={idx % 2 === 0 ? '88%' : '64%'}
+                  sx={skeletonTextSx('bodySReg')}
+                />
+              ))}
+            </Box>
+          ))}
+        </Box>
+
+        {/* Per-requirement rows */}
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: BREAKDOWN.rowGap,
+          }}
+        >
+          {rowKeys.map(rowKey => (
+            <Skeleton
+              key={rowKey}
+              variant="rounded"
+              width="100%"
+              height={BREAKDOWN.rowHeight}
+              sx={{ borderRadius: BORDER_RADIUS.md }}
+            />
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/loading/PageDashboardSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageDashboardSkeleton.tsx
@@ -2,11 +2,12 @@
 
 import Box from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
-import type { Theme } from '@mui/material/styles';
 import { BORDER_RADIUS } from '@/styles/theme-constants';
-import { delayedRevealSx } from './DelayedReveal';
+import DelayedReveal from './DelayedReveal';
 import SkeletonPageHeader from './SkeletonPageHeader';
+import { skeletonBorder } from './skeletonSurface';
 import { skeletonTextSx } from './skeletonText';
+import SkeletonToolbar from './SkeletonToolbar';
 
 /**
  * Loading placeholder for the insights dashboard, which is neither a table nor
@@ -17,12 +18,11 @@ import { skeletonTextSx } from './skeletonText';
  * `RequirementInsightsView`.
  */
 
-/** Compact filter bar, mirroring `TestResultsFilters` in its compact variant. */
+/** Compact filter bar, mirroring `TestResultsFilters` in its compact variant.
+ *  The controls themselves live in SkeletonToolbar. */
 const FILTERS = {
+  /** The compact bar spaces its controls 20px apart, not by spacing units. */
   gap: '20px',
-  filterButtonSize: 36,
-  searchWidth: 240,
-  controlHeight: 38,
   chipWidths: [104, 132, 88],
 } as const;
 
@@ -51,9 +51,6 @@ const BREAKDOWN = {
   rows: 5,
 } as const;
 
-const panelBorder = (theme: Theme) =>
-  `1px solid ${theme.palette.greyscale.border}`;
-
 export interface PageDashboardSkeletonProps {
   /** FAB placeholders in the header, matching the page's action cluster. */
   actionCount?: number;
@@ -70,11 +67,7 @@ export default function PageDashboardSkeleton({
   );
 
   return (
-    <Box
-      sx={{ width: '100%', ...delayedRevealSx }}
-      role="status"
-      aria-label="Loading page"
-    >
+    <DelayedReveal>
       <SkeletonPageHeader actionCount={actionCount} />
 
       <Box
@@ -86,34 +79,12 @@ export default function PageDashboardSkeleton({
         aria-hidden
       >
         {/* Compact filter bar */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: FILTERS.gap }}>
-          <Skeleton
-            variant="rounded"
-            width={FILTERS.filterButtonSize}
-            height={FILTERS.filterButtonSize}
-            sx={{ borderRadius: BORDER_RADIUS.sm, flexShrink: 0 }}
-          />
-          <Skeleton
-            variant="rounded"
-            width={FILTERS.searchWidth}
-            height={FILTERS.controlHeight}
-            sx={{
-              borderRadius: '30px', // Intentional: matches SearchPill's elongated pill
-              flexShrink: 0,
-            }}
-          />
-          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-            {FILTERS.chipWidths.map(width => (
-              <Skeleton
-                key={width}
-                variant="rounded"
-                width={width}
-                height={FILTERS.controlHeight}
-                sx={{ borderRadius: BORDER_RADIUS.pill }}
-              />
-            ))}
-          </Box>
-        </Box>
+        <SkeletonToolbar
+          gap={FILTERS.gap}
+          showTabs={false}
+          rightSlot="chips"
+          chipWidths={FILTERS.chipWidths}
+        />
 
         {/* Pass-rate summary bar */}
         <Box
@@ -121,7 +92,7 @@ export default function PageDashboardSkeleton({
             px: SUMMARY.paddingX,
             py: SUMMARY.paddingY,
             borderRadius: SUMMARY.radius,
-            border: panelBorder,
+            border: skeletonBorder,
             bgcolor: 'background.paper',
           }}
         >
@@ -153,7 +124,7 @@ export default function PageDashboardSkeleton({
                 display: 'flex',
                 flexDirection: 'column',
                 gap: 1,
-                border: panelBorder,
+                border: skeletonBorder,
                 borderRadius: BORDER_RADIUS.md,
                 bgcolor: 'background.paper',
                 p: 2,
@@ -195,6 +166,6 @@ export default function PageDashboardSkeleton({
           ))}
         </Box>
       </Box>
-    </Box>
+    </DelayedReveal>
   );
 }

--- a/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
@@ -6,12 +6,11 @@ import type { Theme } from '@mui/material/styles';
 import {
   BORDER_RADIUS,
   ELEVATION,
-  FAB_GROUP_GAP,
-  FAB_SIZE,
   GRID_CARD_INSET,
   SECTION_GRID,
 } from '@/styles/theme-constants';
 import { delayedRevealSx } from './DelayedReveal';
+import SkeletonPageHeader from './SkeletonPageHeader';
 import { skeletonTextSx } from './skeletonText';
 
 /**
@@ -25,29 +24,11 @@ import { skeletonTextSx } from './skeletonText';
  * (DetailTabPanel `pt: 5`) and `SECTION_GRID` field spacing.
  */
 
-/** Page header, mirroring `PageLayout`. */
+/** Placeholder widths for the header text. Layout geometry lives in
+ *  SkeletonPageHeader, which mirrors PageLayout. */
 const HEADER = {
-  /** `minHeight` of the title row. */
-  rowHeight: 56,
-  /** Gap between the title and the action cluster. */
-  titleGap: '16px',
-  /** Vertical gap between the breadcrumbs and the title block. */
-  stackGap: '20px',
-  /** Bottom margin of the whole header block, in MUI spacing units. */
-  marginBottom: 5,
   titleWidth: 280,
   descriptionWidth: 460,
-} as const;
-
-/** Breadcrumb trail, mirroring `PageBreadcrumbs` in PageLayout. */
-const BREADCRUMB = {
-  /** Gap between crumbs. */
-  gap: '10px',
-  /** Gap between a crumb's label and its separator. */
-  itemGap: '6px',
-  separatorSize: 6,
-  firstWidth: 72,
-  restWidth: 108,
 } as const;
 
 /** Tab bar, mirroring `DetailTabNav`. */
@@ -100,91 +81,18 @@ export default function PageDetailSkeleton({
   actionCount = 2,
   breadcrumbCount = 2,
 }: PageDetailSkeletonProps = {}) {
-  const fabKeys = Array.from({ length: actionCount }, (_, i) => `fab-${i}`);
-  const crumbKeys = Array.from(
-    { length: breadcrumbCount },
-    (_, i) => `crumb-${i}`
-  );
-
   return (
     <Box
       sx={{ width: '100%', ...delayedRevealSx }}
       role="status"
       aria-label="Loading page"
     >
-      {/* PageLayout header: breadcrumbs, then title/description block, mb: 5 */}
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: HEADER.stackGap,
-          mb: HEADER.marginBottom,
-        }}
-        aria-hidden
-      >
-        <Box
-          sx={{ display: 'flex', alignItems: 'center', gap: BREADCRUMB.gap }}
-        >
-          {crumbKeys.map((key, idx) => (
-            <Box
-              key={key}
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: BREADCRUMB.itemGap,
-              }}
-            >
-              <Skeleton
-                variant="text"
-                width={idx === 0 ? BREADCRUMB.firstWidth : BREADCRUMB.restWidth}
-                sx={skeletonTextSx('bodyMReg')}
-              />
-              {idx < crumbKeys.length - 1 && (
-                <Skeleton
-                  variant="circular"
-                  width={BREADCRUMB.separatorSize}
-                  height={BREADCRUMB.separatorSize}
-                />
-              )}
-            </Box>
-          ))}
-        </Box>
-
-        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              gap: HEADER.titleGap,
-              minHeight: HEADER.rowHeight,
-            }}
-          >
-            <Skeleton
-              variant="text"
-              width={HEADER.titleWidth}
-              sx={skeletonTextSx('h4')}
-            />
-            {actionCount > 0 && (
-              <Box sx={{ display: 'flex', gap: FAB_GROUP_GAP, flexShrink: 0 }}>
-                {fabKeys.map(key => (
-                  <Skeleton
-                    key={key}
-                    variant="circular"
-                    width={FAB_SIZE}
-                    height={FAB_SIZE}
-                  />
-                ))}
-              </Box>
-            )}
-          </Box>
-          <Skeleton
-            variant="text"
-            width={HEADER.descriptionWidth}
-            sx={skeletonTextSx('bodyLReg')}
-          />
-        </Box>
-      </Box>
+      <SkeletonPageHeader
+        actionCount={actionCount}
+        breadcrumbCount={breadcrumbCount}
+        titleWidth={HEADER.titleWidth}
+        descriptionWidth={HEADER.descriptionWidth}
+      />
 
       {/* DetailTabNav: 18px labels at 50px gaps, active tab underlined */}
       <Box sx={{ display: 'flex', gap: TABS.gap }} aria-hidden>

--- a/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
@@ -2,15 +2,14 @@
 
 import Box from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
-import type { Theme } from '@mui/material/styles';
 import {
   BORDER_RADIUS,
-  ELEVATION,
   GRID_CARD_INSET,
   SECTION_GRID,
 } from '@/styles/theme-constants';
-import { delayedRevealSx } from './DelayedReveal';
+import DelayedReveal from './DelayedReveal';
 import SkeletonPageHeader from './SkeletonPageHeader';
+import { skeletonSurfaceSx } from './skeletonSurface';
 import { skeletonTextSx } from './skeletonText';
 
 /**
@@ -57,10 +56,6 @@ const SECTION = {
   fieldValueWidth: '72%',
 } as const;
 
-/** Card border, matching the grid card and SectionCard. */
-const cardBorder = (theme: Theme) =>
-  `1px solid ${theme.palette.greyscale.border}`;
-
 /** Tab label widths — detail pages run 3-5 tabs (Overview, Test Sets, …). */
 const TAB_WIDTHS = [78, 96, 132, 62];
 
@@ -89,11 +84,7 @@ export default function PageDetailSkeleton({
   showTabs = true,
 }: PageDetailSkeletonProps = {}) {
   return (
-    <Box
-      sx={{ width: '100%', ...delayedRevealSx }}
-      role="status"
-      aria-label="Loading page"
-    >
+    <DelayedReveal>
       <SkeletonPageHeader
         actionCount={actionCount}
         breadcrumbCount={breadcrumbCount}
@@ -145,10 +136,7 @@ export default function PageDetailSkeleton({
           <Box
             key={section.key}
             sx={{
-              borderRadius: BORDER_RADIUS.md,
-              boxShadow: ELEVATION.xs,
-              border: cardBorder,
-              bgcolor: 'background.paper',
+              ...skeletonSurfaceSx,
               p: SECTION.inset,
             }}
           >
@@ -186,6 +174,6 @@ export default function PageDetailSkeleton({
           </Box>
         ))}
       </Box>
-    </Box>
+    </DelayedReveal>
   );
 }

--- a/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageDetailSkeleton.tsx
@@ -73,13 +73,20 @@ const SECTIONS = [
 export interface PageDetailSkeletonProps {
   /** FAB placeholders in the header, matching the page's action cluster. */
   actionCount?: number;
-  /** Breadcrumb segments before the current page. */
+  /** Breadcrumb segments before the current page. 0 renders no trail. */
   breadcrumbCount?: number;
+  /**
+   * Render the DetailTabNav bar. Settings-style pages stack their section
+   * cards straight under the header with no tab bar, so they pass false and
+   * also drop the DetailTabPanel top inset that the bar would sit above.
+   */
+  showTabs?: boolean;
 }
 
 export default function PageDetailSkeleton({
   actionCount = 2,
   breadcrumbCount = 2,
+  showTabs = true,
 }: PageDetailSkeletonProps = {}) {
   return (
     <Box
@@ -95,33 +102,39 @@ export default function PageDetailSkeleton({
       />
 
       {/* DetailTabNav: 18px labels at 50px gaps, active tab underlined */}
-      <Box sx={{ display: 'flex', gap: TABS.gap }} aria-hidden>
-        {TAB_WIDTHS.map((width, idx) => (
-          <Box
-            key={width}
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: TABS.labelGap,
-            }}
-          >
-            <Skeleton variant="text" width={width} sx={skeletonTextSx('h6')} />
+      {showTabs && (
+        <Box sx={{ display: 'flex', gap: TABS.gap }} aria-hidden>
+          {TAB_WIDTHS.map((width, idx) => (
             <Box
+              key={width}
               sx={{
-                height: TABS.underlineHeight,
-                borderRadius: BORDER_RADIUS.xs,
-                bgcolor: idx === 0 ? 'primary.main' : 'transparent',
-                opacity: idx === 0 ? TABS.underlineOpacity : 0,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: TABS.labelGap,
               }}
-            />
-          </Box>
-        ))}
-      </Box>
+            >
+              <Skeleton
+                variant="text"
+                width={width}
+                sx={skeletonTextSx('h6')}
+              />
+              <Box
+                sx={{
+                  height: TABS.underlineHeight,
+                  borderRadius: BORDER_RADIUS.xs,
+                  bgcolor: idx === 0 ? 'primary.main' : 'transparent',
+                  opacity: idx === 0 ? TABS.underlineOpacity : 0,
+                }}
+              />
+            </Box>
+          ))}
+        </Box>
+      )}
 
       {/* Tab panel content: DetailTabPanel applies pt: 5 */}
       <Box
         sx={{
-          pt: SECTION.panelTop,
+          pt: showTabs ? SECTION.panelTop : 0,
           display: 'flex',
           flexDirection: 'column',
           gap: SECTION.gap,

--- a/apps/frontend/src/components/loading/PageListSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageListSkeleton.tsx
@@ -2,27 +2,24 @@
 
 import Box from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
-import type { Theme } from '@mui/material/styles';
 import {
   BORDER_RADIUS,
-  ELEVATION,
   GRID_CARD_INSET,
   GRID_TOOLBAR_MIN_HEIGHT,
 } from '@/styles/theme-constants';
-import { delayedRevealSx } from './DelayedReveal';
+import DelayedReveal from './DelayedReveal';
 import SkeletonPageHeader from './SkeletonPageHeader';
+import { skeletonBorder, skeletonSurfaceSx } from './skeletonSurface';
 import { skeletonTextSx } from './skeletonText';
+import SkeletonToolbar from './SkeletonToolbar';
 
 /**
- * Loading placeholder for the standard list page: `PageLayout` header (title,
- * description, FAB cluster) above a grid card holding `GridToolbar`, column
- * headers, rows and the pagination footer.
+ * Loading placeholder for the standard list page: `PageLayout` header above a
+ * grid card holding `GridToolbar`, column headers, rows and the pagination
+ * footer.
  *
  * Shared geometry comes from `theme-constants` so this cannot drift from the
- * components it stands in for. The card's border, radius and elevation mirror
- * BaseDataGrid's `GRID_PAPER_SX`, which is re-declared here rather than
- * imported because importing BaseDataGrid would pull @mui/x-data-grid into the
- * loading chunk and defeat the point of a lightweight fallback.
+ * components it stands in for.
  */
 
 /** Placeholder widths for the header text. Layout geometry lives in
@@ -30,16 +27,6 @@ import { skeletonTextSx } from './skeletonText';
 const HEADER = {
   titleWidth: 180,
   descriptionWidth: 420,
-} as const;
-
-/** Toolbar controls, mirroring `GridToolbar`, `FilterButton` and `SearchPill`. */
-const TOOLBAR = {
-  /** Gap between controls, in MUI spacing units. */
-  gap: 1.5,
-  filterButtonSize: 36,
-  searchWidth: 240,
-  controlHeight: 38,
-  pillTabsWidth: 248,
 } as const;
 
 /** Grid rows and footer, mirroring BaseDataGrid's styled DataGrid. */
@@ -53,6 +40,8 @@ const GRID = {
   paginationLabelWidth: 64,
   /** Trailing padding on non-edge cells, in MUI spacing units. */
   cellGap: 2,
+  /** Gap between the footer's controls, in MUI spacing units. */
+  footerGap: 1.5,
 } as const;
 
 /** Column widths approximating a typical entity grid: wide first column, then
@@ -69,12 +58,6 @@ const COLUMNS = [
   { key: 'meta-b', width: '9%', header: 48, cell: 24, kind: 'text' },
   { key: 'actions', width: '6%', header: 56, cell: 24, kind: 'text' },
 ] as const;
-
-/** Text links in the toolbar's right slot (Select / Columns / Density / Export). */
-const TOOLBAR_ACTIONS = [76, 62, 56, 50];
-
-/** Row and cell separator, matching BaseDataGrid's cell borders. */
-const divider = (theme: Theme) => `1px solid ${theme.palette.greyscale.border}`;
 
 export interface PageListSkeletonProps {
   /** FAB placeholders in the header, matching the page's action cluster. */
@@ -99,82 +82,23 @@ export default function PageListSkeleton({
   });
 
   return (
-    <Box
-      sx={{ width: '100%', ...delayedRevealSx }}
-      role="status"
-      aria-label="Loading page"
-    >
+    <DelayedReveal>
       <SkeletonPageHeader
         actionCount={actionCount}
         titleWidth={HEADER.titleWidth}
         descriptionWidth={HEADER.descriptionWidth}
       />
 
-      {/* Grid card — mirrors GRID_PAPER_SX */}
-      <Box
-        sx={{
-          width: '100%',
-          borderRadius: BORDER_RADIUS.md,
-          boxShadow: ELEVATION.xs,
-          border: divider,
-          overflow: 'hidden',
-          bgcolor: 'background.paper',
-        }}
-        aria-hidden
-      >
+      <Box sx={{ width: '100%', ...skeletonSurfaceSx, overflow: 'hidden' }}>
         {showToolbar && (
-          <Box
+          <SkeletonToolbar
+            rightSlot="actions"
             sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: TOOLBAR.gap,
               px: GRID_CARD_INSET,
               py: GRID_CARD_INSET,
               minHeight: GRID_TOOLBAR_MIN_HEIGHT,
             }}
-          >
-            <Skeleton
-              variant="rounded"
-              width={TOOLBAR.filterButtonSize}
-              height={TOOLBAR.filterButtonSize}
-              sx={{ borderRadius: BORDER_RADIUS.sm, flexShrink: 0 }}
-            />
-            <Skeleton
-              variant="rounded"
-              width={TOOLBAR.searchWidth}
-              height={TOOLBAR.controlHeight}
-              sx={{
-                borderRadius: '30px', // Intentional: matches SearchPill's elongated pill
-                flexShrink: 0,
-              }}
-            />
-            {/* Pill tabs sit centred, as ToolbarPillTabs does */}
-            <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
-              <Skeleton
-                variant="rounded"
-                width={TOOLBAR.pillTabsWidth}
-                height={TOOLBAR.controlHeight}
-                sx={{ borderRadius: BORDER_RADIUS.pill }}
-              />
-            </Box>
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: TOOLBAR.gap,
-                flexShrink: 0,
-              }}
-            >
-              {TOOLBAR_ACTIONS.map(width => (
-                <Skeleton
-                  key={width}
-                  variant="text"
-                  width={width}
-                  sx={skeletonTextSx('bodyMReg')}
-                />
-              ))}
-            </Box>
-          </Box>
+          />
         )}
 
         <Box
@@ -182,9 +106,10 @@ export default function PageListSkeleton({
             display: 'flex',
             alignItems: 'center',
             height: GRID.headerHeight,
-            borderTop: divider,
-            borderBottom: divider,
+            borderTop: skeletonBorder,
+            borderBottom: skeletonBorder,
           }}
+          aria-hidden
         >
           {COLUMNS.map((col, idx) => (
             <Box
@@ -207,8 +132,11 @@ export default function PageListSkeleton({
               display: 'flex',
               alignItems: 'center',
               height: GRID.rowHeight,
-              ...(rowIdx < rowKeys.length - 1 && { borderBottom: divider }),
+              ...(rowIdx < rowKeys.length - 1 && {
+                borderBottom: skeletonBorder,
+              }),
             }}
+            aria-hidden
           >
             {COLUMNS.map((col, idx) => (
               <Box
@@ -239,11 +167,12 @@ export default function PageListSkeleton({
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'flex-end',
-            gap: TOOLBAR.gap,
+            gap: GRID.footerGap,
             height: GRID.footerHeight,
             px: GRID_CARD_INSET,
-            borderTop: divider,
+            borderTop: skeletonBorder,
           }}
+          aria-hidden
         >
           <Skeleton
             variant="circular"
@@ -262,6 +191,6 @@ export default function PageListSkeleton({
           />
         </Box>
       </Box>
-    </Box>
+    </DelayedReveal>
   );
 }

--- a/apps/frontend/src/components/loading/PageListSkeleton.tsx
+++ b/apps/frontend/src/components/loading/PageListSkeleton.tsx
@@ -6,12 +6,11 @@ import type { Theme } from '@mui/material/styles';
 import {
   BORDER_RADIUS,
   ELEVATION,
-  FAB_GROUP_GAP,
-  FAB_SIZE,
   GRID_CARD_INSET,
   GRID_TOOLBAR_MIN_HEIGHT,
 } from '@/styles/theme-constants';
 import { delayedRevealSx } from './DelayedReveal';
+import SkeletonPageHeader from './SkeletonPageHeader';
 import { skeletonTextSx } from './skeletonText';
 
 /**
@@ -26,14 +25,9 @@ import { skeletonTextSx } from './skeletonText';
  * loading chunk and defeat the point of a lightweight fallback.
  */
 
-/** Page header, mirroring `PageLayout`. */
+/** Placeholder widths for the header text. Layout geometry lives in
+ *  SkeletonPageHeader, which mirrors PageLayout. */
 const HEADER = {
-  /** `minHeight` of the title row. */
-  rowHeight: 56,
-  /** Gap between the title and the action cluster. */
-  titleGap: '16px',
-  /** Bottom margin of the whole header block, in MUI spacing units. */
-  marginBottom: 5,
   titleWidth: 180,
   descriptionWidth: 420,
 } as const;
@@ -97,7 +91,6 @@ export default function PageListSkeleton({
   showToolbar = true,
 }: PageListSkeletonProps = {}) {
   const rowKeys = Array.from({ length: rows }, (_, i) => `row-${i}`);
-  const fabKeys = Array.from({ length: actionCount }, (_, i) => `fab-${i}`);
 
   /** Edge cells carry the card inset; the rest carry a trailing gap. */
   const cellInsetSx = (idx: number) => ({
@@ -111,49 +104,11 @@ export default function PageListSkeleton({
       role="status"
       aria-label="Loading page"
     >
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          mb: HEADER.marginBottom,
-        }}
-      >
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            gap: HEADER.titleGap,
-            minHeight: HEADER.rowHeight,
-          }}
-        >
-          <Skeleton
-            variant="text"
-            width={HEADER.titleWidth}
-            sx={skeletonTextSx('h4')}
-          />
-          {actionCount > 0 && (
-            <Box
-              sx={{ display: 'flex', gap: FAB_GROUP_GAP, flexShrink: 0 }}
-              aria-hidden
-            >
-              {fabKeys.map(key => (
-                <Skeleton
-                  key={key}
-                  variant="circular"
-                  width={FAB_SIZE}
-                  height={FAB_SIZE}
-                />
-              ))}
-            </Box>
-          )}
-        </Box>
-        <Skeleton
-          variant="text"
-          width={HEADER.descriptionWidth}
-          sx={skeletonTextSx('bodyLReg')}
-        />
-      </Box>
+      <SkeletonPageHeader
+        actionCount={actionCount}
+        titleWidth={HEADER.titleWidth}
+        descriptionWidth={HEADER.descriptionWidth}
+      />
 
       {/* Grid card — mirrors GRID_PAPER_SX */}
       <Box

--- a/apps/frontend/src/components/loading/SkeletonPageHeader.tsx
+++ b/apps/frontend/src/components/loading/SkeletonPageHeader.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
+import { FAB_GROUP_GAP, FAB_SIZE } from '@/styles/theme-constants';
+import { skeletonTextSx } from './skeletonText';
+
+/**
+ * The `PageLayout` header every page skeleton starts with: optional
+ * breadcrumbs, a title row with the FAB cluster, and a description line.
+ *
+ * Shared so the four page skeletons cannot drift from each other or from
+ * `PageLayout`, whose geometry these constants mirror.
+ */
+
+/** Page header, mirroring `PageLayout`. */
+const HEADER = {
+  /** `minHeight` of the title row. */
+  rowHeight: 56,
+  /** Gap between the title and the action cluster. */
+  titleGap: '16px',
+  /** Vertical gap between the breadcrumbs and the title block. */
+  stackGap: '20px',
+  /** Bottom margin of the whole header block, in MUI spacing units. */
+  marginBottom: 5,
+} as const;
+
+/** Breadcrumb trail, mirroring `PageBreadcrumbs` in PageLayout. */
+const BREADCRUMB = {
+  /** Gap between crumbs. */
+  gap: '10px',
+  /** Gap between a crumb's label and its separator. */
+  itemGap: '6px',
+  separatorSize: 6,
+  firstWidth: 72,
+  restWidth: 108,
+} as const;
+
+export interface SkeletonPageHeaderProps {
+  /** FAB placeholders, matching the page's action cluster. */
+  actionCount?: number;
+  /** Breadcrumb segments. 0 renders no trail, as list pages have none. */
+  breadcrumbCount?: number;
+  titleWidth?: number;
+  /** 0 renders no description line. */
+  descriptionWidth?: number;
+}
+
+export default function SkeletonPageHeader({
+  actionCount = 2,
+  breadcrumbCount = 0,
+  titleWidth = 180,
+  descriptionWidth = 420,
+}: SkeletonPageHeaderProps = {}) {
+  const fabKeys = Array.from({ length: actionCount }, (_, i) => `fab-${i}`);
+  const crumbKeys = Array.from(
+    { length: breadcrumbCount },
+    (_, i) => `crumb-${i}`
+  );
+
+  const titleBlock = (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: HEADER.titleGap,
+          minHeight: HEADER.rowHeight,
+        }}
+      >
+        <Skeleton variant="text" width={titleWidth} sx={skeletonTextSx('h4')} />
+        {actionCount > 0 && (
+          <Box sx={{ display: 'flex', gap: FAB_GROUP_GAP, flexShrink: 0 }}>
+            {fabKeys.map(key => (
+              <Skeleton
+                key={key}
+                variant="circular"
+                width={FAB_SIZE}
+                height={FAB_SIZE}
+              />
+            ))}
+          </Box>
+        )}
+      </Box>
+      {descriptionWidth > 0 && (
+        <Skeleton
+          variant="text"
+          width={descriptionWidth}
+          sx={skeletonTextSx('bodyLReg')}
+        />
+      )}
+    </Box>
+  );
+
+  // PageLayout only introduces the 20px stack gap when breadcrumbs are present.
+  if (crumbKeys.length === 0) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          mb: HEADER.marginBottom,
+        }}
+        aria-hidden
+      >
+        {titleBlock}
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: HEADER.stackGap,
+        mb: HEADER.marginBottom,
+      }}
+      aria-hidden
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: BREADCRUMB.gap }}>
+        {crumbKeys.map((key, idx) => (
+          <Box
+            key={key}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: BREADCRUMB.itemGap,
+            }}
+          >
+            <Skeleton
+              variant="text"
+              width={idx === 0 ? BREADCRUMB.firstWidth : BREADCRUMB.restWidth}
+              sx={skeletonTextSx('bodyMReg')}
+            />
+            {idx < crumbKeys.length - 1 && (
+              <Skeleton
+                variant="circular"
+                width={BREADCRUMB.separatorSize}
+                height={BREADCRUMB.separatorSize}
+              />
+            )}
+          </Box>
+        ))}
+      </Box>
+      {titleBlock}
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/loading/SkeletonToolbar.tsx
+++ b/apps/frontend/src/components/loading/SkeletonToolbar.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
+import type { SxProps, Theme } from '@mui/material/styles';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
+import { skeletonTextSx } from './skeletonText';
+
+/**
+ * The filter / search / tabs row that sits above a page's content, standing in
+ * for `GridToolbar`.
+ *
+ * Shared because three page shapes draw it: the bordered grid card, the
+ * borderless card directory (`directoryToolbarSx`) and the insights filter bar.
+ * They differ only in the gap between controls and what occupies the right
+ * side, so those are props rather than three copies of the same row.
+ */
+
+/** Control geometry, mirroring `FilterButton`, `SearchPill` and `ToolbarPillTabs`. */
+const CONTROL = {
+  filterButtonSize: 36,
+  searchWidth: 240,
+  height: 38,
+  pillTabsWidth: 248,
+} as const;
+
+/** Text links in the grid toolbar's right slot (Select / Columns / Density / Export). */
+const ACTION_WIDTHS = [76, 62, 56, 50];
+
+export interface SkeletonToolbarProps {
+  /**
+   * Gap between controls. The grid card uses MUI spacing units (`1.5`), the
+   * card directory a literal `'20px'` from `directoryToolbarSx`.
+   */
+  gap?: number | string;
+  /** Extra styles for the row, e.g. the card directory's inset and margin. */
+  sx?: SxProps<Theme>;
+  /** Render the centred pill tabs. */
+  showTabs?: boolean;
+  /**
+   * Right-hand slot. `actions` draws the grid toolbar's four text links,
+   * `chips` draws filter chips as the insights bar does, `none` leaves it bare
+   * as the card directories do.
+   */
+  rightSlot?: 'actions' | 'chips' | 'none';
+  /** Chip widths when `rightSlot` is `chips`. */
+  chipWidths?: readonly number[];
+}
+
+export default function SkeletonToolbar({
+  gap = 1.5,
+  sx,
+  showTabs = true,
+  rightSlot = 'none',
+  chipWidths = [104, 132, 88],
+}: SkeletonToolbarProps = {}) {
+  return (
+    <Box
+      sx={[
+        { display: 'flex', alignItems: 'center', gap },
+        ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+      ]}
+      aria-hidden
+    >
+      <Skeleton
+        variant="rounded"
+        width={CONTROL.filterButtonSize}
+        height={CONTROL.filterButtonSize}
+        sx={{ borderRadius: BORDER_RADIUS.sm, flexShrink: 0 }}
+      />
+      <Skeleton
+        variant="rounded"
+        width={CONTROL.searchWidth}
+        height={CONTROL.height}
+        sx={{
+          borderRadius: '30px', // Intentional: matches SearchPill's elongated pill
+          flexShrink: 0,
+        }}
+      />
+
+      {showTabs ? (
+        <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
+          <Skeleton
+            variant="rounded"
+            width={CONTROL.pillTabsWidth}
+            height={CONTROL.height}
+            sx={{ borderRadius: BORDER_RADIUS.pill }}
+          />
+        </Box>
+      ) : (
+        rightSlot === 'actions' && <Box sx={{ flex: 1 }} />
+      )}
+
+      {rightSlot === 'actions' && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap, flexShrink: 0 }}>
+          {ACTION_WIDTHS.map(width => (
+            <Skeleton
+              key={width}
+              variant="text"
+              width={width}
+              sx={skeletonTextSx('bodyMReg')}
+            />
+          ))}
+        </Box>
+      )}
+
+      {rightSlot === 'chips' && (
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          {chipWidths.map(width => (
+            <Skeleton
+              key={width}
+              variant="rounded"
+              width={width}
+              height={CONTROL.height}
+              sx={{ borderRadius: BORDER_RADIUS.pill }}
+            />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/loading/SkeletonToolbar.tsx
+++ b/apps/frontend/src/components/loading/SkeletonToolbar.tsx
@@ -35,16 +35,18 @@ export interface SkeletonToolbarProps {
   gap?: number | string;
   /** Extra styles for the row, e.g. the card directory's inset and margin. */
   sx?: SxProps<Theme>;
-  /** Render the centred pill tabs. */
+  /**
+   * Render the centred pill tabs. False for toolbars whose page passes no
+   * `middleContent` to GridToolbar, which would otherwise show tabs that
+   * vanish when content arrives.
+   */
   showTabs?: boolean;
   /**
-   * Right-hand slot. `actions` draws the grid toolbar's four text links,
-   * `chips` draws filter chips as the insights bar does, `none` leaves it bare
-   * as the card directories do.
+   * Right-hand slot. `actions` draws the grid toolbar's four text links
+   * (Select / Columns / Density / Export); `none` leaves it bare, as the card
+   * directories and the insights filter bar do.
    */
-  rightSlot?: 'actions' | 'chips' | 'none';
-  /** Chip widths when `rightSlot` is `chips`. */
-  chipWidths?: readonly number[];
+  rightSlot?: 'actions' | 'none';
 }
 
 export default function SkeletonToolbar({
@@ -52,7 +54,6 @@ export default function SkeletonToolbar({
   sx,
   showTabs = true,
   rightSlot = 'none',
-  chipWidths = [104, 132, 88],
 }: SkeletonToolbarProps = {}) {
   return (
     <Box
@@ -88,7 +89,8 @@ export default function SkeletonToolbar({
           />
         </Box>
       ) : (
-        rightSlot === 'actions' && <Box sx={{ flex: 1 }} />
+        // GridToolbar inserts this spacer whenever middleContent is absent.
+        <Box sx={{ flex: 1 }} />
       )}
 
       {rightSlot === 'actions' && (
@@ -99,20 +101,6 @@ export default function SkeletonToolbar({
               variant="text"
               width={width}
               sx={skeletonTextSx('bodyMReg')}
-            />
-          ))}
-        </Box>
-      )}
-
-      {rightSlot === 'chips' && (
-        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-          {chipWidths.map(width => (
-            <Skeleton
-              key={width}
-              variant="rounded"
-              width={width}
-              height={CONTROL.height}
-              sx={{ borderRadius: BORDER_RADIUS.pill }}
             />
           ))}
         </Box>

--- a/apps/frontend/src/components/loading/skeletonSurface.ts
+++ b/apps/frontend/src/components/loading/skeletonSurface.ts
@@ -1,0 +1,24 @@
+import type { Theme } from '@mui/material/styles';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
+
+/**
+ * The 1px divider the grid card, section cards and dashboard panels all draw.
+ * Matches BaseDataGrid's cell borders and EntityCard's outline.
+ */
+export const skeletonBorder = (theme: Theme) =>
+  `1px solid ${theme.palette.greyscale.border}`;
+
+/**
+ * The elevated card surface every skeleton container sits on: the grid card,
+ * an EntityCard, a SectionCard, a dashboard panel.
+ *
+ * Mirrors BaseDataGrid's `GRID_PAPER_SX`, which is re-declared here rather than
+ * imported because importing BaseDataGrid would pull @mui/x-data-grid into the
+ * loading chunk and defeat the point of a lightweight fallback.
+ */
+export const skeletonSurfaceSx = {
+  borderRadius: BORDER_RADIUS.md,
+  boxShadow: ELEVATION.xs,
+  border: skeletonBorder,
+  bgcolor: 'background.paper',
+} as const;


### PR DESCRIPTION
## Problem

#2679 added route loading skeletons, but only one shape: a DataGrid. Most protected pages are
tables, so the catch-all under `(protected)` fit them. It does not fit the pages that are not
tables, and those got a fake table that dissolved into something else entirely.

Three shapes were missing.

## Card directories

metrics, requirements, models, tools and projects render a grid of the shared `EntityCard` behind
the borderless `directoryToolbarSx` toolbar, not a DataGrid.

All five declare an identical grid (`xs: 1fr`, `sm: 1fr 1fr`, `md: repeat(3, 1fr)` at
`theme.spacing(3)`), so one `PageCardGridSkeleton` covers them. Geometry mirrors `EntityCard`
itself: the 30px inset, the 20px section gap, the description clamped to 3 lines at 22px, the avatar
meta row and the chip section. Six cards by default, two rows at desktop width, overridable per
route.

## Insights dashboard

Insights is not a list at all: a compact filter bar, a pass-rate summary bar, a three-column
requirement breakdown, then a stack of per-requirement rows. `PageDashboardSkeleton` mirrors
`InsightsSummaryBar` and `RequirementInsightsView`.

This is the loosest fit of the set. The per-requirement rows are approximated as plain bars rather
than reproducing `RequirementInsightsRow`'s internals. If that reads as too vague in review, the
commit is self-contained and the route can fall back to a spinner instead.

## Section pages

settings, organizations/settings and organizations/usage stack `SectionCard`s. They are close enough
to a detail page that a fifth component was not warranted: `PageDetailSkeleton` gains a `showTabs`
prop and is reused. settings has no tab bar, so it also drops the `DetailTabPanel` top inset the bar
would sit above. All three pass `actionCount={0}` and `breadcrumbCount={0}`, matching headers that
carry neither.

## Chat page

playground is a chat interface, so its body has no predictable shape and a spinner is the honest
placeholder. Unlike architect it renders a `PageLayout` header with two FABs, so the header is drawn
and only the chat area falls back to the spinner.

## Shared building blocks

Adding two shapes meant four skeletons repeating the same pieces, so the last two commits pull them
out. Each is now declared once:

| Piece | Was | Now |
| --- | --- | --- |
| `PageLayout` header | 4 copies | `SkeletonPageHeader` |
| Filter / search / tabs row | 3 near-identical rows, 3 copies of the same control sizes | `SkeletonToolbar` |
| Card surface (radius, elevation, border) | 3 copies | `skeletonSurfaceSx` |
| Border helper | 4 copies under 3 names | `skeletonBorder` |
| Full-width status wrapper | 4 copies | `DelayedReveal` |

The three toolbars did differ in two real ways, now props rather than duplication: the gap (spacing
units inside the bordered grid card, a literal 20px for `directoryToolbarSx`) and the right slot
(`actions` for the grid's Select/Columns/Density/Export, `chips` for the insights filters, `none` for
card directories).

Worth being straight about the size: this does **not** shrink the code. 1131 lines before, 1134
after, because the two new modules offset what came out of the skeletons. The value is that the
control dimensions (36, 240, 38, 248) and the surface can no longer drift between shapes, not fewer
lines.

## Pages that needed nothing

Worth recording so the next person does not re-check them:

- `organizations`, `organizations/new`, `organizations/[identifier]` and `organizations/team` are
  pure `redirect()` calls. A server redirect resolves well inside the 500ms hold, so no skeleton is
  ever painted.
- `dashboard` and `test-results` are also redirects, to insights.
- `generation` is a client-side redirect that already renders its own spinner.
- `explorer` renders `ExplorerGrid`, a real DataGrid, so the table catch-all is already correct, and
  its default FAB count already matches.

## Testing

- `next build --webpack` passes
- `tsc --noEmit`, `eslint`, `prettier --check` and the hardcoded-styles check pass across all 15
  touched files
- 269 existing tests pass across the metrics, requirements, models, tools, insights and projects
  suites

Each route passes its real header FAB count (metrics 1, requirements 1, models 2, tools 1,
projects 1, insights 2, playground 2, the three section pages 0) rather than the generic default of
2, so the header does not shift when content arrives.

Reviewers may want to look at `/metrics` and `/insights` directly. The 500ms hold means throttling
is needed to see a skeleton at all.
