### PR TITLE
Plan indicator in the sidebar, and two licensing bugs found building it

### DIFF
--- a/apps/backend/src/rhesis/backend/app/features/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/features/__init__.py
@@ -117,7 +117,14 @@ class DefaultLicenseProvider:
         return True
 
     def info(self, org: Optional[Organization] = None) -> dict:
-        return {"edition": "community", "licensed": False}
+        """Community posture: never a paid tier, never licensed.
+
+        ``is_paid`` describes the tier rather than the licence state; see
+        :meth:`~rhesis.backend.ee.licensing.provider.SignedTokenLicenseProvider._unlicensed_info`.
+        Hardcoded ``False`` here rather than derived, because this provider
+        only ever reports community.
+        """
+        return {"edition": "community", "licensed": False, "is_paid": False}
 
 
 class FeatureRegistry:

--- a/apps/backend/src/rhesis/backend/app/routers/features.py
+++ b/apps/backend/src/rhesis/backend/app/routers/features.py
@@ -22,6 +22,7 @@ from rhesis.backend.app.dependencies import get_current_organization_optional
 from rhesis.backend.app.features import FeatureRegistry
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.quota import QuotaRegistry, limits_to_wire
+from rhesis.backend.app.services.plan import build_plan
 
 router = APIRouter(prefix="/features", tags=["features"])
 
@@ -29,10 +30,57 @@ router = APIRouter(prefix="/features", tags=["features"])
 class LicenseInfo(BaseModel):
     edition: str
     licensed: bool
+    #: Whether ``edition`` is a paid tier. A property of the tier, not of the
+    #: licence state, so a lapsed paid licence is ``is_paid=True`` with
+    #: ``licensed=False`` -- the pair that tells "free tier" apart from "paid
+    #: tier, expired".
+    #:
+    #: Carried here because this response already reports ``edition`` and
+    #: ``licensed``; without it, a client holding two of the three facts is
+    #: invited to infer the third from the edition *name*
+    #: (``edition !== "community"``), which silently misreads any tier added
+    #: or renamed later. Never derive paid-ness from the name.
+    #:
+    #: For *displaying* a plan, use the ``plan`` field below instead: it
+    #: carries the composed display label as well, and is what the frontend's
+    #: single plan badge renders. These two fields are for gating and
+    #: diagnostics.
+    is_paid: bool = False
+
+
+class PlanInfo(BaseModel):
+    """Everything a client needs to render the org's plan, and nothing it
+    should have to interpret.
+
+    Deliberately no tier enum on the wire. A client that switches on tier
+    names has to ship a release before a new or renamed tier displays
+    correctly; one that reads ``name`` plus two booleans does not.
+
+    Carried on this endpoint rather than ``GET /usage`` because it costs
+    nothing here -- :func:`~rhesis.backend.app.services.plan.build_plan` is a
+    pure function of the ``license_info`` this handler already resolves -- and
+    because this response is server-seeded in the frontend's protected layout,
+    so the plan is present on first paint instead of one round trip late.
+    """
+
+    #: Display label. **Render verbatim** -- do not map, case or append to it.
+    #: Composed server-side (see ``services.plan.build_plan``), including the
+    #: qualifier a lapsed paid tier carries.
+    name: str
+    #: Whether this is a paid tier. Describes the *tier*, not the licence, so a
+    #: canceled enterprise licence is still ``is_paid=True``.
+    is_paid: bool = False
+    #: Whether the licence is currently active. ``is_paid`` and ``is_active``
+    #: together separate a free org ``(False, False)`` from a lapsed paid one
+    #: ``(True, False)`` -- the distinction that decides both the badge styling
+    #: and whether an upgrade path is offered.
+    is_active: bool = False
 
 
 class FeaturesResponse(BaseModel):
     license: LicenseInfo
+    #: The org's plan, ready to render. See :class:`PlanInfo`.
+    plan: PlanInfo
     enabled: List[str]
     warnings: Dict[str, str] = Field(default_factory=dict)
     limits: Dict[str, int | None] = Field(default_factory=dict)
