### PR TITLE
Surface the target endpoint's HTTP status and reason on failed tests

### DIFF
--- a/apps/backend/src/rhesis/backend/app/outcomes.py
+++ b/apps/backend/src/rhesis/backend/app/outcomes.py
@@ -83,7 +83,7 @@ def outcome_of(execution: Execution, verdict: Optional[Verdict] = None) -> Outco
 
 
 def classify_metrics(
-    metrics: Optional[Dict[str, Any]], *, http_error: bool = False
+    metrics: Optional[Dict[str, Any]], *, endpoint_error: bool = False
 ) -> Tuple[Execution, Optional[Verdict]]:
     """Classify a test result's outcome from its metrics dict.
 
@@ -96,9 +96,11 @@ def classify_metrics(
 
     Precedence, most-informative first:
 
-    1. An HTTP-level error means the endpoint never produced evaluable
+    1. A failed invocation means the endpoint never produced evaluable
        output. Metrics are meaningless even if some happen to be present
-       (a stale evaluation from a retry, for instance) -- ``ERROR``.
+       (a stale evaluation from a retry, for instance) -- ``ERROR``. Note
+       this covers any invoker failure, not only ones carrying an HTTP
+       status: see ``utils/response_extractor.is_endpoint_failure``.
     2. No metrics at all, or nothing metrics-shaped -- nothing was
        evaluated -- ``ERROR``.
     3. Any metric definitively failed -- ``FAIL``. A real failure is never
@@ -113,7 +115,7 @@ def classify_metrics(
        threshold).
     6. Otherwise every metric passed -- ``PASS``.
     """
-    if http_error:
+    if endpoint_error:
         return Execution.ERROR, None
 
     valid = {k: v for k, v in (metrics or {}).items() if isinstance(v, dict)}