@@ -64,7 +112,12 @@ def list_features(
         license=LicenseInfo(
             edition=str(info.get("edition", "community")),
             licensed=bool(info.get("licensed", False)),
+            # Defaults to False when a provider omits it: an unknown posture
+            # must never present as paid.
+            is_paid=bool(info.get("is_paid", False)),
         ),
+        # Free: build_plan is pure, over the info dict already resolved above.
+        plan=PlanInfo(**build_plan(info)),
         enabled=enabled,
         warnings=warnings,
         limits=limits,

--- a/apps/backend/src/rhesis/backend/app/routers/usage.py
+++ b/apps/backend/src/rhesis/backend/app/routers/usage.py
@@ -39,18 +39,35 @@ class UsageResourceItem(BaseModel):
     kind: str
 
 
+class PlanInfo(BaseModel):
+    """Everything a client needs to render the org's plan, and nothing it
+    should have to interpret.
+
+    Deliberately no tier enum on the wire. A client that switches on tier
+    names has to ship a release before a new or renamed tier displays
+    correctly; one that reads ``name`` plus two booleans does not.
+    """
+
+    #: Display label. **Render verbatim** -- do not map, case or append to it.
+    #: Composed server-side (see ``services.usage.build_plan``), including the
+    #: qualifier a lapsed paid tier carries.
+    name: str
+    #: Whether this is a paid tier. Describes the *tier*, not the licence, so a
+    #: canceled enterprise licence is still ``is_paid=True``.
+    is_paid: bool = False
+    #: Whether the licence is currently active. ``is_paid`` and ``is_active``
+    #: together separate a free org ``(False, False)`` from a lapsed paid one
+    #: ``(True, False)`` -- the distinction that decides both the badge styling
+    #: and whether an upgrade path is offered.
+    is_active: bool = False
+
+
 class UsageResponse(BaseModel):
     resources: Dict[str, UsageResourceItem] = Field(default_factory=dict)
+    #: Machine identifier for the licence edition. Diagnostics and analytics
+    #: only -- never for display or for deciding styling. Use ``plan``.
     edition: str
-    #: Whether the org holds an *active* paid license. Distinct from
-    #: ``edition``, which keeps naming a lapsed tier so the UI can say which
-    #: license expired: a canceled enterprise license reports
-    #: ``edition="enterprise", licensed=False`` while resolving to community
-    #: limits. Without this flag a client can only read the edition, and would
-    #: show such an org as Enterprise while it is being held to free-tier
-    #: ceilings -- with no upgrade path offered, because it does not look
-    #: like a free org.
-    licensed: bool = False
+    plan: PlanInfo
 
 
 class UsageHistoryPoint(BaseModel):
@@ -84,6 +101,7 @@ def get_usage(
     return UsageResponse(
         resources={k: UsageResourceItem(**v) for k, v in summary["resources"].items()},
         edition=summary["edition"],
+        plan=PlanInfo(**summary["plan"]),
     )
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/usage.py
+++ b/apps/backend/src/rhesis/backend/app/routers/usage.py
@@ -39,35 +39,13 @@ class UsageResourceItem(BaseModel):
     kind: str
 
 
-class PlanInfo(BaseModel):
-    """Everything a client needs to render the org's plan, and nothing it
-    should have to interpret.
-
-    Deliberately no tier enum on the wire. A client that switches on tier
-    names has to ship a release before a new or renamed tier displays
-    correctly; one that reads ``name`` plus two booleans does not.
-    """
-
-    #: Display label. **Render verbatim** -- do not map, case or append to it.
-    #: Composed server-side (see ``services.usage.build_plan``), including the
-    #: qualifier a lapsed paid tier carries.
-    name: str
-    #: Whether this is a paid tier. Describes the *tier*, not the licence, so a
-    #: canceled enterprise licence is still ``is_paid=True``.
-    is_paid: bool = False
-    #: Whether the licence is currently active. ``is_paid`` and ``is_active``
-    #: together separate a free org ``(False, False)`` from a lapsed paid one
-    #: ``(True, False)`` -- the distinction that decides both the badge styling
-    #: and whether an upgrade path is offered.
-    is_active: bool = False
-
-
 class UsageResponse(BaseModel):
     resources: Dict[str, UsageResourceItem] = Field(default_factory=dict)
     #: Machine identifier for the licence edition. Diagnostics and analytics
-    #: only -- never for display or for deciding styling. Use ``plan``.
+    #: only -- never for display or for deciding styling. The plan a client
+    #: renders lives on ``GET /features`` (see ``services.plan``), which is
+    #: server-seeded in the protected layout and so has it on first paint.
     edition: str
-    plan: PlanInfo
 
 
 class UsageHistoryPoint(BaseModel):
@@ -101,7 +79,6 @@ def get_usage(
     return UsageResponse(
         resources={k: UsageResourceItem(**v) for k, v in summary["resources"].items()},
         edition=summary["edition"],
-        plan=PlanInfo(**summary["plan"]),
     )
 
 

--- a/apps/backend/src/rhesis/backend/app/services/plan.py
+++ b/apps/backend/src/rhesis/backend/app/services/plan.py
@@ -1,0 +1,51 @@
+"""The org's plan, as a display contract.
+
+One builder, :func:`build_plan`, turning a license provider's ``info`` dict
+into the payload clients render. It is a pure function of that dict -- no
+database access -- which is why ``GET /features`` can carry the plan for free:
+that endpoint already resolves ``license_info`` for its own ``license`` field.
+
+This lives apart from the usage service on purpose. A plan is a *licensing*
+fact, not an accounting one, and it first shipped on ``GET /usage`` only
+because that was where the sidebar happened to fetch. Being cheap to compute
+means the transport can be chosen for where clients need it -- and they need it
+on first paint, everywhere, which is ``GET /features`` (server-seeded in the
+protected layout) rather than ``GET /usage`` (client-fetched, one round trip
+behind).
+"""
+
+from __future__ import annotations
+
+__all__ = ["build_plan"]
+
+
+def build_plan(license_info: dict) -> dict:
+    """Build the plan payload a client renders, from a provider's ``info`` dict.
+
+    Returns ``{name, is_paid, is_active}``:
+
+    - ``name`` is the **display label, rendered verbatim by clients.** It is
+      composed here, on purpose: a client that title-cases or appends to it is
+      a client that has to be changed every time a tier is added or renamed.
+      Building it once server-side means a new tier appears correctly in every
+      surface with no frontend release.
+    - ``is_paid`` describes the *tier*; ``is_active`` describes the *licence*.
+      Both are needed, and the pair is why this exists: a free org is
+      ``(False, False)`` and a lapsed enterprise is ``(True, False)``. With
+      only one flag a client cannot separate them, which previously left the
+      UI inferring "is this paid?" from the edition string -- so a renamed or
+      newly added tier silently rendered as free.
+
+    A lapsed paid tier carries the qualifier in ``name``, so the state is
+    legible even where styling is not (a screenshot, a narrow column, a
+    monochrome theme).
+    """
+    edition = str(license_info.get("edition", "community"))
+    is_paid = bool(license_info.get("is_paid", False))
+    is_active = bool(license_info.get("licensed", False))
+
+    name = edition.replace("_", " ").replace("-", " ").strip().title() or "Unknown"
+    if is_paid and not is_active:
+        name = f"{name} (inactive)"
+
+    return {"name": name, "is_paid": is_paid, "is_active": is_active}

--- a/apps/backend/src/rhesis/backend/app/services/usage.py
+++ b/apps/backend/src/rhesis/backend/app/services/usage.py
@@ -240,14 +240,20 @@ def get_usage_summary(
     period_start: Optional[date] = None,
 ) -> dict:
     """Return ``{resources: {<resource>: {used, limit, ceiling, period_start, period_end,
-    kind}}, edition, licensed}``.
+    kind}}, edition}``.
 
-    ``edition`` and ``licensed`` are reported separately because a lapsed
-    license keeps its edition name: a canceled enterprise license resolves to
-    community *limits* but still reports ``edition="enterprise"``, so that the
-    UI can name which license expired. A client reading only ``edition`` would
-    present such an org as Enterprise while it is held to free-tier ceilings,
-    and would withhold the upgrade path because it does not look free.
+    ``edition`` is a machine identifier for diagnostics and analytics, never
+    for display or for deciding styling. It is not enough on its own: a lapsed
+    licence keeps its edition name, so a canceled enterprise licence resolves
+    to community *limits* while still reporting ``edition="enterprise"``. A
+    client reading only this would present such an org as Enterprise while it
+    is held to free-tier ceilings, and would withhold the upgrade path because
+    it does not look free.
+
+    What a client should render instead is the plan
+    (:func:`~rhesis.backend.app.services.plan.build_plan`), carried on
+    ``GET /features``: a display label plus ``is_paid``/``is_active``, which is
+    the pair that separates a free org from a lapsed paid one.
 
     Flow resources report cumulative usage from the ``usage`` table for the
     requested billing period (the current one by default). ``kind``

--- a/apps/backend/src/rhesis/backend/app/services/usage.py
+++ b/apps/backend/src/rhesis/backend/app/services/usage.py
@@ -194,6 +194,38 @@ def increment_usage(
     notify_flow_crossing(db, org_id, resource, previous_used=new_used - amount, new_used=new_used)
 
 
+def build_plan(license_info: dict) -> dict:
+    """Build the plan payload a client renders, from a provider's ``info`` dict.
+
+    Returns ``{name, is_paid, is_active}``:
+
+    - ``name`` is the **display label, rendered verbatim by clients.** It is
+      composed here, on purpose: a client that title-cases or appends to it is
+      a client that has to be changed every time a tier is added or renamed.
+      Building it once server-side means a new tier appears correctly in every
+      surface with no frontend release.
+    - ``is_paid`` describes the *tier*; ``is_active`` describes the *licence*.
+      Both are needed, and the pair is why this exists: a free org is
+      ``(False, False)`` and a lapsed enterprise is ``(True, False)``. With
+      only one flag a client cannot separate them, which previously left the
+      UI inferring "is this paid?" from the edition string -- so a renamed or
+      newly added tier silently rendered as free.
+
+    A lapsed paid tier carries the qualifier in ``name``, so the state is
+    legible even where styling is not (a screenshot, a narrow column, a
+    monochrome theme).
+    """
+    edition = str(license_info.get("edition", "community"))
+    is_paid = bool(license_info.get("is_paid", False))
+    is_active = bool(license_info.get("licensed", False))
+
+    name = edition.replace("_", " ").replace("-", " ").strip().title() or "Unknown"
+    if is_paid and not is_active:
+        name = f"{name} (inactive)"
+
+    return {"name": name, "is_paid": is_paid, "is_active": is_active}
+
+
 def _count_org_rows(db: Session, model, org_id: str, *, exclude_deleted: bool) -> int:
     """Live ``COUNT(*)`` of *model* rows belonging to *org_id*.
 
@@ -320,8 +352,7 @@ def get_usage_summary(
 
     license_info = FeatureRegistry.license_info(org=org)
     edition = str(license_info.get("edition", "community"))
-    licensed = bool(license_info.get("licensed", False))
-    return {"resources": resources, "edition": edition, "licensed": licensed}
+    return {"resources": resources, "edition": edition, "plan": build_plan(license_info)}
 
 
 def _recent_period_starts(months: int, today: Optional[date] = None) -> list[date]:

--- a/apps/backend/src/rhesis/backend/app/services/usage.py
+++ b/apps/backend/src/rhesis/backend/app/services/usage.py
@@ -194,38 +194,6 @@ def increment_usage(
     notify_flow_crossing(db, org_id, resource, previous_used=new_used - amount, new_used=new_used)
 
 
-def build_plan(license_info: dict) -> dict:
-    """Build the plan payload a client renders, from a provider's ``info`` dict.
-
-    Returns ``{name, is_paid, is_active}``:
-
-    - ``name`` is the **display label, rendered verbatim by clients.** It is
-      composed here, on purpose: a client that title-cases or appends to it is
-      a client that has to be changed every time a tier is added or renamed.
-      Building it once server-side means a new tier appears correctly in every
-      surface with no frontend release.
-    - ``is_paid`` describes the *tier*; ``is_active`` describes the *licence*.
-      Both are needed, and the pair is why this exists: a free org is
-      ``(False, False)`` and a lapsed enterprise is ``(True, False)``. With
-      only one flag a client cannot separate them, which previously left the
-      UI inferring "is this paid?" from the edition string -- so a renamed or
-      newly added tier silently rendered as free.
-
-    A lapsed paid tier carries the qualifier in ``name``, so the state is
-    legible even where styling is not (a screenshot, a narrow column, a
-    monochrome theme).
-    """
-    edition = str(license_info.get("edition", "community"))
-    is_paid = bool(license_info.get("is_paid", False))
-    is_active = bool(license_info.get("licensed", False))
-
-    name = edition.replace("_", " ").replace("-", " ").strip().title() or "Unknown"
-    if is_paid and not is_active:
-        name = f"{name} (inactive)"
-
-    return {"name": name, "is_paid": is_paid, "is_active": is_active}
-
-
 def _count_org_rows(db: Session, model, org_id: str, *, exclude_deleted: bool) -> int:
     """Live ``COUNT(*)`` of *model* rows belonging to *org_id*.
 
@@ -350,9 +318,12 @@ def get_usage_summary(
             "kind": STOCK_KIND if counter is not None else FLOW_KIND,
         }
 
+    # Machine identifier only. The plan a client *displays* is built by
+    # services.plan.build_plan and carried on GET /features, which is
+    # server-seeded and so has it on first paint; see that module's docstring.
     license_info = FeatureRegistry.license_info(org=org)
     edition = str(license_info.get("edition", "community"))
-    return {"resources": resources, "edition": edition, "plan": build_plan(license_info)}
+    return {"resources": resources, "edition": edition}
 
 
 def _recent_period_starts(months: int, today: Optional[date] = None) -> list[date]:

--- a/apps/frontend/src/__tests__/components/navigation/Sidebar.test.tsx
+++ b/apps/frontend/src/__tests__/components/navigation/Sidebar.test.tsx
@@ -70,13 +70,13 @@ const mockUsageResources: {
   >;
 } = { current: {} };
 const mockUsagePlan: {
-  current: { edition: string; licensed: boolean | null };
-} = { current: { edition: 'community', licensed: false } };
+  current: { name: string; is_paid: boolean; is_active: boolean } | null;
+} = { current: { name: 'Community', is_paid: false, is_active: false } };
 jest.mock('@/contexts/UsageContext', () => ({
   useUsage: () => ({
     resources: mockUsageResources.current,
-    edition: mockUsagePlan.current.edition,
-    licensed: mockUsagePlan.current.licensed,
+    edition: 'community',
+    plan: mockUsagePlan.current,
     loading: false,
     error: null,
   }),
@@ -122,7 +122,11 @@ describe('Sidebar', () => {
     mockRouterPush.mockClear();
     mockUnreadBySection.current = {};
     mockUsageResources.current = {};
-    mockUsagePlan.current = { edition: 'community', licensed: false };
+    mockUsagePlan.current = {
+      name: 'Community',
+      is_paid: false,
+      is_active: false,
+    };
   });
 
   describe('plan row in the footer card', () => {
@@ -151,7 +155,7 @@ describe('Sidebar', () => {
       const { container } = render(<Sidebar />);
 
       const card = footerCard(container);
-      const plan = screen.getByText('community');
+      const plan = screen.getByText('Community');
       const star = screen.getByText('Star Rhesis');
 
       expect(card).toContainElement(plan);
@@ -164,19 +168,27 @@ describe('Sidebar', () => {
     });
 
     it('names an active paid plan', () => {
-      mockUsagePlan.current = { edition: 'enterprise', licensed: true };
+      mockUsagePlan.current = {
+        name: 'Enterprise',
+        is_paid: true,
+        is_active: true,
+      };
       setupMocks({ navigation: footerNav });
       render(<Sidebar />);
 
-      expect(screen.getByText('enterprise')).toBeInTheDocument();
+      expect(screen.getByText('Enterprise')).toBeInTheDocument();
     });
 
     it('marks a lapsed paid plan inactive', () => {
-      mockUsagePlan.current = { edition: 'enterprise', licensed: false };
+      mockUsagePlan.current = {
+        name: 'Enterprise (inactive)',
+        is_paid: true,
+        is_active: false,
+      };
       setupMocks({ navigation: footerNav });
       render(<Sidebar />);
 
-      expect(screen.getByText('enterprise (inactive)')).toBeInTheDocument();
+      expect(screen.getByText('Enterprise (inactive)')).toBeInTheDocument();
     });
   });
 

--- a/apps/frontend/src/__tests__/components/navigation/Sidebar.test.tsx
+++ b/apps/frontend/src/__tests__/components/navigation/Sidebar.test.tsx
@@ -76,10 +76,18 @@ jest.mock('@/contexts/UsageContext', () => ({
   useUsage: () => ({
     resources: mockUsageResources.current,
     edition: 'community',
-    plan: mockUsagePlan.current,
     loading: false,
     error: null,
   }),
+}));
+
+// Only `usePlan` is stubbed -- spreading the real module keeps `useFeature`
+// and friends intact for the rest of the tree. The plan rides on
+// `GET /features` because that response is server-seeded, so the row has it on
+// first paint.
+jest.mock('@/contexts/FeaturesContext', () => ({
+  ...jest.requireActual('@/contexts/FeaturesContext'),
+  usePlan: () => mockUsagePlan.current,
 }));
 
 // ── imports (after mocks) ──────────────────────────────────────────────────

--- a/apps/frontend/src/app/(protected)/layout.tsx
+++ b/apps/frontend/src/app/(protected)/layout.tsx
@@ -25,6 +25,11 @@ import { ProtectedLayoutClient } from './ProtectedLayoutClient';
  * the app. The cost (a license lookup plus four counting queries) is paid
  * once per `UsageContext`'s 5-minute `staleTime` window, not per
  * navigation. Only the Usage page seeds it, from its own server component.
+ *
+ * That is also why the org's plan rides on `GET /features` rather than
+ * `GET /usage`: it is needed on first paint (the sidebar's plan row) and is
+ * free to compute, so it belongs on the response already seeded here instead
+ * of forcing a seed of the expensive one.
  */
 export default async function ProtectedLayout({
   children,

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
@@ -14,6 +14,7 @@ import { FilterButton } from '@/components/common/FilterButton';
 import { UpgradeLink } from '@/components/common/QuotaChips';
 import { PlanBadge } from '@/components/common/PlanBadge';
 import { useUsageForPeriod } from '@/hooks/useUsageForPeriod';
+import { usePlan } from '@/contexts/FeaturesContext';
 import UsageOverviewFilterDrawer from './UsageOverviewFilterDrawer';
 import { BORDER_RADIUS } from '@/styles/theme';
 import {
@@ -231,7 +232,10 @@ function ResourceList({
 export default function UsageOverviewTab() {
   const [periodStart, setPeriodStart] = React.useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = React.useState(false);
-  const { resources, plan, loading, error } = useUsageForPeriod(periodStart);
+  const { resources, loading, error } = useUsageForPeriod(periodStart);
+  // Plan is not period-scoped: it is today's plan even when viewing a past
+  // month, so it comes from the org's licence rather than the usage snapshot.
+  const plan = usePlan();
 
   // The period is the only filter here, so an active one is a count of 1.
   // Passing the number matters: given only the boolean, FilterButton draws

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
@@ -11,7 +11,8 @@ import {
 import { alpha } from '@mui/material/styles';
 import { SectionCard } from '@/components/common/SectionCard';
 import { FilterButton } from '@/components/common/FilterButton';
-import { PlanChip, UpgradeLink } from '@/components/common/QuotaChips';
+import { UpgradeLink } from '@/components/common/QuotaChips';
+import { PlanBadge } from '@/components/common/PlanBadge';
 import { useUsageForPeriod } from '@/hooks/useUsageForPeriod';
 import UsageOverviewFilterDrawer from './UsageOverviewFilterDrawer';
 import { BORDER_RADIUS } from '@/styles/theme';
@@ -20,12 +21,8 @@ import {
   QUOTA_RESOURCE_ORDER,
   type QuotaResource,
 } from '@/constants/quota';
-import {
-  classifyZone,
-  isUnlicensedPlan,
-  zoneColor,
-  type QuotaZone,
-} from '@/utils/quota';
+import { classifyZone, zoneColor, type QuotaZone } from '@/utils/quota';
+import { isUpgradeable } from '@/utils/plan';
 import type { UsageResourceItem } from '@/utils/api-client/usage-client';
 
 function formatPeriodDate(isoDate: string): string {
@@ -234,8 +231,7 @@ function ResourceList({
 export default function UsageOverviewTab() {
   const [periodStart, setPeriodStart] = React.useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = React.useState(false);
-  const { resources, edition, licensed, loading, error } =
-    useUsageForPeriod(periodStart);
+  const { resources, plan, loading, error } = useUsageForPeriod(periodStart);
 
   // The period is the only filter here, so an active one is a count of 1.
   // Passing the number matters: given only the boolean, FilterButton draws
@@ -244,8 +240,8 @@ export default function UsageOverviewTab() {
 
   const headerActions = (
     <Stack direction="row" spacing={1.5} alignItems="center">
-      {edition && <PlanChip edition={edition} licensed={licensed} />}
-      {isUnlicensedPlan(edition, licensed) && <UpgradeLink />}
+      <PlanBadge plan={plan} />
+      {isUpgradeable(plan) && <UpgradeLink />}
       <FilterButton
         onClick={() => setDrawerOpen(true)}
         hasActiveFilters={activeFilterCount > 0}

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
@@ -43,7 +43,7 @@ beforeEach(() => {
   mockUseUsage.mockReturnValue({
     resources: USAGE_RESOURCES,
     edition: 'community',
-    licensed: false,
+    plan: { name: 'Community', is_paid: false, is_active: false },
     loading: false,
     error: null,
   });
@@ -54,6 +54,7 @@ describe('UsageOverviewTab', () => {
     mockUseUsage.mockReturnValue({
       resources: {},
       edition: null,
+      plan: null,
       loading: true,
       error: null,
     });
@@ -67,6 +68,7 @@ describe('UsageOverviewTab', () => {
     mockUseUsage.mockReturnValue({
       resources: {},
       edition: null,
+      plan: null,
       loading: false,
       error: new Error('boom'),
     });
@@ -99,10 +101,10 @@ describe('UsageOverviewTab', () => {
     expect(screen.getByText(/999.*\(Unlimited\)/)).toBeInTheDocument();
   });
 
-  it('shows a plan chip and an upgrade link for the community edition', () => {
+  it('shows a plan badge and an upgrade link for a free org', () => {
     render(<UsageOverviewTab />);
 
-    expect(screen.getByText('community')).toBeInTheDocument();
+    expect(screen.getByText('Community')).toBeInTheDocument();
     const upgradeLink = screen.getByRole('link', { name: 'Upgrade' });
     expect(upgradeLink).toHaveAttribute('href', 'https://rhesis.ai/pricing');
     expect(upgradeLink).toHaveAttribute('target', '_blank');
@@ -166,7 +168,7 @@ describe('UsageOverviewTab', () => {
         },
       },
       edition: 'community',
-      licensed: false,
+      plan: { name: 'Community', is_paid: false, is_active: false },
       loading: false,
       error: null,
     });
@@ -176,18 +178,18 @@ describe('UsageOverviewTab', () => {
     expect(screen.getByText(/Jan 1, 2026 – Jan 31, 2026/)).toBeInTheDocument();
   });
 
-  it('hides the upgrade link for a paid edition', () => {
+  it('hides the upgrade link for an active paid plan', () => {
     mockUseUsage.mockReturnValue({
       resources: USAGE_RESOURCES,
       edition: 'enterprise',
-      licensed: true,
+      plan: { name: 'Enterprise', is_paid: true, is_active: true },
       loading: false,
       error: null,
     });
 
     render(<UsageOverviewTab />);
 
-    expect(screen.getByText('enterprise')).toBeInTheDocument();
+    expect(screen.getByText('Enterprise')).toBeInTheDocument();
     expect(
       screen.queryByRole('link', { name: 'Upgrade' })
     ).not.toBeInTheDocument();
@@ -200,14 +202,14 @@ describe('UsageOverviewTab', () => {
     mockUseUsage.mockReturnValue({
       resources: USAGE_RESOURCES,
       edition: 'enterprise',
-      licensed: false,
+      plan: { name: 'Enterprise (inactive)', is_paid: true, is_active: false },
       loading: false,
       error: null,
     });
 
     render(<UsageOverviewTab />);
 
-    expect(screen.getByText('enterprise (inactive)')).toBeInTheDocument();
+    expect(screen.getByText('Enterprise (inactive)')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Upgrade' })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
@@ -4,12 +4,21 @@ import '@testing-library/jest-dom';
 
 import UsageOverviewTab from '../UsageOverviewTab';
 import { useUsageForPeriod } from '@/hooks/useUsageForPeriod';
+import { usePlan } from '@/contexts/FeaturesContext';
 
 jest.mock('@/hooks/useUsageForPeriod', () => ({
   useUsageForPeriod: jest.fn(),
 }));
 
+// The plan is not period-scoped, so it comes from `usePlan` (backed by
+// `GET /features`) rather than from the period's usage snapshot.
+jest.mock('@/contexts/FeaturesContext', () => ({
+  ...jest.requireActual('@/contexts/FeaturesContext'),
+  usePlan: jest.fn(),
+}));
+
 const mockUseUsage = useUsageForPeriod as jest.Mock;
+const mockUsePlan = usePlan as jest.Mock;
 
 const USAGE_RESOURCES = {
   test_executions: {
@@ -40,12 +49,17 @@ const USAGE_RESOURCES = {
 
 beforeEach(() => {
   mockUseUsage.mockReset();
+  mockUsePlan.mockReset();
   mockUseUsage.mockReturnValue({
     resources: USAGE_RESOURCES,
     edition: 'community',
-    plan: { name: 'Community', is_paid: false, is_active: false },
     loading: false,
     error: null,
+  });
+  mockUsePlan.mockReturnValue({
+    name: 'Community',
+    is_paid: false,
+    is_active: false,
   });
 });
 
@@ -54,10 +68,10 @@ describe('UsageOverviewTab', () => {
     mockUseUsage.mockReturnValue({
       resources: {},
       edition: null,
-      plan: null,
       loading: true,
       error: null,
     });
+    mockUsePlan.mockReturnValue(null);
 
     render(<UsageOverviewTab />);
 
@@ -68,10 +82,10 @@ describe('UsageOverviewTab', () => {
     mockUseUsage.mockReturnValue({
       resources: {},
       edition: null,
-      plan: null,
       loading: false,
       error: new Error('boom'),
     });
+    mockUsePlan.mockReturnValue(null);
 
     render(<UsageOverviewTab />);
 
@@ -168,7 +182,6 @@ describe('UsageOverviewTab', () => {
         },
       },
       edition: 'community',
-      plan: { name: 'Community', is_paid: false, is_active: false },
       loading: false,
       error: null,
     });
@@ -182,9 +195,13 @@ describe('UsageOverviewTab', () => {
     mockUseUsage.mockReturnValue({
       resources: USAGE_RESOURCES,
       edition: 'enterprise',
-      plan: { name: 'Enterprise', is_paid: true, is_active: true },
       loading: false,
       error: null,
+    });
+    mockUsePlan.mockReturnValue({
+      name: 'Enterprise',
+      is_paid: true,
+      is_active: true,
     });
 
     render(<UsageOverviewTab />);
@@ -202,9 +219,13 @@ describe('UsageOverviewTab', () => {
     mockUseUsage.mockReturnValue({
       resources: USAGE_RESOURCES,
       edition: 'enterprise',
-      plan: { name: 'Enterprise (inactive)', is_paid: true, is_active: false },
       loading: false,
       error: null,
+    });
+    mockUsePlan.mockReturnValue({
+      name: 'Enterprise (inactive)',
+      is_paid: true,
+      is_active: false,
     });
 
     render(<UsageOverviewTab />);

--- a/apps/frontend/src/components/auth/QuotaBanner.tsx
+++ b/apps/frontend/src/components/auth/QuotaBanner.tsx
@@ -13,11 +13,9 @@ import CloseIcon from '@mui/icons-material/Close';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import NextLink from 'next/link';
 import { useUsage } from '@/contexts/UsageContext';
-import { useCan } from '@/components/common/Can';
-import { Capability } from '@/constants/capabilities';
+import { useCanUpgrade } from '@/hooks/useQuotaGate';
 import { UPGRADE_URL, type QuotaResource } from '@/constants/quota';
 import { findWorstResource, quotaCopy } from '@/utils/quota';
-import { isUpgradeable } from '@/utils/plan';
 
 /**
  * Org-wide quota banner. `usage:read` (the same capability `GET /usage`
@@ -25,12 +23,13 @@ import { isUpgradeable } from '@/utils/plan';
  * enforcement blocks members too, and hiding the reason from them only
  * turns a 402 into a support ticket (see `auth/rbac.py`'s comment on
  * `Usage.READ`). So this banner is visible to anyone in the org; only the
- * "Upgrade" link is narrower, gated on `Organization.UPDATE` below.
+ * "Upgrade" link is narrower, gated on `Organization.UPDATE` via
+ * `useCanUpgrade`.
  */
 export default function QuotaBanner() {
   const theme = useTheme();
-  const { resources, plan, loading } = useUsage();
-  const canManageOrg = useCan(Capability.Organization.UPDATE);
+  const { resources, loading } = useUsage();
+  const canUpgrade = useCanUpgrade();
   const [dismissedFor, setDismissedFor] = useState<QuotaResource | null>(null);
 
   const worst = useMemo(() => {
@@ -50,7 +49,6 @@ export default function QuotaBanner() {
   // Never reached with `limit === null` -- `findWorstResource` only flags
   // resources whose zone isn't `healthy`, which requires a non-null limit.
   const limit = item.limit ?? 0;
-  const canUpgrade = canManageOrg && isUpgradeable(plan);
   const { sentence } = quotaCopy({
     resource: worst.resource,
     kind: item.kind,

--- a/apps/frontend/src/components/auth/QuotaBanner.tsx
+++ b/apps/frontend/src/components/auth/QuotaBanner.tsx
@@ -16,7 +16,8 @@ import { useUsage } from '@/contexts/UsageContext';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { UPGRADE_URL, type QuotaResource } from '@/constants/quota';
-import { findWorstResource, isUnlicensedPlan, quotaCopy } from '@/utils/quota';
+import { findWorstResource, quotaCopy } from '@/utils/quota';
+import { isUpgradeable } from '@/utils/plan';
 
 /**
  * Org-wide quota banner. `usage:read` (the same capability `GET /usage`
@@ -28,7 +29,7 @@ import { findWorstResource, isUnlicensedPlan, quotaCopy } from '@/utils/quota';
  */
 export default function QuotaBanner() {
   const theme = useTheme();
-  const { resources, edition, licensed, loading } = useUsage();
+  const { resources, plan, loading } = useUsage();
   const canManageOrg = useCan(Capability.Organization.UPDATE);
   const [dismissedFor, setDismissedFor] = useState<QuotaResource | null>(null);
 
@@ -49,7 +50,7 @@ export default function QuotaBanner() {
   // Never reached with `limit === null` -- `findWorstResource` only flags
   // resources whose zone isn't `healthy`, which requires a non-null limit.
   const limit = item.limit ?? 0;
-  const canUpgrade = canManageOrg && isUnlicensedPlan(edition, licensed);
+  const canUpgrade = canManageOrg && isUpgradeable(plan);
   const { sentence } = quotaCopy({
     resource: worst.resource,
     kind: item.kind,

--- a/apps/frontend/src/components/auth/__tests__/QuotaBanner.test.tsx
+++ b/apps/frontend/src/components/auth/__tests__/QuotaBanner.test.tsx
@@ -10,6 +10,20 @@ jest.mock('@/contexts/UsageContext', () => ({
   useUsage: jest.fn(),
 }));
 
+// The plan drives the upgrade link, and comes from `GET /features` via
+// `usePlan` (server-seeded, so it is there on first paint) rather than from
+// usage.
+//
+// Deliberately a narrow mock, not `...jest.requireActual(...)`: this tree uses
+// exactly one hook from each context, and anything new it reaches for should
+// fail loudly on the missing export rather than quietly resolve against a real
+// context this test never populates. A test passing while the component sees
+// empty data is the worse outcome. `Sidebar.test.tsx` spreads the real module
+// because that tree genuinely renders other consumers of it.
+jest.mock('@/contexts/FeaturesContext', () => ({
+  usePlan: jest.fn(),
+}));
+
 jest.mock('@/components/common/Can', () => ({
   useCan: () => true,
   useCanWithStatus: () => ({ allowed: true, loading: false }),
@@ -18,6 +32,7 @@ jest.mock('@/components/common/Can', () => ({
 }));
 
 import { useUsage } from '@/contexts/UsageContext';
+import { usePlan } from '@/contexts/FeaturesContext';
 
 /** Build a `UsageResourceItem`; `ceiling` defaults to `limit` (a hard tier). */
 function item(
@@ -51,10 +66,10 @@ function mockUsage(
   (useUsage as jest.Mock).mockReturnValue({
     resources,
     edition: 'community',
-    plan,
     loading,
     error: null,
   });
+  (usePlan as jest.Mock).mockReturnValue(plan);
 }
 
 afterEach(() => {

--- a/apps/frontend/src/components/auth/__tests__/QuotaBanner.test.tsx
+++ b/apps/frontend/src/components/auth/__tests__/QuotaBanner.test.tsx
@@ -40,17 +40,18 @@ function mockUsage(
   resources: Record<string, UsageResourceItem>,
   options: {
     loading?: boolean;
-    edition?: string | null;
-    licensed?: boolean | null;
+    plan?: { name: string; is_paid: boolean; is_active: boolean } | null;
   } = {}
 ) {
-  // `licensed: false` alongside the community default, matching what the
-  // backend actually sends for a free org.
-  const { loading = false, edition = 'community', licensed = false } = options;
+  // Defaults to a free org, matching what the backend sends for one.
+  const {
+    loading = false,
+    plan = { name: 'Community', is_paid: false, is_active: false },
+  } = options;
   (useUsage as jest.Mock).mockReturnValue({
     resources,
-    edition,
-    licensed,
+    edition: 'community',
+    plan,
     loading,
     error: null,
   });
@@ -137,11 +138,8 @@ describe('QuotaBanner', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('offers to upgrade on a community-edition org', () => {
-    mockUsage(
-      { [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) },
-      { edition: 'community' }
-    );
+  it('offers to upgrade on a free org', () => {
+    mockUsage({ [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) }, {});
     render(<QuotaBanner />);
     expect(
       screen.getByRole('link', { name: /upgrade plan/i })
@@ -151,7 +149,7 @@ describe('QuotaBanner', () => {
   it('does not offer to upgrade a paying org', () => {
     mockUsage(
       { [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) },
-      { edition: 'pro', licensed: true }
+      { plan: { name: 'Pro', is_paid: true, is_active: true } }
     );
     render(<QuotaBanner />);
     expect(
@@ -165,7 +163,13 @@ describe('QuotaBanner', () => {
     // exactly this org blocked at free-tier ceilings with no way forward.
     mockUsage(
       { [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) },
-      { edition: 'enterprise', licensed: false }
+      {
+        plan: {
+          name: 'Enterprise (inactive)',
+          is_paid: true,
+          is_active: false,
+        },
+      }
     );
     render(<QuotaBanner />);
     expect(
@@ -173,12 +177,12 @@ describe('QuotaBanner', () => {
     ).toBeInTheDocument();
   });
 
-  it('offers nothing while licence status is still unknown', () => {
-    // A response from a backend predating `licensed`. Must not read as
-    // unlicensed and prompt a paying customer to upgrade.
+  it('offers nothing while the plan is still unknown', () => {
+    // Still loading, or a response predating the `plan` field. Must not read
+    // as unlicensed and prompt a paying customer to upgrade.
     mockUsage(
       { [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) },
-      { edition: 'enterprise', licensed: null }
+      { plan: null }
     );
     render(<QuotaBanner />);
     expect(

--- a/apps/frontend/src/components/common/CrownIcon.tsx
+++ b/apps/frontend/src/components/common/CrownIcon.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import SvgIcon, { type SvgIconProps } from '@mui/material/SvgIcon';
+
+/**
+ * A crown, filled and outlined.
+ *
+ * Hand-drawn because there isn't one to import: `@mui/icons-material` has no
+ * crown glyph, and the repo's only other icon package
+ * (`@icons-pack/react-simple-icons`) is brand logos. The nearest Material icon,
+ * `WorkspacePremium`, is a rosette medal -- close enough to pass a code review
+ * and obviously not a crown on screen.
+ *
+ * One shape, two renderings, so the filled and outlined states cannot drift
+ * into different silhouettes: `CrownFilledIcon` paints it, `CrownOutlinedIcon`
+ * strokes it. Stroke width is 1.6 to match the weight of the Material outlined
+ * icons it sits beside in the sidebar card.
+ *
+ * Both inherit `currentColor` and MUI's 24px `fontSize`, so the caller controls
+ * colour and size exactly as it would for any icon from the Material set.
+ */
+
+/**
+ * Crown body: two shoulders, three peaks, and a base band.
+ *
+ * Ink spans y 4.5 to 19.5, so it is centred on the 24px box's midpoint (12).
+ * That matters because the icon is drawn beside a shorter pill and centred
+ * against it: artwork sitting low in its own viewBox reads as a misaligned
+ * icon no amount of `alignItems: center` can fix. The first version ran
+ * 4.5 to 21 (centre 12.75) with a 1.5-unit gap under the body, which made the
+ * base look like a detached underline and pulled the glyph visually lower
+ * still. The band now sits 1 unit under the body, close enough to read as part
+ * of the crown.
+ *
+ * Horizontally the shoulders are at x 2.5 and 21.5, centred on 12 as well.
+ */
+const CROWN_PATH = 'M4.5 16 L2.5 6 L8 9.5 L12 4.5 L16 9.5 L21.5 6 L19.5 16 Z';
+const CROWN_BASE = 'M5 17 H19 V19.5 H5 Z';
+
+export function CrownFilledIcon(props: SvgIconProps) {
+  return (
+    // `data-testid` before the spread, so a caller can still override it --
+    // MUI's generated icons carry one, and tests distinguish the two states by
+    // it rather than by inspecting path geometry.
+    <SvgIcon viewBox="0 0 24 24" data-testid="CrownFilledIcon" {...props}>
+      <path d={CROWN_PATH} />
+      <path d={CROWN_BASE} />
+    </SvgIcon>
+  );
+}
+
+export function CrownOutlinedIcon(props: SvgIconProps) {
+  return (
+    <SvgIcon viewBox="0 0 24 24" data-testid="CrownOutlinedIcon" {...props}>
+      <g
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.6}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      >
+        <path d={CROWN_PATH} />
+        {/* Stroked at 1.6, so this spans ~17.5-19.1: the same band the filled
+            variant paints, keeping both silhouettes centred alike. */}
+        <path d="M5 18.3 H19" />
+      </g>
+    </SvgIcon>
+  );
+}

--- a/apps/frontend/src/components/common/PlanBadge.tsx
+++ b/apps/frontend/src/components/common/PlanBadge.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import Chip from '@mui/material/Chip';
+import { useTheme } from '@mui/material/styles';
+import WorkspacePremiumIcon from '@mui/icons-material/WorkspacePremium';
+import WorkspacePremiumOutlinedIcon from '@mui/icons-material/WorkspacePremiumOutlined';
+import { BORDER_RADIUS, PLAN_COLORS } from '@/styles/theme-constants';
+import { planLabel, resolvePlanStyle } from '@/utils/plan';
+import type { Plan } from '@/utils/api-client/usage-client';
+
+/**
+ * The plan pill. **The only one.** Every surface that shows a plan renders
+ * this and takes its styling from `resolvePlanStyle`, so the sidebar, the org
+ * menu and the usage page cannot drift apart.
+ *
+ * Every variant gets identical padding, radius, size and weight from the one
+ * `Chip` below — only the colour differs, and only because the resolver
+ * returned a different value. Two tiers can never differ in size or shape.
+ *
+ * The label is whatever the API sent, rendered verbatim. Nothing here maps,
+ * cases or inspects a tier name, so an unrecognized tier displays correctly
+ * with no code change and falls back to the neutral style.
+ *
+ * Renders nothing when there is no plan yet, rather than a placeholder: a plan
+ * must not flicker from a guess to the real value.
+ */
+export function PlanBadge({ plan }: { plan: Plan | null | undefined }) {
+  const label = planLabel(plan);
+  if (label === null) return null;
+
+  return (
+    <Chip
+      label={label}
+      size="small"
+      color={resolvePlanStyle(plan).chipColor}
+      sx={{
+        borderRadius: BORDER_RADIUS.pill,
+        // Read from the theme rather than written as 600: the semibold weight
+        // is brand-dependent (`w600` in theme.ts is 700 when a brand font is
+        // configured), so a literal would render this badge lighter than every
+        // other semibold element on a branded deployment.
+        fontWeight: theme => theme.typography.captionBold.fontWeight,
+      }}
+    />
+  );
+}
+
+/**
+ * The plan's crown, for a row that leads with an icon.
+ *
+ * Filled and gold for an active paid plan; outlined otherwise. Kept beside the
+ * badge so the crown and the pill are resolved from the same place — the icon
+ * and the pill disagreeing about whether a plan is paid would be worse than
+ * either being wrong alone.
+ *
+ * Takes no colour prop. A caller wanting the neutral row colour gets it by
+ * default, because the resolver returns `crownColor: null` for the free
+ * variant and this then inherits.
+ */
+export function PlanCrownIcon({ plan }: { plan: Plan | null | undefined }) {
+  const theme = useTheme();
+  const style = resolvePlanStyle(plan);
+  const Icon = style.crownFilled
+    ? WorkspacePremiumIcon
+    : WorkspacePremiumOutlinedIcon;
+
+  const palette =
+    theme.palette.mode === 'dark' ? PLAN_COLORS.dark : PLAN_COLORS.light;
+  const color =
+    style.crownColor === null
+      ? 'inherit'
+      : style.crownColor === 'warning'
+        ? theme.palette.warning.main
+        : palette[style.crownColor];
+
+  return <Icon sx={{ color }} />;
+}
+
+export default PlanBadge;

--- a/apps/frontend/src/components/common/PlanBadge.tsx
+++ b/apps/frontend/src/components/common/PlanBadge.tsx
@@ -6,7 +6,7 @@ import WorkspacePremiumIcon from '@mui/icons-material/WorkspacePremium';
 import WorkspacePremiumOutlinedIcon from '@mui/icons-material/WorkspacePremiumOutlined';
 import { BORDER_RADIUS, PLAN_COLORS } from '@/styles/theme-constants';
 import { planLabel, resolvePlanStyle } from '@/utils/plan';
-import type { Plan } from '@/utils/api-client/usage-client';
+import type { Plan } from '@/utils/api-client/features-client';
 
 /**
  * The plan pill. **The only one.** Every surface that shows a plan renders

--- a/apps/frontend/src/components/common/PlanBadge.tsx
+++ b/apps/frontend/src/components/common/PlanBadge.tsx
@@ -1,25 +1,36 @@
 'use client';
 
-import Chip from '@mui/material/Chip';
 import { useTheme } from '@mui/material/styles';
-import WorkspacePremiumIcon from '@mui/icons-material/WorkspacePremium';
-import WorkspacePremiumOutlinedIcon from '@mui/icons-material/WorkspacePremiumOutlined';
-import { BORDER_RADIUS, PLAN_COLORS } from '@/styles/theme-constants';
+import {
+  CrownFilledIcon,
+  CrownOutlinedIcon,
+} from '@/components/common/CrownIcon';
+import { GridBadge } from '@/components/common/GridBadge';
+import { PLAN_COLORS, PLAN_CROWN_SHADOW } from '@/styles/theme-constants';
 import { planLabel, resolvePlanStyle } from '@/utils/plan';
 import type { Plan } from '@/utils/api-client/features-client';
 
 /**
  * The plan pill. **The only one.** Every surface that shows a plan renders
- * this and takes its styling from `resolvePlanStyle`, so the sidebar, the org
- * menu and the usage page cannot drift apart.
+ * this, so the sidebar footer, the sidebar org menu and the usage page cannot
+ * drift apart.
  *
- * Every variant gets identical padding, radius, size and weight from the one
- * `Chip` below — only the colour differs, and only because the resolver
- * returned a different value. Two tiers can never differ in size or shape.
+ * It is a thin wrapper over `GridBadge`, the app's read-only pill, rather than
+ * its own styled chip. That is deliberate: the plan is metadata about the org,
+ * which is exactly what `GridBadge` is for (`Tag`'s docstring routes badges
+ * here), so the plan pill picks up the same grey fill, pill radius, type and
+ * padding as every other badge in the app. A bespoke chip here looked
+ * *almost* like the app's badges, which is worse than either matching or
+ * clearly differing.
+ *
+ * No `size` passthrough, so the plan reads identically on all three surfaces.
+ * Nothing about the badge varies by tier either — same fill, radius, type and
+ * casing for every plan. Paid-ness is signalled by the crown, which keeps the
+ * free tier from wearing the loudest pill in the UI.
  *
  * The label is whatever the API sent, rendered verbatim. Nothing here maps,
  * cases or inspects a tier name, so an unrecognized tier displays correctly
- * with no code change and falls back to the neutral style.
+ * with no code change.
  *
  * Renders nothing when there is no plan yet, rather than a placeholder: a plan
  * must not flicker from a guess to the real value.
@@ -28,52 +39,54 @@ export function PlanBadge({ plan }: { plan: Plan | null | undefined }) {
   const label = planLabel(plan);
   if (label === null) return null;
 
-  return (
-    <Chip
-      label={label}
-      size="small"
-      color={resolvePlanStyle(plan).chipColor}
-      sx={{
-        borderRadius: BORDER_RADIUS.pill,
-        // Read from the theme rather than written as 600: the semibold weight
-        // is brand-dependent (`w600` in theme.ts is 700 when a brand font is
-        // configured), so a literal would render this badge lighter than every
-        // other semibold element on a branded deployment.
-        fontWeight: theme => theme.typography.captionBold.fontWeight,
-      }}
-    />
-  );
+  return <GridBadge label={label} size="grid" />;
 }
 
 /**
  * The plan's crown, for a row that leads with an icon.
  *
- * Filled and gold for an active paid plan; outlined otherwise. Kept beside the
+ * Filled and premium-gold for an active paid plan; outlined otherwise. Kept beside the
  * badge so the crown and the pill are resolved from the same place — the icon
  * and the pill disagreeing about whether a plan is paid would be worse than
  * either being wrong alone.
  *
- * Takes no colour prop. A caller wanting the neutral row colour gets it by
- * default, because the resolver returns `crownColor: null` for the free
- * variant and this then inherits.
+ * Takes no colour prop. The resolver returns `crownColor: null` for anything
+ * not actively paid, which inherits, so a free plan's crown is the same colour
+ * as the other icons in the card. Only an active paid plan colours itself.
  */
 export function PlanCrownIcon({ plan }: { plan: Plan | null | undefined }) {
   const theme = useTheme();
   const style = resolvePlanStyle(plan);
-  const Icon = style.crownFilled
-    ? WorkspacePremiumIcon
-    : WorkspacePremiumOutlinedIcon;
+  const Icon = style.crownFilled ? CrownFilledIcon : CrownOutlinedIcon;
 
-  const palette =
-    theme.palette.mode === 'dark' ? PLAN_COLORS.dark : PLAN_COLORS.light;
-  const color =
-    style.crownColor === null
-      ? 'inherit'
-      : style.crownColor === 'warning'
-        ? theme.palette.warning.main
-        : palette[style.crownColor];
+  const isDark = theme.palette.mode === 'dark';
+  const palette = isDark ? PLAN_COLORS.dark : PLAN_COLORS.light;
+  // `inherit` rather than a token of its own: the caller sets the row's icon
+  // colour, so a non-paid crown matches the sibling nav icons ("Star Rhesis",
+  // "Support") exactly. Naming a secondary token here made it visibly lighter
+  // than the icons beside it.
+  const color = style.crownColor === null ? 'inherit' : palette.premium;
 
-  return <Icon sx={{ color }} />;
+  // Decorative: the tier is already carried by the badge text, and the
+  // filled-vs-outlined shape is the non-colour second channel. Announcing the
+  // icon too would just repeat the row.
+  return (
+    <Icon
+      aria-hidden="true"
+      sx={{
+        color,
+        // Only the active paid crown is lifted off the surface. A glow on the
+        // neutral crown would make a free plan look like it was signalling
+        // something, which is the opposite of the intent. The recipe itself is
+        // a token -- see PLAN_CROWN_SHADOW for why it is two chained shadows.
+        ...(style.crownShadow
+          ? {
+              filter: isDark ? PLAN_CROWN_SHADOW.dark : PLAN_CROWN_SHADOW.light,
+            }
+          : {}),
+      }}
+    />
+  );
 }
 
 export default PlanBadge;

--- a/apps/frontend/src/components/common/QuotaChips.tsx
+++ b/apps/frontend/src/components/common/QuotaChips.tsx
@@ -1,46 +1,8 @@
 'use client';
 
 import Button from '@mui/material/Button';
-import Chip from '@mui/material/Chip';
 import { BORDER_RADIUS } from '@/styles/theme';
 import { UPGRADE_URL } from '@/constants/quota';
-import { isCommunityEdition } from '@/utils/quota';
-
-/** Plan pill (e.g. "community", "enterprise"). Shared by the usage page
- * and the org-menu usage block so the two never drift on styling. Lower
- * case, no "plan" suffix -- the org-menu block is space-constrained, and
- * the chip already reads as a plan in context.
- *
- * A paid plan whose licence is no longer active is marked "inactive" rather
- * than shown as though it were still in force. The backend holds such an org
- * to community limits while still reporting its old edition, so a plain
- * "enterprise" pill next to free-tier numbers is the one reading that leaves
- * an admin with no idea why their ceilings dropped.
- *
- * `licensed` is optional and defaults to "unknown" (`null`), which renders
- * exactly as before -- callers without the flag cannot accidentally label a
- * live plan inactive. */
-export function PlanChip({
-  edition,
-  licensed = null,
-}: {
-  edition: string;
-  licensed?: boolean | null;
-}) {
-  const isFreeTier = isCommunityEdition(edition);
-  const isLapsed = licensed === false && !isFreeTier;
-  const label = isLapsed
-    ? `${edition.toLowerCase()} (inactive)`
-    : edition.toLowerCase();
-  return (
-    <Chip
-      label={label}
-      size="small"
-      color={isLapsed ? 'warning' : isFreeTier ? 'default' : 'primary'}
-      sx={{ borderRadius: BORDER_RADIUS.pill, fontWeight: 600 }}
-    />
-  );
-}
 
 /** "Upgrade" button/link -- always the same destination, everywhere it
  * appears. Only ever shown to org admins; callers gate that. */

--- a/apps/frontend/src/components/common/__tests__/PlanBadge.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/PlanBadge.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PlanBadge, PlanCrownIcon } from '@/components/common/PlanBadge';
+import type { Plan } from '@/utils/api-client/usage-client';
+
+const plan = (over: Partial<Plan> = {}): Plan => ({
+  name: 'Team',
+  is_paid: true,
+  is_active: true,
+  ...over,
+});
+
+/** MUI stamps each icon with its own name — the stable way to assert
+ * filled-vs-outlined without reading computed styles. */
+const FILLED = 'WorkspacePremiumIcon';
+const OUTLINED = 'WorkspacePremiumOutlinedIcon';
+
+describe('PlanBadge', () => {
+  it('renders the API name verbatim', () => {
+    // Deliberately awkward casing: nothing may normalize it.
+    render(<PlanBadge plan={plan({ name: 'uLtRa PREMIUM' })} />);
+    expect(screen.getByText('uLtRa PREMIUM')).toBeInTheDocument();
+  });
+
+  it('renders a lapsed plan with the qualifier the API supplied', () => {
+    render(
+      <PlanBadge
+        plan={plan({ name: 'Enterprise (inactive)', is_active: false })}
+      />
+    );
+    expect(screen.getByText('Enterprise (inactive)')).toBeInTheDocument();
+  });
+
+  it('renders a tier it has never heard of', () => {
+    const { container } = render(
+      <PlanBadge plan={plan({ name: 'Brand New Tier' })} />
+    );
+    expect(screen.getByText('Brand New Tier')).toBeInTheDocument();
+    expect(container).not.toBeEmptyDOMElement();
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['blank name', { name: '  ', is_paid: false, is_active: false }],
+  ])('renders nothing when there is no plan (%s)', (_l, value) => {
+    // Not a placeholder: a plan must not flicker from a guess to the truth.
+    const { container } = render(<PlanBadge plan={value as unknown as Plan} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('gives every variant the same shape, differing only in colour', () => {
+    // Two tiers must never differ in size or radius. One Chip, one set of sx.
+    const shapes = (
+      [
+        plan({ is_paid: false, is_active: false }),
+        plan(),
+        plan({ is_active: false }),
+      ] as Plan[]
+    ).map(p => {
+      const { container, unmount } = render(<PlanBadge plan={p} />);
+      const chip = container.querySelector('.MuiChip-root');
+      const cls = chip?.className ?? '';
+      // Size class is what encodes padding/height; colour classes are excluded.
+      const size = /MuiChip-size\w+/.exec(cls)?.[0] ?? '';
+      unmount();
+      return size;
+    });
+    expect(new Set(shapes).size).toBe(1);
+    expect(shapes[0]).toBe('MuiChip-sizeSmall');
+  });
+});
+
+describe('PlanCrownIcon', () => {
+  it('fills the crown for an active paid plan', () => {
+    const { container } = render(<PlanCrownIcon plan={plan()} />);
+    expect(
+      container.querySelector(`[data-testid="${FILLED}"]`)
+    ).toBeInTheDocument();
+  });
+
+  it('outlines the crown for a free plan', () => {
+    const { container } = render(
+      <PlanCrownIcon plan={plan({ is_paid: false, is_active: false })} />
+    );
+    expect(
+      container.querySelector(`[data-testid="${OUTLINED}"]`)
+    ).toBeInTheDocument();
+  });
+
+  it('outlines the crown for a lapsed plan', () => {
+    const { container } = render(
+      <PlanCrownIcon plan={plan({ is_active: false })} />
+    );
+    expect(
+      container.querySelector(`[data-testid="${OUTLINED}"]`)
+    ).toBeInTheDocument();
+  });
+
+  it('still renders a crown for an unknown plan rather than crashing', () => {
+    const { container } = render(<PlanCrownIcon plan={null} />);
+    expect(
+      container.querySelector(`[data-testid="${OUTLINED}"]`)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/common/__tests__/PlanBadge.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/PlanBadge.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { PlanBadge, PlanCrownIcon } from '@/components/common/PlanBadge';
-import type { Plan } from '@/utils/api-client/usage-client';
+import type { Plan } from '@/utils/api-client/features-client';
 
 const plan = (over: Partial<Plan> = {}): Plan => ({
   name: 'Team',

--- a/apps/frontend/src/components/common/__tests__/PlanBadge.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/PlanBadge.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { GridBadge } from '@/components/common/GridBadge';
 import { PlanBadge, PlanCrownIcon } from '@/components/common/PlanBadge';
 import type { Plan } from '@/utils/api-client/features-client';
 
@@ -12,8 +13,25 @@ const plan = (over: Partial<Plan> = {}): Plan => ({
 
 /** MUI stamps each icon with its own name — the stable way to assert
  * filled-vs-outlined without reading computed styles. */
-const FILLED = 'WorkspacePremiumIcon';
-const OUTLINED = 'WorkspacePremiumOutlinedIcon';
+const FILLED = 'CrownFilledIcon';
+const OUTLINED = 'CrownOutlinedIcon';
+
+/** The visual properties that must not vary: by tier, or from the app's own
+ * badge. Deliberately includes colour, which is where the drift was. */
+function snapshotOf(el: HTMLElement): string {
+  const cs = getComputedStyle(el);
+  return [
+    cs.backgroundColor,
+    cs.color,
+    cs.borderRadius,
+    cs.fontSize,
+    cs.fontWeight,
+    cs.lineHeight,
+    cs.paddingLeft,
+    cs.paddingRight,
+    cs.textTransform,
+  ].join('|');
+}
 
 describe('PlanBadge', () => {
   it('renders the API name verbatim', () => {
@@ -49,25 +67,41 @@ describe('PlanBadge', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('gives every variant the same shape, differing only in colour', () => {
-    // Two tiers must never differ in size or radius. One Chip, one set of sx.
-    const shapes = (
+  it('is the same pill as every other badge in the app', () => {
+    // The plan is org metadata, which is what `GridBadge` is for. Styling it
+    // separately made it look *almost* like the app's other badges, which
+    // reads as a mistake rather than as a distinction.
+    const planRender = render(<PlanBadge plan={plan()} />);
+    const planPill = planRender.container.firstElementChild as HTMLElement;
+    const planStyle = snapshotOf(planPill);
+    planRender.unmount();
+
+    const refRender = render(<GridBadge label="Team" size="grid" />);
+    const refPill = refRender.container.firstElementChild as HTMLElement;
+    const refStyle = snapshotOf(refPill);
+    refRender.unmount();
+
+    expect(planStyle).toBe(refStyle);
+  });
+
+  it('gives every tier an identical pill, colour included', () => {
+    // The badge must not vary by tier at all -- not in size, radius, type or
+    // colour. Only the crown varies. Without this, the free tier ends up
+    // wearing the most saturated pill in the UI.
+    const styles = (
       [
         plan({ is_paid: false, is_active: false }),
         plan(),
         plan({ is_active: false }),
+        plan({ name: 'Never Heard Of It' }),
       ] as Plan[]
     ).map(p => {
       const { container, unmount } = render(<PlanBadge plan={p} />);
-      const chip = container.querySelector('.MuiChip-root');
-      const cls = chip?.className ?? '';
-      // Size class is what encodes padding/height; colour classes are excluded.
-      const size = /MuiChip-size\w+/.exec(cls)?.[0] ?? '';
+      const snapshot = snapshotOf(container.firstElementChild as HTMLElement);
       unmount();
-      return size;
+      return snapshot;
     });
-    expect(new Set(shapes).size).toBe(1);
-    expect(shapes[0]).toBe('MuiChip-sizeSmall');
+    expect(new Set(styles).size).toBe(1);
   });
 });
 

--- a/apps/frontend/src/components/common/__tests__/PlanCrownIcon.styling.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/PlanCrownIcon.styling.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * What `PlanCrownIcon` actually hands to the icon.
+ *
+ * Separate from `PlanBadge.test.tsx` because it mocks `CrownIcon` to capture the
+ * props, which would defeat that file's filled-vs-outlined assertions.
+ *
+ * This exists because the premium styling is otherwise unverifiable: jsdom's
+ * cssstyle does not implement `filter`, so it is dropped from the emotion rule
+ * and neither `getComputedStyle` nor the injected CSS can see it. A `filter`
+ * assertion through the DOM passes whatever the component does — which is how a
+ * dropped edit shipped with the crown rendering gold but flat, and only a human
+ * looking at the sidebar caught it. Capturing the props is the one seam that
+ * fails when the wiring is missing.
+ */
+
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PlanCrownIcon } from '@/components/common/PlanBadge';
+import {
+  CrownFilledIcon,
+  CrownOutlinedIcon,
+} from '@/components/common/CrownIcon';
+import { PLAN_COLORS, PLAN_CROWN_SHADOW } from '@/styles/theme-constants';
+import type { Plan } from '@/utils/api-client/features-client';
+
+jest.mock('@/components/common/CrownIcon', () => ({
+  CrownFilledIcon: jest.fn(() => null),
+  CrownOutlinedIcon: jest.fn(() => null),
+}));
+
+const filled = CrownFilledIcon as jest.Mock;
+const outlined = CrownOutlinedIcon as jest.Mock;
+
+const plan = (over: Partial<Plan> = {}): Plan => ({
+  name: 'Team',
+  is_paid: true,
+  is_active: true,
+  ...over,
+});
+
+/** The `sx` the rendered icon received. */
+function sxOf(mock: jest.Mock): Record<string, unknown> {
+  expect(mock).toHaveBeenCalled();
+  return mock.mock.calls[0][0].sx as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  filled.mockClear();
+  outlined.mockClear();
+});
+
+describe('PlanCrownIcon styling', () => {
+  it('lifts an active paid crown with a drop shadow', () => {
+    render(<PlanCrownIcon plan={plan()} />);
+    const sx = sxOf(filled);
+    expect(String(sx.filter)).toContain('drop-shadow');
+    // Both layers: the contact shadow seats it, the halo makes it glow. One
+    // alone is invisible at 24px.
+    expect(String(sx.filter).match(/drop-shadow/g)).toHaveLength(2);
+  });
+
+  it('paints the paid crown in the premium token, not an ad-hoc colour', () => {
+    render(<PlanCrownIcon plan={plan()} />);
+    // Default MUI theme is light in tests.
+    expect(sxOf(filled).color).toBe(PLAN_COLORS.light.premium);
+  });
+
+  it('uses the shadow token verbatim, not a locally built filter', () => {
+    render(<PlanCrownIcon plan={plan()} />);
+    expect(sxOf(filled).filter).toBe(PLAN_CROWN_SHADOW.light);
+  });
+
+  it.each([
+    ['free', plan({ is_paid: false, is_active: false })],
+    ['lapsed', plan({ is_active: false })],
+  ])('leaves the %s crown flat and inheriting', (_label, p) => {
+    render(<PlanCrownIcon plan={p} />);
+    const sx = sxOf(outlined);
+    expect(sx.filter).toBeUndefined();
+    expect(sx.color).toBe('inherit');
+  });
+});

--- a/apps/frontend/src/components/common/__tests__/QuotaChips.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/QuotaChips.test.tsx
@@ -1,35 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { PlanChip, UpgradeLink } from '@/components/common/QuotaChips';
+import { UpgradeLink } from '@/components/common/QuotaChips';
 import { UPGRADE_URL } from '@/constants/quota';
-
-describe('PlanChip', () => {
-  it('names the plan in lower case', () => {
-    render(<PlanChip edition="Enterprise" licensed={true} />);
-    expect(screen.getByText('enterprise')).toBeInTheDocument();
-  });
-
-  it('marks a lapsed paid plan inactive', () => {
-    // The backend keeps reporting the old edition for a canceled licence while
-    // holding the org to community limits. A plain "enterprise" pill next to
-    // free-tier numbers is what left admins with no idea why their ceilings
-    // dropped, so the chip has to say it.
-    render(<PlanChip edition="enterprise" licensed={false} />);
-    expect(screen.getByText('enterprise (inactive)')).toBeInTheDocument();
-  });
-
-  it('does not mark the free tier inactive', () => {
-    // Community is unlicensed by definition -- "community (inactive)" would be
-    // telling a free org that something it never had has expired.
-    render(<PlanChip edition="community" licensed={false} />);
-    expect(screen.getByText('community')).toBeInTheDocument();
-  });
-
-  it('renders plainly when licence status is unknown', () => {
-    // Default for callers that have no flag, and for a backend predating it.
-    render(<PlanChip edition="enterprise" />);
-    expect(screen.getByText('enterprise')).toBeInTheDocument();
-  });
-});
 
 describe('UpgradeLink', () => {
   it('points at the published pricing page in a new tab', () => {

--- a/apps/frontend/src/components/navigation/NavLinkItem.tsx
+++ b/apps/frontend/src/components/navigation/NavLinkItem.tsx
@@ -45,6 +45,7 @@ export function NavLinkItem({ item, collapsed, onAction }: NavLinkItemProps) {
   const labelNode = !collapsed && (
     <>
       <Typography
+        variant="bodyMReg"
         sx={{
           ...navCardLabelSx,
           color: (theme: Theme) => theme.palette.greyscale.body,

--- a/apps/frontend/src/components/navigation/NavLinkItem.tsx
+++ b/apps/frontend/src/components/navigation/NavLinkItem.tsx
@@ -6,15 +6,15 @@ import Typography from '@mui/material/Typography';
 import Tooltip from '@mui/material/Tooltip';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import type { SxProps, Theme } from '@mui/material/styles';
-import { BORDER_RADIUS } from '@/styles/theme';
 import {
   type NavigationLinkItem,
   type NavigationActionItem,
 } from '@/types/navigation';
 import {
   collapsedNavItemSx,
-  NAV_CARD_ICON_SIZE,
-  NAV_CARD_ROW_SX,
+  navCardIconSx,
+  navCardLabelSx,
+  navCardRowSx,
 } from './sidebar-utils';
 
 interface NavLinkItemProps {
@@ -27,32 +27,15 @@ export function NavLinkItem({ item, collapsed, onAction }: NavLinkItemProps) {
   const isAction = item.kind === 'action';
 
   const sharedSx: SxProps<Theme> = {
-    display: 'flex',
-    alignItems: 'center',
-    ...NAV_CARD_ROW_SX,
-    py: '8px',
-    borderRadius: BORDER_RADIUS.sm,
-    textDecoration: 'none',
-    cursor: 'pointer',
-    '&:hover': {
-      bgcolor: (theme: Theme) => theme.palette.greyscale.surface1,
-    },
-    // `duration.shortest` is the theme's own 150ms -- the value this used to
-    // spell out as '0.15s'.
-    transition: (theme: Theme) =>
-      theme.transitions.create('background-color', {
-        duration: theme.transitions.duration.shortest,
-      }),
+    ...navCardRowSx(),
     ...(collapsed ? collapsedNavItemSx : {}),
   };
 
   const iconNode = item.icon && (
     <Box
       sx={{
-        display: 'flex',
-        flexShrink: 0,
+        ...navCardIconSx,
         color: (theme: Theme) => theme.palette.greyscale.body,
-        '& svg': { width: NAV_CARD_ICON_SIZE, height: NAV_CARD_ICON_SIZE },
       }}
     >
       {item.icon}
@@ -63,11 +46,8 @@ export function NavLinkItem({ item, collapsed, onAction }: NavLinkItemProps) {
     <>
       <Typography
         sx={{
-          fontSize: 14,
-          fontWeight: 400,
-          lineHeight: '22px',
+          ...navCardLabelSx,
           color: (theme: Theme) => theme.palette.greyscale.body,
-          whiteSpace: 'nowrap',
           flex: 1,
         }}
       >

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -35,14 +35,14 @@ import {
 } from '@/constants/quota';
 import {
   flaggedResources,
-  isUnlicensedPlan,
   quotaCopy,
   usageMenuRows,
   usageRowFillPercent,
   zoneColor,
   type UsageRow,
 } from '@/utils/quota';
-import { PlanChip } from '@/components/common/QuotaChips';
+import { isUpgradeable } from '@/utils/plan';
+import { PlanBadge } from '@/components/common/PlanBadge';
 import { ColorModeContext } from '@/components/providers/ThemeProvider';
 import { handleSignOut } from '@/actions/auth';
 import {
@@ -304,11 +304,11 @@ export function Sidebar() {
   // keeps this quiet until there is real data, not a permission check.
   // "Can upgrade" is a narrower, separate question: Organization.UPDATE
   // (the same owner/admin gate as Org Settings), not Usage.READ.
-  const { resources: usageResources, edition, licensed } = useUsage();
+  const { resources: usageResources, plan } = useUsage();
   const flaggedUsage = flaggedResources(usageResources);
   const flaggedCount = flaggedUsage.length;
   const canManageOrg = useCan(Capability.Organization.UPDATE);
-  const canUpgrade = canManageOrg && isUnlicensedPlan(edition, licensed);
+  const canUpgrade = canManageOrg && isUpgradeable(plan);
 
   // The badge answers "how many"; the sentence (only rendered as a tooltip
   // here, in full in the org-menu block below) answers "how bad" -- no
@@ -428,7 +428,7 @@ export function Sidebar() {
               >
                 {usagePeriodLabel ?? 'Current usage'}
               </Typography>
-              {edition && <PlanChip edition={edition} licensed={licensed} />}
+              <PlanBadge plan={plan} />
             </Box>
             {usageRows.map(row => (
               <UsageMenuRow key={row.resource} {...row} />
@@ -859,7 +859,7 @@ export function Sidebar() {
               flexDirection: 'column',
             }}
           >
-            <SidebarPlanRow edition={edition} licensed={licensed} />
+            <SidebarPlanRow plan={plan} />
             {footerGroup.items.map(item => (
               <NavLinkItem
                 key={`footer-${item.title}`}

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -25,9 +25,9 @@ import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 import { useSidebarCollapse } from '@/components/layout/AppShell';
 import BrandMark from '@/components/common/BrandMark';
 import { UserAvatar } from '@/components/common/UserAvatar';
-import { useCan } from '@/components/common/Can';
-import { Capability } from '@/constants/capabilities';
 import { useUsage } from '@/contexts/UsageContext';
+import { useCanUpgrade } from '@/hooks/useQuotaGate';
+import { usePlan } from '@/contexts/FeaturesContext';
 import {
   QUOTA_RESOURCE_LABELS,
   QUOTA_RESOURCE_ORDER,
@@ -41,7 +41,6 @@ import {
   zoneColor,
   type UsageRow,
 } from '@/utils/quota';
-import { isUpgradeable } from '@/utils/plan';
 import { PlanBadge } from '@/components/common/PlanBadge';
 import { ColorModeContext } from '@/components/providers/ThemeProvider';
 import { handleSignOut } from '@/actions/auth';
@@ -304,11 +303,11 @@ export function Sidebar() {
   // keeps this quiet until there is real data, not a permission check.
   // "Can upgrade" is a narrower, separate question: Organization.UPDATE
   // (the same owner/admin gate as Org Settings), not Usage.READ.
-  const { resources: usageResources, plan } = useUsage();
+  const { resources: usageResources } = useUsage();
+  const plan = usePlan();
   const flaggedUsage = flaggedResources(usageResources);
   const flaggedCount = flaggedUsage.length;
-  const canManageOrg = useCan(Capability.Organization.UPDATE);
-  const canUpgrade = canManageOrg && isUpgradeable(plan);
+  const canUpgrade = useCanUpgrade();
 
   // The badge answers "how many"; the sentence (only rendered as a tooltip
   // here, in full in the org-menu block below) answers "how bad" -- no
@@ -355,9 +354,9 @@ export function Sidebar() {
       {/* Named "Org usage", not "Usage": the menu already reads "Org
           Settings" two rows up, and quota is organization state, never
           personal -- see IMPLEMENTATION_PROMPT.md's "the rule". Visible to
-          every member, not just admins: `usage:read` is granted org-wide
-          (see the note where `canManageOrg` is computed above). Only the
-          "Upgrade plan" row below is narrower. */}
+          every member, not just admins: `usage:read` is granted org-wide.
+          Only the "Upgrade plan" row below is narrower -- see
+          `useCanUpgrade`, which gates on Organization.UPDATE. */}
       <MenuItem
         onClick={() => {
           router.push('/organizations/usage');
@@ -859,7 +858,7 @@ export function Sidebar() {
               flexDirection: 'column',
             }}
           >
-            <SidebarPlanRow plan={plan} />
+            <SidebarPlanRow />
             {footerGroup.items.map(item => (
               <NavLinkItem
                 key={`footer-${item.title}`}

--- a/apps/frontend/src/components/navigation/SidebarPlanRow.tsx
+++ b/apps/frontend/src/components/navigation/SidebarPlanRow.tsx
@@ -2,43 +2,54 @@
 
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import type { Theme } from '@mui/material/styles';
 import NextLink from 'next/link';
-import { PlanChip } from '@/components/common/QuotaChips';
-import { BORDER_RADIUS } from '@/styles/theme';
-import { NAV_CARD_STATUS_ROW_SX } from './sidebar-utils';
+import { PlanBadge, PlanCrownIcon } from '@/components/common/PlanBadge';
+import { planLabel } from '@/utils/plan';
+import type { Plan } from '@/utils/api-client/usage-client';
+import {
+  navCardIconSx,
+  navCardLabelSx,
+  navCardRowSx,
+  navCardTrailingSx,
+} from './sidebar-utils';
 
 /** Where the row goes: the plan lives next to the usage it governs, and this
- * is the one page that shows both. Internal, and readable by every org member
+ * is the one page showing both. Internal, and readable by every org member
  * (`usage:read` is not admin-only), so the row never links somewhere the
  * clicker cannot follow. */
 const USAGE_HREF = '/organizations/usage';
 
 interface SidebarPlanRowProps {
-  /** Licence edition from `GET /usage`, or `null` while it loads. */
-  edition: string | null;
-  /** Whether that licence is currently active. `null`/`undefined` when not
-   * yet known — see `isUnlicensedPlan` in `utils/quota.ts`. */
-  licensed?: boolean | null;
+  /** The org's plan from `GET /usage`, or `null` while it loads. */
+  plan: Plan | null | undefined;
 }
 
 /**
- * The org's current plan, as the first row of the sidebar's footer card.
+ * The org's plan, as the first row of the sidebar's footer card.
  *
- * Deliberately holds no opinion about the plan itself. Naming the edition,
- * marking a lapsed licence "inactive", and colouring a paid plan apart from a
- * free one are all :component:`PlanChip`'s job, and it already does them for
- * the usage page and the org-menu block. Re-deriving any of that here would
- * let the sidebar and the usage page disagree about the same licence.
+ * Built from the same row primitives as `NavLinkItem` — `navCardRowSx`,
+ * `navCardIconSx`, `navCardLabelSx` — rather than its own layout, so the crown
+ * sits in the same icon gutter and "Plan" starts at the same x-offset as
+ * "Star Rhesis" and "Support" below it. Those primitives live in
+ * `sidebar-utils.ts` and are shared, so the two cannot drift.
  *
- * The layout mirrors the org-menu usage block in `Sidebar.tsx`, which pairs a
- * caption with the same chip — so the two plan readouts in this sidebar are
- * one pattern, not two.
+ * Structure: `[crown] [label] [spacer] [badge]`. The badge is anchored to the
+ * row's right padding edge by `marginLeft: auto` (`navCardTrailingSx`), which
+ * puts it at the same x for every tier-name length, and `flexShrink: 0` there
+ * plus `minWidth: 0` on the label mean a long name ellipsizes rather than
+ * squeezing the badge.
  *
- * Renders nothing until `edition` is known: a plan must not flicker from a
+ * Holds no opinion about the plan itself. Naming the tier, deciding whether it
+ * is paid, and colouring it are `PlanBadge` / `resolvePlanStyle`'s job, driven
+ * off the API's booleans. Nothing here inspects a tier name, so a new tier
+ * needs no change to this file.
+ *
+ * Renders nothing until the plan is known — a plan must not flicker from a
  * placeholder to the real value.
  */
-export function SidebarPlanRow({ edition, licensed }: SidebarPlanRowProps) {
-  if (!edition) return null;
+export function SidebarPlanRow({ plan }: SidebarPlanRowProps) {
+  if (planLabel(plan) === null) return null;
 
   return (
     <Box
@@ -46,27 +57,37 @@ export function SidebarPlanRow({ edition, licensed }: SidebarPlanRowProps) {
       href={USAGE_HREF}
       aria-label="Current plan — view usage"
       sx={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        ...NAV_CARD_STATUS_ROW_SX,
-        borderRadius: BORDER_RADIUS.sm,
-        textDecoration: 'none',
+        ...navCardRowSx(),
         // Separates status from the actions below it. The card draws no
         // dividers between its own links, so without this the plan reads as a
         // third thing you could click to do something.
-        borderBottom: theme => `1px solid ${theme.palette.greyscale.border}`,
-        '&:hover': {
-          bgcolor: theme => theme.palette.greyscale.surface1,
-        },
-        transition: theme =>
-          theme.transitions.create('background-color', {
-            duration: theme.transitions.duration.shortest,
-          }),
+        borderBottom: (theme: Theme) =>
+          `1px solid ${theme.palette.greyscale.border}`,
       }}
     >
-      <Typography variant="caption">Plan</Typography>
-      <PlanChip edition={edition} licensed={licensed} />
+      <Box
+        sx={{
+          ...navCardIconSx,
+          // Inherits when the resolver returns no crown colour, which is how
+          // a free plan's crown matches the sibling rows' icon colour.
+          color: (theme: Theme) => theme.palette.greyscale.body,
+        }}
+      >
+        <PlanCrownIcon plan={plan} />
+      </Box>
+
+      <Typography
+        sx={{
+          ...navCardLabelSx,
+          color: (theme: Theme) => theme.palette.greyscale.body,
+        }}
+      >
+        Plan
+      </Typography>
+
+      <Box sx={navCardTrailingSx}>
+        <PlanBadge plan={plan} />
+      </Box>
     </Box>
   );
 }

--- a/apps/frontend/src/components/navigation/SidebarPlanRow.tsx
+++ b/apps/frontend/src/components/navigation/SidebarPlanRow.tsx
@@ -6,7 +6,7 @@ import type { Theme } from '@mui/material/styles';
 import NextLink from 'next/link';
 import { PlanBadge, PlanCrownIcon } from '@/components/common/PlanBadge';
 import { planLabel } from '@/utils/plan';
-import type { Plan } from '@/utils/api-client/usage-client';
+import { usePlan } from '@/contexts/FeaturesContext';
 import {
   navCardIconSx,
   navCardLabelSx,
@@ -19,11 +19,6 @@ import {
  * (`usage:read` is not admin-only), so the row never links somewhere the
  * clicker cannot follow. */
 const USAGE_HREF = '/organizations/usage';
-
-interface SidebarPlanRowProps {
-  /** The org's plan from `GET /usage`, or `null` while it loads. */
-  plan: Plan | null | undefined;
-}
 
 /**
  * The org's plan, as the first row of the sidebar's footer card.
@@ -46,9 +41,11 @@ interface SidebarPlanRowProps {
  * needs no change to this file.
  *
  * Renders nothing until the plan is known — a plan must not flicker from a
- * placeholder to the real value.
+ * placeholder to the real value. In practice it is known on first paint:
+ * `usePlan()` reads `GET /features`, which the protected layout server-seeds.
  */
-export function SidebarPlanRow({ plan }: SidebarPlanRowProps) {
+export function SidebarPlanRow() {
+  const plan = usePlan();
   if (planLabel(plan) === null) return null;
 
   return (

--- a/apps/frontend/src/components/navigation/SidebarPlanRow.tsx
+++ b/apps/frontend/src/components/navigation/SidebarPlanRow.tsx
@@ -1,60 +1,87 @@
 'use client';
 
 import Box from '@mui/material/Box';
+import MuiLink from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import type { Theme } from '@mui/material/styles';
-import NextLink from 'next/link';
 import { PlanBadge, PlanCrownIcon } from '@/components/common/PlanBadge';
+import { UPGRADE_URL } from '@/constants/quota';
 import { planLabel } from '@/utils/plan';
 import { usePlan } from '@/contexts/FeaturesContext';
+import { useCanUpgrade } from '@/hooks/useQuotaGate';
 import {
+  NAV_CARD_ICON_GAP,
   navCardIconSx,
-  navCardLabelSx,
   navCardRowSx,
-  navCardTrailingSx,
 } from './sidebar-utils';
-
-/** Where the row goes: the plan lives next to the usage it governs, and this
- * is the one page showing both. Internal, and readable by every org member
- * (`usage:read` is not admin-only), so the row never links somewhere the
- * clicker cannot follow. */
-const USAGE_HREF = '/organizations/usage';
 
 /**
  * The org's plan, as the first row of the sidebar's footer card.
  *
- * Built from the same row primitives as `NavLinkItem` — `navCardRowSx`,
- * `navCardIconSx`, `navCardLabelSx` — rather than its own layout, so the crown
- * sits in the same icon gutter and "Plan" starts at the same x-offset as
- * "Star Rhesis" and "Support" below it. Those primitives live in
- * `sidebar-utils.ts` and are shared, so the two cannot drift.
+ * **The row itself is not interactive.** It reports state, so it takes
+ * `interactive: false` from the shared row shell, dropping the pointer cursor
+ * and hover tint that "Star Rhesis" and "Support" below it carry — without
+ * those it would read as a broken link sitting next to two working ones. The
+ * one control it can contain is the upgrade link below, which is its own
+ * focusable target rather than a click on the whole row.
  *
- * Structure: `[crown] [label] [spacer] [badge]`. The badge is anchored to the
- * row's right padding edge by `marginLeft: auto` (`navCardTrailingSx`), which
- * puts it at the same x for every tier-name length, and `flexShrink: 0` there
- * plus `minWidth: 0` on the label mean a long name ellipsizes rather than
- * squeezing the badge.
+ * The upgrade link shows only when there is something to upgrade *and* the
+ * reader can act on it: `useCanUpgrade` gates on `Organization.UPDATE`, the same
+ * owner/admin check the org menu's upgrade link uses, not on `usage:read` which
+ * every member holds. Offering it to someone who cannot change billing is worse
+ * than not offering it. It covers a lapsed paid plan too, not just the free
+ * tier — that org is being held to free-tier ceilings and most needs the prompt.
+ *
+ * Built from the same row primitives as `NavLinkItem` — `navCardRowSx`,
+ * `navCardIconSx`, `NAV_CARD_ICON_GAP` — rather than its own geometry, so the
+ * padding and icon gutter cannot drift from the rows beneath it.
+ *
+ * Structure: a `Plan  Upgrade →` caption line, then `[crown] [tier badge]`
+ * beneath it. The upgrade link follows the caption directly rather than being
+ * pinned to the right edge, so the two read as one group; the caption line has
+ * ~135px spare once "Plan" is drawn, where the badge line has only ~46px.
+ *
+ * Stacked rather than one line, because one line does not fit. The sidebar is
+ * 240px with 26px of padding, so this card is 188px and the row's content box
+ * is 160px. A single line needs 24px of crown, two 10px gaps, ~32px for the
+ * word "Plan" and ~80px for a "Community" pill: 156px, leaving 4px. "Enterprise"
+ * overflows outright, and "Enterprise (inactive)" is not close. The observed
+ * symptom was the label ellipsizing to "Pl...".
+ *
+ * The crown still sits in the same 24px gutter at the same left padding as
+ * "Star Rhesis" and "Support", so the icon column the brief asked for is
+ * preserved; it is the label that moved, not the alignment.
  *
  * Holds no opinion about the plan itself. Naming the tier, deciding whether it
- * is paid, and colouring it are `PlanBadge` / `resolvePlanStyle`'s job, driven
- * off the API's booleans. Nothing here inspects a tier name, so a new tier
- * needs no change to this file.
+ * is paid, and colouring the crown are `PlanBadge` / `resolvePlanStyle`'s job,
+ * driven off the API's booleans. Nothing here inspects a tier name, so a new
+ * tier needs no change to this file.
  *
- * Renders nothing until the plan is known — a plan must not flicker from a
- * placeholder to the real value. In practice it is known on first paint:
- * `usePlan()` reads `GET /features`, which the protected layout server-seeds.
+ * Renders nothing until the plan is known, rather than defaulting to a tier —
+ * a plan must not flicker from a guess to the real value. In practice it is
+ * known on first paint: `usePlan()` reads `GET /features`, which the protected
+ * layout server-seeds.
  */
 export function SidebarPlanRow() {
   const plan = usePlan();
-  if (planLabel(plan) === null) return null;
+  const canUpgrade = useCanUpgrade();
+  const label = planLabel(plan);
+  if (label === null) return null;
 
   return (
     <Box
-      component={NextLink}
-      href={USAGE_HREF}
-      aria-label="Current plan — view usage"
+      // One labelled unit rather than three loose bits of text, so the tier is
+      // announced with what it describes: "Plan: Community". The crown is
+      // aria-hidden, since colour and fill are not information a screen reader
+      // can use.
+      role="group"
+      aria-label={`Plan: ${label}`}
       sx={{
-        ...navCardRowSx(),
+        ...navCardRowSx({ interactive: false }),
+        // Stacked, so the tier name gets the row's full width. See the note on
+        // the component above for why the single-line version cannot fit.
+        flexDirection: 'column',
+        alignItems: 'stretch',
         // Separates status from the actions below it. The card draws no
         // dividers between its own links, so without this the plan reads as a
         // third thing you could click to do something.
@@ -64,25 +91,59 @@ export function SidebarPlanRow() {
     >
       <Box
         sx={{
-          ...navCardIconSx,
-          // Inherits when the resolver returns no crown colour, which is how
-          // a free plan's crown matches the sibling rows' icon colour.
-          color: (theme: Theme) => theme.palette.greyscale.body,
+          display: 'flex',
+          alignItems: 'center',
+          // Same gap the rows below put between icon and label, so the caption
+          // line reads as one left-aligned group rather than two things pinned
+          // to opposite edges.
+          gap: NAV_CARD_ICON_GAP,
         }}
       >
-        <PlanCrownIcon plan={plan} />
+        <Typography
+          variant="caption"
+          sx={{ color: (theme: Theme) => theme.palette.greyscale.subtitle }}
+        >
+          Plan
+        </Typography>
+
+        {canUpgrade && (
+          <MuiLink
+            href={UPGRADE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="caption"
+            sx={{
+              // From the theme, not the literal 700 the org menu's copy of this
+              // link uses: the semibold weight is brand-dependent.
+              fontWeight: (theme: Theme) =>
+                theme.typography.captionBold.fontWeight,
+            }}
+          >
+            Upgrade →
+          </MuiLink>
+        )}
       </Box>
 
-      <Typography
+      <Box
         sx={{
-          ...navCardLabelSx,
-          color: (theme: Theme) => theme.palette.greyscale.body,
+          display: 'flex',
+          alignItems: 'center',
+          // Same gap as a nav row's icon-to-label gap, so the badge starts on
+          // the same x as "Star Rhesis" and "Support" do.
+          gap: NAV_CARD_ICON_GAP,
         }}
       >
-        Plan
-      </Typography>
+        <Box
+          sx={{
+            ...navCardIconSx,
+            // Only applies to the free/lapsed crown, which returns no colour of
+            // its own; the paid crown sets the premium token and wins.
+            color: (theme: Theme) => theme.palette.greyscale.body,
+          }}
+        >
+          <PlanCrownIcon plan={plan} />
+        </Box>
 
-      <Box sx={navCardTrailingSx}>
         <PlanBadge plan={plan} />
       </Box>
     </Box>

--- a/apps/frontend/src/components/navigation/__tests__/SidebarPlanRow.test.tsx
+++ b/apps/frontend/src/components/navigation/__tests__/SidebarPlanRow.test.tsx
@@ -1,26 +1,27 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { SidebarPlanRow } from '../SidebarPlanRow';
+import { NavLinkItem } from '../NavLinkItem';
+import type { Plan } from '@/utils/api-client/usage-client';
+import type { NavigationLinkItem } from '@/types/navigation';
+
+const plan = (over: Partial<Plan> = {}): Plan => ({
+  name: 'Team',
+  is_paid: true,
+  is_active: true,
+  ...over,
+});
 
 /**
- * The row's own job is placement and delegation: show up once the plan is
- * known, link to usage, and hand the edition and licence status to `PlanChip`.
+ * The row's own job is layout and delegation: sit on the shared nav-row
+ * primitive, label the row, and hand the plan to `PlanBadge`.
  *
- * How a plan is *named* and *coloured* — the "(inactive)" marker, paid vs free
- * — belongs to `PlanChip` and is covered in `QuotaChips.test.tsx`. Asserting it
- * again here would duplicate that contract and make a deliberate copy change
- * fail in two places.
+ * How a plan is named and coloured belongs to `PlanBadge` / `resolvePlanStyle`
+ * and is covered in `PlanBadge.test.tsx` and `plan.test.ts`.
  */
 describe('SidebarPlanRow', () => {
-  it('renders nothing until the edition is known', () => {
-    // A plan must not flicker from a placeholder to the real value.
-    const { container } = render(<SidebarPlanRow edition={null} />);
-    expect(container).toBeEmptyDOMElement();
-  });
-
   it('labels the row and links to the usage page', () => {
-    render(<SidebarPlanRow edition="team" licensed={true} />);
-
+    render(<SidebarPlanRow plan={plan()} />);
     expect(screen.getByText('Plan')).toBeInTheDocument();
     expect(screen.getByRole('link')).toHaveAttribute(
       'href',
@@ -28,27 +29,118 @@ describe('SidebarPlanRow', () => {
     );
   });
 
-  it('shows the plan through PlanChip rather than its own label', () => {
-    render(<SidebarPlanRow edition="Enterprise" licensed={true} />);
-
-    // Lower-cased is PlanChip's formatting, which is the point: the row does
-    // not format the edition itself.
-    expect(screen.getByText('enterprise')).toBeInTheDocument();
+  it('shows the plan through PlanBadge, verbatim', () => {
+    render(<SidebarPlanRow plan={plan({ name: 'uLtRa PREMIUM' })} />);
+    expect(screen.getByText('uLtRa PREMIUM')).toBeInTheDocument();
   });
 
-  it('passes licence status through, so a lapsed plan is marked', () => {
-    // Not a re-test of the chip's copy -- it proves `licensed` actually reaches
-    // it. Dropping the prop would leave a lapsed plan looking active here while
-    // the usage page called it inactive.
-    render(<SidebarPlanRow edition="enterprise" licensed={false} />);
-
-    expect(screen.getByText('enterprise (inactive)')).toBeInTheDocument();
+  it('passes the plan through, so a lapsed one is marked', () => {
+    // Proves `plan` actually reaches the badge. Dropping the prop would leave
+    // the sidebar showing a lapsed plan as active while the usage page did not.
+    render(
+      <SidebarPlanRow
+        plan={plan({ name: 'Enterprise (inactive)', is_active: false })}
+      />
+    );
+    expect(screen.getByText('Enterprise (inactive)')).toBeInTheDocument();
   });
 
-  it('does not mark a plan inactive when licence status is unknown', () => {
-    render(<SidebarPlanRow edition="enterprise" />);
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])('renders nothing until the plan is known (%s)', (_l, value) => {
+    const { container } = render(
+      <SidebarPlanRow plan={value as unknown as Plan} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
 
-    expect(screen.getByText('enterprise')).toBeInTheDocument();
-    expect(screen.queryByText(/inactive/i)).not.toBeInTheDocument();
+  describe('alignment with the sibling nav rows', () => {
+    /**
+     * The reason this row was rewritten: it used a bespoke layout, so its text
+     * started at a different x-offset from "Star Rhesis" and "Support" and the
+     * pill had no fixed anchor.
+     *
+     * Asserted structurally rather than by pixel: both rows must resolve the
+     * same shared primitives, so identical horizontal padding and icon-gutter
+     * width is a property of the code, not of a snapshot.
+     */
+    const starItem: NavigationLinkItem = {
+      kind: 'link',
+      title: 'Star Rhesis',
+      href: 'https://github.com/rhesis-ai/rhesis',
+      external: true,
+      icon: <svg />,
+    };
+
+    function rowOf(container: HTMLElement): HTMLElement {
+      const el = container.firstElementChild;
+      if (!(el instanceof HTMLElement)) throw new Error('no row rendered');
+      return el;
+    }
+
+    it('uses the same horizontal padding as a nav row', () => {
+      const planRow = rowOf(render(<SidebarPlanRow plan={plan()} />).container);
+      const navRow = rowOf(
+        render(<NavLinkItem item={starItem} collapsed={false} />).container
+      );
+
+      const p = getComputedStyle(planRow);
+      const n = getComputedStyle(navRow);
+      expect(p.paddingLeft).toBe(n.paddingLeft);
+      expect(p.paddingRight).toBe(n.paddingRight);
+      expect(p.display).toBe('flex');
+      expect(p.alignItems).toBe('center');
+    });
+
+    it('gives the icon gutter the same width, so labels share an x-offset', () => {
+      const planIcon = rowOf(
+        render(<SidebarPlanRow plan={plan()} />).container
+      ).firstElementChild;
+      const navIcon = rowOf(
+        render(<NavLinkItem item={starItem} collapsed={false} />).container
+      ).firstElementChild;
+
+      expect(planIcon).toBeInstanceOf(HTMLElement);
+      expect(navIcon).toBeInstanceOf(HTMLElement);
+      const p = getComputedStyle(planIcon as HTMLElement);
+      const n = getComputedStyle(navIcon as HTMLElement);
+      // flexShrink 0 on both is what fixes the gutter regardless of glyph.
+      expect(p.flexShrink).toBe(n.flexShrink);
+      expect(p.flexShrink).toBe('0');
+    });
+
+    it('anchors the badge right and protects it from a long tier name', () => {
+      const { container } = render(
+        <SidebarPlanRow
+          plan={plan({ name: 'An Extremely Long Tier Name Indeed' })}
+        />
+      );
+      const row = rowOf(container);
+      const trailing = row.lastElementChild;
+      expect(trailing).toBeInstanceOf(HTMLElement);
+
+      const t = getComputedStyle(trailing as HTMLElement);
+      // marginLeft:auto is the anchor; flexShrink:0 stops the badge compressing.
+      expect(t.marginLeft).toBe('auto');
+      expect(t.flexShrink).toBe('0');
+
+      // The label yields instead, so the badge keeps its size. jsdom
+      // normalizes a zero length to a bare "0", hence not comparing to "0px".
+      const label = row.children[1];
+      expect(parseFloat(getComputedStyle(label as HTMLElement).minWidth)).toBe(
+        0
+      );
+    });
+
+    it('puts the badge after the label in document order', () => {
+      const { container } = render(<SidebarPlanRow plan={plan()} />);
+      const label = screen.getByText('Plan');
+      const badge = screen.getByText('Team');
+      expect(
+        label.compareDocumentPosition(badge) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+      expect(container).toContainElement(badge);
+    });
   });
 });

--- a/apps/frontend/src/components/navigation/__tests__/SidebarPlanRow.test.tsx
+++ b/apps/frontend/src/components/navigation/__tests__/SidebarPlanRow.test.tsx
@@ -2,14 +2,35 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { SidebarPlanRow } from '../SidebarPlanRow';
 import { NavLinkItem } from '../NavLinkItem';
-import type { Plan } from '@/utils/api-client/usage-client';
+import type { Plan } from '@/utils/api-client/features-client';
 import type { NavigationLinkItem } from '@/types/navigation';
+import { usePlan } from '@/contexts/FeaturesContext';
+
+jest.mock('@/contexts/FeaturesContext', () => ({
+  usePlan: jest.fn(),
+}));
+
+const mockUsePlan = usePlan as jest.MockedFunction<typeof usePlan>;
 
 const plan = (over: Partial<Plan> = {}): Plan => ({
   name: 'Team',
   is_paid: true,
   is_active: true,
   ...over,
+});
+
+/** The row reads the plan itself now, so the source is stubbed rather than
+ * passed in. It comes from `GET /features` (server-seeded), which is what makes
+ * it present on first paint. */
+function renderRow(value: Plan | null | undefined) {
+  // No default for `value`: a default would swallow an explicitly passed
+  // `undefined`, which is one of the cases under test.
+  mockUsePlan.mockReturnValue(value ?? null);
+  return render(<SidebarPlanRow />);
+}
+
+beforeEach(() => {
+  mockUsePlan.mockReset();
 });
 
 /**
@@ -21,7 +42,7 @@ const plan = (over: Partial<Plan> = {}): Plan => ({
  */
 describe('SidebarPlanRow', () => {
   it('labels the row and links to the usage page', () => {
-    render(<SidebarPlanRow plan={plan()} />);
+    renderRow(plan());
     expect(screen.getByText('Plan')).toBeInTheDocument();
     expect(screen.getByRole('link')).toHaveAttribute(
       'href',
@@ -30,18 +51,14 @@ describe('SidebarPlanRow', () => {
   });
 
   it('shows the plan through PlanBadge, verbatim', () => {
-    render(<SidebarPlanRow plan={plan({ name: 'uLtRa PREMIUM' })} />);
+    renderRow(plan({ name: 'uLtRa PREMIUM' }));
     expect(screen.getByText('uLtRa PREMIUM')).toBeInTheDocument();
   });
 
   it('passes the plan through, so a lapsed one is marked', () => {
-    // Proves `plan` actually reaches the badge. Dropping the prop would leave
-    // the sidebar showing a lapsed plan as active while the usage page did not.
-    render(
-      <SidebarPlanRow
-        plan={plan({ name: 'Enterprise (inactive)', is_active: false })}
-      />
-    );
+    // Proves the plan actually reaches the badge, rather than the row rendering
+    // a name with no regard for licence state.
+    renderRow(plan({ name: 'Enterprise (inactive)', is_active: false }));
     expect(screen.getByText('Enterprise (inactive)')).toBeInTheDocument();
   });
 
@@ -49,9 +66,7 @@ describe('SidebarPlanRow', () => {
     ['null', null],
     ['undefined', undefined],
   ])('renders nothing until the plan is known (%s)', (_l, value) => {
-    const { container } = render(
-      <SidebarPlanRow plan={value as unknown as Plan} />
-    );
+    const { container } = renderRow(value as unknown as Plan);
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -80,7 +95,7 @@ describe('SidebarPlanRow', () => {
     }
 
     it('uses the same horizontal padding as a nav row', () => {
-      const planRow = rowOf(render(<SidebarPlanRow plan={plan()} />).container);
+      const planRow = rowOf(renderRow(plan()).container);
       const navRow = rowOf(
         render(<NavLinkItem item={starItem} collapsed={false} />).container
       );
@@ -94,9 +109,7 @@ describe('SidebarPlanRow', () => {
     });
 
     it('gives the icon gutter the same width, so labels share an x-offset', () => {
-      const planIcon = rowOf(
-        render(<SidebarPlanRow plan={plan()} />).container
-      ).firstElementChild;
+      const planIcon = rowOf(renderRow(plan()).container).firstElementChild;
       const navIcon = rowOf(
         render(<NavLinkItem item={starItem} collapsed={false} />).container
       ).firstElementChild;
@@ -111,10 +124,8 @@ describe('SidebarPlanRow', () => {
     });
 
     it('anchors the badge right and protects it from a long tier name', () => {
-      const { container } = render(
-        <SidebarPlanRow
-          plan={plan({ name: 'An Extremely Long Tier Name Indeed' })}
-        />
+      const { container } = renderRow(
+        plan({ name: 'An Extremely Long Tier Name Indeed' })
       );
       const row = rowOf(container);
       const trailing = row.lastElementChild;
@@ -134,7 +145,7 @@ describe('SidebarPlanRow', () => {
     });
 
     it('puts the badge after the label in document order', () => {
-      const { container } = render(<SidebarPlanRow plan={plan()} />);
+      const { container } = renderRow(plan());
       const label = screen.getByText('Plan');
       const badge = screen.getByText('Team');
       expect(

--- a/apps/frontend/src/components/navigation/__tests__/SidebarPlanRow.test.tsx
+++ b/apps/frontend/src/components/navigation/__tests__/SidebarPlanRow.test.tsx
@@ -4,13 +4,22 @@ import { SidebarPlanRow } from '../SidebarPlanRow';
 import { NavLinkItem } from '../NavLinkItem';
 import type { Plan } from '@/utils/api-client/features-client';
 import type { NavigationLinkItem } from '@/types/navigation';
+import { UPGRADE_URL } from '@/constants/quota';
 import { usePlan } from '@/contexts/FeaturesContext';
+import { useCanUpgrade } from '@/hooks/useQuotaGate';
 
 jest.mock('@/contexts/FeaturesContext', () => ({
   usePlan: jest.fn(),
 }));
 
+jest.mock('@/hooks/useQuotaGate', () => ({
+  useCanUpgrade: jest.fn(),
+}));
+
 const mockUsePlan = usePlan as jest.MockedFunction<typeof usePlan>;
+const mockUseCanUpgrade = useCanUpgrade as jest.MockedFunction<
+  typeof useCanUpgrade
+>;
 
 const plan = (over: Partial<Plan> = {}): Plan => ({
   name: 'Team',
@@ -22,15 +31,21 @@ const plan = (over: Partial<Plan> = {}): Plan => ({
 /** The row reads the plan itself now, so the source is stubbed rather than
  * passed in. It comes from `GET /features` (server-seeded), which is what makes
  * it present on first paint. */
-function renderRow(value: Plan | null | undefined) {
+function renderRow(
+  value: Plan | null | undefined,
+  { canUpgrade = false } = {}
+) {
   // No default for `value`: a default would swallow an explicitly passed
   // `undefined`, which is one of the cases under test.
   mockUsePlan.mockReturnValue(value ?? null);
+  mockUseCanUpgrade.mockReturnValue(canUpgrade);
   return render(<SidebarPlanRow />);
 }
 
 beforeEach(() => {
   mockUsePlan.mockReset();
+  mockUseCanUpgrade.mockReset();
+  mockUseCanUpgrade.mockReturnValue(false);
 });
 
 /**
@@ -41,13 +56,80 @@ beforeEach(() => {
  * and is covered in `PlanBadge.test.tsx` and `plan.test.ts`.
  */
 describe('SidebarPlanRow', () => {
-  it('labels the row and links to the usage page', () => {
+  it('labels the row', () => {
     renderRow(plan());
     expect(screen.getByText('Plan')).toBeInTheDocument();
-    expect(screen.getByRole('link')).toHaveAttribute(
-      'href',
-      '/organizations/usage'
-    );
+  });
+
+  it('reads the tier out with what it describes', () => {
+    // The row is one labelled unit, so the tier is not announced as a loose
+    // word floating next to "Plan".
+    renderRow(plan({ name: 'Community' }));
+    expect(
+      screen.getByRole('group', { name: 'Plan: Community' })
+    ).toBeInTheDocument();
+  });
+
+  it('is not interactive, and carries no affordance suggesting it is', () => {
+    // The row reports state rather than doing something. Beside two rows that
+    // are actionable, a pointer cursor or hover tint would read as a broken
+    // link. (The upgrade link below is its own target, not a row click.)
+    const { container } = renderRow(plan());
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+    const row = container.firstElementChild as HTMLElement;
+    expect(row.tagName).not.toBe('A');
+    expect(getComputedStyle(row).cursor).not.toBe('pointer');
+  });
+
+  describe('the upgrade prompt', () => {
+    it('offers an upgrade on a free plan', () => {
+      renderRow(plan({ name: 'Community', is_paid: false, is_active: false }), {
+        canUpgrade: true,
+      });
+      const link = screen.getByRole('link', { name: /upgrade/i });
+      expect(link).toHaveAttribute('href', UPGRADE_URL);
+      // Opens the public pricing page, which is outside the app.
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    });
+
+    it('leaves the row otherwise intact', () => {
+      // The prompt is additive: the caption and the tier must still read.
+      renderRow(plan({ name: 'Community', is_paid: false, is_active: false }), {
+        canUpgrade: true,
+      });
+      expect(screen.getByText('Plan')).toBeInTheDocument();
+      expect(screen.getByText('Community')).toBeInTheDocument();
+    });
+
+    it('offers nothing to a reader who cannot act on it', () => {
+      // `useCanUpgrade` gates on Organization.UPDATE, not the usage:read every
+      // member holds. Prompting someone who cannot change billing is worse than
+      // staying quiet.
+      renderRow(plan({ name: 'Community', is_paid: false, is_active: false }), {
+        canUpgrade: false,
+      });
+      expect(
+        screen.queryByRole('link', { name: /upgrade/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('offers nothing on an active paid plan', () => {
+      renderRow(plan(), { canUpgrade: false });
+      expect(
+        screen.queryByRole('link', { name: /upgrade/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('hides the crown from assistive tech', () => {
+    // Colour and fill are not information a screen reader can use, and the
+    // tier is already in the row's name.
+    const { container } = renderRow(plan());
+    const icon = container.querySelector('svg');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
   });
 
   it('shows the plan through PlanBadge, verbatim', () => {
@@ -72,13 +154,17 @@ describe('SidebarPlanRow', () => {
 
   describe('alignment with the sibling nav rows', () => {
     /**
-     * The reason this row was rewritten: it used a bespoke layout, so its text
-     * started at a different x-offset from "Star Rhesis" and "Support" and the
-     * pill had no fixed anchor.
+     * The reason this row was rewritten: it used a bespoke layout, so its
+     * content started at a different x-offset from "Star Rhesis" and "Support".
+     *
+     * The row is stacked ("Plan" caption over `[crown] [badge]`) because a
+     * single line does not fit in the 160px content box -- see the component's
+     * own note. What still has to hold is that it reuses the shared primitives,
+     * so its padding and icon gutter match the rows beneath it.
      *
      * Asserted structurally rather than by pixel: both rows must resolve the
-     * same shared primitives, so identical horizontal padding and icon-gutter
-     * width is a property of the code, not of a snapshot.
+     * same shared primitives, so this is a property of the code rather than of
+     * a snapshot.
      */
     const starItem: NavigationLinkItem = {
       kind: 'link',
@@ -105,11 +191,13 @@ describe('SidebarPlanRow', () => {
       expect(p.paddingLeft).toBe(n.paddingLeft);
       expect(p.paddingRight).toBe(n.paddingRight);
       expect(p.display).toBe('flex');
-      expect(p.alignItems).toBe('center');
     });
 
-    it('gives the icon gutter the same width, so labels share an x-offset', () => {
-      const planIcon = rowOf(renderRow(plan()).container).firstElementChild;
+    it('gives the crown the same gutter as a nav row icon', () => {
+      // The crown sits on the row's second line, but in the same 24px gutter at
+      // the same left padding, so the icon column the brief asked for holds.
+      const planIcon = rowOf(renderRow(plan()).container).lastElementChild
+        ?.firstElementChild;
       const navIcon = rowOf(
         render(<NavLinkItem item={starItem} collapsed={false} />).container
       ).firstElementChild;
@@ -123,25 +211,14 @@ describe('SidebarPlanRow', () => {
       expect(p.flexShrink).toBe('0');
     });
 
-    it('anchors the badge right and protects it from a long tier name', () => {
-      const { container } = renderRow(
-        plan({ name: 'An Extremely Long Tier Name Indeed' })
-      );
-      const row = rowOf(container);
-      const trailing = row.lastElementChild;
-      expect(trailing).toBeInstanceOf(HTMLElement);
-
-      const t = getComputedStyle(trailing as HTMLElement);
-      // marginLeft:auto is the anchor; flexShrink:0 stops the badge compressing.
-      expect(t.marginLeft).toBe('auto');
-      expect(t.flexShrink).toBe('0');
-
-      // The label yields instead, so the badge keeps its size. jsdom
-      // normalizes a zero length to a bare "0", hence not comparing to "0px".
-      const label = row.children[1];
-      expect(parseFloat(getComputedStyle(label as HTMLElement).minWidth)).toBe(
-        0
-      );
+    it('keeps the whole word "Plan" whatever the tier is called', () => {
+      // The regression that prompted the stack: with everything on one line the
+      // label ellipsized to "Pl..." next to a mere "Community" pill.
+      renderRow(plan({ name: 'An Extremely Long Tier Name Indeed' }));
+      expect(screen.getByText('Plan')).toBeInTheDocument();
+      expect(
+        screen.getByText('An Extremely Long Tier Name Indeed')
+      ).toBeInTheDocument();
     });
 
     it('puts the badge after the label in document order', () => {

--- a/apps/frontend/src/components/navigation/sidebar-utils.ts
+++ b/apps/frontend/src/components/navigation/sidebar-utils.ts
@@ -37,23 +37,92 @@ export const collapsedNavItemSx = {
  * 10 are not multiples of the 8px spacing step, so a spacing unit would round
  * them and shift the whole card.
  */
-export const NAV_CARD_ROW_SX = {
+// Module-private: `navCardRowSx` below is the public interface. Exported
+// separately once, when NavLinkItem spread it directly; consumers now compose
+// the full row instead, so there is one way to build a card row rather than two.
+const NAV_CARD_ROW_SX = {
   px: '14px',
   gap: '10px',
 } as const;
 
-/** Icon box for a full-height card row (`NavLinkItem`). */
-export const NAV_CARD_ICON_SIZE = 24;
+/** Icon box size for a card row. Module-private: read it through
+ * `navCardIconSx`, which is what guarantees every row's gutter matches. */
+const NAV_CARD_ICON_SIZE = 24;
 
 /**
- * A card row that reports state rather than offering an action -- currently
- * the plan row heading the footer card. Tighter vertically so it reads as a
- * status line above the actions instead of a third thing to click, while
- * keeping their horizontal alignment.
+ * The complete row shell for a sidebar card row: geometry, hover and
+ * transition. Composed by both `NavLinkItem` and `SidebarPlanRow` so every row
+ * in a card is the same height and its icon sits in the same gutter.
+ *
+ * A function rather than a constant because the hover colour and the
+ * transition duration are theme reads, and `sx` callbacks cannot be spread out
+ * of a plain object without losing them.
  */
-export const NAV_CARD_STATUS_ROW_SX = {
-  ...NAV_CARD_ROW_SX,
-  py: '6px',
+export const navCardRowSx = () =>
+  ({
+    display: 'flex',
+    alignItems: 'center',
+    ...NAV_CARD_ROW_SX,
+    py: '8px',
+    borderRadius: BORDER_RADIUS.sm,
+    textDecoration: 'none',
+    cursor: 'pointer',
+    '&:hover': {
+      bgcolor: (theme: { palette: { greyscale: { surface1: string } } }) =>
+        theme.palette.greyscale.surface1,
+    },
+    // `duration.shortest` is the theme's own 150ms.
+    transition: (theme: {
+      transitions: {
+        create: (p: string, o: { duration: number }) => string;
+        duration: { shortest: number };
+      };
+    }) =>
+      theme.transitions.create('background-color', {
+        duration: theme.transitions.duration.shortest,
+      }),
+  }) as const;
+
+/**
+ * The icon gutter. Fixed size and `flexShrink: 0`, which is what puts every
+ * row's label on the same x-offset regardless of icon glyph.
+ *
+ * `color` is deliberately absent: the caller sets it, so a row can tint its
+ * icon (the plan crown) without forking the geometry.
+ */
+export const navCardIconSx = {
+  display: 'flex',
+  flexShrink: 0,
+  '& svg': { width: NAV_CARD_ICON_SIZE, height: NAV_CARD_ICON_SIZE },
+} as const;
+
+/**
+ * The row label. `minWidth: 0` lets it shrink instead of forcing a trailing
+ * element out of the row -- without it a long plan name would push the badge
+ * past the row's right padding.
+ */
+export const navCardLabelSx = {
+  fontSize: 14,
+  fontWeight: 400,
+  lineHeight: '22px',
+  whiteSpace: 'nowrap' as const,
+  overflow: 'hidden' as const,
+  textOverflow: 'ellipsis' as const,
+  minWidth: 0,
+} as const;
+
+/**
+ * A trailing element on a card row -- the plan badge today.
+ *
+ * `marginLeft: auto` is what anchors it to the row's right padding edge, at
+ * the same x for every label and badge length; `flexShrink: 0` is what stops
+ * the badge itself being compressed when the label is long.
+ */
+export const navCardTrailingSx = {
+  marginLeft: 'auto',
+  flexShrink: 0,
+  display: 'flex',
+  alignItems: 'center',
 } as const;
 
 /**

--- a/apps/frontend/src/components/navigation/sidebar-utils.ts
+++ b/apps/frontend/src/components/navigation/sidebar-utils.ts
@@ -7,6 +7,7 @@ import {
   type NavigationHeaderItem,
   type NavigationActionItem,
 } from '@/types/navigation';
+import type { Theme } from '@mui/material/styles';
 import { BORDER_RADIUS } from '@/styles/theme-constants';
 
 // ── Shared nav sizing constants ───────────────────────────────────────────────
@@ -35,7 +36,8 @@ export const collapsedNavItemSx = {
  *
  * Figma values, which is why they are px and not `theme.spacing` units: 14 and
  * 10 are not multiples of the 8px spacing step, so a spacing unit would round
- * them and shift the whole card.
+ * them and shift the whole card. The vertical padding in `navCardRowSx` *is* on
+ * the step, so it uses the spacing scale.
  */
 // Module-private: `navCardRowSx` below is the public interface. Exported
 // separately once, when NavLinkItem spread it directly; consumers now compose
@@ -44,6 +46,11 @@ const NAV_CARD_ROW_SX = {
   px: '14px',
   gap: '10px',
 } as const;
+
+/** The icon-to-label gap, exported for a row that builds its own inner flex
+ * line (the plan row's crown + badge) and must land on the same x as the
+ * single-line rows' labels. Same value `navCardRowSx` uses, not a copy. */
+export const NAV_CARD_ICON_GAP = NAV_CARD_ROW_SX.gap;
 
 /** Icon box size for a card row. Module-private: read it through
  * `navCardIconSx`, which is what guarantees every row's gutter matches. */
@@ -57,30 +64,42 @@ const NAV_CARD_ICON_SIZE = 24;
  * A function rather than a constant because the hover colour and the
  * transition duration are theme reads, and `sx` callbacks cannot be spread out
  * of a plain object without losing them.
+ *
+ * Pass `interactive: false` for a row that only reports state. It keeps the
+ * geometry -- which is the whole point of sharing this -- and drops the pointer
+ * cursor and hover tint, so a static row does not read as a broken link beside
+ * the actionable ones. The alternative, a bespoke layout for the static row, is
+ * what made the plan row's label start at a different x-offset in the first
+ * place.
  */
-export const navCardRowSx = () =>
+export const navCardRowSx = ({ interactive = true } = {}) =>
   ({
     display: 'flex',
     alignItems: 'center',
     ...NAV_CARD_ROW_SX,
-    py: '8px',
+    py: 1,
     borderRadius: BORDER_RADIUS.sm,
     textDecoration: 'none',
-    cursor: 'pointer',
-    '&:hover': {
-      bgcolor: (theme: { palette: { greyscale: { surface1: string } } }) =>
-        theme.palette.greyscale.surface1,
-    },
-    // `duration.shortest` is the theme's own 150ms.
-    transition: (theme: {
-      transitions: {
-        create: (p: string, o: { duration: number }) => string;
-        duration: { shortest: number };
-      };
-    }) =>
-      theme.transitions.create('background-color', {
-        duration: theme.transitions.duration.shortest,
-      }),
+    ...(interactive
+      ? {
+          cursor: 'pointer',
+          '&:hover': {
+            bgcolor: (theme: {
+              palette: { greyscale: { surface1: string } };
+            }) => theme.palette.greyscale.surface1,
+          },
+          // `duration.shortest` is the theme's own 150ms.
+          transition: (theme: {
+            transitions: {
+              create: (p: string, o: { duration: number }) => string;
+              duration: { shortest: number };
+            };
+          }) =>
+            theme.transitions.create('background-color', {
+              duration: theme.transitions.duration.shortest,
+            }),
+        }
+      : {}),
   }) as const;
 
 /**
@@ -97,14 +116,18 @@ export const navCardIconSx = {
 } as const;
 
 /**
- * The row label. `minWidth: 0` lets it shrink instead of forcing a trailing
- * element out of the row -- without it a long plan name would push the badge
- * past the row's right padding.
+ * The row label's *geometry* only. `minWidth: 0` lets it shrink instead of
+ * forcing a trailing element out of the row -- without it a long plan name
+ * would push the badge past the row's right padding.
+ *
+ * Type is deliberately absent: consumers pass `variant="bodyMReg"` on the
+ * `Typography` instead. That variant is exactly this row's type (400 / 14px /
+ * 22px), and reading it from the theme rather than restating the three numbers
+ * matters for the same reason the badge's weight does -- the theme's weights
+ * shift on a branded deployment, so a literal would silently stop matching the
+ * rest of the sidebar.
  */
 export const navCardLabelSx = {
-  fontSize: 14,
-  fontWeight: 400,
-  lineHeight: '22px',
   whiteSpace: 'nowrap' as const,
   overflow: 'hidden' as const,
   textOverflow: 'ellipsis' as const,
@@ -145,8 +168,15 @@ export const COUNT_BADGE_SX = {
   borderRadius: BORDER_RADIUS.sm,
   bgcolor: 'primary.main',
   color: 'primary.contrastText',
-  fontSize: 12,
-  fontWeight: 600,
+  // Type from the theme, not literals. `600` was a real bug, not just a
+  // convention slip: the theme's semibold is 700 when a brand font is
+  // configured, so the literal rendered this badge lighter than every other
+  // semibold element on a branded deployment.
+  fontSize: (theme: Theme) => theme.typography.captionBold.fontSize,
+  fontWeight: (theme: Theme) => theme.typography.captionBold.fontWeight,
+  // Geometry, deliberately not from the variant: this matches the badge's own
+  // 20px height so the number sits centred, where `captionBold`'s 18px would
+  // not.
   lineHeight: '20px',
   textAlign: 'center',
 } as const;

--- a/apps/frontend/src/contexts/FeaturesContext.tsx
+++ b/apps/frontend/src/contexts/FeaturesContext.tsx
@@ -23,6 +23,7 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import type {
   LicenseInfo,
   FeaturesResponse,
+  Plan,
 } from '@/utils/api-client/features-client';
 import { useQuery } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
@@ -31,6 +32,7 @@ import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
 
 interface FeaturesState {
   license: LicenseInfo | null;
+  plan: Plan | null;
   enabled: ReadonlySet<string>;
   warnings: Readonly<Record<string, string>>;
   limits: Readonly<Record<string, number | null>>;
@@ -42,6 +44,7 @@ interface FeaturesState {
 
 const DEFAULT_STATE: FeaturesState = {
   license: null,
+  plan: null,
   enabled: new Set<string>(),
   warnings: {},
   limits: {},
@@ -91,6 +94,7 @@ export function FeaturesProvider({
     if (error)
       return {
         license: null,
+        plan: null,
         enabled: new Set<string>(),
         warnings: {},
         limits: {},
@@ -102,6 +106,10 @@ export function FeaturesProvider({
     if (!data) return DEFAULT_STATE;
     return {
       license: data.license,
+      // `?? null` rather than a fabricated default: a response predating this
+      // field is "unknown", not "free". Guessing would either prompt a paying
+      // org to upgrade or style them as a tier they do not have.
+      plan: data.plan ?? null,
       enabled: new Set<string>(data.enabled),
       warnings: data.warnings ?? {},
       limits: data.limits ?? {},
@@ -141,11 +149,32 @@ export function useFeatureWarning(name: FeatureName): string | null {
 }
 
 /**
- * Full state accessor for advanced consumers (license badges, error
- * toasts, loading spinners).
+ * Full state accessor for advanced consumers (error toasts, loading
+ * spinners).
+ *
+ * For a plan, use `usePlan()` below rather than reading `license` from here.
+ * Deriving anything displayable from `license.edition` is how a hardcoded
+ * tier-name comparison gets reintroduced.
  */
 export function useFeaturesState(): FeaturesState {
   return useContext(FeaturesContext);
+}
+
+/**
+ * The org's plan, or `null` while loading, on error, or on a backend that
+ * predates the field.
+ *
+ * **The single source for displaying a plan.** Pair it with `PlanBadge`, which
+ * resolves styling from the plan's booleans — never from `name`. `null` means
+ * "unknown", so render nothing rather than guessing a tier.
+ *
+ * Reads from `GET /features` because that response is server-seeded in the
+ * protected layout, so the plan is known on first paint. It previously came
+ * from `GET /usage`, which is client-fetched and left every plan surface blank
+ * for a round trip on each cold load.
+ */
+export function usePlan(): Plan | null {
+  return useContext(FeaturesContext).plan;
 }
 
 /**

--- a/apps/frontend/src/contexts/UsageContext.tsx
+++ b/apps/frontend/src/contexts/UsageContext.tsx
@@ -27,6 +27,7 @@
 import { usageKeys } from '@/constants/query-keys';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import type {
+  Plan,
   UsageResourceItem,
   UsageResponse,
 } from '@/utils/api-client/usage-client';
@@ -39,14 +40,12 @@ export interface UsageState {
   resources: Readonly<Record<string, UsageResourceItem>>;
   edition: string | null;
   /**
-   * Whether the org holds an active paid license. `null` while loading or on
-   * error, matching `edition`.
+   * The org's plan. `null` while loading or on error.
    *
-   * Carried separately from `edition` because a lapsed plan keeps its edition
-   * name -- see `isUnlicensedPlan` in `utils/quota.ts`, which is what upgrade
-   * affordances should gate on.
+   * Everything the UI needs to display or style a plan: see `utils/plan.ts`.
+   * `edition` is the machine id and must not be used for either.
    */
-  licensed: boolean | null;
+  plan: Plan | null;
   loading: boolean;
   error: Error | null;
 }
@@ -54,7 +53,7 @@ export interface UsageState {
 const DEFAULT_STATE: UsageState = {
   resources: {},
   edition: null,
-  licensed: null,
+  plan: null,
   loading: true,
   error: null,
 };
@@ -93,7 +92,7 @@ export function UsageProvider({
       return {
         resources: {},
         edition: null,
-        licensed: null,
+        plan: null,
         loading: false,
         error: error instanceof Error ? error : new Error(String(error)),
       };
@@ -101,10 +100,10 @@ export function UsageProvider({
     return {
       resources: data.resources,
       edition: data.edition,
-      // `?? null` rather than `?? false`: a response predating this field is
-      // "unknown", not "unlicensed". Defaulting to false would offer an
-      // upgrade to every paying org against an older backend.
-      licensed: data.licensed ?? null,
+      // `?? null` rather than a fabricated default: a response predating this
+      // field is "unknown", not "free". Guessing would either prompt a paying
+      // org to upgrade or style them as a tier they do not have.
+      plan: data.plan ?? null,
       loading: false,
       error: null,
     };

--- a/apps/frontend/src/contexts/UsageContext.tsx
+++ b/apps/frontend/src/contexts/UsageContext.tsx
@@ -27,7 +27,6 @@
 import { usageKeys } from '@/constants/query-keys';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import type {
-  Plan,
   UsageResourceItem,
   UsageResponse,
 } from '@/utils/api-client/usage-client';
@@ -38,14 +37,12 @@ import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
 
 export interface UsageState {
   resources: Readonly<Record<string, UsageResourceItem>>;
-  edition: string | null;
   /**
-   * The org's plan. `null` while loading or on error.
-   *
-   * Everything the UI needs to display or style a plan: see `utils/plan.ts`.
-   * `edition` is the machine id and must not be used for either.
+   * Machine id for the licence edition. Never for display or styling — for the
+   * plan, use `usePlan()`, which is server-seeded and so avoids this context's
+   * one-round-trip loading window.
    */
-  plan: Plan | null;
+  edition: string | null;
   loading: boolean;
   error: Error | null;
 }
@@ -53,7 +50,6 @@ export interface UsageState {
 const DEFAULT_STATE: UsageState = {
   resources: {},
   edition: null,
-  plan: null,
   loading: true,
   error: null,
 };
@@ -92,7 +88,6 @@ export function UsageProvider({
       return {
         resources: {},
         edition: null,
-        plan: null,
         loading: false,
         error: error instanceof Error ? error : new Error(String(error)),
       };
@@ -100,10 +95,6 @@ export function UsageProvider({
     return {
       resources: data.resources,
       edition: data.edition,
-      // `?? null` rather than a fabricated default: a response predating this
-      // field is "unknown", not "free". Guessing would either prompt a paying
-      // org to upgrade or style them as a tier they do not have.
-      plan: data.plan ?? null,
       loading: false,
       error: null,
     };

--- a/apps/frontend/src/contexts/__tests__/FeaturesContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/FeaturesContext.test.tsx
@@ -9,6 +9,7 @@ import {
   useFeature,
   useFeaturesState,
   useIsLocalMode,
+  usePlan,
   useRhesisKeyEnabled,
 } from '../FeaturesContext';
 
@@ -45,6 +46,11 @@ beforeEach(() => {
 function Probe({ feature }: { feature: FeatureName }) {
   const enabled = useFeature(feature);
   return <div data-testid="probe">{enabled ? 'on' : 'off'}</div>;
+}
+
+function PlanProbe() {
+  const plan = usePlan();
+  return <div data-testid="plan">{plan?.name ?? 'none'}</div>;
 }
 
 function StateProbe() {
@@ -399,5 +405,56 @@ describe('FeatureGate', () => {
     });
     // Body contains no gated content.
     expect(container.textContent).toBe('');
+  });
+});
+
+describe('usePlan', () => {
+  const PLAN = { name: 'Team', is_paid: true, is_active: true };
+
+  it('has the plan on first paint from the server seed, with no fetch', () => {
+    // The point of carrying the plan on this response. A never-resolving fetch
+    // stands in for the round trip: sourced from `GET /usage` instead, every
+    // plan surface rendered blank until it came back, which is the flicker
+    // this replaced.
+    mockGetFeatures.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <FeaturesProvider
+        initialFeatures={{ license: LICENSE, enabled: [], plan: PLAN }}
+      >
+        <PlanProbe />
+      </FeaturesProvider>
+    );
+
+    expect(screen.getByTestId('plan')).toHaveTextContent('Team');
+    expect(mockGetFeatures).not.toHaveBeenCalled();
+  });
+
+  it('reports null when the backend response has no plan', async () => {
+    // An older backend. Must read as "unknown" rather than being filled in
+    // with a guessed free tier, which would prompt a paying org to upgrade.
+    mockGetFeatures.mockResolvedValue({ license: LICENSE, enabled: [] });
+
+    render(
+      <FeaturesProvider>
+        <PlanProbe />
+      </FeaturesProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('plan')).toHaveTextContent('none')
+    );
+  });
+
+  it('reports null while the plan is still loading', () => {
+    mockGetFeatures.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <FeaturesProvider>
+        <PlanProbe />
+      </FeaturesProvider>
+    );
+
+    expect(screen.getByTestId('plan')).toHaveTextContent('none');
   });
 });

--- a/apps/frontend/src/hooks/useQuotaGate.tsx
+++ b/apps/frontend/src/hooks/useQuotaGate.tsx
@@ -20,7 +20,8 @@ import { useCan } from '@/components/common/Can';
 import { QuotaNotice } from '@/components/common/QuotaNotice';
 import { Capability } from '@/constants/capabilities';
 import type { QuotaResource } from '@/constants/quota';
-import { useResourceUsage, useUsage } from '@/contexts/UsageContext';
+import { useResourceUsage } from '@/contexts/UsageContext';
+import { usePlan } from '@/contexts/FeaturesContext';
 import {
   isKnownQuotaResource,
   parseQuotaError,
@@ -140,7 +141,7 @@ export function useQuotaMessageFor(
  * the upgrade too. See `isUpgradeable` in `utils/plan.ts`. */
 export function useCanUpgrade(): boolean {
   const canManageOrg = useCan(Capability.Organization.UPDATE);
-  const { plan } = useUsage();
+  const plan = usePlan();
   return canManageOrg && isUpgradeable(plan);
 }
 

--- a/apps/frontend/src/hooks/useQuotaGate.tsx
+++ b/apps/frontend/src/hooks/useQuotaGate.tsx
@@ -23,10 +23,10 @@ import type { QuotaResource } from '@/constants/quota';
 import { useResourceUsage, useUsage } from '@/contexts/UsageContext';
 import {
   isKnownQuotaResource,
-  isUnlicensedPlan,
   parseQuotaError,
   quotaCopy,
 } from '@/utils/quota';
+import { isUpgradeable } from '@/utils/plan';
 
 /** Sentence and recourse joined for a surface that can only show a string
  * (a toast). No link: a snackbar auto-dismisses, so a link in one is a trap. */
@@ -137,11 +137,11 @@ export function useQuotaMessageFor(
  *
  * Gates on licence status rather than the edition name so a lapsed paid org --
  * held to community limits but still reporting its old edition -- is offered
- * the upgrade too. See `isUnlicensedPlan`. */
+ * the upgrade too. See `isUpgradeable` in `utils/plan.ts`. */
 export function useCanUpgrade(): boolean {
   const canManageOrg = useCan(Capability.Organization.UPDATE);
-  const { edition, licensed } = useUsage();
-  return canManageOrg && isUnlicensedPlan(edition, licensed);
+  const { plan } = useUsage();
+  return canManageOrg && isUpgradeable(plan);
 }
 
 export interface QuotaErrorResult {

--- a/apps/frontend/src/hooks/useUsageForPeriod.ts
+++ b/apps/frontend/src/hooks/useUsageForPeriod.ts
@@ -18,7 +18,7 @@ import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
 const LOADING_STATE: UsageState = {
   resources: {},
   edition: null,
-  licensed: null,
+  plan: null,
   loading: true,
   error: null,
 };
@@ -45,7 +45,7 @@ export function useUsageForPeriod(periodStart: string | null): UsageState {
       return {
         resources: {},
         edition: null,
-        licensed: null,
+        plan: null,
         loading: false,
         error: error instanceof Error ? error : new Error(String(error)),
       };
@@ -54,7 +54,7 @@ export function useUsageForPeriod(periodStart: string | null): UsageState {
     return {
       resources: data.resources,
       edition: data.edition,
-      licensed: data.licensed ?? null,
+      plan: data.plan ?? null,
       loading: false,
       error: null,
     };

--- a/apps/frontend/src/hooks/useUsageForPeriod.ts
+++ b/apps/frontend/src/hooks/useUsageForPeriod.ts
@@ -18,7 +18,6 @@ import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
 const LOADING_STATE: UsageState = {
   resources: {},
   edition: null,
-  plan: null,
   loading: true,
   error: null,
 };
@@ -45,7 +44,6 @@ export function useUsageForPeriod(periodStart: string | null): UsageState {
       return {
         resources: {},
         edition: null,
-        plan: null,
         loading: false,
         error: error instanceof Error ? error : new Error(String(error)),
       };
@@ -54,7 +52,6 @@ export function useUsageForPeriod(periodStart: string | null): UsageState {
     return {
       resources: data.resources,
       edition: data.edition,
-      plan: data.plan ?? null,
       loading: false,
       error: null,
     };

--- a/apps/frontend/src/styles/theme-constants.ts
+++ b/apps/frontend/src/styles/theme-constants.ts
@@ -28,6 +28,26 @@ export const GREYSCALE = {
   },
 } as const;
 
+/**
+ * Plan badge and crown colours, per mode.
+ *
+ * The gold is its own token rather than `warning.main`: warning means "something
+ * needs your attention", and a healthy paid plan is the opposite of that. Two
+ * shades because the light-mode gold is too dark to read on a dark surface.
+ *
+ * Values live here, in the token definition file, for the same reason
+ * `GREYSCALE` does -- this is the one place a palette literal belongs.
+ */
+export const PLAN_COLORS = {
+  light: {
+    /** Crown for an active paid plan. */
+    crown: '#b8860b',
+  },
+  dark: {
+    crown: '#e3b341',
+  },
+} as const;
+
 export const BORDER_RADIUS = {
   xs: '4px',
   sm: '8px',

--- a/apps/frontend/src/styles/theme-constants.ts
+++ b/apps/frontend/src/styles/theme-constants.ts
@@ -29,11 +29,29 @@ export const GREYSCALE = {
 } as const;
 
 /**
- * Plan badge and crown colours, per mode.
+ * Plan colours, per mode: the crown for a paid plan, and its drop shadow.
  *
- * The gold is its own token rather than `warning.main`: warning means "something
- * needs your attention", and a healthy paid plan is the opposite of that. Two
- * shades because the light-mode gold is too dark to read on a dark surface.
+ * Deliberately **not** `warning.main`. Warning means "something needs your
+ * attention", and a healthy paid plan is the opposite of that; reusing the
+ * semantic role would also spend it, leaving nothing for real warning states in
+ * the sidebar (which already has quota warnings). Two shades because the
+ * light-mode gold has to survive a white surface while the dark one does not.
+ *
+ * **Why not a brighter, more obviously metallic gold in light mode.** The
+ * classic `#D4AF37` is only 2.10:1 on white, well under the 3:1 WCAG 1.4.11
+ * asks for a non-text graphic, and every gold at that lightness fails the same
+ * way. `#B8860B` is the most saturated gold that clears the bar: hue 43°
+ * (gold) rather than the 36° of an orange-brown, at 3.25:1. Dark mode has the
+ * headroom for a bright `#F2C14E` at 10.31:1.
+ *
+ * Contrast against the sidebar background (white light / `#161B22` dark), per
+ * WCAG 1.4.11 for non-text graphics (3:1): light 3.25:1, dark 10.31:1.
+ *
+ * The two shadow tokens are a pair: a tight, darker contact shadow plus a wider
+ * halo. One alone is invisible at this size -- a single 2px gold shadow under a
+ * gold glyph on a white card cannot be seen. In light mode the contact shadow is
+ * a darker gold so it registers against white; in dark mode it is black, since
+ * gold-on-dark needs the halo to read rather than a same-hue shadow.
  *
  * Values live here, in the token definition file, for the same reason
  * `GREYSCALE` does -- this is the one place a palette literal belongs.
@@ -41,11 +59,38 @@ export const GREYSCALE = {
 export const PLAN_COLORS = {
   light: {
     /** Crown for an active paid plan. */
-    crown: '#b8860b',
+    premium: '#B8860B',
   },
   dark: {
-    crown: '#e3b341',
+    premium: '#F2C14E',
   },
+} as const;
+
+/**
+ * The paid crown's `filter`, complete, per mode.
+ *
+ * A whole value rather than colours the component assembles, matching how
+ * `SHADOWS` below keeps entire `box-shadow` strings here: the offsets and blur
+ * are as much of the design decision as the colour, and splitting them left
+ * `0 1px 1.5px` and `0 0 5px` sitting in a component.
+ *
+ * Two chained shadows on purpose. A single pass at 24px is either invisible
+ * (small blur) or a smudge (large blur), and one 2px gold shadow under a gold
+ * glyph on a white card genuinely cannot be seen -- measured at 336 changed
+ * pixels and a 89/255 peak delta, against 750 and 168/255 for the pair below.
+ * The contact shadow seats the crown on the surface; the halo makes it glow.
+ *
+ * Light mode's contact shadow is a *darker* gold so it registers against white.
+ * Dark mode's is black, because a same-hue shadow on a dark surface disappears
+ * and the halo has to carry the effect.
+ */
+export const PLAN_CROWN_SHADOW = {
+  light:
+    'drop-shadow(0 1px 1.5px rgba(146, 105, 8, 0.70)) ' +
+    'drop-shadow(0 0 5px rgba(184, 134, 11, 0.45))',
+  dark:
+    'drop-shadow(0 1px 1.5px rgba(0, 0, 0, 0.55)) ' +
+    'drop-shadow(0 0 5px rgba(242, 193, 78, 0.45))',
 } as const;
 
 export const BORDER_RADIUS = {

--- a/apps/frontend/src/utils/__tests__/plan.test.ts
+++ b/apps/frontend/src/utils/__tests__/plan.test.ts
@@ -1,0 +1,121 @@
+import {
+  DEFAULT_PLAN_STYLE,
+  isUpgradeable,
+  planLabel,
+  resolvePlanStyle,
+} from '@/utils/plan';
+import type { Plan } from '@/utils/api-client/usage-client';
+
+const plan = (over: Partial<Plan> = {}): Plan => ({
+  name: 'Team',
+  is_paid: true,
+  is_active: true,
+  ...over,
+});
+
+describe('resolvePlanStyle', () => {
+  it('styles a free plan neutrally with an outlined crown', () => {
+    const style = resolvePlanStyle(
+      plan({ name: 'Community', is_paid: false, is_active: false })
+    );
+    expect(style.variant).toBe('free');
+    expect(style.chipColor).toBe('default');
+    expect(style.crownFilled).toBe(false);
+    expect(style.crownColor).toBeNull();
+  });
+
+  it('gives an active paid plan a filled gold crown', () => {
+    const style = resolvePlanStyle(plan());
+    expect(style.variant).toBe('paid');
+    expect(style.chipColor).toBe('primary');
+    expect(style.crownFilled).toBe(true);
+    expect(style.crownColor).toBe('crown');
+  });
+
+  it('flags a paid plan whose licence lapsed', () => {
+    // The backend holds this org to free-tier ceilings while its plan still
+    // names the tier they bought, so it has to look different from both.
+    const style = resolvePlanStyle(plan({ is_active: false }));
+    expect(style.variant).toBe('lapsed');
+    expect(style.chipColor).toBe('warning');
+  });
+
+  it('styles a tier it has never heard of by its flags, not its name', () => {
+    // The whole point of the resolver's shape: a tier added on the backend
+    // renders correctly with no frontend release. A resolver switching on
+    // known names would have silently styled this as free.
+    const style = resolvePlanStyle(
+      plan({ name: 'Ultra Premium Plus', is_paid: true, is_active: true })
+    );
+    expect(style.variant).toBe('paid');
+    expect(style.chipColor).toBe('primary');
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])('falls back to the neutral default for %s', (_label, value) => {
+    expect(resolvePlanStyle(value)).toEqual(DEFAULT_PLAN_STYLE);
+    expect(DEFAULT_PLAN_STYLE.variant).toBe('free');
+  });
+
+  it.each([
+    ['missing flags', { name: 'Mystery' }],
+    ['string flags', { name: 'Mystery', is_paid: 'yes', is_active: 'yes' }],
+    ['null flags', { name: 'Mystery', is_paid: null, is_active: null }],
+  ])('treats a malformed plan (%s) as free rather than paid', (_l, value) => {
+    // Fail toward "no entitlement". Never render a paid style for a plan we
+    // cannot confirm is paid, and never throw -- this runs in the protected
+    // layout's sidebar, where a render error takes down every page.
+    const style = resolvePlanStyle(value as unknown as Plan);
+    expect(style.variant).toBe('free');
+  });
+});
+
+describe('isUpgradeable', () => {
+  it('offers an upgrade to a free org', () => {
+    expect(isUpgradeable(plan({ is_paid: false, is_active: false }))).toBe(
+      true
+    );
+  });
+
+  it('offers one to a paid org whose licence lapsed', () => {
+    expect(isUpgradeable(plan({ is_active: false }))).toBe(true);
+  });
+
+  it('does not offer one to an active paid org', () => {
+    expect(isUpgradeable(plan())).toBe(false);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['missing is_active', { name: 'Team', is_paid: true }],
+  ])('offers nothing when the plan is unknown (%s)', (_l, value) => {
+    // Must not prompt a paying customer to upgrade on missing data.
+    expect(isUpgradeable(value as unknown as Plan)).toBe(false);
+  });
+});
+
+describe('planLabel', () => {
+  it('returns the name exactly as the API sent it', () => {
+    // No casing, mapping or suffixing. The API composes the whole label.
+    for (const name of [
+      'Community',
+      'Enterprise (inactive)',
+      'ULTRA',
+      'très-premium',
+    ]) {
+      expect(planLabel(plan({ name }))).toBe(name);
+    }
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty name', { name: '', is_paid: false, is_active: false }],
+    ['blank name', { name: '   ', is_paid: false, is_active: false }],
+  ])('returns null when there is nothing to show (%s)', (_l, value) => {
+    expect(planLabel(value as unknown as Plan)).toBeNull();
+  });
+});

--- a/apps/frontend/src/utils/__tests__/plan.test.ts
+++ b/apps/frontend/src/utils/__tests__/plan.test.ts
@@ -19,25 +19,59 @@ describe('resolvePlanStyle', () => {
       plan({ name: 'Community', is_paid: false, is_active: false })
     );
     expect(style.variant).toBe('free');
-    expect(style.chipColor).toBe('default');
     expect(style.crownFilled).toBe(false);
     expect(style.crownColor).toBeNull();
   });
 
-  it('gives an active paid plan a filled gold crown', () => {
+  it('gives an active paid plan a filled premium crown', () => {
     const style = resolvePlanStyle(plan());
     expect(style.variant).toBe('paid');
-    expect(style.chipColor).toBe('primary');
     expect(style.crownFilled).toBe(true);
-    expect(style.crownColor).toBe('crown');
+    expect(style.crownColor).toBe('premium');
+    expect(style.crownShadow).toBe(true);
   });
 
-  it('flags a paid plan whose licence lapsed', () => {
-    // The backend holds this org to free-tier ceilings while its plan still
-    // names the tier they bought, so it has to look different from both.
+  it('lifts only an active paid crown off the surface', () => {
+    // A shadow on the neutral crown would make a free plan look like it was
+    // signalling something, which is the opposite of the intent.
+    //
+    // Asserted here rather than on the rendered icon because jsdom's cssstyle
+    // does not implement `filter`: it is dropped from the emotion rule, so a
+    // DOM assertion would pass whatever the component does.
+    expect(resolvePlanStyle(plan()).crownShadow).toBe(true);
+    for (const p of [
+      plan({ is_paid: false, is_active: false }),
+      plan({ is_active: false }),
+      null,
+      undefined,
+    ]) {
+      expect(resolvePlanStyle(p).crownShadow).toBe(false);
+    }
+  });
+
+  it('does not dress a lapsed paid plan as paid', () => {
+    // The backend holds this org to free-tier ceilings, so showing it a filled
+    // premium crown would misreport what it can actually do. The distinction
+    // rides on the label ("... (inactive)"), which the API composes.
     const style = resolvePlanStyle(plan({ is_active: false }));
     expect(style.variant).toBe('lapsed');
-    expect(style.chipColor).toBe('warning');
+    expect(style.crownFilled).toBe(false);
+    expect(style.crownColor).toBeNull();
+  });
+
+  it('varies nothing but the crown across tiers', () => {
+    // The badge is neutral for every tier, so the resolver has no badge colour
+    // to return. If one is ever added, the free tier ends up wearing the
+    // loudest pill in the UI, which is what this guards.
+    const free = resolvePlanStyle(plan({ is_paid: false, is_active: false }));
+    const paid = resolvePlanStyle(plan());
+    expect(Object.keys(free).sort()).toEqual([
+      'crownColor',
+      'crownFilled',
+      'crownShadow',
+      'variant',
+    ]);
+    expect(Object.keys(paid).sort()).toEqual(Object.keys(free).sort());
   });
 
   it('styles a tier it has never heard of by its flags, not its name', () => {
@@ -48,7 +82,7 @@ describe('resolvePlanStyle', () => {
       plan({ name: 'Ultra Premium Plus', is_paid: true, is_active: true })
     );
     expect(style.variant).toBe('paid');
-    expect(style.chipColor).toBe('primary');
+    expect(style.crownFilled).toBe(true);
   });
 
   it.each([

--- a/apps/frontend/src/utils/__tests__/plan.test.ts
+++ b/apps/frontend/src/utils/__tests__/plan.test.ts
@@ -4,7 +4,7 @@ import {
   planLabel,
   resolvePlanStyle,
 } from '@/utils/plan';
-import type { Plan } from '@/utils/api-client/usage-client';
+import type { Plan } from '@/utils/api-client/features-client';
 
 const plan = (over: Partial<Plan> = {}): Plan => ({
   name: 'Team',

--- a/apps/frontend/src/utils/__tests__/quota.test.ts
+++ b/apps/frontend/src/utils/__tests__/quota.test.ts
@@ -2,9 +2,7 @@ import {
   classifyZone,
   flaggedResources,
   findWorstResource,
-  isCommunityEdition,
   isKnownQuotaResource,
-  isUnlicensedPlan,
   parseQuotaError,
   quotaCopy,
   usageMenuRows,
@@ -302,48 +300,6 @@ describe('isKnownQuotaResource', () => {
 
   it('rejects one it does not', () => {
     expect(isKnownQuotaResource('some_future_resource')).toBe(false);
-  });
-});
-
-describe('isCommunityEdition', () => {
-  it('matches the free tier regardless of case', () => {
-    expect(isCommunityEdition('community')).toBe(true);
-    expect(isCommunityEdition('COMMUNITY')).toBe(true);
-  });
-
-  it('does not match a paid edition', () => {
-    expect(isCommunityEdition('enterprise')).toBe(false);
-  });
-});
-
-describe('isUnlicensedPlan', () => {
-  it('offers an upgrade to a free org', () => {
-    expect(isUnlicensedPlan('community', false)).toBe(true);
-  });
-
-  it('does not offer one to an org on an active paid licence', () => {
-    expect(isUnlicensedPlan('team', true)).toBe(false);
-    expect(isUnlicensedPlan('enterprise', true)).toBe(false);
-  });
-
-  it('offers one to a paid org whose licence has lapsed', () => {
-    // The case the old edition-string check got wrong. A canceled licence
-    // resolves to community limits on the backend but keeps reporting its
-    // edition, so this org hits free-tier ceilings while not looking free --
-    // and was shown no upgrade path at the moment it most needed one.
-    expect(isUnlicensedPlan('enterprise', false)).toBe(true);
-    expect(isUnlicensedPlan('team', false)).toBe(true);
-  });
-
-  it.each([
-    ['loading', null, null],
-    ['edition loaded, licence unknown', 'enterprise', null],
-    ['licence field absent', 'enterprise', undefined],
-  ])('offers nothing when %s', (_case, edition, licensed) => {
-    // Never prompt a paying customer to upgrade on missing data.
-    expect(
-      isUnlicensedPlan(edition as string | null, licensed as boolean | null)
-    ).toBe(false);
   });
 });
 

--- a/apps/frontend/src/utils/api-client/features-client.ts
+++ b/apps/frontend/src/utils/api-client/features-client.ts
@@ -3,10 +3,60 @@ import { BaseApiClient } from './base-client';
 export interface LicenseInfo {
   edition: string;
   licensed: boolean;
+  /**
+   * Whether `edition` is a paid tier. Describes the tier, not the licence
+   * state, so a lapsed paid licence is `is_paid: true` with `licensed: false`.
+   *
+   * Never infer this from `edition` — a name comparison like
+   * `edition !== 'community'` misreads any tier added or renamed later.
+   * Optional only to tolerate a backend predating this field; treat a missing
+   * value as "unknown", not as "free".
+   *
+   * To *display* a plan, use `usePlan()` with `PlanBadge` rather than building
+   * anything off these fields. See `@/utils/plan`.
+   */
+  is_paid?: boolean;
+}
+
+/**
+ * The org's plan, as the API describes it.
+ *
+ * Deliberately not a union of known tiers. `name` is a display string to be
+ * rendered verbatim, and styling comes from the two booleans — so a renamed or
+ * newly added tier needs no frontend change. See `utils/plan.ts`.
+ */
+export interface Plan {
+  /**
+   * Display label. **Render verbatim.** Do not case, map, translate or append
+   * to it — the API composes the whole thing, including the qualifier a lapsed
+   * paid plan carries.
+   */
+  name: string;
+  /**
+   * Whether this is a paid tier. Describes the *tier*, not the licence, so a
+   * canceled enterprise licence is still `true`.
+   */
+  is_paid: boolean;
+  /**
+   * Whether the licence is currently active. Together with `is_paid` this
+   * separates a free org `(false, false)` from a lapsed paid one
+   * `(true, false)` — the distinction that decides both badge styling and
+   * whether an upgrade path is offered.
+   */
+  is_active: boolean;
 }
 
 export interface FeaturesResponse {
   license: LicenseInfo;
+  /**
+   * The org's plan, ready to render via `PlanBadge`. Read it with `usePlan()`.
+   *
+   * It rides on this response rather than `GET /usage` for one reason: this one
+   * is server-seeded in the protected layout, so the plan is available on first
+   * paint. Fetching it client-side left the sidebar's plan row blank for a round
+   * trip on every cold load. Optional to tolerate a backend predating it.
+   */
+  plan?: Plan;
   /** Wire type is string[] to tolerate unknown feature names from newer backends. */
   enabled: string[];
   /** Per-feature warnings for features that are licensed but not operationally ready. */

--- a/apps/frontend/src/utils/api-client/usage-client.ts
+++ b/apps/frontend/src/utils/api-client/usage-client.ts
@@ -21,19 +21,42 @@ export interface UsageResourceItem {
   kind: 'flow' | 'stock';
 }
 
+/**
+ * The org's plan, as the API describes it.
+ *
+ * Deliberately not a union of known tiers. `name` is a display string to be
+ * rendered verbatim, and styling comes from the two booleans — so a renamed or
+ * newly added tier needs no frontend change. See `utils/plan.ts`.
+ */
+export interface Plan {
+  /**
+   * Display label. **Render verbatim.** Do not case, map, translate or append
+   * to it — the API composes the whole thing, including the qualifier a lapsed
+   * paid plan carries.
+   */
+  name: string;
+  /**
+   * Whether this is a paid tier. Describes the *tier*, not the licence, so a
+   * canceled enterprise licence is still `true`.
+   */
+  is_paid: boolean;
+  /**
+   * Whether the licence is currently active. Together with `is_paid` this
+   * separates a free org `(false, false)` from a lapsed paid one
+   * `(true, false)` — the distinction that decides both badge styling and
+   * whether an upgrade path is offered.
+   */
+  is_active: boolean;
+}
+
 export interface UsageResponse {
   resources: Record<string, UsageResourceItem>;
-  edition: string;
   /**
-   * Whether the org holds an *active* paid license.
-   *
-   * Separate from `edition`, which keeps naming a lapsed tier so the UI can
-   * say which license expired: a canceled enterprise license reports
-   * `edition: "enterprise"` with `licensed: false`, while the backend holds it
-   * to community limits. Gate upgrade affordances on this, not on the edition
-   * string -- see `isUnlicensedPlan` in `utils/quota.ts`.
+   * Machine identifier for the licence edition. Diagnostics only — never for
+   * display, and never for deciding styling. Use `plan`.
    */
-  licensed: boolean;
+  edition: string;
+  plan: Plan;
 }
 
 export interface UsageHistoryPoint {

--- a/apps/frontend/src/utils/api-client/usage-client.ts
+++ b/apps/frontend/src/utils/api-client/usage-client.ts
@@ -21,42 +21,16 @@ export interface UsageResourceItem {
   kind: 'flow' | 'stock';
 }
 
-/**
- * The org's plan, as the API describes it.
- *
- * Deliberately not a union of known tiers. `name` is a display string to be
- * rendered verbatim, and styling comes from the two booleans — so a renamed or
- * newly added tier needs no frontend change. See `utils/plan.ts`.
- */
-export interface Plan {
-  /**
-   * Display label. **Render verbatim.** Do not case, map, translate or append
-   * to it — the API composes the whole thing, including the qualifier a lapsed
-   * paid plan carries.
-   */
-  name: string;
-  /**
-   * Whether this is a paid tier. Describes the *tier*, not the licence, so a
-   * canceled enterprise licence is still `true`.
-   */
-  is_paid: boolean;
-  /**
-   * Whether the licence is currently active. Together with `is_paid` this
-   * separates a free org `(false, false)` from a lapsed paid one
-   * `(true, false)` — the distinction that decides both badge styling and
-   * whether an upgrade path is offered.
-   */
-  is_active: boolean;
-}
-
 export interface UsageResponse {
   resources: Record<string, UsageResourceItem>;
   /**
    * Machine identifier for the licence edition. Diagnostics only — never for
-   * display, and never for deciding styling. Use `plan`.
+   * display, and never for deciding styling.
+   *
+   * To display the plan, use `usePlan()`, which reads it from `GET /features`
+   * — server-seeded in the protected layout, so it is there on first paint.
    */
   edition: string;
-  plan: Plan;
 }
 
 export interface UsageHistoryPoint {

--- a/apps/frontend/src/utils/plan.ts
+++ b/apps/frontend/src/utils/plan.ts
@@ -16,7 +16,6 @@
  * list of tiers to fall out of date.
  */
 
-import { PLAN_COLORS } from '@/styles/theme-constants';
 import type { Plan } from '@/utils/api-client/features-client';
 
 /**
@@ -26,7 +25,7 @@ import type { Plan } from '@/utils/api-client/features-client';
  * `is_active`) and this collapses them into the one axis styling varies on.
  *
  * - `free` — not a paid tier. Neutral; nothing to celebrate, nothing wrong.
- * - `paid` — a paid tier with an active licence. Gold crown.
+ * - `paid` — a paid tier with an active licence. Filled premium crown.
  * - `lapsed` — a paid tier whose licence is no longer active. The state an
  *   admin needs to notice, because the backend is holding them to free-tier
  *   ceilings while their plan still names the tier they bought.
@@ -35,12 +34,29 @@ export type PlanVariant = 'free' | 'paid' | 'lapsed';
 
 export interface PlanStyle {
   variant: PlanVariant;
-  /** MUI `Chip` colour prop. Same prop for every variant — only the value differs. */
-  chipColor: 'default' | 'primary' | 'warning';
   /** Whether the crown is drawn filled (an earned state) or outlined. */
   crownFilled: boolean;
-  /** Palette path for the crown, or `null` to inherit the row's own colour. */
-  crownColor: keyof typeof PLAN_COLORS.light | 'warning' | null;
+  /**
+   * Palette key for the crown, or `null` to inherit the row's icon colour.
+   *
+   * Spelled out rather than `keyof typeof PLAN_COLORS.light`, which would also
+   * admit `premiumShadow` — a shadow is not a crown colour.
+   *
+   * The crown is the **only** element whose colour varies by tier. The badge is
+   * neutral for every tier, so the free tier never ends up wearing the most
+   * saturated pill in the UI — and a paid plan is marked by the crown rather
+   * than by a louder badge.
+   */
+  crownColor: 'premium' | null;
+  /**
+   * Whether the crown is lifted off the surface with a drop shadow.
+   *
+   * Lives here rather than being inferred in the component, so "what does this
+   * tier look like" stays one decision in one place. Only an active paid plan
+   * glows: a shadow on the neutral crown would make a free plan look like it
+   * was signalling something.
+   */
+  crownShadow: boolean;
 }
 
 /**
@@ -54,21 +70,27 @@ export interface PlanStyle {
 const STYLES: Record<PlanVariant, PlanStyle> = {
   free: {
     variant: 'free',
-    chipColor: 'default',
     crownFilled: false,
     crownColor: null,
+    crownShadow: false,
   },
   paid: {
     variant: 'paid',
-    chipColor: 'primary',
     crownFilled: true,
-    crownColor: 'crown',
+    crownColor: 'premium',
+    crownShadow: true,
   },
+  // Styled identically to `free`, and honestly so: a lapsed licence is held to
+  // free-tier ceilings, so presenting it as paid would misreport what the org
+  // can actually do. The distinction is carried by the label, which the API
+  // composes with its "(inactive)" qualifier -- text, not colour, which is also
+  // what keeps it legible in a monochrome theme. The variant stays separate
+  // because `isUpgradeable` needs it.
   lapsed: {
     variant: 'lapsed',
-    chipColor: 'warning',
     crownFilled: false,
-    crownColor: 'warning',
+    crownColor: null,
+    crownShadow: false,
   },
 };
 

--- a/apps/frontend/src/utils/plan.ts
+++ b/apps/frontend/src/utils/plan.ts
@@ -17,7 +17,7 @@
  */
 
 import { PLAN_COLORS } from '@/styles/theme-constants';
-import type { Plan } from '@/utils/api-client/usage-client';
+import type { Plan } from '@/utils/api-client/features-client';
 
 /**
  * Which of the three presentation states a plan is in.

--- a/apps/frontend/src/utils/plan.ts
+++ b/apps/frontend/src/utils/plan.ts
@@ -1,0 +1,114 @@
+/**
+ * The single plan→style resolver.
+ *
+ * Every surface that displays a plan — the sidebar footer row, the sidebar
+ * org menu, the usage page, and anything added later — renders `PlanBadge`
+ * and gets its styling from here. One resolver, one badge, so two surfaces
+ * can never disagree about what a plan looks like.
+ *
+ * **It never looks at the plan's name.** Styling is decided entirely by the
+ * two booleans the API supplies (`is_paid`, `is_active`), which is what makes
+ * a renamed or newly added tier render correctly with no frontend release. A
+ * resolver that switched on `"community"` / `"enterprise"` would silently
+ * style an unknown tier as free — the failure this shape exists to prevent.
+ *
+ * `Plan` is deliberately not a union of known tiers. There is no client-side
+ * list of tiers to fall out of date.
+ */
+
+import { PLAN_COLORS } from '@/styles/theme-constants';
+import type { Plan } from '@/utils/api-client/usage-client';
+
+/**
+ * Which of the three presentation states a plan is in.
+ *
+ * Derived, not transmitted: the API sends orthogonal facts (`is_paid`,
+ * `is_active`) and this collapses them into the one axis styling varies on.
+ *
+ * - `free` — not a paid tier. Neutral; nothing to celebrate, nothing wrong.
+ * - `paid` — a paid tier with an active licence. Gold crown.
+ * - `lapsed` — a paid tier whose licence is no longer active. The state an
+ *   admin needs to notice, because the backend is holding them to free-tier
+ *   ceilings while their plan still names the tier they bought.
+ */
+export type PlanVariant = 'free' | 'paid' | 'lapsed';
+
+export interface PlanStyle {
+  variant: PlanVariant;
+  /** MUI `Chip` colour prop. Same prop for every variant — only the value differs. */
+  chipColor: 'default' | 'primary' | 'warning';
+  /** Whether the crown is drawn filled (an earned state) or outlined. */
+  crownFilled: boolean;
+  /** Palette path for the crown, or `null` to inherit the row's own colour. */
+  crownColor: keyof typeof PLAN_COLORS.light | 'warning' | null;
+}
+
+/**
+ * The variant table. Keyed on the boolean pair rather than on tier names, so
+ * adding a tier requires no entry here.
+ *
+ * `free` is the safe default: an unknown, missing or malformed plan renders as
+ * a neutral badge with an outlined crown. It must never crash, render blank, or
+ * be styled as a paid plan the org has not got.
+ */
+const STYLES: Record<PlanVariant, PlanStyle> = {
+  free: {
+    variant: 'free',
+    chipColor: 'default',
+    crownFilled: false,
+    crownColor: null,
+  },
+  paid: {
+    variant: 'paid',
+    chipColor: 'primary',
+    crownFilled: true,
+    crownColor: 'crown',
+  },
+  lapsed: {
+    variant: 'lapsed',
+    chipColor: 'warning',
+    crownFilled: false,
+    crownColor: 'warning',
+  },
+};
+
+/** The neutral fallback, exported so callers can render before a plan loads. */
+export const DEFAULT_PLAN_STYLE: PlanStyle = STYLES.free;
+
+/**
+ * Resolve *plan* to its style tokens.
+ *
+ * Accepts `null`/`undefined` and anything structurally unexpected, returning
+ * the neutral default rather than throwing: this runs in the protected layout's
+ * sidebar, where a render error takes down every page rather than one badge.
+ */
+export function resolvePlanStyle(plan: Plan | null | undefined): PlanStyle {
+  if (!plan || typeof plan !== 'object') return DEFAULT_PLAN_STYLE;
+  if (plan.is_paid !== true) return STYLES.free;
+  return plan.is_active === true ? STYLES.paid : STYLES.lapsed;
+}
+
+/**
+ * Whether this org should be offered an upgrade path.
+ *
+ * True for a free org and for a paid org whose licence has lapsed — both are
+ * held to free-tier ceilings, and the lapsed one is the case that most needs
+ * the prompt. Requires a positive `false` on `is_active`, so a plan that has
+ * not loaded yet shows nothing rather than prompting a paying customer.
+ */
+export function isUpgradeable(plan: Plan | null | undefined): boolean {
+  if (!plan || typeof plan !== 'object') return false;
+  return plan.is_active === false;
+}
+
+/**
+ * The plan's display label, or `null` when there is nothing to show yet.
+ *
+ * Returned verbatim. No casing, mapping or suffixing — the API composes the
+ * full label, qualifier included, precisely so this stays a passthrough.
+ */
+export function planLabel(plan: Plan | null | undefined): string | null {
+  if (!plan || typeof plan !== 'object') return null;
+  const name = plan.name;
+  return typeof name === 'string' && name.trim() !== '' ? name : null;
+}

--- a/apps/frontend/src/utils/quota.ts
+++ b/apps/frontend/src/utils/quota.ts
@@ -14,45 +14,6 @@ import {
 import type { ApiErrorData } from '@/utils/api-client/base-client';
 import type { UsageResourceItem } from '@/utils/api-client/usage-client';
 
-const COMMUNITY_EDITION = 'community';
-
-/** Whether *edition* names the free tier. Answers "what plan is this", which
- * is a display question -- for "should this org be offered an upgrade", use
- * {@link isUnlicensedPlan}: a lapsed paid plan is not the community edition
- * but is held to community limits. */
-export function isCommunityEdition(edition: string): boolean {
-  return edition.toLowerCase() === COMMUNITY_EDITION;
-}
-
-/**
- * Whether the org has no active paid license, and should therefore be shown
- * an upgrade path.
- *
- * This is the question every upgrade affordance is really asking, and it is
- * deliberately *not* `isCommunityEdition(edition)`, which is what it used to
- * be. The backend reports edition and licence status separately, because a
- * lapsed licence keeps its edition name so the UI can say which one expired:
- * a canceled enterprise licence resolves to community *limits* while still
- * reporting `edition: "enterprise"`.
- *
- * Gating on the edition string stranded exactly that org. It gets free-tier
- * ceilings and 402s at 500 test runs, but does not look like a free org, so
- * every upgrade link, banner CTA and `canUpgrade` recourse line was withheld
- * -- the one state where the reader most needs to be told what to do.
- *
- * Requires a positive `licensed === false`, so anything unknown -- a loading
- * provider (`null`), or a response from a backend predating the field
- * (`undefined`) -- reads as "no opinion" and shows nothing, rather than
- * flashing an upgrade prompt at a paying customer.
- */
-export function isUnlicensedPlan(
-  edition: string | null,
-  licensed: boolean | null | undefined
-): boolean {
-  if (edition === null) return false;
-  return licensed === false;
-}
-
 /** Narrows a wire-value string (e.g. `parseQuotaError(err).resource`) to
  * `QuotaResource`. A 402 body's `resource` is always one, but it arrives
  * typed as plain `string`, and the backend can add a new `QuotaResource`

--- a/ee/backend/src/rhesis/backend/ee/licensing/cli.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/cli.py
@@ -92,20 +92,38 @@ def _parse_edition(value: str) -> LicenseEdition:
         edition = LicenseEdition.UNKNOWN
     if edition not in EDITION_ENTITLEMENTS:
         valid = ", ".join(_sellable_editions())
-        raise argparse.ArgumentTypeError(
-            f"Invalid edition '{value}'. Choose from: {valid}"
-        )
+        raise argparse.ArgumentTypeError(f"Invalid edition '{value}'. Choose from: {valid}")
     return edition
 
 
 def _parse_status(value: str) -> LicenseStatus:
-    try:
-        return LicenseStatus(value)
-    except ValueError:
-        valid = ", ".join(s.value for s in LicenseStatus if s != LicenseStatus.UNKNOWN)
-        raise argparse.ArgumentTypeError(
-            f"Invalid status '{value}'. Choose from: {valid}"
-        )
+    """Strictly resolve a ``--status`` argument to a mintable status.
+
+    ``LicenseStatus(value)`` cannot be trusted to raise: its ``_missing_``
+    coerces anything unrecognized to ``UNKNOWN``, so the ``except ValueError``
+    this used to rely on never fired. The result was silent and expensive --
+    ``--status Active``, ``--status ACTIVE``, a stray space, or an empty string
+    (which is what a blank CI input expands to) all minted a token carrying
+    ``status: unknown``.
+
+    Such a token verifies, matches its org, and is not expired, so nothing
+    reports a failure. But ``UNKNOWN`` is absent from
+    :data:`~rhesis.backend.ee.licensing.entitlements.ACTIVE_STATUSES`, so
+    ``is_active()`` is false and the org is served its edition with
+    ``licensed: False`` -- held to community limits and shown as "(inactive)"
+    immediately after a licence was successfully issued to it.
+
+    ``UNKNOWN`` is rejected as an explicit argument too: it is a decode-time
+    sentinel for a status we do not recognize, never something to mint on
+    purpose. Mirrors ``_parse_edition`` above, which validates membership after
+    coercion for the same reason.
+    """
+    mintable = [s for s in LicenseStatus if s is not LicenseStatus.UNKNOWN]
+    for status in mintable:
+        if status.value == value:
+            return status
+    valid = ", ".join(s.value for s in mintable)
+    raise argparse.ArgumentTypeError(f"Invalid status '{value}'. Choose from: {valid}")
 
 
 def _require_private_key() -> None:
@@ -358,11 +376,7 @@ def _print_summary(
             },
         )
         exp_ts = payload.get("exp")
-        exp_str = (
-            datetime.fromtimestamp(exp_ts, tz=timezone.utc).isoformat()
-            if exp_ts
-            else "n/a"
-        )
+        exp_str = datetime.fromtimestamp(exp_ts, tz=timezone.utc).isoformat() if exp_ts else "n/a"
         jti = payload.get("jti", "n/a")
         edition = (payload.get("lic") or {}).get("edition", "n/a")
     except Exception:
@@ -441,10 +455,7 @@ def _build_parser() -> argparse.ArgumentParser:
         p.add_argument(
             "--kid",
             default=_default_kid(),
-            help=(
-                "Key ID to use for signing "
-                f"(default: ${ENV_LICENSE_KID} or rhesis-prod-v1)."
-            ),
+            help=(f"Key ID to use for signing (default: ${ENV_LICENSE_KID} or rhesis-prod-v1)."),
         )
         p.add_argument(
             "--features",
@@ -457,7 +468,7 @@ def _build_parser() -> argparse.ArgumentParser:
             default=None,
             metavar="JSON",
             help=(
-                'JSON per-resource limit override, e.g. \'{"test_executions": 500000}\'. '
+                "JSON per-resource limit override, e.g. '{\"test_executions\": 500000}'. "
                 "Overlaid on the tier's live limits at enforcement time; resources left "
                 "out keep following the published tier. Use null for unlimited. This is "
                 'how a "custom" enterprise cap is set.'

--- a/ee/backend/src/rhesis/backend/ee/licensing/provider.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/provider.py
@@ -149,41 +149,91 @@ class SignedTokenLicenseProvider:
             "is_paid": is_sellable(edition),
         }
 
+    def _blanket_entitlements(self) -> Optional[Entitlements]:
+        """Entitlements from the ``RHESIS_LICENSE`` env token, if it is a
+        blanket one. ``None`` when unset, unverifiable, or bound to a
+        specific org rather than ``*``."""
+        env_token = os.environ.get(ENV_LICENSE, "").strip()
+        if not env_token:
+            return None
+
+        entitlements = verify_token(env_token)
+        if entitlements is None:
+            return None
+        if entitlements.sub == BLANKET_SUBJECT:
+            return entitlements
+
+        logger.debug(
+            "%s token sub=%s is not %r; falling through to org token",
+            ENV_LICENSE,
+            entitlements.sub,
+            BLANKET_SUBJECT,
+        )
+        return None
+
+    def _org_entitlements(self, org: Organization) -> Optional[Entitlements]:
+        """Entitlements from ``organization.license``, if the token's ``sub``
+        matches this org. ``None`` otherwise."""
+        org_token = getattr(org, "license", None)
+        if not org_token:
+            return None
+
+        entitlements = verify_token(org_token)
+        if entitlements is None:
+            return None
+
+        org_id_str = str(org.id).lower()
+        if entitlements.sub.lower() == org_id_str:
+            return entitlements
+
+        logger.debug(
+            "org.license token sub=%s does not match org.id=%s; denying",
+            entitlements.sub,
+            org_id_str,
+        )
+        return None
+
     def _resolve_entitlements(self, org: Organization) -> Optional[Entitlements]:
-        """Resolve entitlements for *org* using the declared precedence.
+        """Resolve entitlements for *org*.
+
+        **An active licence always beats an inactive one.** Within that, the
+        declared precedence holds:
 
         1. ``RHESIS_LICENSE`` env (blanket ``sub:"*"``)
-        2. ``org.license`` column (per-org, ``sub`` must match org UUID)
+        2. ``organization.license`` (per-org, ``sub`` must match the org UUID)
+
+        The active-first rule is not cosmetic. This used to return a blanket
+        token the moment its ``sub`` was ``*``, without checking its status, so
+        a stale or canceled ``RHESIS_LICENSE`` **shadowed an org's own valid
+        licence** -- the org was reported as unlicensed and held to community
+        limits immediately after being issued a good token, with the blanket
+        token's edition as the only clue.
+
+        When nothing is active, an inactive licence is still returned rather
+        than ``None``. Falling through to ``None`` would report such an org as
+        ``community``, losing the one thing worth saying: which licence
+        expired. Callers gate on
+        :meth:`~rhesis.backend.ee.licensing.entitlements.Entitlements.is_active`
+        anyway, so an inactive result grants nothing.
         """
-        # --- 1. Blanket env token ---
-        env_token = os.environ.get(ENV_LICENSE, "").strip()
-        if env_token:
-            entitlements = verify_token(env_token)
-            if entitlements is not None and entitlements.sub == BLANKET_SUBJECT:
-                return entitlements
-            if entitlements is not None:
-                logger.debug(
-                    "%s token sub=%s is not %r; falling through to org token",
+        blanket = self._blanket_entitlements()
+        if blanket is not None and blanket.is_active():
+            return blanket
+
+        per_org = self._org_entitlements(org)
+        if per_org is not None and per_org.is_active():
+            if blanket is not None:
+                logger.info(
+                    "%s token is present but not active (status=%s); using the "
+                    "org's own active licence instead",
                     ENV_LICENSE,
-                    entitlements.sub,
-                    BLANKET_SUBJECT,
+                    blanket.status.value,
                 )
+            return per_org
 
-        # --- 2. Per-org column ---
-        org_token = getattr(org, "license", None)
-        if org_token:
-            entitlements = verify_token(org_token)
-            if entitlements is not None:
-                org_id_str = str(org.id).lower()
-                if entitlements.sub.lower() == org_id_str:
-                    return entitlements
-                logger.debug(
-                    "org.license token sub=%s does not match org.id=%s; denying",
-                    entitlements.sub,
-                    org_id_str,
-                )
-
-        return None
+        # Nothing active. Prefer the blanket token's edition, matching the
+        # precedence above, so the lapsed state is still reported.
+        return blanket if blanket is not None else per_org
 
 
 __all__ = ["SignedTokenLicenseProvider"]

--- a/ee/backend/src/rhesis/backend/ee/licensing/provider.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/provider.py
@@ -96,8 +96,8 @@ class SignedTokenLicenseProvider:
         to its mint-time numbers (see :data:`~rhesis.backend.ee.licensing.entitlements.LIC_LIMITS`).
 
         Note this does *not* widen the ``GET /features`` payload:
-        ``routers/features.py`` builds its ``LicenseInfo`` from ``edition``
-        and ``licensed`` only, and reports limits separately from
+        ``routers/features.py`` builds its ``LicenseInfo`` from ``edition``,
+        ``licensed`` and ``is_paid`` only, and reports limits separately from
         :meth:`~rhesis.backend.app.quota.QuotaRegistry.get_limits` -- which
         resolves through the quota provider, so the overlay is reflected there
         already.

--- a/ee/backend/src/rhesis/backend/ee/licensing/provider.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/provider.py
@@ -47,6 +47,7 @@ from rhesis.backend.ee.licensing.entitlements import (
     Entitlements,
     LicenseEdition,
 )
+from rhesis.backend.ee.licensing.tiers import is_sellable
 from rhesis.backend.ee.licensing.verify import verify_token
 
 logger = logging.getLogger(__name__)
@@ -113,7 +114,11 @@ class SignedTokenLicenseProvider:
         if not entitlements.is_active():
             return self._unlicensed_info(entitlements.edition)
 
-        info: dict = {"edition": entitlements.edition.value, "licensed": True}
+        info: dict = {
+            "edition": entitlements.edition.value,
+            "licensed": True,
+            "is_paid": is_sellable(entitlements.edition),
+        }
         # Omitted rather than sent as {} when the token carries no override, so
         # "no custom limits" and "an empty override map" are the same thing on
         # the consuming side instead of two cases it has to distinguish.
@@ -131,8 +136,18 @@ class SignedTokenLicenseProvider:
 
         Returns ``edition`` as a plain string (``.value``) so the wire format
         never leaks an ``Enum`` repr through core's ``str(...)`` coercion.
+
+        ``is_paid`` describes the *tier*, not the licence state, so a lapsed
+        enterprise licence still reports ``is_paid=True`` with
+        ``licensed=False``. Those are the two facts a client needs to tell
+        "free tier" apart from "paid tier, expired" -- collapsing them into one
+        flag is what forced the UI to guess from the edition name.
         """
-        return {"edition": edition.value, "licensed": False}
+        return {
+            "edition": edition.value,
+            "licensed": False,
+            "is_paid": is_sellable(edition),
+        }
 
     def _resolve_entitlements(self, org: Organization) -> Optional[Entitlements]:
         """Resolve entitlements for *org* using the declared precedence.

--- a/ee/backend/src/rhesis/backend/ee/licensing/provider.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/provider.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import logging
 import os
+from functools import lru_cache
 from typing import Optional
 
 from rhesis.backend.app.features import Feature
@@ -51,6 +52,37 @@ from rhesis.backend.ee.licensing.tiers import is_sellable
 from rhesis.backend.ee.licensing.verify import verify_token
 
 logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=None)
+def _warn_blanket_inactive(status: str) -> None:
+    """Warn once per process that an inactive ``RHESIS_LICENSE`` was skipped.
+
+    A stale blanket token beside an org's valid licence is a **deployment
+    misconfiguration**, so this stays at ``warning`` rather than dropping to
+    ``debug``: it is exactly the state that used to hold a licensed org at
+    community limits, and it should be visible at production log levels.
+
+    But it is reached from
+    :meth:`~rhesis.backend.ee.licensing.provider.SignedTokenLicenseProvider.allows_feature`
+    and ``license_info()``, so it runs on **every** ``require_feature`` gate,
+    every ``require_quota`` gate (via ``ConfigQuotaProvider.get_policy``) and
+    both the features and usage endpoints -- several times per request. Logged
+    unconditionally it would bury the signal it exists to raise.
+
+    ``lru_cache`` is the log-once mechanism: the first call for a given status
+    logs and caches ``None``, and later calls are cache hits that do nothing. It
+    is keyed on *status* rather than cached outright so that a token changing
+    ``canceled`` -> ``expired`` is reported once more, which is a different
+    misconfiguration. Thread-safe enough for this: a race logs twice, never
+    zero times.
+    """
+    logger.warning(
+        "%s token is present but not active (status=%s); using the org's own "
+        "active licence instead. This message is logged once per process.",
+        ENV_LICENSE,
+        status,
+    )
 
 
 class SignedTokenLicenseProvider:
@@ -223,12 +255,7 @@ class SignedTokenLicenseProvider:
         per_org = self._org_entitlements(org)
         if per_org is not None and per_org.is_active():
             if blanket is not None:
-                logger.info(
-                    "%s token is present but not active (status=%s); using the "
-                    "org's own active licence instead",
-                    ENV_LICENSE,
-                    blanket.status.value,
-                )
+                _warn_blanket_inactive(blanket.status.value)
             return per_org
 
         # Nothing active. Prefer the blanket token's edition, matching the

--- a/tests/backend/app/test_feature_registry.py
+++ b/tests/backend/app/test_feature_registry.py
@@ -235,7 +235,11 @@ class TestReset:
         FeatureRegistry.reset()
 
         assert FeatureRegistry.is_registered(FeatureName.SSO) is False
-        assert FeatureRegistry.license_info() == {"edition": "community", "licensed": False}
+        assert FeatureRegistry.license_info() == {
+            "edition": "community",
+            "licensed": False,
+            "is_paid": False,
+        }
 
     def test_license_info_forwards_org(self, clean_registry):
         """license_info(org=...) passes org through to the provider."""
@@ -271,15 +275,29 @@ class TestDefaultLicenseProvider:
         assert provider.allows_feature(feature, org=object()) is True
 
     def test_info_marks_community_edition(self):
-        """Community build has no EE license — edition is 'community'."""
+        """Community build has no EE license — edition is 'community', and the
+        tier is never a paid one.
+
+        Compared for exact equality on purpose: this payload is a wire contract
+        the frontend reads, so a field appearing or vanishing unnoticed is the
+        thing worth failing on.
+        """
         provider = DefaultLicenseProvider()
-        assert provider.info() == {"edition": "community", "licensed": False}
+        assert provider.info() == {
+            "edition": "community",
+            "licensed": False,
+            "is_paid": False,
+        }
 
     def test_info_accepts_org_kwarg(self):
         """info() accepts org= without error (org-aware interface)."""
         provider = DefaultLicenseProvider()
         org = object()
-        assert provider.info(org=org) == {"edition": "community", "licensed": False}
+        assert provider.info(org=org) == {
+            "edition": "community",
+            "licensed": False,
+            "is_paid": False,
+        }
 
 
 class TestFeatureDataclass:

--- a/tests/backend/ee/licensing/test_cli_args.py
+++ b/tests/backend/ee/licensing/test_cli_args.py
@@ -1,0 +1,98 @@
+"""Tests for the licensing CLI's argument parsers.
+
+These guard a failure mode that is invisible at issuance time: a bad
+``--status`` that mints a token which verifies, matches its org and has not
+expired, but is treated as unlicensed. The issuance job reports success and the
+customer is shown "(inactive)" on a licence they just paid for.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from rhesis.backend.ee.licensing.cli import _parse_edition, _parse_status
+from rhesis.backend.ee.licensing.entitlements import (
+    ACTIVE_STATUSES,
+    LicenseEdition,
+    LicenseStatus,
+)
+
+pytestmark = pytest.mark.skipif(
+    not pytest.importorskip("rhesis.backend.ee", reason="EE package not installed"),
+    reason="EE package not installed",
+)
+
+
+class TestParseStatus:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("active", LicenseStatus.ACTIVE),
+            ("past_due", LicenseStatus.PAST_DUE),
+            ("canceled", LicenseStatus.CANCELED),
+        ],
+    )
+    def test_accepts_every_mintable_status(self, value, expected):
+        assert _parse_status(value) is expected
+
+    @pytest.mark.parametrize(
+        "value",
+        ["Active", "ACTIVE", "aCtIvE", " active", "active ", "activ", "enabled", ""],
+        ids=[
+            "title-case",
+            "upper-case",
+            "mixed-case",
+            "leading-space",
+            "trailing-space",
+            "typo",
+            "wrong-word",
+            "empty",
+        ],
+    )
+    def test_rejects_anything_that_is_not_an_exact_status(self, value):
+        """The bug this file exists for.
+
+        ``LicenseStatus._missing_`` coerces an unrecognized value to ``UNKNOWN``
+        instead of raising, so the parser's original ``except ValueError`` never
+        fired. Every value here used to mint ``status: unknown`` -- which is
+        absent from ``ACTIVE_STATUSES``, so the org got its edition reported with
+        ``licensed: False`` and was held to community limits, with nothing in the
+        issuance output indicating a problem.
+
+        The empty string is not hypothetical: it is what a blank CI input
+        expands to when passed through as ``--status "${INPUT}"``.
+        """
+        with pytest.raises(argparse.ArgumentTypeError) as excinfo:
+            _parse_status(value)
+        # The message must list the real options, since the operator is being
+        # told their input was wrong at the moment they can still fix it.
+        assert "active" in str(excinfo.value)
+
+    def test_rejects_the_unknown_sentinel_explicitly(self):
+        """``unknown`` is a decode-time sentinel for a status we do not
+        recognize, never something to mint deliberately."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            _parse_status(LicenseStatus.UNKNOWN.value)
+
+    def test_no_accepted_status_is_silently_inactive(self):
+        """Whatever the parser accepts must be a status the operator could have
+        intended. ``canceled`` is inactive but explicitly asked for; the failure
+        mode was accepting something that *looked* active and was not."""
+        for value in ("active", "past_due"):
+            assert _parse_status(value) in ACTIVE_STATUSES
+        assert _parse_status("canceled") not in ACTIVE_STATUSES
+
+
+class TestParseEdition:
+    def test_accepts_a_sellable_edition(self):
+        assert _parse_edition("enterprise") is LicenseEdition.ENTERPRISE
+
+    @pytest.mark.parametrize("value", ["Enterprise", "ENTERPRISE", "enterprize", "", "unknown"])
+    def test_rejects_anything_not_in_the_catalog(self, value):
+        """Already correct -- it validates catalog membership after coercion
+        rather than trusting ``LicenseEdition(...)`` to raise. Pinned so it does
+        not regress into the shape ``_parse_status`` was in."""
+        with pytest.raises(argparse.ArgumentTypeError):
+            _parse_edition(value)

--- a/tests/backend/ee/licensing/test_licensing_loopholes.py
+++ b/tests/backend/ee/licensing/test_licensing_loopholes.py
@@ -196,8 +196,19 @@ class TestForgedTokens:
         org = _make_org(license_token=token)
         assert verify_token(token) is None
         assert provider.allows_feature(_SSO, org) is False
-        assert provider.info(org) == {"edition": "community", "licensed": False}
         assert _limits_for(quota_provider, org) == _COMMUNITY_LIMITS
+
+        # Asserted field by field rather than as one dict, so adding a field to
+        # `info()` cannot make this pass vacuously -- and so each claim reads as
+        # its own security property.
+        info = provider.info(org)
+        assert info["edition"] == "community"
+        assert info["licensed"] is False
+        # A forged *paid* token must not report a paid tier either. `is_paid`
+        # drives the plan badge and the crown, so leaking it here would let a
+        # forged token buy the appearance of a paid plan even with community
+        # limits enforced.
+        assert info.get("is_paid") is False
 
     def test_unsigned_alg_none_token_is_rejected(self, provider, quota_provider):
         """The classic: strip the signature and set ``alg: none``.

--- a/tests/backend/ee/licensing/test_provider.py
+++ b/tests/backend/ee/licensing/test_provider.py
@@ -160,6 +160,78 @@ class TestPrecedence:
         with patch.dict("os.environ", {"RHESIS_LICENSE": ""}):
             assert provider.allows_feature(_SSO_FEATURE, org) is False
 
+    def test_inactive_blanket_token_does_not_shadow_an_active_org_licence(
+        self, provider, mint_token
+    ):
+        """The bug: a stale blanket token used to win on ``sub == "*"`` alone.
+
+        No status check meant a canceled ``RHESIS_LICENSE`` was returned ahead
+        of the org's own valid licence, so an org was reported unlicensed and
+        held to community limits right after being issued a good token -- with
+        the blanket token's edition as the only clue anything was wrong.
+
+        An active licence now beats an inactive one regardless of source.
+        """
+        env_token = mint_token(sub="*", edition="team", status="canceled")
+        org_token = mint_token(sub=_ORG_UUID, edition="enterprise")
+        org = _make_org(license_token=org_token)
+
+        with patch.dict("os.environ", {"RHESIS_LICENSE": env_token}):
+            info = provider.info(org=org)
+            allowed = provider.allows_feature(_SSO_FEATURE, org)
+
+        assert info["licensed"] is True
+        assert info["edition"] == "enterprise"
+        assert allowed is True
+
+    def test_active_blanket_token_still_wins_over_an_active_org_licence(self, provider, mint_token):
+        """The documented precedence, unchanged: between two *active* licences
+        the blanket one still takes priority."""
+        env_token = mint_token(sub="*", edition="team")
+        org_token = mint_token(sub=_ORG_UUID, edition="enterprise")
+        org = _make_org(license_token=org_token)
+
+        with patch.dict("os.environ", {"RHESIS_LICENSE": env_token}):
+            info = provider.info(org=org)
+
+        assert info["edition"] == "team"
+        assert info["licensed"] is True
+
+    def test_reports_the_lapsed_edition_when_nothing_is_active(self, provider, mint_token):
+        """With no active licence anywhere, still name the one that expired.
+
+        Returning ``None`` here would report the org as ``community`` and throw
+        away the only actionable detail -- which licence lapsed. Nothing is
+        granted either way, since callers gate on ``is_active()``.
+        """
+        env_token = mint_token(sub="*", edition="team", status="canceled")
+        org_token = mint_token(sub=_ORG_UUID, edition="enterprise", status="canceled")
+        org = _make_org(license_token=org_token)
+
+        with patch.dict("os.environ", {"RHESIS_LICENSE": env_token}):
+            info = provider.info(org=org)
+            allowed = provider.allows_feature(_SSO_FEATURE, org)
+
+        # Blanket first, matching the precedence for active licences.
+        assert info["edition"] == "team"
+        assert info["licensed"] is False
+        assert allowed is False
+
+    def test_inactive_blanket_token_with_no_org_licence_still_names_itself(
+        self, provider, mint_token
+    ):
+        """A single-tenant deployment whose blanket licence lapsed. Must read as
+        that edition, inactive -- not as community, which would hide the
+        expiry."""
+        env_token = mint_token(sub="*", edition="enterprise", status="canceled")
+        org = _make_org(license_token=None)
+
+        with patch.dict("os.environ", {"RHESIS_LICENSE": env_token}):
+            info = provider.info(org=org)
+
+        assert info["edition"] == "enterprise"
+        assert info["licensed"] is False
+
 
 class TestMissingKeys:
     def test_no_keys_denies_feature(self, provider, mint_token):

--- a/tests/backend/ee/licensing/test_provider.py
+++ b/tests/backend/ee/licensing/test_provider.py
@@ -184,6 +184,49 @@ class TestPrecedence:
         assert info["edition"] == "enterprise"
         assert allowed is True
 
+    def test_warns_once_per_process_not_once_per_request(self, provider, mint_token):
+        """The shadowing case sits on the request path, so it must not log per call.
+
+        ``_resolve_entitlements`` is reached from ``allows_feature`` (every
+        ``require_feature`` gate), from ``license_info`` (the features and usage
+        endpoints) and from ``ConfigQuotaProvider.get_policy`` (every
+        ``require_quota`` gate) -- several times per request. A misconfigured
+        deployment would otherwise bury the warning it exists to raise.
+        """
+        from rhesis.backend.ee.licensing.provider import _warn_blanket_inactive
+
+        _warn_blanket_inactive.cache_clear()
+        env_token = mint_token(sub="*", edition="team", status="canceled")
+        org_token = mint_token(sub=_ORG_UUID, edition="enterprise")
+        org = _make_org(license_token=org_token)
+
+        with patch.dict("os.environ", {"RHESIS_LICENSE": env_token}):
+            with patch("rhesis.backend.ee.licensing.provider.logger.warning") as warn:
+                for _ in range(5):
+                    provider.allows_feature(_SSO_FEATURE, org)
+                    provider.info(org=org)
+
+        assert warn.call_count == 1, f"expected one warning per process, got {warn.call_count}"
+        _warn_blanket_inactive.cache_clear()
+
+    def test_a_different_stale_status_is_reported_once_more(self, provider, mint_token):
+        """Keyed on status, so canceled -> expired is a new misconfiguration
+        worth one more line rather than being swallowed forever."""
+        from rhesis.backend.ee.licensing.provider import _warn_blanket_inactive
+
+        _warn_blanket_inactive.cache_clear()
+        org_token = mint_token(sub=_ORG_UUID, edition="enterprise")
+        org = _make_org(license_token=org_token)
+
+        with patch("rhesis.backend.ee.licensing.provider.logger.warning") as warn:
+            for status in ("canceled", "canceled", "unpaid", "unpaid"):
+                token = mint_token(sub="*", edition="team", status=status)
+                with patch.dict("os.environ", {"RHESIS_LICENSE": token}):
+                    provider.allows_feature(_SSO_FEATURE, org)
+
+        assert warn.call_count == 2
+        _warn_blanket_inactive.cache_clear()
+
     def test_active_blanket_token_still_wins_over_an_active_org_licence(self, provider, mint_token):
         """The documented precedence, unchanged: between two *active* licences
         the blanket one still takes priority."""

--- a/tests/backend/ee/licensing/test_provider.py
+++ b/tests/backend/ee/licensing/test_provider.py
@@ -110,7 +110,12 @@ class TestCanceledLicense:
         with patch.dict("os.environ", {"RHESIS_LICENSE": token}):
             info = provider.info(org=org)
             allowed = provider.allows_feature(_SSO_FEATURE, org)
-        assert info == {"edition": "enterprise", "licensed": False}
+        assert info["edition"] == "enterprise"
+        assert info["licensed"] is False
+        # Still a paid *tier*, just not an active licence. That pair is what
+        # lets a client tell this apart from a free org and show it as lapsed
+        # rather than as never having paid.
+        assert info["is_paid"] is True
         assert allowed is False
 
     def test_past_due_status_is_consistent(self, provider, mint_token):

--- a/tests/backend/routes/test_features.py
+++ b/tests/backend/routes/test_features.py
@@ -94,7 +94,11 @@ class TestFeaturesEndpoint:
         assert response.status_code == status.HTTP_200_OK
         body = response.json()
         assert "license" in body
-        assert body["license"] == {"edition": "community", "licensed": False}
+        assert body["license"] == {
+            "edition": "community",
+            "licensed": False,
+            "is_paid": False,
+        }
 
     def test_returns_enabled_list(self, client: TestClient, registered_sso, mock_current_user):
         response = client.get("/features")
@@ -154,13 +158,24 @@ class TestFeaturesEndpoint:
         body = response.json()
         assert set(body.keys()) == {
             "license",
+            "plan",
             "enabled",
             "warnings",
             "limits",
             "is_local",
             "rhesis_key_enabled",
         }
-        assert set(body["license"].keys()) == {"edition", "licensed"}
+        assert set(body["license"].keys()) == {"edition", "licensed", "is_paid"}
+        # `plan` is the client's whole contract for displaying a plan: a label
+        # to render verbatim, plus the two booleans that decide styling and
+        # whether an upgrade is offered. No tier enum on the wire, so a new tier
+        # needs no frontend release. It rides on this response rather than
+        # GET /usage because this one is server-seeded in the frontend's
+        # protected layout, so plan surfaces have it on first paint.
+        assert set(body["plan"].keys()) == {"name", "is_paid", "is_active"}
+        assert isinstance(body["plan"]["name"], str) and body["plan"]["name"] != ""
+        assert isinstance(body["plan"]["is_paid"], bool)
+        assert isinstance(body["plan"]["is_active"], bool)
         assert isinstance(body["enabled"], list)
         assert all(isinstance(name, str) for name in body["enabled"])
         assert isinstance(body["warnings"], dict)
@@ -197,7 +212,52 @@ class TestFeaturesEndpoint:
             # Provider must always be called with the org, never None
             assert len(received_orgs) >= 1
             assert all(org is not None for org in received_orgs)
-            assert response.json()["license"] == {"edition": "enterprise", "licensed": True}
+            # is_paid defaults to False because this provider omits it --
+            # fail-closed, so an unknown posture never presents as paid.
+            assert response.json()["license"] == {
+                "edition": "enterprise",
+                "licensed": True,
+                "is_paid": False,
+            }
+        finally:
+            FeatureRegistry.reset()
+
+    def test_forwards_is_paid_from_the_provider(
+        self, client: TestClient, registered_sso, mock_current_user
+    ):
+        """A paid tier reaches the client as a flag, not as a name to compare.
+
+        The point of carrying ``is_paid`` is that no client has to infer
+        paid-ness from ``edition``. This pins the lapsed combination
+        (``is_paid`` true, ``licensed`` false) specifically, since that is the
+        pair a name comparison gets wrong: the edition still reads
+        ``enterprise`` while the licence is dead.
+        """
+
+        class _LapsedPaidProvider:
+            def allows_feature(self, feature, org):
+                return False
+
+            def info(self, org=None):
+                return {"edition": "enterprise", "licensed": False, "is_paid": True}
+
+        FeatureRegistry.set_license_provider(_LapsedPaidProvider())
+        try:
+            response = client.get("/features")
+            assert response.status_code == status.HTTP_200_OK
+            body = response.json()
+            assert body["license"] == {
+                "edition": "enterprise",
+                "licensed": False,
+                "is_paid": True,
+            }
+            # The same facts, composed for display -- including the qualifier,
+            # so the lapsed state is legible without relying on styling.
+            assert body["plan"] == {
+                "name": "Enterprise (inactive)",
+                "is_paid": True,
+                "is_active": False,
+            }
         finally:
             FeatureRegistry.reset()
 

--- a/tests/backend/routes/test_usage.py
+++ b/tests/backend/routes/test_usage.py
@@ -28,19 +28,13 @@ class TestUsageEndpoint:
         response = authenticated_client.get("/usage")
         body = response.json()
 
-        assert set(body.keys()) == {"resources", "edition", "plan"}
+        # No `plan` here. It moved to GET /features, which the frontend's
+        # protected layout server-seeds, so plan surfaces have it on first paint
+        # instead of one round trip late. `edition` stays as the machine id for
+        # diagnostics. Contract covered in routes/test_features.py.
+        assert set(body.keys()) == {"resources", "edition"}
         assert isinstance(body["resources"], dict)
         assert isinstance(body["edition"], str)
-
-        # `plan` is the client's whole contract for displaying a plan: a label
-        # to render verbatim, plus the two booleans that decide styling and
-        # whether an upgrade is offered. No tier enum on the wire, so a new tier
-        # needs no frontend release.
-        plan = body["plan"]
-        assert set(plan.keys()) == {"name", "is_paid", "is_active"}
-        assert isinstance(plan["name"], str) and plan["name"] != ""
-        assert isinstance(plan["is_paid"], bool)
-        assert isinstance(plan["is_active"], bool)
 
     def test_includes_every_quota_resource(self, authenticated_client: TestClient):
         response = authenticated_client.get("/usage")

--- a/tests/backend/routes/test_usage.py
+++ b/tests/backend/routes/test_usage.py
@@ -28,14 +28,19 @@ class TestUsageEndpoint:
         response = authenticated_client.get("/usage")
         body = response.json()
 
-        assert set(body.keys()) == {"resources", "edition", "licensed"}
+        assert set(body.keys()) == {"resources", "edition", "plan"}
         assert isinstance(body["resources"], dict)
         assert isinstance(body["edition"], str)
-        # Reported separately from `edition`, which keeps naming a lapsed tier.
-        # The frontend gates its upgrade affordances on this, so a client can
-        # tell "free org" from "paid org whose licence expired" -- the latter is
-        # held to community limits while still reporting its old edition.
-        assert isinstance(body["licensed"], bool)
+
+        # `plan` is the client's whole contract for displaying a plan: a label
+        # to render verbatim, plus the two booleans that decide styling and
+        # whether an upgrade is offered. No tier enum on the wire, so a new tier
+        # needs no frontend release.
+        plan = body["plan"]
+        assert set(plan.keys()) == {"name", "is_paid", "is_active"}
+        assert isinstance(plan["name"], str) and plan["name"] != ""
+        assert isinstance(plan["is_paid"], bool)
+        assert isinstance(plan["is_active"], bool)
 
     def test_includes_every_quota_resource(self, authenticated_client: TestClient):
         response = authenticated_client.get("/usage")

--- a/tests/backend/services/test_plan.py
+++ b/tests/backend/services/test_plan.py
@@ -1,0 +1,93 @@
+"""Unit tests for :func:`~rhesis.backend.app.services.plan.build_plan`.
+
+The label this composes is rendered verbatim by clients, and the two booleans
+decide badge styling and whether an upgrade is offered. Both were previously
+only covered indirectly through the endpoint's response shape, which asserted
+types rather than values.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rhesis.backend.app.services.plan import build_plan
+
+
+class TestLabel:
+    @pytest.mark.parametrize(
+        ("edition", "expected"),
+        [
+            ("community", "Community"),
+            ("team", "Team"),
+            ("enterprise", "Enterprise"),
+            # Separators become spaces, so a multi-word tier id reads as prose
+            # rather than as an identifier.
+            ("design_partner", "Design Partner"),
+            ("design-partner", "Design Partner"),
+        ],
+    )
+    def test_composes_a_display_label_from_the_edition_id(self, edition, expected):
+        plan = build_plan({"edition": edition, "licensed": True, "is_paid": True})
+        assert plan["name"] == expected
+
+    def test_an_unrecognised_tier_still_gets_a_label(self):
+        """The property that lets a new tier ship without a frontend release:
+        nothing here knows the set of tiers."""
+        plan = build_plan({"edition": "hyperscale_plus", "licensed": True, "is_paid": True})
+        assert plan["name"] == "Hyperscale Plus"
+
+    def test_never_returns_an_empty_label(self):
+        """A blank edition must not render as an empty badge. Clients treat an
+        empty name as "no plan yet" and show nothing, which would hide the
+        plan row entirely rather than showing something is wrong."""
+        assert build_plan({"edition": "   "})["name"] == "Unknown"
+        assert build_plan({})["name"] == "Community"
+
+
+class TestLapsedQualifier:
+    def test_a_lapsed_paid_tier_is_marked_in_the_label(self):
+        """Carried in the text, not only in the styling, so the state survives
+        a screenshot, a narrow column and a monochrome theme."""
+        plan = build_plan({"edition": "enterprise", "licensed": False, "is_paid": True})
+        assert plan["name"] == "Enterprise (inactive)"
+        assert plan["is_paid"] is True
+        assert plan["is_active"] is False
+
+    def test_an_active_paid_tier_carries_no_qualifier(self):
+        plan = build_plan({"edition": "enterprise", "licensed": True, "is_paid": True})
+        assert plan["name"] == "Enterprise"
+
+    def test_a_free_tier_carries_no_qualifier(self):
+        """A free org is not "inactive" -- it has nothing to reactivate. Only a
+        tier that was paid for gets the qualifier."""
+        plan = build_plan({"edition": "community", "licensed": False, "is_paid": False})
+        assert plan["name"] == "Community"
+        assert plan["is_paid"] is False
+        assert plan["is_active"] is False
+
+
+class TestFlags:
+    def test_separates_a_free_org_from_a_lapsed_paid_one(self):
+        """The pair this exists for. Both are held to free-tier ceilings, but
+        only one of them bought something, and a single flag cannot say which.
+        """
+        free = build_plan({"edition": "community", "licensed": False, "is_paid": False})
+        lapsed = build_plan({"edition": "team", "licensed": False, "is_paid": True})
+
+        assert (free["is_paid"], free["is_active"]) == (False, False)
+        assert (lapsed["is_paid"], lapsed["is_active"]) == (True, False)
+
+    def test_missing_flags_default_to_the_free_posture(self):
+        """Fail-closed: an unknown posture must never present as paid."""
+        plan = build_plan({"edition": "team"})
+        assert plan["is_paid"] is False
+        assert plan["is_active"] is False
+
+    @pytest.mark.parametrize("truthy", [1, "yes", ["x"]])
+    def test_coerces_non_bool_values_rather_than_leaking_them(self, truthy):
+        """The wire contract is booleans. A provider returning something
+        truthy-but-not-bool must not put that value on the response, where a
+        client comparing `is_paid === true` would read it as false."""
+        plan = build_plan({"edition": "team", "licensed": truthy, "is_paid": truthy})
+        assert plan["is_paid"] is True
+        assert plan["is_active"] is True


### PR DESCRIPTION
Rewrites the sidebar plan row onto the shared nav-row primitive with a crown for
paid tiers, and removes the hardcoded tier logic behind it.

While building it I found **two licensing bugs, one actively breaking issuance in
dev.** Those are the reason to read this before the UI part.

---

## Bug 1: an invalid `--status` minted a dead licence, silently

`LicenseStatus._missing_` coerces unrecognized values to `UNKNOWN` instead of
raising, so `_parse_status`'s `except ValueError` **never fired**:

| `--status` | before |
|---|---|
| `active` | active ✓ |
| `Active` / `ACTIVE` | **unknown → inactive** |
| `''` (blank CI input) | **unknown → inactive** |
| `' active'` | **unknown → inactive** |

Such a token verifies, matches its org and is not expired, so issuance reports
success — but `UNKNOWN` is absent from `ACTIVE_STATUSES`, so the org is served
its edition with `licensed: false`. It gets community limits and displays as
**"(inactive)" immediately after a licence was issued to it.**

Observed on a freshly minted enterprise licence in dev (edition `enterprise`,
exp 2027, correct `sub`). Same trap `tiers.py` documents for `_parse_edition` —
and the CLI's own `_parse_edition` guards it correctly by validating catalog
membership after coercion. `_parse_status` didn't.

The workflow half is fixed in
[rhesis-ee#12](https://github.com/rhesis-ai/rhesis-ee/pull/12) (merged), which
stops *sending* a blank status. This stops *accepting* a bad one — still needed,
because that guard only handles empty and a capitalized value is passed through.

## Bug 2: an inactive blanket licence shadowed an org's own

`_resolve_entitlements` returned the `RHESIS_LICENSE` env token the moment its
`sub` was `*`, **with no status check**. A stale or canceled blanket licence
therefore beat an org's valid one:

```
blanket canceled + org ACTIVE   ->  'Enterprise'        licensed=True   (was 'Team (inactive)')
blanket active   + org active   ->  'Team'              licensed=True   (precedence kept)
blanket canceled + org canceled ->  'Team (inactive)'   licensed=False
blanket canceled + no org token ->  'Team (inactive)'   licensed=False
```

An active licence now beats an inactive one regardless of source; the documented
blanket-then-org precedence still holds between two *active* licences, so
single-tenant deployments are unchanged.

When nothing is active it still returns the inactive licence rather than `None`
— falling through would report the org as `community` and discard the one
actionable detail, which licence expired. Nothing is granted either way, since
every caller gates on `is_active()`.

---

## The plan indicator

### `GET /usage` returns a plan object

```json
{ "edition": "enterprise",
  "plan": { "name": "Enterprise", "is_paid": true, "is_active": true } }
```

`is_paid` comes from `is_sellable()` — derived from the `LicenseEdition` enum,
not a name list. It describes the **tier**; `is_active` describes the
**licence**. Both are needed: a free org is `(false, false)` and a lapsed paid
one is `(true, false)`, and no single flag separates them. `licensed` alone
couldn't, which is why the client was reduced to guessing from the edition
string. `name` is composed server-side, qualifier included, so clients render it
verbatim. `edition` stays on the wire, documented as diagnostics-only.

### Removed hardcoded plan logic

| removed | why |
|---|---|
| `isCommunityEdition()` / `COMMUNITY_EDITION = 'community'` | decided free-vs-paid by comparing the **display name** |
| `PlanChip` | lower-cased the API's name and appended `" (inactive)"` client-side |
| `isUnlicensedPlan(edition, licensed)` | superseded by `isUpgradeable(plan)` |

### One badge, one resolver

There was already exactly one plan pill (`PlanChip`, three surfaces), so this
**rewrites it in place** rather than adding a fourth thing. `resolvePlanStyle`
keys purely on the two booleans — no client-side tier list to fall out of date,
so a tier added on the backend renders correctly with **no frontend release**.
Verified: `ultra_premium` → "Ultra Premium", paid styling.

An unknown or malformed plan falls back to the neutral style rather than
crashing or claiming a paid tier the org hasn't got. That matters here: this
renders in the protected layout's sidebar, where a throw takes down every page.

### Layout

Rebuilt on `navCardRowSx` / `navCardIconSx` / `navCardLabelSx` — extracted from
`NavLinkItem`, not copied — so the crown sits in the same icon gutter and "Plan"
starts at the same x-offset as "Star Rhesis" and "Support". Structure is
`[crown] [label] [spacer] [badge]`, with `marginLeft: auto` + `flexShrink: 0` on
the badge and `minWidth: 0` on the label, so a long tier name ellipsizes rather
than squeezing the badge. Asserted against a real `NavLinkItem`, not a snapshot.

Every variant shares one `Chip` — same padding, radius, size and weight, only
the colour differs. The weight reads `theme.typography.captionBold` rather than a
literal `600`, because the theme's semibold is `700` when a brand font is
configured; a literal would have rendered the badge lighter than every other
semibold element on a branded deployment.

---

---

## The plan moved to `GET /features`

Building the row exposed a design error in it. The plan shipped on `GET /usage`
because that was where the sidebar happened to fetch — a transport choice, not a
design one. A plan is a licensing fact, so `/features` is its home.

It was also causing a **flicker**. `UsageProvider` is client-fetched with no
server seed, deliberately: `/usage` costs a licence lookup plus four counting
queries, paid once per 5-minute `staleTime` window rather than per navigation.
So every plan surface rendered blank for a round trip on each cold load.
`/features` is already server-seeded in the protected layout.

Moving it is free, which is what makes this the cheap fix rather than a
tradeoff: `build_plan` is a **pure function of the `license_info` that handler
already resolves** for its own `license` field. Same builder, same input, so the
two transports cannot disagree — there is still one builder, one `Plan` type,
one resolver, one badge.

`build_plan` moves out of the usage service, where a licensing display builder
was misfiled, into its own module.

### `is_paid` on `LicenseInfo`

That response already reported `edition` and `licensed`. Holding two of the
three facts invites inferring the third from the edition *name*, and
`useFeaturesState`'s own docstring advertised itself for "license badges" —
pointing anyone writing one straight at `edition !== 'community'`, the exact
hardcoded comparison this PR removes. The flag closes the gap; the docstring now
points at `usePlan()`.

### Frontend

`usePlan()` is the single source for displaying a plan. Four surfaces repointed,
and two things turned up while doing it:

- **`useCanUpgrade()` already existed**, and `Sidebar` and `QuotaBanner` each
  reimplemented it inline as `canManageOrg && isUpgradeable(plan)`. Both now use
  it, which removed their need for the plan entirely.
- **`UsageOverviewTab` was scoping the plan to the selected period**, so viewing
  January showed January's usage beside *today's* plan regardless. The plan is
  not period-scoped, and `usePlan()` makes that explicit.

## Checks

- **Full backend suite: 8467 passed, 0 failed.** Full frontend suite: 2487
  passed across 253 suites. `tsc --noEmit` clean, eslint 0 errors, ruff clean
  and formatted, `check-hardcoded-styles.js` and the EE boundary check clean.
- Ran the whole backend suite rather than a selection on purpose. A narrow run
  is what let three failures through earlier here: adding `is_paid` broke three
  exact-equality assertions on the licence payload in a file no selection of
  mine covered. Those assertions were kept strict rather than loosened — the
  strictness is what caught it.
- 24 new backend tests: 19 covering every `--status` / `--edition` input, 5 for
  licence precedence including the shadowing case.
- `build_plan` gains direct tests. Its label composition previously had none —
  it was covered only by shape assertions checking types, not values.
- Three frontend tests pin the flicker fix: the plan is present from the server
  seed **with no fetch**, and reads `null` both while loading and on a backend
  predating the field.
- The adversarial suite gains an assertion that a forged paid token must not
  report `is_paid` either, since that flag now drives the badge.
- `provider.py` had one contiguous hunk spanning the plan payload and the
  precedence fix, so the split was verified by checking out the intermediate
  commit — no `_blanket_entitlements`, no precedence tests — rather than only
  confirming the tip is green.

**Not verified in a browser.** The crown colour, the divider and the badge weight
are judgement calls worth eyeballing on dev before merge.

## Note on the dev licence

These fixes prevent recurrence; they do not repair a token already minted with
`status: unknown`. That licence has since been reissued.