--- a/apps/backend/src/rhesis/backend/app/services/architect/runner.py
+++ b/apps/backend/src/rhesis/backend/app/services/architect/runner.py
@@ -347,8 +347,12 @@ def _make_target_factory(org_id: str, user_id: str, project_id: Optional[str] = 
     svc = EndpointService()
 
     def _invoke(endpoint_id: str, input_data: dict) -> dict:
+        from rhesis.backend.app.services.endpoint.result_processing import (
+            process_endpoint_result,
+        )
+
         with get_db_with_tenant_variables(org_id or "", user_id or "", project_id or "") as db:
-            return run_sync(
+            result = run_sync(
                 svc.invoke_endpoint(
                     db,
                     endpoint_id,
@@ -358,6 +362,11 @@ def _make_target_factory(org_id: str, user_id: str, project_id: Optional[str] = 
                     project_id=project_id,
                 )
             )
+        # LocalEndpointTarget's contract is a dict with an ``output`` key, and a failed
+        # invocation returns an ErrorResponse model instead. Handing that over raw made the
+        # target's `result.get(...)` raise, and the session was told "'ErrorResponse' object
+        # has no attribute 'get'" instead of which status the endpoint actually returned.
+        return process_endpoint_result(result)
 
     def factory(endpoint_id: str) -> LocalEndpointTarget:
         name = endpoint_id

--- a/apps/backend/src/rhesis/backend/app/services/endpoint/service.py
+++ b/apps/backend/src/rhesis/backend/app/services/endpoint/service.py
@@ -14,6 +14,7 @@ from rhesis.backend.app.models.endpoint import Endpoint
 from rhesis.backend.app.schemas.endpoint import EndpointTestRequest
 from rhesis.backend.app.services.invokers import create_invoker
 from rhesis.backend.app.services.invokers.common.errors import EndpointInvocationError
+from rhesis.backend.app.services.invokers.common.schemas import ErrorResponse
 from rhesis.backend.app.services.invokers.context import InvocationContext
 from rhesis.backend.app.services.invokers.conversation import (
     ConversationTracker,
@@ -274,10 +275,17 @@ class EndpointService:
                         result = await invoker.invoke()
                         trace_ctx["result"] = result
 
-                    if deferred_trace and isinstance(result, dict):
+                    if deferred_trace:
                         deferred_data = trace_ctx.get("_deferred_trace")
-                        if deferred_data:
+                        if deferred_data and isinstance(result, dict):
                             result["_deferred_trace"] = deferred_data
+                        elif deferred_data is not None and isinstance(result, ErrorResponse):
+                            # A failed invocation is the one you most want a trace for.
+                            # ErrorResponse allows extra fields; the batch caller pops this
+                            # off before the result is stored. Without it, every errored
+                            # batch test lost its trace, because the dict branch above
+                            # silently skipped anything that wasn't a dict.
+                            result.deferred_trace = deferred_data
             else:
                 result = await invoker.invoke()
 

--- a/apps/backend/src/rhesis/backend/app/services/explorer/invocation.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/invocation.py
@@ -13,12 +13,25 @@ from typing import Optional, Tuple
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app.services.endpoint.result_processing import process_endpoint_result
+from rhesis.backend.app.utils.response_extractor import (
+    get_http_error_status_code,
+    is_endpoint_failure,
+)
 
 logger = logging.getLogger(__name__)
 
 # Endpoint output when the endpoint responded but said nothing. Callers treat this as
 # "not worth evaluating" rather than as a failure.
 NO_OUTPUT = "[no output]"
+
+
+def _failure_message(processed: dict) -> str:
+    """Describe a failed invocation for the caller's error slot."""
+    message = processed.get("output") or processed.get("message") or "Endpoint invocation failed"
+    status_code = get_http_error_status_code(processed)
+    if status_code is not None and f"{status_code}" not in str(message):
+        return f"HTTP {status_code}: {message}"
+    return str(message)
 
 
 class EndpointInvoker:
@@ -80,6 +93,12 @@ class EndpointInvoker:
                         user_id=self._user_id,
                     )
                 processed = process_endpoint_result(raw)
+                # An invoker failure comes back as a *return value*, not an exception, so
+                # the handler below never sees it. Without this check the error text was
+                # returned as a successful output: callers then persisted "HTTP 401 error
+                # from endpoint" as a test's output and ran LLM judges over it.
+                if is_endpoint_failure(processed):
+                    return "", _failure_message(processed)
                 return (processed.get("output") or "").strip() or NO_OUTPUT, None
             except Exception as e:  # noqa: BLE001
                 return "", str(e)

--- a/apps/backend/src/rhesis/backend/app/services/invokers/common/errors.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/common/errors.py
@@ -8,7 +8,7 @@ Contains:
   transient from permanent failures and retry accordingly.
 """
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from .schemas import ErrorResponse, RequestDetails
 
@@ -103,6 +103,12 @@ class EndpointInvocationError(Exception):
         error_type: Machine-readable error category from the invoker.
         retry_after: Seconds to wait before retrying (from Retry-After
             header or rate-limit response), or ``None``.
+        error_response: The originating ``ErrorResponse``, when this was
+            raised from one. Carried so a caller that wants to report the
+            failure as a result rather than a crash keeps the reason phrase
+            and the target's own response body -- ``str(exc)`` alone drops
+            both, which is how a 400 used to reach the UI as a bare
+            "No response available".
     """
 
     def __init__(
@@ -113,13 +119,26 @@ class EndpointInvocationError(Exception):
         status_code: Optional[int] = None,
         error_type: Optional[str] = None,
         retry_after: Optional[float] = None,
+        error_response: Optional[Any] = None,
     ):
         super().__init__(message)
         self.transient = transient
         self.status_code = status_code
         self.error_type = error_type
         self.retry_after = retry_after
+        self.error_response = error_response
 
+
+# ``EndpointService.invoke_endpoint`` wraps *our own* unexpected exceptions in
+# ``EndpointInvocationError`` too, tagged with this error_type. It is the discriminator that
+# separates "the user's endpoint refused" from "we have a bug", and callers must branch on
+# it before attributing a failure to the target or passing the message to the caller.
+INTERNAL_ERROR_TYPE = "internal_error"
+
+# Permanent failures that are genuinely the target's or the endpoint config's, so retrying
+# is pointless. Deliberately excludes INTERNAL_ERROR_TYPE: an unexpected exception on our
+# side is exactly the sort of thing a second attempt can get past.
+PERMANENT_TARGET_ERROR_TYPES = frozenset({"http_error", "validation_error"})
 
 _TRANSIENT_STATUS_CODES = frozenset({408, 429, 502, 503, 504})
 
@@ -161,4 +180,5 @@ def classify_error_response(error_response: ErrorResponse) -> EndpointInvocation
         status_code=status_code,
         error_type=error_type,
         retry_after=retry_after,
+        error_response=error_response,
     )

--- a/apps/backend/src/rhesis/backend/app/services/invokers/common/schemas.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/common/schemas.py
@@ -36,8 +36,10 @@ class ErrorResponse(BaseModel):
     status_code: Optional[int] = Field(None, description="HTTP status code")
     reason: Optional[str] = Field(None, description="HTTP reason phrase")
     response_headers: Optional[Dict[str, Any]] = Field(None, description="HTTP response headers")
-    response_content: Optional[str] = Field(None, description="HTTP response content")
-    response_body: Optional[str] = Field(None, description="HTTP response body")
+    # The one field for the target's own response body. There used to be a second,
+    # ``response_body``, which the WebSocket invoker wrote and nothing read -- so a
+    # rejected handshake carried its reason where no consumer looked. Keep it single.
+    response_content: Optional[str] = Field(None, description="Target response body, as text")
 
     # Performance fields
     duration_ms: Optional[float] = Field(None, description="Operation duration in milliseconds")

--- a/apps/backend/src/rhesis/backend/app/services/invokers/websocket_invoker.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/websocket_invoker.py
@@ -16,6 +16,16 @@ from .context import InvocationContext
 
 logger = logging.getLogger(__name__)
 
+
+def _decode_response_body(body: Any) -> Optional[str]:
+    """Render a handshake-rejection body as text for ``ErrorResponse.response_content``."""
+    if body is None:
+        return None
+    if isinstance(body, bytes):
+        return body.decode("utf-8", errors="replace")
+    return str(body)
+
+
 # Mapping of Unicode characters commonly produced by AI services to their
 # ASCII equivalents.  Defined once at module load rather than rebuilt on
 # every call to _normalize_unicode_text.
@@ -496,7 +506,9 @@ class WebSocketEndpointInvoker(BaseEndpointInvoker):
                     response_headers=self._sanitize_headers(dict(status_err.response.headers))
                     if status_err.response.headers
                     else {},
-                    response_body=status_err.response.body,
+                    # response_content, not response_body: every reader (and the UI) keys
+                    # off the former, so a body written to the latter is invisible.
+                    response_content=_decode_response_body(status_err.response.body),
                 )
 
             except Exception as e:

--- a/apps/backend/src/rhesis/backend/app/services/preflight/checks.py
+++ b/apps/backend/src/rhesis/backend/app/services/preflight/checks.py
@@ -209,8 +209,13 @@ async def check_endpoint_connectivity(
         )
 
         if is_error:
+            # ``output`` over ``message``: a connectivity check is read to find out *why* the
+            # endpoint refused, and only ``output`` carries the status line plus the target's
+            # own response body. ``message`` stops at "HTTP 401 error from endpoint".
             detail = (
-                response.message if isinstance(response, ErrorResponse) else response.get("error")
+                (response.output or response.message)
+                if isinstance(response, ErrorResponse)
+                else (response.get("output") or response.get("error"))
             )
             result = _make_result(
                 check_id,

--- a/apps/backend/src/rhesis/backend/app/services/websocket/handlers/chat.py
+++ b/apps/backend/src/rhesis/backend/app/services/websocket/handlers/chat.py
@@ -169,6 +169,7 @@ async def handle_chat_message(
                     correlation_id,
                     result.output,
                     error_type=result.error_type,
+                    status_code=result.status_code,
                 )
                 return
 
@@ -247,6 +248,7 @@ async def _send_chat_error(
     correlation_id: str | None,
     error_message: str,
     error_type: str = "Error",
+    status_code: int | None = None,
 ) -> None:
     """Send a chat error response.
 
@@ -256,15 +258,21 @@ async def _send_chat_error(
         correlation_id: The correlation ID from the request.
         error_message: The error message to send.
         error_type: The type/class of the error.
+        status_code: HTTP status the target returned, when it had one, so the
+            client gets something machine-readable rather than only prose.
     """
+    payload: dict = {
+        "error": error_message,
+        "error_type": error_type,
+    }
+    if status_code is not None:
+        payload["status_code"] = status_code
+
     await manager.broadcast(
         WebSocketMessage(
             type=EventType.CHAT_ERROR,
             correlation_id=correlation_id,
-            payload={
-                "error": error_message,
-                "error_type": error_type,
-            },
+            payload=payload,
         ),
         ConnectionTarget(connection_id=conn_id),
     )

--- a/apps/backend/src/rhesis/backend/app/utils/execution_validation.py
+++ b/apps/backend/src/rhesis/backend/app/utils/execution_validation.py
@@ -12,8 +12,12 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import get_tenant_db_session
-from rhesis.backend.app.error_handlers import internal_error
+from rhesis.backend.app.error_handlers import UpstreamHTTPException, internal_error
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.services.invokers.common.errors import (
+    INTERNAL_ERROR_TYPE,
+    EndpointInvocationError,
+)
 from rhesis.backend.app.utils.database_exceptions import ItemDeletedException
 from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 from rhesis.backend.app.utils.user_model_utils import validate_model
@@ -134,6 +138,27 @@ def handle_execution_error(error: Exception, operation: str = "execute tests") -
     if isinstance(error, PermissionError):
         logger.warning(f"Permission denied for {operation}: {str(error)}")
         return HTTPException(status_code=403, detail=str(error))
+
+    if isinstance(error, EndpointInvocationError):
+        status_code = error.status_code or 500
+        # EndpointService wraps our *own* unexpected exceptions in this same type, so the
+        # error_type is what separates the user's endpoint from our bug. Without this
+        # branch a Rhesis-side failure answers with the raw exception text (paths,
+        # connection details) attributed to the caller's endpoint.
+        if error.error_type == INTERNAL_ERROR_TYPE:
+            return internal_error(error, context=f"failed to {operation}", status_code=status_code)
+        # The target refused the call, which is the reportable fact the caller needs; an
+        # opaque 500 from the fallback below is not something they can act on.
+        # UpstreamHTTPException so the global handler passes the detail through, exactly as
+        # routers/endpoint.py does for the same exception.
+        logger.warning(
+            "Endpoint invocation failed for %s: %s (status=%s, type=%s)",
+            operation,
+            error,
+            error.status_code,
+            error.error_type,
+        )
+        return UpstreamHTTPException(status_code=status_code, detail=str(error))
 
     # Unexpected: the reason goes to the log with a stack, not to the caller.
     return internal_error(error, context=f"failed to {operation}")

--- a/apps/backend/src/rhesis/backend/app/utils/response_extractor.py
+++ b/apps/backend/src/rhesis/backend/app/utils/response_extractor.py
@@ -12,8 +12,13 @@ from typing import Any, Dict, List, Optional, Union
 logger = logging.getLogger(__name__)
 
 
-def _as_response_dict(result: Union[Dict, Any]) -> Dict[str, Any]:
-    """Normalize invoker results (dict or ErrorResponse) to a plain dict."""
+def as_response_dict(result: Union[Dict, Any]) -> Dict[str, Any]:
+    """Normalize invoker results (dict or ErrorResponse) to a plain dict.
+
+    Public because callers outside this module need the same conversion and a hand-rolled
+    ``to_dict()``/``dict()`` version misses cases and can raise. A dict is returned as-is
+    rather than copied, so a caller may still pop keys off the original.
+    """
     if not result:
         return {}
     if isinstance(result, dict):
@@ -51,7 +56,7 @@ def is_http_error_response(result: Union[Dict, Any]) -> bool:
     ``error`` with ``status_code >= 400``). Does not match on free-text
     messages.
     """
-    data = _as_response_dict(result)
+    data = as_response_dict(result)
     if not data:
         return False
 
@@ -80,7 +85,7 @@ def is_endpoint_failure(result: Union[Dict, Any]) -> bool:
     so a target whose mapped response happens to contain an ``error`` field is not mistaken
     for an invocation failure.
     """
-    data = _as_response_dict(result)
+    data = as_response_dict(result)
     if not data:
         return False
 
@@ -99,7 +104,7 @@ def has_endpoint_failure_in_result(result: Union[Dict, Any]) -> bool:
     if is_endpoint_failure(result):
         return True
 
-    data = _as_response_dict(result)
+    data = as_response_dict(result)
     target_interaction = _first_send_message_interaction(data.get("history"))
     if target_interaction is None:
         return False
@@ -114,7 +119,7 @@ def get_endpoint_error_details(result: Union[Dict, Any]) -> Dict[str, Any]:
     each needing to know that multi-turn buries them under the first turn's tool message.
     Returns ``{}`` when the result is not a failure.
     """
-    data = _as_response_dict(result)
+    data = as_response_dict(result)
     if not data:
         return {}
 
@@ -129,6 +134,21 @@ def get_endpoint_error_details(result: Union[Dict, Any]) -> Dict[str, Any]:
     return error_details if is_endpoint_failure(error_details) else {}
 
 
+# A failure summary becomes a log line and one ActivityLog row per reported test, and a
+# target is free to answer a 4xx with an arbitrarily large body: an HTML error page, a
+# stack trace, a rejected payload echoed back. ActivityLog.message is unbounded Text, so
+# nothing downstream would refuse it. Generous enough that a real explanation survives
+# whole (the safeguarding rejection that prompted this is ~100 characters).
+NARRATION_MESSAGE_LIMIT = 500
+
+
+def truncate_for_narration(text: str) -> str:
+    """Bound a message destined for a log line or an activity-log row."""
+    if len(text) <= NARRATION_MESSAGE_LIMIT:
+        return text
+    return f"{text[:NARRATION_MESSAGE_LIMIT].rstrip()}... (truncated)"
+
+
 def summarize_endpoint_failure(result: Union[Dict, Any]) -> Optional[Dict[str, Any]]:
     """Describe a failed invocation for logs and job activity narration.
 
@@ -140,13 +160,18 @@ def summarize_endpoint_failure(result: Union[Dict, Any]) -> Optional[Dict[str, A
 
     Keys: ``summary`` (log-ready line), ``message`` (the target's own reason) and
     ``status_code`` (``None`` for failures that never carried one, e.g. SDK/connector).
+
+    Both text fields are capped: see ``NARRATION_MESSAGE_LIMIT``. The untruncated text
+    stays in ``test_output`` for the detail view, which is where a reader wants all of it.
     """
     details = get_endpoint_error_details(result)
     if not details:
         return None
 
     status_code = get_http_error_status_code(result)
-    message = str(details.get("output") or details.get("message") or "").strip()
+    message = truncate_for_narration(
+        str(details.get("output") or details.get("message") or "").strip()
+    )
 
     label = f"HTTP {status_code}" if status_code is not None else "an error"
     summary = f"Endpoint returned {label}"
@@ -165,7 +190,7 @@ def summarize_endpoint_failure(result: Union[Dict, Any]) -> Optional[Dict[str, A
 
 def get_http_error_status_code(result: Union[Dict, Any]) -> Optional[int]:
     """Return HTTP status from a flat response or multi-turn first-turn error_details."""
-    data = _as_response_dict(result)
+    data = as_response_dict(result)
     if not data:
         return None
 
@@ -244,7 +269,7 @@ def has_http_error_in_result(result: Union[Dict, Any]) -> bool:
     if is_http_error_response(result):
         return True
 
-    data = _as_response_dict(result)
+    data = as_response_dict(result)
     target_interaction = _first_send_message_interaction(data.get("history"))
     if target_interaction is None:
         return False

--- a/apps/backend/src/rhesis/backend/app/utils/response_extractor.py
+++ b/apps/backend/src/rhesis/backend/app/utils/response_extractor.py
@@ -65,6 +65,104 @@ def is_http_error_response(result: Union[Dict, Any]) -> bool:
     return False
 
 
+def is_endpoint_failure(result: Union[Dict, Any]) -> bool:
+    """Return True when the invoker reported the target call as failed, HTTP status or not.
+
+    Broader than :func:`is_http_error_response`, which by design only matches failures
+    carrying a 4xx/5xx status. Several invokers never have one to report: the SDK/connector
+    invoker sets ``error_type`` like ``sdk_timeout`` or ``sdk_function_error`` with no
+    status code at all, and the WebSocket invoker does the same for a mid-stream failure.
+    Judging those on ``is_http_error_response`` alone reads them as a real answer and scores
+    the error text into a Pass/Fail verdict, so anything deciding "did we get output worth
+    evaluating?" must use this instead.
+
+    ``error_type`` is required alongside ``error`` on purpose: only our own invokers set it,
+    so a target whose mapped response happens to contain an ``error`` field is not mistaken
+    for an invocation failure.
+    """
+    data = _as_response_dict(result)
+    if not data:
+        return False
+
+    if is_http_error_response(data):
+        return True
+
+    return bool(data.get("error")) and bool(data.get("error_type"))
+
+
+def has_endpoint_failure_in_result(result: Union[Dict, Any]) -> bool:
+    """Return True for a flat invoker failure or a multi-turn first-message failure.
+
+    The :func:`is_endpoint_failure` counterpart of :func:`has_http_error_in_result`; see
+    that function for why only the first ``send_message_to_target`` turn is inspected.
+    """
+    if is_endpoint_failure(result):
+        return True
+
+    data = _as_response_dict(result)
+    target_interaction = _first_send_message_interaction(data.get("history"))
+    if target_interaction is None:
+        return False
+
+    return is_endpoint_failure(_error_details_from_tool_execution(target_interaction))
+
+
+def get_endpoint_error_details(result: Union[Dict, Any]) -> Dict[str, Any]:
+    """Return the invoker error dict for a failed call, flat or multi-turn nested.
+
+    Gives callers one place to reach the status code, reason and response body without
+    each needing to know that multi-turn buries them under the first turn's tool message.
+    Returns ``{}`` when the result is not a failure.
+    """
+    data = _as_response_dict(result)
+    if not data:
+        return {}
+
+    if is_endpoint_failure(data):
+        return data
+
+    target_interaction = _first_send_message_interaction(data.get("history"))
+    if target_interaction is None:
+        return {}
+
+    error_details = _error_details_from_tool_execution(target_interaction)
+    return error_details if is_endpoint_failure(error_details) else {}
+
+
+def summarize_endpoint_failure(result: Union[Dict, Any]) -> Optional[Dict[str, Any]]:
+    """Describe a failed invocation for logs and job activity narration.
+
+    Returns ``None`` when the result is not a failure, so callers can use it as both the
+    test and the value. Lives here rather than in ``jobs/`` because the sequential
+    executors, the batch runner and the activity log all need the same wording -- and
+    because a reader opening the Jobs page to ask "why did this run produce nothing?"
+    should not get a different answer depending on which execution mode ran.
+
+    Keys: ``summary`` (log-ready line), ``message`` (the target's own reason) and
+    ``status_code`` (``None`` for failures that never carried one, e.g. SDK/connector).
+    """
+    details = get_endpoint_error_details(result)
+    if not details:
+        return None
+
+    status_code = get_http_error_status_code(result)
+    message = str(details.get("output") or details.get("message") or "").strip()
+
+    label = f"HTTP {status_code}" if status_code is not None else "an error"
+    summary = f"Endpoint returned {label}"
+    # The invoker's text usually already names the status; don't say it twice.
+    if message and (status_code is None or f"{status_code}" not in message):
+        summary = f"{summary}: {message}"
+    elif message:
+        summary = message
+
+    return {
+        "summary": summary,
+        "message": message or summary,
+        "status_code": status_code,
+    }
+
+
 def get_http_error_status_code(result: Union[Dict, Any]) -> Optional[int]:
     """Return HTTP status from a flat response or multi-turn first-turn error_details."""
     data = _as_response_dict(result)
@@ -137,6 +235,11 @@ def has_http_error_in_result(result: Union[Dict, Any]) -> bool:
 
     Multi-turn: only the first ``send_message_to_target`` interaction is checked.
     Later turns with HTTP failures are left to normal Pass/Fail scoring.
+
+    Deciding whether to skip metric evaluation? Use
+    :func:`has_endpoint_failure_in_result` instead. This one matches only failures that
+    carry an HTTP status, so an SDK/connector or WebSocket failure slips past it and gets
+    scored into a Pass/Fail verdict. Kept for callers that specifically mean "HTTP".
     """
     if is_http_error_response(result):
         return True
@@ -186,9 +289,16 @@ def extract_response_with_fallback(result: Union[Dict, Any]) -> str:
 
     # Handle error responses first
     if result.get("error", False):
-        # If there's an error, use the error message as the actual response
-        error_message = result.get("message", "Unknown error occurred")
-        return error_message
+        # ``output`` carries the full user-facing text (status, reason, and the target's
+        # own response body); ``message`` is the short technical variant with the body
+        # stripped. Prefer ``output`` so the reason the target rejected the call survives
+        # -- an endpoint answering "blocked by safeguarding" is the whole story here.
+        error_message = result.get("output") or result.get("message")
+        if isinstance(error_message, (dict, list)):
+            return json.dumps(error_message)
+        if error_message and str(error_message).strip():
+            return str(error_message)
+        return "Unknown error occurred"
 
     # Try to extract output from successful responses
     actual_response = result.get("output", "")

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/__init__.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/__init__.py
@@ -105,11 +105,19 @@ def _persist_failed_results(ctx: "ExecutionContext", results: List[Dict[str, Any
             continue
 
         message = result.get("error", "Execution failed")
-        # ``output`` as well as ``error``: the detail views read ``output``, so an error
-        # record that sets only ``error`` renders as "No response available". Any
-        # status code / error_type the invoker classified is carried through too, so this
-        # row is recognised as an endpoint failure on re-score instead of being scored.
-        error_output: Dict[str, Any] = {"output": message, "error": message}
+        # Mirrors the ErrorResponse shape the primary path stores (``_run_single_turn``
+        # persists the invoker dict verbatim), so ``test_output.error`` means the same
+        # thing however the row was written: a boolean flag, with the human text in
+        # ``output``/``message``. It previously held the message here and a bool there,
+        # which left readers guessing at the type.
+        #
+        # ``output`` matters because the detail views read it: a record setting only
+        # ``error`` renders as "No response available".
+        error_output: Dict[str, Any] = {
+            "output": message,
+            "message": message,
+            "error": True,
+        }
         # ...but only when the target is actually to blame. EndpointService tags its own
         # unexpected exceptions error_type="internal_error", status_code=500; attributing
         # those would have the UI tell the user their endpoint returned HTTP 500 and send

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/__init__.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/__init__.py
@@ -67,6 +67,7 @@ def _persist_failed_results(ctx: "ExecutionContext", results: List[Dict[str, Any
 
     from rhesis.backend.app.database import get_db_with_tenant_variables
     from rhesis.backend.app.models.test_result import TestResult
+    from rhesis.backend.app.services.invokers.common.errors import INTERNAL_ERROR_TYPE
     from rhesis.backend.jobs.execution.batch.persist import persist_result
 
     failed = [r for r in results if r.get("status") == "failed"]
@@ -103,12 +104,27 @@ def _persist_failed_results(ctx: "ExecutionContext", results: List[Dict[str, Any
             logger.warning(f"[BATCH] Cannot persist error record for {tid}: no snapshot data")
             continue
 
+        message = result.get("error", "Execution failed")
+        # ``output`` as well as ``error``: the detail views read ``output``, so an error
+        # record that sets only ``error`` renders as "No response available". Any
+        # status code / error_type the invoker classified is carried through too, so this
+        # row is recognised as an endpoint failure on re-score instead of being scored.
+        error_output: Dict[str, Any] = {"output": message, "error": message}
+        # ...but only when the target is actually to blame. EndpointService tags its own
+        # unexpected exceptions error_type="internal_error", status_code=500; attributing
+        # those would have the UI tell the user their endpoint returned HTTP 500 and send
+        # them debugging a service that never saw the request.
+        if result.get("error_type") and result["error_type"] != INTERNAL_ERROR_TYPE:
+            error_output["error_type"] = result["error_type"]
+            if result.get("status_code") is not None:
+                error_output["status_code"] = result["status_code"]
+
         try:
             persist_result(
                 ctx,
                 tid,
                 snapshot["test"],
-                {"error": result.get("error", "Execution failed")},
+                error_output,
                 {},
                 [],
                 result.get("execution_time", 0),
@@ -219,10 +235,16 @@ def execute_tests_as_batch(
     succeeded = sum(1 for r in results if r.get("status") == "succeeded")
     failed = sum(1 for r in results if r.get("status") == "failed")
     cancelled = sum(1 for r in results if r.get("status") == "cancelled")
+    endpoint_errors = sum(1 for r in results if r.get("status") == "endpoint_error")
     if on_progress:
         on_progress(total_tests, total_tests)
     if on_emit:
         parts = [f"{succeeded} succeeded", f"{failed} failed"]
+        # Counted separately from both: the test ran and produced a row, but the endpoint
+        # rejected the call, so folding it into "succeeded" hides the only fact that
+        # matters when an entire run comes back empty.
+        if endpoint_errors:
+            parts.append(f"{endpoint_errors} rejected by endpoint")
         if cancelled:
             parts.append(f"{cancelled} cancelled")
         on_emit(f"Batch complete: {', '.join(parts)}")

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/evaluation.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/evaluation.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, Optional
 from rhesis.backend.app.models.test import Test
 from rhesis.backend.app.utils.response_extractor import (
     get_http_error_status_code,
-    has_http_error_in_result,
+    has_endpoint_failure_in_result,
 )
 from rhesis.backend.jobs.execution.batch.context import ExecutionContext
 from rhesis.backend.jobs.execution.constants import PENELOPE_EVALUATED_METRICS, MetricScope
@@ -30,11 +30,12 @@ async def evaluate_metrics(
     on_emit: Optional[Callable[[str], None]] = None,
 ) -> Dict[str, Any]:
     """Run async metric evaluation, returning merged results."""
-    # HTTP errors are not model answers; do not score metrics against them.
-    if has_http_error_in_result(output):
+    # A failed invocation is not a model answer; do not score metrics against it.
+    if has_endpoint_failure_in_result(output):
         status_code = get_http_error_status_code(output)
         logger.info(
-            f"[BATCH] HTTP error for test {test_id} (status_code={status_code}); skipping metrics"
+            f"[BATCH] Endpoint failure for test {test_id} "
+            f"(status_code={status_code}); skipping metrics"
         )
         return {}
 

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/invocation.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/invocation.py
@@ -250,15 +250,36 @@ async def _run_single_turn(
             deferred_trace=True,
         )
 
-    result = await invoke_with_retry(
-        _invoke,
-        max_attempts=ctx.invoke_max_attempts,
-        min_wait=ctx.invoke_retry_min_wait,
-        max_wait=ctx.invoke_retry_max_wait,
-        label=f"single_turn[{test_id[:8]}]",
-    )
+    from rhesis.backend.app.services.invokers.common.errors import EndpointInvocationError
 
-    deferred_trace = result.pop("_deferred_trace", None) if isinstance(result, dict) else None
+    try:
+        result = await invoke_with_retry(
+            _invoke,
+            max_attempts=ctx.invoke_max_attempts,
+            min_wait=ctx.invoke_retry_min_wait,
+            max_wait=ctx.invoke_retry_max_wait,
+            label=f"single_turn[{test_id[:8]}]",
+        )
+    except EndpointInvocationError as e:
+        # A permanent target failure (400, 401, 422, …) is a result, not a crash. Returning
+        # it here routes it through the same persist path the sequential runner uses, so the
+        # status code, reason and the target's own response body all reach ``test_output``.
+        # Letting it propagate instead lands in the batch runner's generic except, which
+        # keeps only ``str(exc)`` and stores it under a key the UI never reads.
+        #
+        # Transient failures still propagate: ``invoke_with_retry`` has already exhausted its
+        # attempts, and the recovery rounds in ``run_batch`` are the remaining chance for a
+        # flaky endpoint. Reporting them as results here would silently retire that retry.
+        if e.transient or e.error_response is None:
+            raise
+        result = e.error_response
+
+    if not isinstance(result, dict):
+        result = result.to_dict() if hasattr(result, "to_dict") else dict(result)
+
+    # "deferred_trace" is the key set on an ErrorResponse (extra field); "_deferred_trace"
+    # the one set on a successful dict. Pop both so neither ends up stored in test_output.
+    deferred_trace = result.pop("_deferred_trace", None) or result.pop("deferred_trace", None)
     if deferred_trace:
         deferred_traces.append(deferred_trace)
 

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/invocation.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/invocation.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from rhesis.backend.app.models.test import Test
+from rhesis.backend.app.utils.response_extractor import as_response_dict
 from rhesis.backend.jobs.execution.batch.context import ExecutionContext
 
 logger = logging.getLogger(__name__)
@@ -274,8 +275,11 @@ async def _run_single_turn(
             raise
         result = e.error_response
 
-    if not isinstance(result, dict):
-        result = result.to_dict() if hasattr(result, "to_dict") else dict(result)
+    # The shared normalizer rather than a local to_dict()/dict() pair: it covers the
+    # Pydantic v1/v2 variants too and never raises on something unexpected. Not
+    # process_endpoint_result, which deep-copies -- the deferred trace has to come off
+    # first, or a copy of it is what gets persisted.
+    result = as_response_dict(result)
 
     # "deferred_trace" is the key set on an ErrorResponse (extra field); "_deferred_trace"
     # the one set on a successful dict. Pop both so neither ends up stored in test_output.

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/profiling.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/profiling.py
@@ -55,7 +55,12 @@ def log_batch_report(
     """Emit a structured batch profiling report via the standard logger."""
     failed = sum(1 for r in results if isinstance(r, dict) and r.get("status") == "failed")
     skipped = sum(1 for r in results if isinstance(r, dict) and r.get("status") == "skipped")
-    succeeded = total_tests - failed - skipped
+    # Broken out of the succeeded remainder: a run the endpoint rejected wholesale would
+    # otherwise be logged as 100% ok, which is exactly the wrong signal when triaging.
+    rejected = sum(
+        1 for r in results if isinstance(r, dict) and r.get("status") == "endpoint_error"
+    )
+    succeeded = total_tests - failed - skipped - rejected
 
     user = round(after.user_cpu_s - before.user_cpu_s, 2)
     sys_cpu = round(after.system_cpu_s - before.system_cpu_s, 2)
@@ -69,7 +74,7 @@ def log_batch_report(
     cpu_pct = round(total_cpu / (wall_s or 1) * 100, 1)
 
     logger.info(
-        "[BATCH] run=%s tests=%d (ok=%d fail=%d skip=%d) concurrency=%d | "
+        "[BATCH] run=%s tests=%d (ok=%d fail=%d skip=%d rejected=%d) concurrency=%d | "
         "wall=%ss | cpu: user=%ss sys=%ss total=%ss (%s%%) | "
         "mem: peak_rss=%sMB growth=%sMB | ctx_sw: vol=%d invol=%d",
         test_run_id,
@@ -77,6 +82,7 @@ def log_batch_report(
         succeeded,
         failed,
         skipped,
+        rejected,
         concurrency,
         wall_s,
         user,

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/runner.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/runner.py
@@ -15,6 +15,7 @@ from rhesis.backend.app.services.test_run_timing import TestPhase
 from rhesis.backend.app.utils.response_extractor import (
     has_endpoint_failure_in_result,
     summarize_endpoint_failure,
+    truncate_for_narration,
 )
 from rhesis.backend.jobs.execution.batch.context import ExecutionContext
 from rhesis.backend.jobs.execution.batch.evaluation import evaluate_metrics
@@ -119,9 +120,11 @@ def _is_retriable_failure(result: Dict[str, Any]) -> bool:
     # EndpointService also marks its own unexpected exceptions non-transient
     # (error_type="internal_error"), and those are precisely the "unexpected exceptions"
     # this function's docstring promises a recovery round to.
-    if result.get("transient") is False and result.get("error_type") in (
-        PERMANENT_TARGET_ERROR_TYPES
-    ):
+    target_rejected_it = (
+        result.get("transient") is False
+        and result.get("error_type") in PERMANENT_TARGET_ERROR_TYPES
+    )
+    if target_rejected_it:
         return False
 
     error = result.get("error", "")
@@ -204,7 +207,13 @@ async def _run_gather(
                     try:
                         label = f" — {category}" if category else ""
                         error = result.get("error", "") if isinstance(result, dict) else ""
-                        suffix = f": {error}" if error and is_failure else ""
+                        # Bounded for the same reason the count is: a stringified
+                        # invocation error carries the target's whole response body, and
+                        # this line becomes an ActivityLog row. The full text is kept in
+                        # test_output.
+                        suffix = (
+                            f": {truncate_for_narration(error)}" if error and is_failure else ""
+                        )
                         wording = _NARRATED_STATUS_WORDING.get(status, status)
                         on_emit(f"Test {current}/{progress_total} {wording}{label}{suffix}")
                         last_emit_time = now

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/runner.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/runner.py
@@ -8,16 +8,32 @@ Delegates to `invocation.py` and `evaluation.py`.
 import asyncio
 import logging
 import time
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
+from rhesis.backend.app.services.invokers.common.errors import PERMANENT_TARGET_ERROR_TYPES
 from rhesis.backend.app.services.test_run_timing import TestPhase
-from rhesis.backend.app.utils.response_extractor import has_http_error_in_result
+from rhesis.backend.app.utils.response_extractor import (
+    has_endpoint_failure_in_result,
+    summarize_endpoint_failure,
+)
 from rhesis.backend.jobs.execution.batch.context import ExecutionContext
 from rhesis.backend.jobs.execution.batch.evaluation import evaluate_metrics
 from rhesis.backend.jobs.execution.batch.invocation import is_multi_turn_test, run_test
 from rhesis.backend.jobs.execution.shared import is_task_revoked
 
 logger = logging.getLogger(__name__)
+
+# Per-test statuses the activity log narrates ahead of the throttle.
+_NARRATED_FAILURE_STATUSES = frozenset({"failed", "endpoint_error"})
+
+# How many of those may bypass the throttle per batch. Bounds the blast radius when an
+# endpoint rejects every test in a large run, which is otherwise one ActivityLogged row
+# (and one DB session) per test -- ~4,000 for a 4,000-test run.
+_MAX_UNTHROTTLED_FAILURE_EMITS = 20
+
+# How a per-test status reads in the activity log. "endpoint_error" would otherwise
+# surface as a bare enum value to someone reading the Jobs page.
+_NARRATED_STATUS_WORDING = {"endpoint_error": "endpoint error"}
 
 
 # ---------------------------------------------------------------------------
@@ -53,6 +69,34 @@ async def _cancellation_watchdog(
 # ---------------------------------------------------------------------------
 
 
+def _failure_result(test_id: str, exc: BaseException, execution_time: float) -> Dict[str, Any]:
+    """Build the per-test failure dict, keeping whatever the invoker classified.
+
+    ``str(exc)`` alone loses the status code and error category, which are what
+    ``_persist_failed_results`` needs to write a recognisable endpoint-failure record and
+    what ``_is_retriable_failure`` needs to avoid re-invoking a permanent rejection.
+    """
+    failure: Dict[str, Any] = {
+        "test_id": test_id,
+        "status": "failed",
+        "error": str(exc),
+        "execution_time": execution_time,
+        "exception_type": type(exc).__name__,
+    }
+
+    status_code = getattr(exc, "status_code", None)
+    if status_code is not None:
+        failure["status_code"] = status_code
+    error_type = getattr(exc, "error_type", None)
+    if error_type:
+        failure["error_type"] = error_type
+    transient = getattr(exc, "transient", None)
+    if transient is not None:
+        failure["transient"] = transient
+
+    return failure
+
+
 def _is_retriable_failure(result: Dict[str, Any]) -> bool:
     """Return True for transient failures that are worth retrying.
 
@@ -62,9 +106,24 @@ def _is_retriable_failure(result: Dict[str, Any]) -> bool:
     - ``succeeded``  — already done
     - Timeout        — the endpoint was too slow; a retry will likely timeout again
     - Missing data   — pre-fetch issue, won't resolve on retry
+    - Rejections the target issued itself (4xx, bad endpoint config) — see below
     """
     if result.get("status") != "failed":
         return False
+
+    # A rejection the target itself issued fails identically on a second attempt, so
+    # re-invoking only spends another call against the user's endpoint. A run whose every
+    # test is rejected used to hit the target twice over.
+    #
+    # Restricted to target-attributable categories rather than trusting `transient` alone:
+    # EndpointService also marks its own unexpected exceptions non-transient
+    # (error_type="internal_error"), and those are precisely the "unexpected exceptions"
+    # this function's docstring promises a recovery round to.
+    if result.get("transient") is False and result.get("error_type") in (
+        PERMANENT_TARGET_ERROR_TYPES
+    ):
+        return False
+
     error = result.get("error", "")
     if error.startswith("Timeout after") or error.startswith("Test data not pre-fetched"):
         return False
@@ -86,6 +145,7 @@ async def _run_gather(
     """Fan out test_ids as asyncio Tasks and gather results."""
     completed_count = 0
     last_emit_time = time.monotonic()
+    narrated_failures = 0
     # At most ~20 progress lines per batch, or one every 2s, whichever comes
     # first, plus always the last one. Emitting every single test completion
     # was producing ~4,000 ActivityLogged events (each opening a DB session)
@@ -93,7 +153,7 @@ async def _run_gather(
     emit_interval = max(1, progress_total // 20) if progress_total else 1
 
     async def _tracked(test_id: str) -> Dict[str, Any]:
-        nonlocal completed_count, last_emit_time
+        nonlocal completed_count, last_emit_time, narrated_failures
         td = ctx.test_data.get(test_id)
         test_obj = td.get("test") if td else None
         cat_obj = getattr(test_obj, "category", None)
@@ -122,11 +182,21 @@ async def _run_gather(
                     pass
             if on_emit and progress_total:
                 now = time.monotonic()
-                # Failures are never throttled -- they carry the error text,
-                # which is the whole reason to read the activity log, and
-                # they are rare enough not to reintroduce the volume problem.
+                # Failures skip the throttle -- they carry the error text, which is the
+                # whole reason to read the activity log. An endpoint rejection counts as
+                # one: it answers "why did this run produce nothing?", and throttling it
+                # away would leave a wholly-rejected run looking like it simply ran.
+                #
+                # Capped, though, because the old assumption that failures "are rare
+                # enough" does not hold for a rejecting endpoint: it fails *every* test,
+                # so an uncapped bypass would reintroduce the very per-test event volume
+                # the throttle exists to prevent. Past the cap they fall back to normal
+                # throttling, and the "Batch complete" line still reports the full count.
+                is_failure = status in _NARRATED_FAILURE_STATUSES
+                if is_failure:
+                    narrated_failures += 1
                 if (
-                    status == "failed"
+                    (is_failure and narrated_failures <= _MAX_UNTHROTTLED_FAILURE_EMITS)
                     or current % emit_interval == 0
                     or current == progress_total
                     or now - last_emit_time > 2.0
@@ -134,8 +204,9 @@ async def _run_gather(
                     try:
                         label = f" — {category}" if category else ""
                         error = result.get("error", "") if isinstance(result, dict) else ""
-                        suffix = f": {error}" if error and status == "failed" else ""
-                        on_emit(f"Test {current}/{progress_total} {status}{label}{suffix}")
+                        suffix = f": {error}" if error and is_failure else ""
+                        wording = _NARRATED_STATUS_WORDING.get(status, status)
+                        on_emit(f"Test {current}/{progress_total} {wording}{label}{suffix}")
                         last_emit_time = now
                     except Exception:
                         pass
@@ -415,15 +486,10 @@ async def _execute_single_test(
                 }
             except Exception as e:
                 logger.error(f"[BATCH] Test {test_id} failed: {e}", exc_info=True)
-                return {
-                    "test_id": test_id,
-                    "status": "failed",
-                    "error": str(e),
-                    "execution_time": (time.monotonic() - start_time) * 1000,
-                    "exception_type": type(e).__name__,
-                }
+                return _failure_result(test_id, e, (time.monotonic() - start_time) * 1000)
 
             # --- Async metric evaluation ---
+            endpoint_failure: Optional[Dict[str, Any]] = None
             if not contract_usable:
                 # The conversation was never run (see invocation._run_multi_turn), so there is
                 # nothing to score. Checked before the evaluator branch below: that one would
@@ -432,16 +498,16 @@ async def _execute_single_test(
                 logger.info(
                     f"[BATCH] Test {test_id} reported as Error: evaluation contract was not usable"
                 )
-            elif has_http_error_in_result(output):
+            elif has_endpoint_failure_in_result(output):
                 metrics_results = {}
-                logger.info(f"[BATCH] HTTP error for test {test_id}; skipping metrics")
-                if on_emit:
-                    from rhesis.backend.app.utils.response_extractor import (
-                        get_http_error_status_code,
-                    )
-
-                    code = get_http_error_status_code(output)
-                    on_emit(f"  Endpoint returned HTTP {code}, skipping metrics")
+                endpoint_failure = summarize_endpoint_failure(output)
+                logger.info(
+                    f"[BATCH] Endpoint failure for test {test_id} "
+                    f"(status_code={(endpoint_failure or {}).get('status_code')}); "
+                    f"skipping metrics"
+                )
+                if on_emit and endpoint_failure:
+                    on_emit(f"  {endpoint_failure['summary']}, skipping metrics")
             elif evaluator and ctx.get_metric_configs_for_test(test_id):
                 metrics_results = await evaluate_metrics(
                     ctx,
@@ -482,6 +548,21 @@ async def _execute_single_test(
                     "status": "failed",
                     "error": f"Persist failed: {e}",
                     "execution_time": execution_time,
+                }
+
+            if endpoint_failure:
+                # Persisted as an Error row, so this is not a "failed" test in the sense the
+                # recovery pass and _persist_failed_results mean (nothing to retry, nothing
+                # left to write). But it is not a success either: reporting it as one made
+                # the activity log narrate "succeeded" for a run the endpoint rejected
+                # wholesale, which is the opposite of what the reader needs.
+                return {
+                    "test_id": test_id,
+                    "status": "endpoint_error",
+                    "error": endpoint_failure["message"],
+                    "status_code": endpoint_failure.get("status_code"),
+                    "execution_time": execution_time,
+                    "metrics": metrics_results,
                 }
 
             return {

--- a/apps/backend/src/rhesis/backend/jobs/execution/executors/multi_turn.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/executors/multi_turn.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app.models.test_configuration import TestConfiguration
 from rhesis.backend.app.services.test_run_timing import TestPhase
+from rhesis.backend.app.utils.response_extractor import summarize_endpoint_failure
 from rhesis.backend.jobs.execution.executors.base import BaseTestExecutor
 from rhesis.backend.jobs.execution.executors.data import get_test_and_prompt
 from rhesis.backend.jobs.execution.executors.output_providers import (
@@ -149,12 +150,17 @@ class MultiTurnTestExecutor(BaseTestExecutor):
             )
 
             # Return execution summary
-            result_summary = {
+            result_summary: Dict[str, Any] = {
                 "test_id": test_id,
                 "test_result_id": str(test_result_id) if test_result_id else None,
                 "execution_time": execution_time,
                 "metrics": metrics_results,
             }
+            # Same as the single-turn executor: lets the caller say why in the activity
+            # log. For multi-turn the detail is buried in the first turn's tool message.
+            endpoint_failure = summarize_endpoint_failure(penelope_trace)
+            if endpoint_failure:
+                result_summary["endpoint_error"] = endpoint_failure
 
             logger.info(
                 f"[MultiTurnExecutor] Multi-turn test execution completed successfully "

--- a/apps/backend/src/rhesis/backend/jobs/execution/executors/results.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/executors/results.py
@@ -21,7 +21,7 @@ from rhesis.backend.app.outcomes import (
     outcome_to_test_result_status_name,
 )
 from rhesis.backend.app.utils.crud_utils import get_or_create_status
-from rhesis.backend.app.utils.response_extractor import has_http_error_in_result
+from rhesis.backend.app.utils.response_extractor import has_endpoint_failure_in_result
 
 logger = logging.getLogger(__name__)
 
@@ -246,12 +246,12 @@ def create_test_result_record(
     Returns:
         UUID of the created test result, or None if creation failed
     """
-    # HTTP errors must never become Pass/Fail from metric scores.
-    http_error = has_http_error_in_result(processed_result)
-    if http_error:
+    # A failed invocation must never become Pass/Fail from metric scores.
+    endpoint_error = has_endpoint_failure_in_result(processed_result)
+    if endpoint_error:
         metrics_results = {}
 
-    execution, verdict = classify_metrics(metrics_results, http_error=http_error)
+    execution, verdict = classify_metrics(metrics_results, endpoint_error=endpoint_error)
     outcome = outcome_of(execution, verdict)
     status_value = outcome_to_test_result_status_name(outcome)
 

--- a/apps/backend/src/rhesis/backend/jobs/execution/executors/runners.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/executors/runners.py
@@ -10,8 +10,8 @@ from rhesis.backend.app.models.test import Test
 from rhesis.backend.app.services.test_run_timing import TestPhase
 from rhesis.backend.app.utils.response_extractor import (
     get_http_error_status_code,
-    has_http_error_in_result,
-    is_http_error_response,
+    has_endpoint_failure_in_result,
+    is_endpoint_failure,
     normalize_context_to_list,
 )
 from rhesis.backend.jobs.execution.constants import PENELOPE_EVALUATED_METRICS, MetricScope
@@ -245,11 +245,11 @@ class SingleTurnRunner(BaseRunner):
             except Exception:
                 logger.debug("on_test_phase(evaluating) failed", exc_info=True)
 
-        # HTTP errors are not model answers; skip metrics and leave status Error.
-        if is_http_error_response(processed_result):
+        # A failed invocation is not a model answer; skip metrics and leave status Error.
+        if is_endpoint_failure(processed_result):
             status_code = get_http_error_status_code(processed_result)
             logger.info(
-                f"[SingleTurnRunner] HTTP error for test {test_id} "
+                f"[SingleTurnRunner] Endpoint failure for test {test_id} "
                 f"(status_code={status_code}); skipping metrics"
             )
             return execution_time, processed_result, {}
@@ -416,11 +416,11 @@ class MultiTurnRunner(BaseRunner):
             except Exception:
                 logger.debug("on_test_phase(evaluating) failed", exc_info=True)
 
-        # First target message HTTP error → no metrics, status Error.
-        if has_http_error_in_result(penelope_trace):
+        # First target message failed → no metrics, status Error.
+        if has_endpoint_failure_in_result(penelope_trace):
             status_code = get_http_error_status_code(penelope_trace)
             logger.info(
-                f"[MultiTurnRunner] HTTP error on first target message "
+                f"[MultiTurnRunner] Endpoint failure on first target message "
                 f"(status_code={status_code}); skipping metrics"
             )
             return execution_time, penelope_trace, {}

--- a/apps/backend/src/rhesis/backend/jobs/execution/executors/single_turn.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/executors/single_turn.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app.models.test_configuration import TestConfiguration
 from rhesis.backend.app.services.test_run_timing import TestPhase
+from rhesis.backend.app.utils.response_extractor import summarize_endpoint_failure
 from rhesis.backend.jobs.execution.executors.base import BaseTestExecutor
 from rhesis.backend.jobs.execution.executors.data import get_test_and_prompt
 from rhesis.backend.jobs.execution.executors.output_providers import (
@@ -150,12 +151,18 @@ class SingleTurnTestExecutor(BaseTestExecutor):
 
             # Return execution summary
             logger.debug(f"Test execution completed: {test_id}")
-            return {
+            summary: Dict[str, Any] = {
                 "test_id": test_id,
                 "test_result_id": str(test_result_id) if test_result_id else None,
                 "execution_time": execution_time,
                 "metrics": metrics_results,
             }
+            # The row is persisted as Error either way; this is what lets the caller
+            # narrate *why* in the activity log instead of reporting a bare "completed".
+            endpoint_failure = summarize_endpoint_failure(processed_result)
+            if endpoint_failure:
+                summary["endpoint_error"] = endpoint_failure
+            return summary
 
         except Exception as e:
             logger.error(

--- a/apps/backend/src/rhesis/backend/jobs/execution/penelope_target.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/penelope_target.py
@@ -20,7 +20,7 @@ from rhesis.backend.app.models.endpoint import Endpoint
 from rhesis.backend.app.services.invokers.common.errors import EndpointInvocationError
 from rhesis.backend.app.services.invokers.common.schemas import ErrorResponse
 from rhesis.backend.app.usage_attribution import with_usage_attribution
-from rhesis.backend.app.utils.response_extractor import is_http_error_response
+from rhesis.backend.app.utils.response_extractor import is_endpoint_failure
 from rhesis.penelope.targets.base import Target, TargetResponse
 
 logger = logging.getLogger(__name__)
@@ -383,7 +383,7 @@ class BackendEndpointTarget(Target):
                 metadata={"error_details": response_dict},
             )
 
-        if isinstance(response_data, dict) and is_http_error_response(response_data):
+        if isinstance(response_data, dict) and is_endpoint_failure(response_data):
             return TargetResponse(
                 success=False,
                 content="",

--- a/apps/backend/src/rhesis/backend/jobs/execution/sequential.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/sequential.py
@@ -26,6 +26,35 @@ from rhesis.backend.jobs.execution.test_execution import execute_test
 logger = logging.getLogger(__name__)
 
 
+def _narrate_completion(
+    result: Any,
+    index: int,
+    total: int,
+    on_progress=None,
+    on_emit=None,
+) -> None:
+    """Report one finished test to the progress and activity-log callbacks.
+
+    A test whose endpoint rejected the call still returns normally here (the Error row is
+    already persisted), so a bare "completed" line told a reader nothing about a run the
+    target refused wholesale. Reports the status code and the target's own reason instead.
+    """
+    endpoint_error = result.get("endpoint_error") if isinstance(result, dict) else None
+
+    if endpoint_error:
+        logger.info(f"Test {index}/{total} reported as Error: {endpoint_error['summary']}")
+    else:
+        logger.info(f"Test {index}/{total} completed successfully")
+
+    if on_progress:
+        on_progress(index, total)
+    if on_emit:
+        if endpoint_error:
+            on_emit(f"Test {index}/{total} endpoint error: {endpoint_error['message']}")
+        else:
+            on_emit(f"Test {index}/{total} completed")
+
+
 def execute_tests_sequentially(
     session: Session,
     test_config: TestConfiguration,
@@ -181,11 +210,7 @@ def execute_tests_sequentially(
             )
             results.append(result)
 
-            logger.info(f"Test {i}/{len(tests)} completed successfully")
-            if on_progress:
-                on_progress(i, len(tests))
-            if on_emit:
-                on_emit(f"Test {i}/{len(tests)} completed")
+            _narrate_completion(result, i, len(tests), on_progress, on_emit)
 
         except Exception as e:
             logger.error(f"Test {i}/{len(tests)} failed: {str(e)}")
@@ -195,7 +220,9 @@ def execute_tests_sequentially(
             if on_progress:
                 on_progress(i, len(tests))
             if on_emit:
-                on_emit(f"Test {i}/{len(tests)} failed")
+                # The reason is the whole point of reading the activity log; the batch
+                # path has always included it and this one silently dropped it.
+                on_emit(f"Test {i}/{len(tests)} failed: {e}")
         finally:
             if on_test_phase:
                 try:

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
@@ -842,8 +842,12 @@ describe('MetricTuningTab — agreement', () => {
     render(<MetricTuningTab metricId={METRIC_ID} />);
     await screen.findByText(/nothing judged yet/i);
 
+    // findByRole, not getByRole: the tile and the mark come from two independent
+    // requests (getTuningRun and getTuningCases), so awaiting the tile says nothing
+    // about whether the cases have arrived. Whichever promise settles first is a
+    // scheduling detail, which made this fail about three runs in five.
     fireEvent.click(
-      screen.getByRole('button', { name: /accept this verdict/i })
+      await screen.findByRole('button', { name: /accept this verdict/i })
     );
 
     expect(await screen.findByText('100%')).toBeInTheDocument();

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailConversationTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailConversationTab.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/utils/conversation-from-spans';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 import { getEffectiveTestResultStatus } from '@/utils/test-result-status';
+import { getEndpointFailure } from '@/utils/endpoint-failure';
 
 interface TestDetailConversationTabProps {
   test: TestResultDetail;
@@ -173,6 +174,10 @@ export default function TestDetailConversationTab({
   }, [test.test_reviews]);
 
   if (!isMultiTurn) {
+    // With no `output` (a rejected call), the turn used to render as an empty bubble and
+    // was then dropped by ConversationHistory's "nothing to show" filter, so the tab read
+    // "No conversation history available". Show what the endpoint actually sent back.
+    const endpointFailure = getEndpointFailure(test.test_output);
     const singleTurnSummary = [
       {
         turn: 1,
@@ -180,7 +185,13 @@ export default function TestDetailConversationTab({
         session_id: '',
         penelope_reasoning: '',
         penelope_message: test.test?.prompt?.content ?? '',
-        target_response: test.test_output?.output ?? '',
+        // `||`, not `??`: an empty-string output hits the same dropped-turn path as a
+        // missing one, and is what a rejected call actually leaves behind.
+        target_response:
+          test.test_output?.output ||
+          endpointFailure?.responseBody ||
+          endpointFailure?.summary ||
+          '',
         // Single-turn results have no goal_evaluation, so the turn status comes
         // from the result status (review > backend status > metrics).
         success: getEffectiveTestResultStatus(test) === 'Pass',

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailMetricsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailMetricsTab.tsx
@@ -26,8 +26,11 @@ import {
   TableCell,
   Tooltip,
   Chip,
+  Alert,
+  AlertTitle,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import RateReviewIcon from '@mui/icons-material/RateReview';
 import { alpha } from '@mui/material/styles';
 import {
@@ -45,6 +48,8 @@ import {
 } from '@/utils/api-client/interfaces/test-configuration';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
 import { passRate } from '@/constants/outcomes';
+import { getEndpointFailure } from '@/utils/endpoint-failure';
+import { getEffectiveTestResultStatus } from '@/utils/test-result-status';
 
 interface TestDetailMetricsTabProps {
   test: TestResultDetail;
@@ -355,6 +360,11 @@ export default function TestDetailMetricsTab({
     return map;
   }, [test.test_reviews]);
 
+  const endpointFailure = useMemo(
+    () => getEndpointFailure(test.test_output),
+    [test.test_output]
+  );
+
   const handleFilterChange = (
     _event: React.MouseEvent<HTMLElement>,
     newFilter: 'all' | 'passed' | 'failed' | null
@@ -363,6 +373,35 @@ export default function TestDetailMetricsTab({
       setFilterStatus(newFilter);
     }
   };
+
+  // Nothing was evaluated because the endpoint never answered. The cards below would
+  // otherwise render "0.0%" and "0 of 0 metrics passed", which reads as a real score of
+  // zero rather than as an absence of one.
+  //
+  // Keyed off getEffectiveTestResultStatus, the same arbiter the chip and the grid use, so
+  // this cannot disagree with the status shown next to it. The metricsData check keeps real
+  // metrics visible if any were somehow recorded alongside the failure.
+  if (
+    endpointFailure &&
+    getEffectiveTestResultStatus(test) === 'Error' &&
+    metricsData.length === 0
+  ) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Alert severity="warning" icon={<ErrorOutlineIcon />}>
+          <AlertTitle>
+            {endpointFailure.statusCode !== undefined
+              ? `Not scored: target endpoint returned HTTP ${endpointFailure.statusCode}`
+              : 'Not scored: target endpoint did not return a response'}
+          </AlertTitle>
+          <Typography variant="body2">
+            No metrics were evaluated, because there was no response to evaluate
+            them against. See the Overview tab for what the endpoint returned.
+          </Typography>
+        </Alert>
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ p: 3 }}>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
@@ -170,6 +170,14 @@ export default function TestDetailOverviewTab({
     [test.test_output]
   );
 
+  // `error` is a boolean flag on an invoker result and prose on a multi-turn contract
+  // failure, so only the prose form is usable as display text. Rendering the flag would
+  // put a bare "true" in the Response field.
+  const contractError =
+    typeof test.test_output?.error === 'string'
+      ? test.test_output.error
+      : undefined;
+
   const responseContent = useMemo(() => {
     if (isMultiTurn) {
       // goal_evaluation.reason is absent when no metric ran at all -- e.g. the evaluation
@@ -177,7 +185,7 @@ export default function TestDetailOverviewTab({
       // that explanation over a generic "no reasoning" dead end.
       return (
         test.test_output?.goal_evaluation?.reason ||
-        test.test_output?.error ||
+        contractError ||
         endpointFailure?.message ||
         'No evaluation reasoning available'
       );
@@ -189,10 +197,10 @@ export default function TestDetailOverviewTab({
       test.test_output?.output ||
       endpointFailure?.responseBody ||
       endpointFailure?.message ||
-      test.test_output?.error ||
+      contractError ||
       'No response available'
     );
-  }, [isMultiTurn, test, endpointFailure]);
+  }, [isMultiTurn, test, endpointFailure, contractError]);
 
   const testStatus = useMemo(() => getEffectiveTestResultStatus(test), [test]);
   const testLabel = useMemo(() => {

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
@@ -10,9 +10,12 @@ import {
   Divider,
   Collapse,
   IconButton,
+  Alert,
+  AlertTitle,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import CheckIcon from '@mui/icons-material/Check';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import TestResultTags from './TestResultTags';
 import StatusChip from '@/components/common/StatusChip';
@@ -24,6 +27,7 @@ import { testPreviewSx } from '@/app/(protected)/endpoints/components/endpoint-s
 import { looksLikeMarkdown, parseJsonString } from '@/utils/message-content';
 import { useFiles } from '@/hooks/useFiles';
 import { getEffectiveTestResultStatus } from '@/utils/test-result-status';
+import { getEndpointFailure } from '@/utils/endpoint-failure';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
 
 interface TestDetailOverviewTabProps {
@@ -159,6 +163,13 @@ export default function TestDetailOverviewTab({
       : test.test?.prompt?.content || 'No prompt available';
   }, [isMultiTurn, test, prompts, testConfig]);
 
+  // Non-null when the target rejected or never answered the call. Everything the endpoint
+  // did say about why lives in here; see utils/endpoint-failure.ts.
+  const endpointFailure = useMemo(
+    () => getEndpointFailure(test.test_output),
+    [test.test_output]
+  );
+
   const responseContent = useMemo(() => {
     if (isMultiTurn) {
       // goal_evaluation.reason is absent when no metric ran at all -- e.g. the evaluation
@@ -167,11 +178,21 @@ export default function TestDetailOverviewTab({
       return (
         test.test_output?.goal_evaluation?.reason ||
         test.test_output?.error ||
+        endpointFailure?.message ||
         'No evaluation reasoning available'
       );
     }
-    return test.test_output?.output || 'No response available';
-  }, [isMultiTurn, test]);
+    // On a failed call the target's response body *is* the response, and it is the only
+    // place the actual reason appears (a safeguarding rejection, say). Falling straight to
+    // "No response available" threw away the one thing the reader came for.
+    return (
+      test.test_output?.output ||
+      endpointFailure?.responseBody ||
+      endpointFailure?.message ||
+      test.test_output?.error ||
+      'No response available'
+    );
+  }, [isMultiTurn, test, endpointFailure]);
 
   const testStatus = useMemo(() => getEffectiveTestResultStatus(test), [test]);
   const testLabel = useMemo(() => {
@@ -212,6 +233,41 @@ export default function TestDetailOverviewTab({
     </Box>
   );
 
+  // Explains an Error status that would otherwise be unexplained: the status chip alone
+  // never said the target had rejected the call, let alone with which code.
+  //
+  // Gated on testStatus rather than on endpointFailure alone: getEffectiveTestResultStatus
+  // is the single arbiter of a result's status (it projects the backend's execution/verdict
+  // pair), so this only ever explains a status it decided. A result a reviewer has since
+  // overridden to Pass must not still be topped by a failure banner.
+  const endpointFailureBanner =
+    endpointFailure && testStatus === 'Error' ? (
+      <Alert
+        severity="warning"
+        icon={<ErrorOutlineIcon />}
+        sx={{ mb: 3, borderRadius: BORDER_RADIUS.md }}
+      >
+        <AlertTitle>
+          {endpointFailure.statusCode !== undefined
+            ? `Target endpoint returned HTTP ${endpointFailure.statusCode}`
+            : 'Target endpoint did not return a response'}
+          {endpointFailure.reason ? ` (${endpointFailure.reason})` : ''}
+        </AlertTitle>
+        <Typography
+          variant="body2"
+          sx={{ mb: endpointFailure.message ? 1 : 0 }}
+        >
+          The test could not be scored, because the endpoint never produced an
+          answer to evaluate.
+        </Typography>
+        {endpointFailure.message && (
+          <Box component="pre" sx={{ ...testPreviewSx, minHeight: 'unset' }}>
+            {endpointFailure.message}
+          </Box>
+        )}
+      </Alert>
+    ) : null;
+
   // Shared card styling matching Figma "Data Output Textfield" card
   const cardSx = {
     p: '30px',
@@ -228,6 +284,7 @@ export default function TestDetailOverviewTab({
     return (
       <Box sx={{ p: 3 }}>
         {statusHeader}
+        {endpointFailureBanner}
 
         <Paper variant="outlined" sx={cardSx}>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
@@ -429,6 +486,7 @@ export default function TestDetailOverviewTab({
   return (
     <Box sx={{ p: 3 }}>
       {statusHeader}
+      {endpointFailureBanner}
 
       <Paper variant="outlined" sx={cardSx}>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 5 }}>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/test-run-results-grid-utils.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/test-run-results-grid-utils.ts
@@ -8,6 +8,7 @@ import {
   getTestResultLabel,
   isPassedStatusName,
 } from '@/utils/test-result-status';
+import { getEndpointFailure } from '@/utils/endpoint-failure';
 import { getLatestMetricReviewForResult } from './test-run-summary-utils';
 
 export type TestResultDisplayStatus = {
@@ -239,26 +240,6 @@ export function getTestResultDisplayStatus(
   };
 }
 
-function getHttpErrorReason(test: TestResultDetail): string | undefined {
-  const output = test.test_output as Record<string, unknown> | undefined;
-  if (!output) return undefined;
-
-  const isHttpError =
-    output.error_type === 'http_error' ||
-    (output.error &&
-      typeof output.status_code === 'number' &&
-      output.status_code >= 400);
-  if (!isHttpError) return undefined;
-
-  const statusCode =
-    typeof output.status_code === 'number' ? output.status_code : undefined;
-  const errorMsg = typeof output.error === 'string' ? output.error : '';
-  if (statusCode) {
-    return `Endpoint returned HTTP ${statusCode}${errorMsg ? `: ${errorMsg}` : ''}`;
-  }
-  return `Endpoint returned an error${errorMsg ? `: ${errorMsg}` : ''}`;
-}
-
 export function getExecutionErrorTooltip(
   test: TestResultDetail,
   status: TestResultDisplayStatus,
@@ -266,8 +247,11 @@ export function getExecutionErrorTooltip(
 ): string {
   if (!status.hasExecutionError) return '';
 
-  const httpReason = getHttpErrorReason(test);
-  if (httpReason) return httpReason;
+  // Was a local reimplementation that only matched failures carrying an HTTP status and
+  // only read the flat shape, so SDK/connector errors and every multi-turn failure fell
+  // through to the generic message.
+  const failure = getEndpointFailure(test.test_output);
+  if (failure) return failure.summary;
 
   const requirement = test.test?.requirement;
   if (requirement && requirements) {

--- a/apps/frontend/src/utils/__tests__/endpoint-failure.test.ts
+++ b/apps/frontend/src/utils/__tests__/endpoint-failure.test.ts
@@ -1,0 +1,166 @@
+import { getEndpointFailure } from '../endpoint-failure';
+import { TestOutput } from '@/utils/api-client/interfaces/test-results';
+
+const SAFEGUARDING_BODY = '{"detail":"Blocked by safeguarding policy"}';
+
+/** What the backend stores for a single-turn call the target answered with 400. */
+function flatHttpFailure(): TestOutput {
+  return {
+    output: `HTTP 400 error from endpoint: Bad Request. Response content: ${SAFEGUARDING_BODY}`,
+    error: 'HTTP 400 error from endpoint',
+    error_type: 'http_error',
+    status_code: 400,
+    reason: 'Bad Request',
+    response_content: SAFEGUARDING_BODY,
+  } as TestOutput;
+}
+
+/** Penelope trace whose first target message hit a 403. */
+function multiTurnFailure(): TestOutput {
+  return {
+    history: [
+      {
+        target_interaction: {
+          tool_name: 'send_message_to_target',
+          tool_message: {
+            content: JSON.stringify({
+              metadata: {
+                error_details: {
+                  error: true,
+                  error_type: 'http_error',
+                  status_code: 403,
+                  message: 'HTTP 403 error from endpoint',
+                  output: 'HTTP 403 error from endpoint: Forbidden',
+                },
+              },
+            }),
+          },
+        },
+      },
+    ],
+  } as TestOutput;
+}
+
+describe('getEndpointFailure', () => {
+  describe('flat single-turn failures', () => {
+    it('reads the status code, reason and response body', () => {
+      const failure = getEndpointFailure(flatHttpFailure());
+
+      expect(failure).not.toBeNull();
+      expect(failure?.statusCode).toBe(400);
+      expect(failure?.reason).toBe('Bad Request');
+      expect(failure?.responseBody).toBe(SAFEGUARDING_BODY);
+      expect(failure?.errorType).toBe('http_error');
+    });
+
+    it('summarises without repeating the status code', () => {
+      const failure = getEndpointFailure(flatHttpFailure());
+
+      expect(failure?.summary).toContain('400');
+      expect(failure?.summary.match(/400/g)).toHaveLength(1);
+    });
+
+    it('accepts a status code sent as a string', () => {
+      const failure = getEndpointFailure({
+        error: 'rejected',
+        error_type: 'http_error',
+        status_code: '429',
+      } as unknown as TestOutput);
+
+      expect(failure?.statusCode).toBe(429);
+    });
+
+    it('falls back to response_body for rows written before the invokers were normalised', () => {
+      const failure = getEndpointFailure({
+        error: 'ws rejected',
+        error_type: 'websocket_connection_error',
+        status_code: 403,
+        response_body: '{"detail":"forbidden"}',
+      } as unknown as TestOutput);
+
+      expect(failure?.responseBody).toBe('{"detail":"forbidden"}');
+    });
+  });
+
+  describe('multi-turn failures', () => {
+    it('reads the error nested in the first target interaction', () => {
+      const failure = getEndpointFailure(multiTurnFailure());
+
+      expect(failure).not.toBeNull();
+      expect(failure?.statusCode).toBe(403);
+      expect(failure?.message).toContain('Forbidden');
+    });
+
+    it('ignores turns that are not send_message_to_target', () => {
+      const output = {
+        history: [
+          {
+            target_interaction: {
+              tool_name: 'some_other_tool',
+              tool_message: { content: '{}' },
+            },
+          },
+        ],
+      } as TestOutput;
+
+      expect(getEndpointFailure(output)).toBeNull();
+    });
+
+    it('survives a tool message that is not valid JSON', () => {
+      const output = {
+        history: [
+          {
+            target_interaction: {
+              tool_name: 'send_message_to_target',
+              tool_message: { content: 'not json at all' },
+            },
+          },
+        ],
+      } as TestOutput;
+
+      expect(getEndpointFailure(output)).toBeNull();
+    });
+  });
+
+  describe('failures carrying no HTTP status', () => {
+    // SDK/connector and network failures never have one. They are still failures, and
+    // treating them as answers is how their error text got scored into a verdict.
+    it.each(['sdk_function_error', 'sdk_timeout', 'network_error'])(
+      'detects %s',
+      errorType => {
+        const failure = getEndpointFailure({
+          output: `failure: ${errorType}`,
+          error: errorType,
+          error_type: errorType,
+        } as unknown as TestOutput);
+
+        expect(failure).not.toBeNull();
+        expect(failure?.statusCode).toBeUndefined();
+        expect(failure?.summary).toContain('an error');
+      }
+    );
+  });
+
+  describe('results that did not fail', () => {
+    it('returns null for a successful response', () => {
+      expect(
+        getEndpointFailure({ output: 'the model answered' } as TestOutput)
+      ).toBeNull();
+    });
+
+    it('returns null for a target that maps its own "error" field', () => {
+      // error_type is required alongside error precisely so this is not a false positive.
+      expect(
+        getEndpointFailure({
+          output: 'an answer',
+          error: 'some field the target happened to map',
+        } as TestOutput)
+      ).toBeNull();
+    });
+
+    it('returns null for missing output', () => {
+      expect(getEndpointFailure(undefined)).toBeNull();
+      expect(getEndpointFailure(null)).toBeNull();
+    });
+  });
+});

--- a/apps/frontend/src/utils/api-client/interfaces/test-results.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/test-results.ts
@@ -98,9 +98,11 @@ export interface GoalEvaluation {
 }
 
 export interface TestOutput {
-  // Single-turn fields
-  output: string;
-  context: string[];
+  // Single-turn fields.
+  // Optional because a failed invocation may produce no model answer at all; read it
+  // through getEndpointFailure() (utils/endpoint-failure.ts) rather than assuming a string.
+  output?: string;
+  context?: string[];
   metadata?: Record<string, unknown>;
 
   // Multi-turn (Penelope) fields
@@ -123,12 +125,46 @@ export interface TestOutput {
   // Status field for multi-turn tests
   status?: 'success' | 'failure' | 'timeout' | 'error';
   /**
-   * Why a multi-turn result has no metrics and reports Error -- e.g. the test's evaluation
-   * contract is stale or too ambiguous to score against. Set by the backend's
-   * evaluate_multi_turn_metrics (re-score) or resolve_multi_turn_contract (live, when the
-   * conversation was never run). Not an HTTP error field.
+   * Why this result has no metrics and reports Error. Two unrelated writers set it:
+   * a multi-turn contract that was stale or too ambiguous to score against
+   * (evaluate_multi_turn_metrics / resolve_multi_turn_contract), and a failed
+   * invocation, where it holds the same text as `output`.
    */
   error?: string;
+
+  /**
+   * Invoker failure detail, present when the target rejected or never answered the call.
+   * Written by every invoker via ErrorResponse, and by the batch path's error records.
+   * `error_type` is the discriminator: `http_error` for a 4xx/5xx, or an invoker-specific
+   * category such as `sdk_timeout` / `network_error` that carries no status code.
+   * Read these through getEndpointFailure() rather than individually.
+   */
+  error_type?: string;
+  status_code?: number;
+  reason?: string;
+  /** The target's own response body, which is usually where the real reason is. */
+  response_content?: string;
+  /** Pre-existing rows only: the WebSocket invoker used to write the body here. */
+  response_body?: string;
+  response_headers?: Record<string, unknown>;
+  request?: Record<string, unknown>;
+
+  /** Multi-turn: the invoker error is nested in the first turn's tool message. */
+  history?: PenelopeTurn[];
+}
+
+/**
+ * One entry of a Penelope trace's `history`. Only the parts the UI reads are typed: the
+ * first `send_message_to_target` interaction is where a multi-turn endpoint failure is
+ * recorded, and nothing else in the frontend had been reaching into it.
+ */
+export interface PenelopeTurn {
+  target_interaction?: {
+    tool_name?: string;
+    tool_message?: {
+      content?: string | Record<string, unknown>;
+    };
+  };
 }
 
 // Test Reviews interfaces

--- a/apps/frontend/src/utils/api-client/interfaces/test-results.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/test-results.ts
@@ -125,12 +125,15 @@ export interface TestOutput {
   // Status field for multi-turn tests
   status?: 'success' | 'failure' | 'timeout' | 'error';
   /**
-   * Why this result has no metrics and reports Error. Two unrelated writers set it:
-   * a multi-turn contract that was stale or too ambiguous to score against
-   * (evaluate_multi_turn_metrics / resolve_multi_turn_contract), and a failed
-   * invocation, where it holds the same text as `output`.
+   * Why this result has no metrics and reports Error. Two unrelated writers set it, with
+   * two different types, so narrow before using it as text:
+   *
+   * - A failed invocation stores the invoker's boolean flag (`true`), with the human text
+   *   in `output`/`message`. Read those, or `getEndpointFailure()`, for the reason.
+   * - A multi-turn contract that was stale or too ambiguous to score against stores prose
+   *   (evaluate_multi_turn_metrics / resolve_multi_turn_contract).
    */
-  error?: string;
+  error?: string | boolean;
 
   /**
    * Invoker failure detail, present when the target rejected or never answered the call.

--- a/apps/frontend/src/utils/endpoint-failure.ts
+++ b/apps/frontend/src/utils/endpoint-failure.ts
@@ -1,0 +1,148 @@
+/**
+ * Reading an invoker failure out of a test result's `test_output`.
+ *
+ * The backend records a failed target call in one of two shapes, and before this existed
+ * every consumer guessed at one of them: a flat error object for single-turn, or nested
+ * under the first `send_message_to_target` turn for multi-turn (Penelope). Nothing in the
+ * frontend read the nested one at all, so a multi-turn test whose endpoint rejected the
+ * very first message displayed "No evaluation reasoning available".
+ *
+ * Mirrors `apps/backend/src/rhesis/backend/app/utils/response_extractor.py` --
+ * `is_endpoint_failure` / `get_endpoint_error_details` / `summarize_endpoint_failure`.
+ * Keep the two in step.
+ */
+
+import {
+  TestOutput,
+  PenelopeTurn,
+} from '@/utils/api-client/interfaces/test-results';
+
+export interface EndpointFailure {
+  /** HTTP status, when the failure carried one. Absent for SDK/connector and network errors. */
+  statusCode?: number;
+  /** Invoker category, e.g. `http_error`, `sdk_timeout`, `network_error`. */
+  errorType?: string;
+  /** HTTP reason phrase, e.g. "Bad Request". */
+  reason?: string;
+  /** The target's own words about why it refused. */
+  message: string;
+  /** The target's raw response body, which is usually where the real reason is. */
+  responseBody?: string;
+  /** One-line summary suitable for a tooltip or a banner heading. */
+  summary: string;
+}
+
+type RawOutput = Record<string, unknown>;
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  // Status codes arrive as strings from some invokers.
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+/**
+ * Whether this object is an invoker failure.
+ *
+ * `error_type` is required alongside `error` so a target whose own mapped response happens
+ * to contain an `error` field is not mistaken for a failed invocation.
+ */
+function isFailureShape(output: RawOutput): boolean {
+  if (output.error_type === 'http_error') return true;
+
+  const statusCode = asNumber(output.status_code);
+  if (output.error && statusCode !== undefined && statusCode >= 400)
+    return true;
+
+  return Boolean(output.error) && Boolean(output.error_type);
+}
+
+/** Pull the invoker's error object out of a Penelope trace's first target interaction. */
+function nestedFailure(
+  history: PenelopeTurn[] | undefined
+): RawOutput | undefined {
+  if (!Array.isArray(history)) return undefined;
+
+  for (const turn of history) {
+    const interaction = turn?.target_interaction;
+    if (interaction?.tool_name !== 'send_message_to_target') continue;
+
+    const content = interaction.tool_message?.content;
+    let parsed: unknown = content;
+    if (typeof content === 'string') {
+      try {
+        parsed = JSON.parse(content);
+      } catch {
+        return undefined;
+      }
+    }
+    if (!parsed || typeof parsed !== 'object') return undefined;
+
+    const metadata = (parsed as RawOutput).metadata;
+    if (!metadata || typeof metadata !== 'object') return undefined;
+
+    const details = (metadata as RawOutput).error_details;
+    if (!details || typeof details !== 'object') return undefined;
+
+    return details as RawOutput;
+  }
+
+  // Only the first target turn is inspected, matching the backend: a later turn failing is
+  // left to normal Pass/Fail scoring rather than voiding the whole conversation.
+  return undefined;
+}
+
+function buildSummary(statusCode: number | undefined, message: string): string {
+  const label = statusCode !== undefined ? `HTTP ${statusCode}` : 'an error';
+  const base = `Endpoint returned ${label}`;
+  if (!message) return base;
+  // The invoker's text usually already names the status; don't say it twice.
+  if (statusCode !== undefined && message.includes(String(statusCode))) {
+    return message;
+  }
+  return `${base}: ${message}`;
+}
+
+/**
+ * Describe the target's failure, or `null` when the call did not fail.
+ *
+ * Usable as both the test and the value: `const failure = getEndpointFailure(output)`.
+ */
+export function getEndpointFailure(
+  testOutput: TestOutput | undefined | null
+): EndpointFailure | null {
+  if (!testOutput) return null;
+
+  const output = testOutput as unknown as RawOutput;
+  const details = isFailureShape(output)
+    ? output
+    : nestedFailure(testOutput.history);
+
+  if (!details || !isFailureShape(details)) return null;
+
+  const statusCode = asNumber(details.status_code);
+  const message =
+    asString(details.output) ??
+    asString(details.message) ??
+    asString(details.error) ??
+    '';
+
+  return {
+    statusCode,
+    errorType: asString(details.error_type),
+    reason: asString(details.reason),
+    message,
+    // response_body is only present on rows written before the invokers were normalised
+    // onto response_content; read both so old runs still show their body.
+    responseBody:
+      asString(details.response_content) ?? asString(details.response_body),
+    summary: buildSummary(statusCode, message),
+  };
+}

--- a/apps/frontend/src/utils/test-result-status.ts
+++ b/apps/frontend/src/utils/test-result-status.ts
@@ -9,6 +9,7 @@ import {
   STATUS_LABEL,
   type TestResultStatus,
 } from '@/constants/outcomes';
+import { getEndpointFailure } from './endpoint-failure';
 
 // Re-export the TestResultStatus type for convenience
 export type { TestResultStatus } from '@/constants/outcomes';
@@ -227,6 +228,14 @@ export function getTestEvaluationSummary(test: TestResultDetail): string {
     .filter(Boolean);
   if (evidence && evidence.length > 0) {
     return evidence.join(' · ');
+  }
+
+  // Last resort, and the only thing available when the endpoint refused the call: there is
+  // no metric reasoning to show because nothing was evaluated. Returning '' left the grid's
+  // Evaluation cell showing a bare dash for the whole run.
+  const failure = getEndpointFailure(test.test_output);
+  if (failure) {
+    return failure.summary;
   }
 
   return '';

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -180,6 +180,87 @@ def isolate_storage_settings_cache():
     get_storage_settings.cache_clear()
 
 
+_ENCRYPTION_PROBE_PLAINTEXT = "db-encryption-key-guard-probe"
+
+
+def _reset_encryption_caches() -> None:
+    """Clear both lru_caches the DB encryption key flows through."""
+    from importlib import import_module
+
+    import_module("rhesis.backend.app.utils.encryption")._get_fernet.cache_clear()
+    import_module("rhesis.backend.app.config.settings").get_security_settings.cache_clear()
+
+
+@pytest.fixture(scope="session")
+def _encryption_key_probe() -> str:
+    """A ciphertext written once with the session's configured encryption key.
+
+    Session-scoped so it is created before any function-scoped fixture gets the chance to
+    change the key, which is what makes it a trustworthy reference point for the guard
+    below.
+    """
+    from importlib import import_module
+
+    return import_module("rhesis.backend.app.utils.encryption").encrypt(_ENCRYPTION_PROBE_PLAINTEXT)
+
+
+@pytest.fixture(autouse=True)
+def guard_db_encryption_key(_encryption_key_probe):
+    """Fail the test that leaves the DB encryption key unusable, and repair it.
+
+    The key reaches Fernet through two lru_caches (``get_security_settings()``, then
+    ``_get_fernet()``), so restoring ``DB_ENCRYPTION_KEY`` is not sufficient on its own. A
+    test that sets a throwaway key while those caches happen to be empty bakes it into the
+    cached Fernet, and putting the env var back afterwards does not rebuild it. Everything
+    encrypted earlier in the session then fails to decrypt, which is how two fixtures under
+    ``tests/backend/utils/`` once turned ~50 unrelated route tests red with DecryptionError
+    while reading the session auth token, for the remainder of the run.
+
+    Comparing the env var would not have caught that, because it *was* restored correctly.
+    So this decrypts a probe written with the original key: the same operation the real
+    failure performed, against the same cached Fernet.
+
+    Repairs before failing, so the guilty test is the only casualty instead of the first of
+    many. To swap the key inside a test deliberately, follow
+    ``tests/backend/test_encryption.py`` and clear both caches after restoring it.
+    """
+    yield
+
+    from importlib import import_module
+
+    encryption = import_module("rhesis.backend.app.utils.encryption")
+
+    expected_key = _TEST_ENV_VARS["DB_ENCRYPTION_KEY"]
+    actual_key = os.environ.get("DB_ENCRYPTION_KEY")
+
+    try:
+        probe_ok = encryption.decrypt(_encryption_key_probe) == _ENCRYPTION_PROBE_PLAINTEXT
+    except Exception:
+        # Any failure to read back our own probe means the effective key changed.
+        probe_ok = False
+
+    if actual_key == expected_key and probe_ok:
+        return
+
+    # Repair first: leave the session usable whatever we report.
+    os.environ["DB_ENCRYPTION_KEY"] = expected_key
+    _reset_encryption_caches()
+
+    cause = (
+        "the cached Fernet no longer matches it"
+        if actual_key == expected_key
+        else f"DB_ENCRYPTION_KEY is now {actual_key!r}"
+    )
+    pytest.fail(
+        f"This test left the DB encryption key unusable: {cause}. Anything encrypted "
+        "earlier in the session, the auth token included, would fail to decrypt for every "
+        "test after this one. The key has been restored so the rest of the run is "
+        "unaffected. If this test changes the key on purpose, clear both caches after "
+        "restoring it (see _reset_encryption_caches in tests/backend/test_encryption.py).",
+        pytrace=False,
+    )
+
+
 @pytest.fixture(autouse=True)
 def _ensure_ee_features_registered():
     """Re-bootstrap EE features when the registry has been wiped.

--- a/tests/backend/jobs/test_endpoint_failure_surfacing.py
+++ b/tests/backend/jobs/test_endpoint_failure_surfacing.py
@@ -180,6 +180,19 @@ class TestBatchRoutesPermanentFailuresAsResults:
         assert has_endpoint_failure_in_result(result["output"]) is True
 
     @pytest.mark.asyncio
+    async def test_error_field_is_a_flag_on_both_persist_paths(self):
+        """``test_output.error`` must mean one thing regardless of which path wrote the row.
+
+        The primary path stores the invoker dict verbatim, so ``error`` is the boolean
+        ``True`` with the text in ``output``. ``_persist_failed_results`` used to store the
+        message there instead, leaving readers to guess the type from the row's provenance.
+        """
+        result = await self._run_single_turn_with(_http_400_error_response())
+
+        assert result["output"]["error"] is True
+        assert isinstance(result["output"]["output"], str)
+
+    @pytest.mark.asyncio
     async def test_transient_failure_still_propagates(self):
         """Recovery rounds are a flaky endpoint's remaining chance; reporting a transient
         failure as a result here would silently retire that retry.
@@ -283,6 +296,8 @@ class TestOurOwnFailuresAreNotBlamedOnTheTarget:
 
         # The message is kept so the row still explains itself...
         assert captured["output"] == "internal boom"
+        # ...as a flag, matching what the primary path stores (see the shape test below).
+        assert captured["error"] is True
         # ...but nothing marks it as the target's failure, so the UI won't claim the
         # endpoint returned HTTP 500.
         assert "status_code" not in captured

--- a/tests/backend/jobs/test_endpoint_failure_surfacing.py
+++ b/tests/backend/jobs/test_endpoint_failure_surfacing.py
@@ -26,6 +26,8 @@ from rhesis.backend.app.services.invokers.common.errors import (
 )
 from rhesis.backend.app.services.invokers.common.schemas import ErrorResponse
 from rhesis.backend.app.utils.response_extractor import (
+    NARRATION_MESSAGE_LIMIT,
+    as_response_dict,
     has_endpoint_failure_in_result,
     is_endpoint_failure,
     summarize_endpoint_failure,
@@ -399,3 +401,58 @@ class TestActivityLogNarration:
 
     def test_returns_none_for_a_successful_result(self):
         assert summarize_endpoint_failure({"output": "the model answered"}) is None
+
+    def test_a_huge_response_body_is_capped(self):
+        """A target may answer a 4xx with an HTML error page or an echoed payload. Each
+        narrated test becomes an ActivityLog row on an unbounded Text column, so the
+        summary has to be bounded even though the stored test_output stays complete.
+        """
+        huge = ErrorResponse(
+            output=f"HTTP 400 error from endpoint: Bad Request. Response content: {'x' * 50_000}",
+            error=True,
+            error_type="http_error",
+            message="HTTP 400 error from endpoint",
+            status_code=400,
+            response_content="x" * 50_000,
+        )
+        processed = process_endpoint_result(huge)
+        summary = summarize_endpoint_failure(processed)
+
+        assert summary is not None
+        assert len(summary["message"]) <= NARRATION_MESSAGE_LIMIT + len("... (truncated)")
+        assert summary["message"].endswith("... (truncated)")
+        # The status code still leads the line, so the narration stays useful.
+        assert "400" in summary["summary"]
+        # ...and the untruncated body remains available for the detail view.
+        assert len(processed["response_content"]) == 50_000
+
+    def test_a_normal_reason_is_not_truncated(self):
+        """The case that prompted all this is ~100 characters; it must survive whole."""
+        summary = summarize_endpoint_failure(process_endpoint_result(_http_400_error_response()))
+
+        assert summary is not None
+        assert SAFEGUARDING_BODY in summary["message"]
+        assert "truncated" not in summary["message"]
+
+
+@pytest.mark.unit
+class TestResultNormalisation:
+    """`_run_single_turn` converts the raised ErrorResponse with the shared normalizer
+    rather than a local to_dict()/dict() pair, which missed the Pydantic v1/v2 variants
+    and could raise on anything unexpected.
+    """
+
+    def test_error_response_is_normalised(self):
+        assert as_response_dict(_http_400_error_response())["status_code"] == 400
+
+    def test_a_dict_passes_through_by_reference(self):
+        # _run_single_turn pops the deferred trace off the result, so the caller has to be
+        # handed the same object rather than a copy.
+        original = {"output": "answer"}
+        assert as_response_dict(original) is original
+
+    def test_an_unconvertible_object_does_not_raise(self):
+        class Opaque:
+            pass
+
+        assert as_response_dict(Opaque()) == {}

--- a/tests/backend/jobs/test_endpoint_failure_surfacing.py
+++ b/tests/backend/jobs/test_endpoint_failure_surfacing.py
@@ -1,0 +1,401 @@
+"""A failed target call must reach the user with its status code and the target's reason.
+
+Regression cover for a customer report: a test set whose endpoint answered 400 ("blocked by
+safeguarding") showed status Error with "No response available" and nothing else anywhere in
+the UI. Three separate defects produced that, and each gets a test here:
+
+1. Batch single-turn raised the invoker's ``ErrorResponse`` as an exception, so only
+   ``str(exc)`` survived and it was stored under ``error`` -- a key the detail view does not
+   read -- with no ``status_code`` or ``error_type``.
+2. ``extract_response_with_fallback`` preferred the short ``message`` over ``output``,
+   dropping the target's response body (the part naming the actual reason).
+3. Failures with no HTTP status (SDK/connector, WebSocket mid-stream) were not detected as
+   failures at all, so their error text was scored into a Pass/Fail verdict.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rhesis.backend.app.outcomes import Execution, classify_metrics
+from rhesis.backend.app.services.endpoint.result_processing import process_endpoint_result
+from rhesis.backend.app.services.invokers.common.errors import (
+    INTERNAL_ERROR_TYPE,
+    EndpointInvocationError,
+    classify_error_response,
+)
+from rhesis.backend.app.services.invokers.common.schemas import ErrorResponse
+from rhesis.backend.app.utils.response_extractor import (
+    has_endpoint_failure_in_result,
+    is_endpoint_failure,
+    summarize_endpoint_failure,
+)
+from rhesis.backend.jobs.execution.batch.runner import (
+    _failure_result,
+    _is_retriable_failure,
+)
+
+SAFEGUARDING_BODY = '{"detail":"Blocked by safeguarding policy"}'
+
+
+def _http_400_error_response() -> ErrorResponse:
+    """Exactly what RestEndpointInvoker._handle_http_error builds for a 400."""
+    return ErrorResponse(
+        output=(
+            f"HTTP 400 error from endpoint: Bad Request. Response content: {SAFEGUARDING_BODY}"
+        ),
+        error=True,
+        error_type="http_error",
+        message="HTTP 400 error from endpoint",
+        status_code=400,
+        reason="Bad Request",
+        response_content=SAFEGUARDING_BODY,
+    )
+
+
+@pytest.mark.unit
+class TestStoredOutputKeepsTheReason:
+    """What lands in ``test_output`` has to answer "why did this fail?"."""
+
+    def test_output_keeps_the_targets_response_body(self):
+        """The reason lives in the response body, so ``output`` must not be the short
+        ``message`` variant -- that stops at "HTTP 400 error from endpoint".
+        """
+        processed = process_endpoint_result(_http_400_error_response())
+
+        assert SAFEGUARDING_BODY in processed["output"]
+        assert processed["output"] != "HTTP 400 error from endpoint"
+
+    def test_structured_fields_survive_alongside_the_message(self):
+        processed = process_endpoint_result(_http_400_error_response())
+
+        assert processed["status_code"] == 400
+        assert processed["error_type"] == "http_error"
+        assert processed["reason"] == "Bad Request"
+        assert processed["response_content"] == SAFEGUARDING_BODY
+
+    def test_unknown_error_still_reports_something(self):
+        """An error carrying neither text field must not render as an empty response."""
+        processed = process_endpoint_result({"error": True, "error_type": "http_error"})
+
+        assert processed["output"] == "Unknown error occurred"
+
+
+@pytest.mark.unit
+class TestFailuresWithoutAnHttpStatus:
+    """SDK/connector and network failures never carry a status code. They are still
+    failures, and scoring their error text into a verdict is the worst outcome available.
+    """
+
+    @pytest.mark.parametrize(
+        "error_type",
+        ["sdk_function_error", "sdk_timeout", "sdk_disconnected", "network_error"],
+    )
+    def test_detected_as_a_failure(self, error_type):
+        response = ErrorResponse(
+            output=f"failure: {error_type}",
+            error=True,
+            error_type=error_type,
+            message=error_type,
+        )
+        processed = process_endpoint_result(response)
+
+        assert is_endpoint_failure(processed) is True
+        assert has_endpoint_failure_in_result(processed) is True
+
+    def test_failure_forces_error_never_a_verdict(self):
+        """The whole point: an unscoreable call must not become Pass."""
+        execution, verdict = classify_metrics(
+            {"Accuracy": {"is_successful": True}}, endpoint_error=True
+        )
+
+        assert execution == Execution.ERROR
+        assert verdict is None
+
+    def test_a_target_mapping_an_error_field_is_not_a_failure(self):
+        """``error_type`` is required alongside ``error`` so a target whose own mapped
+        response happens to contain an ``error`` field is not mistaken for a failure.
+        """
+        assert is_endpoint_failure({"output": "answer", "error": "some mapped field"}) is False
+
+    def test_success_is_untouched(self):
+        assert is_endpoint_failure({"output": "the model answered", "error": False}) is False
+
+
+@pytest.mark.unit
+class TestBatchRoutesPermanentFailuresAsResults:
+    """The batch path's structural fix: a permanent rejection is a result, not a crash."""
+
+    @staticmethod
+    async def _run_single_turn_with(invoke_result):
+        from rhesis.backend.jobs.execution.batch.invocation import _run_single_turn
+
+        ctx = MagicMock()
+        ctx.endpoint.id = "endpoint-1"
+        ctx.test_run.attributes = {}
+        ctx.organization_id = "org-1"
+        ctx.user_id = "user-1"
+        ctx.invoke_max_attempts = 1
+        ctx.invoke_retry_min_wait = 0
+        ctx.invoke_retry_max_wait = 0
+        ctx.input_files = {}
+
+        service = MagicMock()
+        service.invoke_endpoint = AsyncMock(return_value=invoke_result)
+
+        with (
+            patch(
+                "rhesis.backend.app.dependencies.get_endpoint_service",
+                return_value=service,
+            ),
+            patch(
+                "rhesis.backend.jobs.execution.batch.invocation.load_input_files_lazy",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            return await _run_single_turn(ctx, "test-1", "a prompt", {}, [])
+
+    @pytest.mark.asyncio
+    async def test_400_is_returned_as_output_not_raised(self):
+        """Previously this raised, and the error reached the DB as ``{"error": str(exc)}``
+        with no ``output`` key -- which is what rendered as "No response available".
+        """
+        result = await self._run_single_turn_with(_http_400_error_response())
+
+        output = result["output"]
+        assert output["status_code"] == 400
+        assert output["error_type"] == "http_error"
+        assert SAFEGUARDING_BODY in output["output"]
+
+    @pytest.mark.asyncio
+    async def test_returned_output_is_recognised_as_a_failure(self):
+        """So create_test_result_record classifies it Error by the endpoint-failure rule
+        rather than falling through to the "no metrics" rule, and a later re-score of the
+        row does not try to grade the error text.
+        """
+        result = await self._run_single_turn_with(_http_400_error_response())
+
+        assert has_endpoint_failure_in_result(result["output"]) is True
+
+    @pytest.mark.asyncio
+    async def test_transient_failure_still_propagates(self):
+        """Recovery rounds are a flaky endpoint's remaining chance; reporting a transient
+        failure as a result here would silently retire that retry.
+        """
+        transient = ErrorResponse(
+            output="HTTP 503 error from endpoint: Service Unavailable",
+            error=True,
+            error_type="http_error",
+            message="HTTP 503 error from endpoint",
+            status_code=503,
+        )
+
+        with pytest.raises(EndpointInvocationError):
+            await self._run_single_turn_with(transient)
+
+
+@pytest.mark.unit
+class TestPermanentFailuresAreNotReInvoked:
+    """A 400 fails identically on a retry; re-invoking only spends another target call."""
+
+    def test_permanent_invoker_failure_is_not_retried(self):
+        exc = classify_error_response(_http_400_error_response())
+        result = _failure_result("test-1", exc, 12.0)
+
+        assert result["transient"] is False
+        assert result["status_code"] == 400
+        assert _is_retriable_failure(result) is False
+
+    def test_transient_invoker_failure_is_still_retried(self):
+        exc = EndpointInvocationError("boom", transient=True, status_code=503)
+        result = _failure_result("test-1", exc, 12.0)
+
+        assert _is_retriable_failure(result) is True
+
+    def test_our_own_unexpected_exception_still_gets_a_recovery_round(self):
+        """EndpointService tags its own bugs error_type="internal_error", transient=False.
+        Those are the "unexpected exceptions" recovery rounds exist for, so a blanket
+        "non-transient means don't retry" would quietly remove their only second chance.
+        """
+        exc = EndpointInvocationError(
+            "some sqlalchemy explosion",
+            transient=False,
+            status_code=500,
+            error_type=INTERNAL_ERROR_TYPE,
+        )
+        result = _failure_result("test-1", exc, 12.0)
+
+        assert _is_retriable_failure(result) is True
+
+    def test_unclassified_failure_keeps_the_previous_behaviour(self):
+        """No ``transient`` key means no invoker verdict, so fall back to string sniffing."""
+        assert _is_retriable_failure({"status": "failed", "error": "something odd"}) is True
+        assert _is_retriable_failure({"status": "failed", "error": "Timeout after 30s"}) is False
+
+
+@pytest.mark.unit
+class TestOurOwnFailuresAreNotBlamedOnTheTarget:
+    """`internal_error` means we broke, not the endpoint. Attributing it would send a
+    customer debugging a service that never received the request.
+    """
+
+    def test_persisted_error_record_omits_internal_error_attribution(self):
+        from rhesis.backend.jobs.execution.batch import _persist_failed_results
+
+        captured: dict = {}
+
+        def _fake_persist(_ctx, _tid, _test, output, *args):
+            captured.update(output)
+
+        ctx = MagicMock()
+        ctx.organization_id = "org-1"
+        ctx.user_id = "user-1"
+        ctx.project_id = None
+        ctx.test_run.id = "11111111-1111-1111-1111-111111111111"
+        ctx.test_data_snapshot = {"22222222-2222-2222-2222-222222222222": {"test": MagicMock()}}
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = []
+
+        with (
+            patch("rhesis.backend.app.database.get_db_with_tenant_variables") as get_db,
+            patch(
+                "rhesis.backend.jobs.execution.batch.persist.persist_result",
+                new=_fake_persist,
+            ),
+        ):
+            get_db.return_value.__enter__.return_value = db
+            _persist_failed_results(
+                ctx,
+                [
+                    {
+                        "test_id": "22222222-2222-2222-2222-222222222222",
+                        "status": "failed",
+                        "error": "internal boom",
+                        "error_type": INTERNAL_ERROR_TYPE,
+                        "status_code": 500,
+                        "execution_time": 5,
+                    }
+                ],
+            )
+
+        # The message is kept so the row still explains itself...
+        assert captured["output"] == "internal boom"
+        # ...but nothing marks it as the target's failure, so the UI won't claim the
+        # endpoint returned HTTP 500.
+        assert "status_code" not in captured
+        assert "error_type" not in captured
+        assert is_endpoint_failure(captured) is False
+
+    def test_a_real_target_rejection_is_still_attributed(self):
+        from rhesis.backend.jobs.execution.batch import _persist_failed_results
+
+        captured: dict = {}
+
+        def _fake_persist(_ctx, _tid, _test, output, *args):
+            captured.update(output)
+
+        ctx = MagicMock()
+        ctx.organization_id = "org-1"
+        ctx.user_id = "user-1"
+        ctx.project_id = None
+        ctx.test_run.id = "11111111-1111-1111-1111-111111111111"
+        ctx.test_data_snapshot = {"22222222-2222-2222-2222-222222222222": {"test": MagicMock()}}
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = []
+
+        with (
+            patch("rhesis.backend.app.database.get_db_with_tenant_variables") as get_db,
+            patch(
+                "rhesis.backend.jobs.execution.batch.persist.persist_result",
+                new=_fake_persist,
+            ),
+        ):
+            get_db.return_value.__enter__.return_value = db
+            _persist_failed_results(
+                ctx,
+                [
+                    {
+                        "test_id": "22222222-2222-2222-2222-222222222222",
+                        "status": "failed",
+                        "error": "HTTP 400 error from endpoint",
+                        "error_type": "http_error",
+                        "status_code": 400,
+                        "execution_time": 5,
+                    }
+                ],
+            )
+
+        assert captured["status_code"] == 400
+        assert is_endpoint_failure(captured) is True
+
+
+@pytest.mark.unit
+class TestInPlaceExecutionErrorMapping:
+    """`POST /tests/execute` must report a target rejection without laundering our own
+    bugs' exception text into the response.
+    """
+
+    def test_target_rejection_reports_the_targets_status_and_detail(self):
+        from rhesis.backend.app.error_handlers import UpstreamHTTPException
+        from rhesis.backend.app.utils.execution_validation import handle_execution_error
+
+        exc = classify_error_response(_http_400_error_response())
+        result = handle_execution_error(exc, operation="execute test")
+
+        assert isinstance(result, UpstreamHTTPException)
+        assert result.status_code == 400
+        assert SAFEGUARDING_BODY in str(result.detail)
+
+    def test_our_own_failure_is_not_attributed_to_the_endpoint(self):
+        from rhesis.backend.app.error_handlers import UpstreamHTTPException
+        from rhesis.backend.app.utils.execution_validation import handle_execution_error
+
+        exc = EndpointInvocationError(
+            "/srv/rhesis/secret/path exploded",
+            transient=False,
+            status_code=500,
+            error_type=INTERNAL_ERROR_TYPE,
+        )
+        result = handle_execution_error(exc, operation="execute test")
+
+        # Not an upstream failure, and the internal text must not reach the caller.
+        assert not isinstance(result, UpstreamHTTPException)
+        assert result.status_code == 500
+        assert "secret/path" not in str(result.detail)
+
+
+@pytest.mark.unit
+class TestActivityLogNarration:
+    """The Jobs page is where someone goes to ask why a run produced nothing."""
+
+    def test_summary_names_the_status_and_the_reason(self):
+        summary = summarize_endpoint_failure(process_endpoint_result(_http_400_error_response()))
+
+        assert summary is not None
+        assert summary["status_code"] == 400
+        assert "400" in summary["summary"]
+        assert SAFEGUARDING_BODY in summary["message"]
+
+    def test_status_is_not_repeated_when_the_text_already_names_it(self):
+        summary = summarize_endpoint_failure(process_endpoint_result(_http_400_error_response()))
+
+        assert summary is not None
+        assert summary["summary"].count("400") == 1
+
+    def test_failure_without_a_status_code_still_reads_sensibly(self):
+        response = ErrorResponse(
+            output="SDK function error: rejected by policy",
+            error=True,
+            error_type="sdk_function_error",
+            message="rejected by policy",
+        )
+        summary = summarize_endpoint_failure(process_endpoint_result(response))
+
+        assert summary is not None
+        assert summary["status_code"] is None
+        assert "rejected by policy" in summary["summary"]
+
+    def test_returns_none_for_a_successful_result(self):
+        assert summarize_endpoint_failure({"output": "the model answered"}) is None

--- a/tests/backend/jobs/test_progress_narration.py
+++ b/tests/backend/jobs/test_progress_narration.py
@@ -344,7 +344,9 @@ class TestSequentialExecutionNarration:
                 on_emit=lambda m: emit_calls.append(m),
             )
 
-        assert emit_calls == ["Test 1/1 failed"]
+        # The reason is included: the activity log is read to find out *why* a test
+        # failed, and the batch path has always named it while this one did not.
+        assert emit_calls == ["Test 1/1 failed: boom"]
 
 
 @pytest.mark.unit
@@ -375,10 +377,16 @@ class TestMetricLevelNarration:
         test.test_configuration = {}
         test.test_metadata = {}
 
-        async def _fake_single_turn(_ctx, ev, _test, _output, _prompt, _expected, _configs, on_metric_complete=None):
+        async def _fake_single_turn(
+            _ctx, ev, _test, _output, _prompt, _expected, _configs, on_metric_complete=None
+        ):
             return await ev.a_evaluate(
-                input_text=_prompt, output_text="resp", expected_output=_expected,
-                context=[], metrics=_configs, on_metric_complete=on_metric_complete,
+                input_text=_prompt,
+                output_text="resp",
+                expected_output=_expected,
+                context=[],
+                metrics=_configs,
+                on_metric_complete=on_metric_complete,
             )
 
         with patch(
@@ -387,9 +395,15 @@ class TestMetricLevelNarration:
         ):
             result = asyncio.run(
                 evaluate_metrics(
-                    ctx, evaluator, test, "t1",
-                    {"response": "hello"}, "prompt", "expected",
-                    False, {},
+                    ctx,
+                    evaluator,
+                    test,
+                    "t1",
+                    {"response": "hello"},
+                    "prompt",
+                    "expected",
+                    False,
+                    {},
                 )
             )
         assert result == {}
@@ -415,10 +429,16 @@ class TestMetricLevelNarration:
 
         emit_calls = []
 
-        async def _fake_single_turn(_ctx, ev, _test, _output, _prompt, _expected, _configs, on_metric_complete=None):
+        async def _fake_single_turn(
+            _ctx, ev, _test, _output, _prompt, _expected, _configs, on_metric_complete=None
+        ):
             return await ev.a_evaluate(
-                input_text=_prompt, output_text="resp", expected_output=_expected,
-                context=[], metrics=_configs, on_metric_complete=on_metric_complete,
+                input_text=_prompt,
+                output_text="resp",
+                expected_output=_expected,
+                context=[],
+                metrics=_configs,
+                on_metric_complete=on_metric_complete,
             )
 
         with patch(
@@ -427,9 +447,15 @@ class TestMetricLevelNarration:
         ):
             result = asyncio.run(
                 evaluate_metrics(
-                    ctx, evaluator, test, "t1",
-                    {"response": "hello"}, "prompt", "expected",
-                    False, {},
+                    ctx,
+                    evaluator,
+                    test,
+                    "t1",
+                    {"response": "hello"},
+                    "prompt",
+                    "expected",
+                    False,
+                    {},
                     on_emit=lambda m: emit_calls.append(m),
                 )
             )
@@ -467,7 +493,9 @@ class TestBatchExecutionNarration:
         emit_calls = []
         progress_calls = []
 
-        async def _fake_single(ctx, test_id, semaphore, agent, evaluator, on_emit=None, on_test_phase=None):
+        async def _fake_single(
+            ctx, test_id, semaphore, agent, evaluator, on_emit=None, on_test_phase=None
+        ):
             return {"test_id": test_id, "status": "succeeded", "execution_time": 10}
 
         with patch(
@@ -504,7 +532,9 @@ class TestBatchExecutionNarration:
 
         emit_calls = []
 
-        async def _fake_single(ctx, test_id, semaphore, agent, evaluator, on_emit=None, on_test_phase=None):
+        async def _fake_single(
+            ctx, test_id, semaphore, agent, evaluator, on_emit=None, on_test_phase=None
+        ):
             return {
                 "test_id": test_id,
                 "status": "failed",
@@ -518,7 +548,8 @@ class TestBatchExecutionNarration:
         ):
             asyncio.run(
                 run_batch(
-                    ctx, ["t1"],
+                    ctx,
+                    ["t1"],
                     on_emit=lambda m: emit_calls.append(m),
                 )
             )

--- a/tests/backend/test_outcomes.py
+++ b/tests/backend/test_outcomes.py
@@ -71,13 +71,13 @@ class TestClassifyMetrics:
         metrics = {"Accuracy": {"is_successful": True}, "Toxicity": {"is_successful": False}}
         assert classify_metrics(metrics) == (Execution.OK, Verdict.FAIL)
 
-    def test_http_error_beats_present_metrics(self):
-        """Bug: a stale/partial metrics dict must never paper over an HTTP
-        error -- the endpoint's answer was never obtained, so nothing it
+    def test_endpoint_error_beats_present_metrics(self):
+        """Bug: a stale/partial metrics dict must never paper over a failed
+        invocation -- the endpoint's answer was never obtained, so nothing it
         appears to say can be trusted.
         """
         metrics = {"Accuracy": {"is_successful": True}}
-        assert classify_metrics(metrics, http_error=True) == (Execution.ERROR, None)
+        assert classify_metrics(metrics, endpoint_error=True) == (Execution.ERROR, None)
 
     def test_no_metrics_is_error(self):
         assert classify_metrics({}) == (Execution.ERROR, None)
@@ -135,7 +135,7 @@ class TestClassifyMetrics:
         raising -- the classifier and the projection must never disagree
         about which combinations are legal.
         """
-        for metrics, http_error in [
+        for metrics, endpoint_error in [
             ({"a": {"is_successful": True}}, False),
             ({"a": {"is_successful": False}}, False),
             ({"a": {"is_successful": None}}, False),
@@ -144,7 +144,7 @@ class TestClassifyMetrics:
             (None, False),
             ({"a": {"is_successful": True}}, True),
         ]:
-            execution, verdict = classify_metrics(metrics, http_error=http_error)
+            execution, verdict = classify_metrics(metrics, endpoint_error=endpoint_error)
             outcome_of(execution, verdict)  # must not raise
 
 

--- a/tests/backend/utils/test_endpoint_encryption.py
+++ b/tests/backend/utils/test_endpoint_encryption.py
@@ -1,10 +1,8 @@
-import os
-
 import pytest
-from cryptography.fernet import Fernet
 from faker import Faker
 from sqlalchemy import text
 
+from rhesis.backend.app.config.settings import get_security_settings
 from rhesis.backend.app.models.endpoint import Endpoint
 from rhesis.backend.app.utils.encryption import is_encrypted
 from tests.backend.routes.fixtures.data_factories import BaseDataFactory
@@ -65,17 +63,24 @@ class EndpointEncryptionDataFactory(BaseDataFactory):
 
 @pytest.fixture
 def encryption_key():
-    """Provide test encryption key"""
-    # Preserve original value
-    original_key = os.environ.get("DB_ENCRYPTION_KEY")
-    key = Fernet.generate_key().decode()
-    os.environ["DB_ENCRYPTION_KEY"] = key
-    yield key
-    # Restore original value or remove if it wasn't set
-    if original_key is not None:
-        os.environ["DB_ENCRYPTION_KEY"] = original_key
-    elif "DB_ENCRYPTION_KEY" in os.environ:
-        del os.environ["DB_ENCRYPTION_KEY"]
+    """Yield the session's configured encryption key.
+
+    Deliberately does not touch ``DB_ENCRYPTION_KEY``. It used to overwrite it with a
+    throwaway key and restore it on teardown, without clearing either cache the key flows
+    through (``get_security_settings()`` and ``_get_fernet()``, both ``lru_cache``d). That
+    made the swap a no-op in isolation, and a session-wide corruption in company: if any
+    other test clears those caches while this fixture is active -- ``test_encryption.py``
+    and ``ee/sso/test_sso_encryption.py`` both do -- the throwaway key gets baked into the
+    cached Fernet and *stays* there, because teardown restored the env var but never
+    rebuilt the cache. Every later encrypt/decrypt in the worker then used the wrong key,
+    and any row written earlier (a session auth token, for one) became undecryptable,
+    failing ~50 unrelated route tests with DecryptionError for the rest of the session.
+
+    No test here needs a distinct key: they assert that a field is stored encrypted and
+    round-trips through the ORM, which the configured key does. So the fix is to stop
+    mutating process-global state rather than to manage the caches around it.
+    """
+    return get_security_settings().db_encryption_key
 
 
 class TestEndpointEncryption:

--- a/tests/backend/utils/test_model_encryption.py
+++ b/tests/backend/utils/test_model_encryption.py
@@ -1,11 +1,9 @@
-import os
-
 import pytest
 from sqlalchemy.exc import IntegrityError
-from cryptography.fernet import Fernet
 from faker import Faker
 from sqlalchemy import text
 
+from rhesis.backend.app.config.settings import get_security_settings
 from rhesis.backend.app.models.model import Model
 from rhesis.backend.app.utils.encryption import is_encrypted
 from tests.backend.routes.fixtures.data_factories import BaseDataFactory
@@ -57,17 +55,13 @@ class ModelEncryptionDataFactory(BaseDataFactory):
 
 @pytest.fixture
 def encryption_key():
-    """Provide test encryption key"""
-    # Preserve original value
-    original_key = os.environ.get("DB_ENCRYPTION_KEY")
-    key = Fernet.generate_key().decode()
-    os.environ["DB_ENCRYPTION_KEY"] = key
-    yield key
-    # Restore original value or remove if it wasn't set
-    if original_key is not None:
-        os.environ["DB_ENCRYPTION_KEY"] = original_key
-    elif "DB_ENCRYPTION_KEY" in os.environ:
-        del os.environ["DB_ENCRYPTION_KEY"]
+    """Yield the session's configured encryption key.
+
+    Deliberately does not touch ``DB_ENCRYPTION_KEY`` -- see the identical fixture in
+    ``test_endpoint_encryption.py`` for why overwriting it corrupted the encryption key for
+    the rest of the worker session. No test here needs a distinct key.
+    """
+    return get_security_settings().db_encryption_key
 
 
 class TestModelEncryption:


### PR DESCRIPTION
## Purpose

A customer ran a test set against an endpoint that answers `400` with "blocked by safeguarding". 68 tests passed and the rest showed status `Error` with "No response available", and nothing anywhere in the product named the status code or the reason. They only worked out what was happening by inspecting their own endpoint's logs. As they put it: the safeguarding was working correctly, it just was not recorded as such because it came back as a 400.

The detail was never missing. Every invoker already builds an `ErrorResponse` carrying `status_code`, `reason` and the target's own `response_content`. It was being discarded on the way to the database, and what did survive was stored under a key no view reads.

Auditing the rest of the execution paths turned up two bugs worse than the one reported, both of which produce wrong answers rather than blank ones:

- **SDK/connector and WebSocket failures were scored into verdicts.** `is_http_error_response` only matches failures carrying a 4xx/5xx status, and no error path in `sdk_invoker.py` sets one. So the metrics-skip guard never fired, the error text went to the judges, and a call the target never answered could be stored as `Pass`.
- **The explorer reported failed invocations as successful outputs.** An invoker failure is a return value, not an exception, so the `except` clause never saw it. `generate_outputs` persisted "HTTP 401 error from endpoint" into `Test.test_metadata["output"]` and counted it as generated, and the suggestion pipeline ran LLM judges over it.

## What Changed

Four commits, one logical change each, reviewable in order.

**`fix(backend): detect status-less endpoint failures`** adds `is_endpoint_failure` / `has_endpoint_failure_in_result`, which treat any invoker failure as unscoreable regardless of whether it carries an HTTP status, and points the four metrics-skip sites at them. `is_http_error_response` stays for callers that specifically mean HTTP. Also fixes `extract_response_with_fallback` preferring `message` over `output` (those differ: `output` carries the status line plus the target's response body, `message` stops at "HTTP 400 error from endpoint"), and normalises the WebSocket invoker's `response_body` onto `response_content`, the key every reader actually uses.

**`fix(backend): keep 40x detail in batch results`** is the reported bug. Batch is the default mode and the only path that lost the detail: `invoke_with_retry` raises the `ErrorResponse`, so `_execute_single_test` caught it and stored `{"error": str(exc)}` as the whole of `test_output`, with no `output` key (hence the blank), no `status_code` and no `error_type`. A target rejection is a result rather than a crash, so it now returns through the same persist path the sequential runner uses. The deferred trace survives too, which it never did before. Permanent rejections also stop being re-invoked by the recovery round, which was hitting the customer's endpoint twice for every test that could never pass.

**`fix(backend): report endpoint errors to callers`** covers the four remaining entry points: the explorer contract above, the architect path (which reported `'ErrorResponse' object has no attribute 'get'` instead of the real 401), `POST /tests/execute` returning an opaque 500, and preflight dropping the response body. It also introduces the `internal_error` discriminator on the paths that were missing it, so a Rhesis-side bug is never attributed to the customer's endpoint.

**`fix(frontend): show endpoint failure detail`** adds one helper, `getEndpointFailure`, reading both shapes the backend writes: the flat error object for single-turn and the one nested under the first target turn for multi-turn. Nothing in the frontend had ever read the nested shape, which is why a multi-turn test rejected on its first message showed "No evaluation reasoning available". It replaces `getHttpErrorReason`, a local reimplementation in the grid utils that handled only the flat shape and only status-bearing failures.

For a reader, this is what changes: Overview gains a banner naming the status and reason and shows the target's actual response body instead of "No response available"; Metrics stops reporting "0.0%" and "0 of 0 metrics passed" for a test that nothing evaluated; Conversation renders the turn instead of dropping it for having an empty response; the grid's Evaluation column shows the failure instead of a bare dash, and its result-badge tooltip works again.

The Jobs activity log is now correct in both execution modes. Per test it reads `Test 37/120 endpoint error: HTTP 400 error from endpoint: Bad Request. Response content: {...}`, and the summary reads `Batch complete: 0 succeeded, 0 failed, 120 rejected by endpoint`. Sequential mode previously said "Test 1/1 completed" whatever happened and dropped the reason entirely on a real failure.

## Additional Context

Two things reviewers should weigh:

- **This is larger than the skill's 400-line guidance** (33 files, ~1400 lines added). The scope was chosen deliberately because the root cause is one shape problem with five symptoms across five services, and fixing the reported bug alone would have left the silent-wrong-verdict paths in place. The commits are separated so it can be read in four passes; commits 1 and 2 were each verified green in isolation for bisect.
- **Not yet exercised against a live endpoint.** Everything here is covered by unit tests and the type checker, but the end-to-end path (a real 400 from a real target, through a real batch run, into the drawer) has not been run. That is the main thing worth checking before this reaches the customer.

One thing found and preserved rather than changed: the frontend already had HTTP-error-aware code in `getHttpErrorReason`, feeding a hover tooltip on the result badge. It was dead in batch mode because the backend was not storing the fields it needed. The backend half of this PR brings that existing affordance back to life on its own.

`MetricTuningTab.test.tsx` fails on this branch and on `main` alike. It is a pre-existing `waitFor` flake with no import overlap with anything here.

## Testing

Automated, all passing:

```bash
cd apps/backend
uv run pytest ../../tests/backend/jobs/ ../../tests/backend/test_outcomes.py   # 624
uv run pytest ../../tests/backend/routes/ ../../tests/backend/services/        # 3932

cd apps/frontend
./node_modules/.bin/tsc --noEmit && npm run lint
npm test -- endpoint-failure                                                   # 13
```

New coverage: `tests/backend/jobs/test_endpoint_failure_surfacing.py` (25 tests) pins the stored output keeping the response body, status-less failures being detected, the batch path returning a 400 as a result while a transient failure still propagates, permanent rejections not being retried while our own exceptions still get their recovery round, and our own failures not being blamed on the target. `apps/frontend/src/utils/__tests__/endpoint-failure.test.ts` (13 tests) covers both output shapes, string status codes, the legacy `response_body` fallback, and the non-failure cases.

Manual check, which is the one that matters here:

1. Point an endpoint at something that returns `400` with a JSON body explaining why, for example a content filter.
2. Run a test set against it in parallel mode (the default).
3. In the test run, confirm the result badge tooltip names the status, and the Evaluation column shows the reason rather than a dash.
4. Open a failed result. Overview should show the banner with `HTTP 400` and the reason, and the Response field should contain the target's body. Metrics should say the test was not scored rather than showing 0%. Conversation should render the turn.
5. Open the run's job in Jobs and confirm the activity log names the status code and the reason, and that the summary counts the tests as rejected by the endpoint rather than as succeeded.
6. Confirm the endpoint received one request per test, not two.
