### PR TITLE
Enforce tracing-span limits through retention and an ingest backstop

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/b258958270d0_add_trace_retention_index.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/b258958270d0_add_trace_retention_index.py
@@ -1,0 +1,31 @@
+"""Add trace retention index (organization_id, created_at).
+
+The trace retention sweep (jobs/trace_retention.py) hard-deletes rows
+per org filtered by created_at. Without this composite index the sweep
+would need a sequential scan per org on every run.
+
+Revision ID: b258958270d0
+Revises: ff71b040aebf
+Create Date: 2026-09-01
+"""
+
+from typing import Union
+
+from alembic import op
+
+revision: str = "b258958270d0"
+down_revision: Union[str, None] = "ff71b040aebf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_trace_org_created",
+        "trace",
+        ["organization_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_trace_org_created", table_name="trace")

--- a/apps/backend/src/rhesis/backend/alembic/versions/b258958270d0_add_trace_retention_index.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/b258958270d0_add_trace_retention_index.py
@@ -5,7 +5,7 @@ per org filtered by created_at. Without this composite index the sweep
 would need a sequential scan per org on every run.
 
 Revision ID: b258958270d0
-Revises: ff71b040aebf
+Revises: 42f4cf7014a0
 Create Date: 2026-09-01
 """
 
@@ -14,7 +14,7 @@ from typing import Union
 from alembic import op
 
 revision: str = "b258958270d0"
-down_revision: Union[str, None] = "ff71b040aebf"
+down_revision: Union[str, None] = "42f4cf7014a0"
 branch_labels = None
 depends_on = None
 

--- a/apps/backend/src/rhesis/backend/app/auth/quota_gates.py
+++ b/apps/backend/src/rhesis/backend/app/auth/quota_gates.py
@@ -35,7 +35,11 @@ import logging
 from fastapi import Depends, Response
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app.dependencies import get_current_organization, get_tenant_db_session
+from rhesis.backend.app.dependencies import (
+    get_current_organization,
+    get_tenant_context,
+    get_tenant_db_session,
+)
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.quota import QuotaResource, QuotaResourceLike
 from rhesis.backend.app.quota.enforcement import (
@@ -98,6 +102,15 @@ def require_backstop(resource: QuotaResourceLike):
     request through. The telemetry ingest route's contract is that
     ingestion never fails because of a billing-side problem.
 
+    That contract is why this takes ``tenant_context`` and looks the org up
+    itself rather than depending on ``get_current_organization``. FastAPI
+    resolves sub-dependencies *before* the function body, so a
+    ``get_current_organization`` that 403s on a missing org row -- or 500s
+    on a transient failure in its own ``db.get`` -- would break ingestion
+    from outside the ``try``, which is exactly what this gate exists to
+    prevent. Both dependencies below are already on the ingest route, so
+    FastAPI dedupes them and this adds no new pre-body failure mode.
+
     Returns ``None`` (not the org) because the ingest route does not need
     the org from this dependency -- it already has it from its own
     ``get_tenant_context``.
@@ -105,11 +118,17 @@ def require_backstop(resource: QuotaResourceLike):
     resource = resource if isinstance(resource, QuotaResource) else QuotaResource(resource)
 
     def _dep(
-        org: Organization = Depends(get_current_organization),
+        tenant_context: tuple = Depends(get_tenant_context),
         db: Session = Depends(get_tenant_db_session),
     ) -> None:
+        organization_id = None
         try:
-            verdict = check_backstop(db, str(org.id), org, resource)
+            organization_id, _user_id = tenant_context
+            if not organization_id:
+                # No org to attribute usage to; nothing to backstop.
+                return
+            org = db.get(Organization, organization_id)
+            verdict = check_backstop(db, str(organization_id), org, resource)
             if not verdict.allowed:
                 raise QuotaExceededError(verdict)
         except QuotaExceededError:
@@ -117,7 +136,7 @@ def require_backstop(resource: QuotaResourceLike):
         except Exception:
             logger.warning(
                 "Backstop check failed for org %s, allowing request (fail-open)",
-                org.id,
+                organization_id,
                 exc_info=True,
             )
 

--- a/apps/backend/src/rhesis/backend/app/auth/quota_gates.py
+++ b/apps/backend/src/rhesis/backend/app/auth/quota_gates.py
@@ -30,13 +30,21 @@ of the same thing.
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import Depends, Response
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app.dependencies import get_current_organization, get_tenant_db_session
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.quota import QuotaResource, QuotaResourceLike
-from rhesis.backend.app.quota.enforcement import enforce_quota
+from rhesis.backend.app.quota.enforcement import (
+    QuotaExceededError,
+    check_backstop,
+    enforce_quota,
+)
+
+logger = logging.getLogger(__name__)
 
 #: Set on the response when a SOFT-policy org is past its limit but still
 #: inside the grace band -- allowed, but worth surfacing before the request
@@ -81,4 +89,39 @@ def require_quota(resource: QuotaResourceLike):
     return _dep
 
 
-__all__ = ["QUOTA_WARNING_HEADER", "require_quota"]
+def require_backstop(resource: QuotaResourceLike):
+    """Dependency factory: reject only at ``BACKSTOP_MULTIPLIER`` x the tier limit.
+
+    Unlike :func:`require_quota` this is a safety valve, not normal
+    enforcement. It **fails open**: any error during the check (DB
+    unreachable, bad org state, coding bug) logs a warning and allows the
+    request through. The telemetry ingest route's contract is that
+    ingestion never fails because of a billing-side problem.
+
+    Returns ``None`` (not the org) because the ingest route does not need
+    the org from this dependency -- it already has it from its own
+    ``get_tenant_context``.
+    """
+    resource = resource if isinstance(resource, QuotaResource) else QuotaResource(resource)
+
+    def _dep(
+        org: Organization = Depends(get_current_organization),
+        db: Session = Depends(get_tenant_db_session),
+    ) -> None:
+        try:
+            verdict = check_backstop(db, str(org.id), org, resource)
+            if not verdict.allowed:
+                raise QuotaExceededError(verdict)
+        except QuotaExceededError:
+            raise
+        except Exception:
+            logger.warning(
+                "Backstop check failed for org %s, allowing request (fail-open)",
+                org.id,
+                exc_info=True,
+            )
+
+    return _dep
+
+
+__all__ = ["QUOTA_WARNING_HEADER", "require_backstop", "require_quota"]

--- a/apps/backend/src/rhesis/backend/app/auth/quota_gates.py
+++ b/apps/backend/src/rhesis/backend/app/auth/quota_gates.py
@@ -128,6 +128,17 @@ def require_backstop(resource: QuotaResourceLike):
                 # No org to attribute usage to; nothing to backstop.
                 return
             org = db.get(Organization, organization_id)
+            if org is None:
+                # Bad org state, so fail open like any other lookup problem.
+                # Falling through with org=None would resolve the *community*
+                # policy and backstop a possibly-paid org at 10x the free
+                # tier -- a 402 on ingest caused purely by a billing-side
+                # lookup, which is what this gate exists to prevent.
+                logger.warning(
+                    "Backstop skipped: no organization row for %s (fail-open)",
+                    organization_id,
+                )
+                return
             verdict = check_backstop(db, str(organization_id), org, resource)
             if not verdict.allowed:
                 raise QuotaExceededError(verdict)

--- a/apps/backend/src/rhesis/backend/app/config/settings.py
+++ b/apps/backend/src/rhesis/backend/app/config/settings.py
@@ -356,6 +356,25 @@ class JobRetentionSettings(BaseSettings):
     retention_days: int = Field(default=90, alias="JOB_RETENTION_DAYS", gt=0)
 
 
+class TraceRetentionSettings(BaseSettings):
+    """Retention sweep for trace (span) rows, per-tier.
+
+    Disabled by default. When enabled, the sweep hard-deletes traces past
+    each org's tier-resolved retention window (``QuotaPolicy.retention_days``).
+    Starts in dry-run mode so the blast radius is visible before anything is
+    actually deleted.
+
+    ``TRACE_RETENTION_DAYS`` overrides the tier value for every org when set,
+    useful for self-hosted deployments without the EE tier system.
+    """
+
+    model_config = SettingsConfigDict(env_ignore_empty=True)
+
+    enabled: bool = Field(default=False, alias="TRACE_RETENTION_ENABLED")
+    dry_run: bool = Field(default=True, alias="TRACE_RETENTION_DRY_RUN")
+    override_days: int | None = Field(default=None, alias="TRACE_RETENTION_DAYS", gt=0)
+
+
 @lru_cache
 def get_database_settings() -> DatabaseSettings:
     return DatabaseSettings()
@@ -419,3 +438,8 @@ def get_telemetry_settings() -> TelemetrySettings:
 @lru_cache
 def get_job_retention_settings() -> JobRetentionSettings:
     return JobRetentionSettings()
+
+
+@lru_cache
+def get_trace_retention_settings() -> TraceRetentionSettings:
+    return TraceRetentionSettings()

--- a/apps/backend/src/rhesis/backend/app/models/trace.py
+++ b/apps/backend/src/rhesis/backend/app/models/trace.py
@@ -126,6 +126,7 @@ class Trace(
         Index("idx_trace_environment_time", "environment", start_time.desc()),
         Index("idx_trace_status_time", "status_code", start_time.desc()),
         Index("idx_trace_org_time", "organization_id", start_time.desc()),
+        Index("idx_trace_org_created", "organization_id", "created_at"),
         Index("idx_trace_test_run", "test_run_id", start_time.desc()),
         Index("idx_trace_test_result", "test_result_id"),
         Index("idx_trace_test", "test_id"),

--- a/apps/backend/src/rhesis/backend/app/quota/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/quota/__init__.py
@@ -49,6 +49,11 @@ class QuotaResource(str, Enum):
         return self.value
 
     TEST_EXECUTIONS = "test_executions"
+    # Not enforced at the published limit (a 402 would be silently dropped
+    # by the exporter's BatchSpanProcessor). Instead: crossing notification
+    # at the tier cap, tier-based retention sweep (jobs/trace_retention.py),
+    # and a backstop at BACKSTOP_MULTIPLIER x the limit on the ingest route
+    # (require_backstop in auth/quota_gates.py).
     TRACING_SPANS = "tracing_spans"
     TEST_GENERATION = "test_generation"
     MODEL_TOKENS = "model_tokens"
@@ -129,6 +134,8 @@ FREE_TIER_LIMITS: dict[QuotaResource, int | None] = {
     QuotaResource.ENDPOINTS: 3,
 }
 
+FREE_TIER_RETENTION_DAYS: int = 14
+
 # Every resource explicitly set to None (unlimited). Explicit keys rather than
 # an empty dict so the /features wire shape stays stable: callers always see
 # all seven resource names, whether the deployment enforces quotas or not.
@@ -146,6 +153,8 @@ class QuotaPolicy:
     :param overage_tolerance_percent: how far past a limit a ``SOFT`` tier
         may run before it hard-blocks, as a whole percent. ``0`` means no
         grace, which makes ``SOFT`` behave identically to ``HARD``.
+    :param retention_days: how many days of trace/span data the org keeps.
+        ``None`` means no retention enforcement (data kept indefinitely).
 
     A percent rather than a float multiplier so the tier YAML reads as
     ``overage_tolerance_percent: 25`` instead of ``1.25``, and so
@@ -158,6 +167,7 @@ class QuotaPolicy:
     limits: dict[QuotaResource, int | None] = field(default_factory=dict)
     overage: OveragePolicy = OveragePolicy.HARD
     overage_tolerance_percent: int = 0
+    retention_days: int | None = None
 
     def ceiling_for(self, limit: Optional[int]) -> Optional[int]:
         """Return the value of ``used`` at which *limit* actually blocks.
@@ -199,6 +209,16 @@ class QuotaPolicy:
             limits={**self.limits, **overrides},
             overage=self.overage,
             overage_tolerance_percent=self.overage_tolerance_percent,
+            retention_days=self.retention_days,
+        )
+
+    def with_retention_override(self, days: int) -> "QuotaPolicy":
+        """Return a copy with :attr:`retention_days` replaced."""
+        return QuotaPolicy(
+            limits=dict(self.limits),
+            overage=self.overage,
+            overage_tolerance_percent=self.overage_tolerance_percent,
+            retention_days=days,
         )
 
 
@@ -302,7 +322,7 @@ class DefaultQuotaProvider:
     """
 
     def get_policy(self, org: Optional[Organization] = None) -> QuotaPolicy:
-        return QuotaPolicy(limits=dict(FREE_TIER_LIMITS))
+        return QuotaPolicy(limits=dict(FREE_TIER_LIMITS), retention_days=FREE_TIER_RETENTION_DAYS)
 
 
 class QuotaRegistry:
@@ -374,6 +394,7 @@ class QuotaRegistry:
 __all__ = [
     "DefaultQuotaProvider",
     "FREE_TIER_LIMITS",
+    "FREE_TIER_RETENTION_DAYS",
     "OveragePolicy",
     "QUOTA_RESOURCE_LABELS",
     "QuotaPolicy",

--- a/apps/backend/src/rhesis/backend/app/quota/enforcement.py
+++ b/apps/backend/src/rhesis/backend/app/quota/enforcement.py
@@ -244,9 +244,57 @@ def enforce_quota(
     return verdict
 
 
+BACKSTOP_MULTIPLIER = 10
+
+
+def check_backstop(
+    db: Session,
+    org_id: str,
+    org: Optional[Organization],
+    resource: QuotaResource,
+) -> QuotaVerdict:
+    """Like :func:`check_quota` but at ``BACKSTOP_MULTIPLIER`` x the tier limit.
+
+    The backstop is a safety valve for runaway exporters, not normal quota
+    enforcement. It uses the tier's published limit (not the overage ceiling)
+    as the base, so a 10x backstop on a 1M-span Team tier fires at 10M, well
+    clear of the 1.25M soft overage band.
+
+    An unlimited tier (``limit is None``) is never backstopped.
+    """
+    policy = QuotaRegistry.get_policy(org)
+    limit = policy.limits.get(resource)
+    if limit is None:
+        return QuotaVerdict(
+            resource=resource,
+            used=0,
+            limit=None,
+            allowed=True,
+            over_limit=False,
+            kind=FLOW_KIND,
+            period_end=None,
+        )
+
+    used = _read_usage(db, org_id, resource)
+    backstop_ceiling = limit * BACKSTOP_MULTIPLIER
+    period_end = _current_period()[1].isoformat()
+
+    return QuotaVerdict(
+        resource=resource,
+        used=used,
+        limit=backstop_ceiling,
+        allowed=used < backstop_ceiling,
+        over_limit=used >= limit,
+        kind=FLOW_KIND,
+        period_end=period_end,
+    )
+
+
 __all__ = [
+    "BACKSTOP_MULTIPLIER",
     "QuotaExceededError",
     "QuotaVerdict",
+    "check_backstop",
     "check_quota",
     "enforce_quota",
     "quota_exceeded_response_body",

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -13,6 +13,7 @@ from rhesis.backend.app import schemas
 from rhesis.backend.app.auth.affordances import populate_review_permitted_actions
 from rhesis.backend.app.auth.capabilities import Permission
 from rhesis.backend.app.auth.principal import resolve_principal_from_request
+from rhesis.backend.app.auth.quota_gates import require_backstop
 from rhesis.backend.app.auth.rbac import project_id_from_scope
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.constants import EnrichedDataKeys, EntityType, TestResultStatus
@@ -32,6 +33,7 @@ from rhesis.backend.app.dependencies import (
     get_tenant_db_session,
 )
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.telemetry import (
     OTELTraceBatch,
@@ -79,6 +81,7 @@ def ingest_trace(
     tenant_context=Depends(get_tenant_context),
     scope_project_id: str | None = Depends(get_project_context),
     current_user: User = Depends(require_current_user_or_token),
+    _backstop: None = Depends(require_backstop(QuotaResource.TRACING_SPANS)),
 ) -> TraceResponse:
     """
     Ingest OpenTelemetry traces from SDK.
@@ -88,7 +91,11 @@ def ingest_trace(
 
     **Authentication**: Requires valid API key in Bearer token
 
-    **Rate Limiting**: Subject to per-project rate limits
+    **Quota**: Spans are metered (``QuotaResource.TRACING_SPANS``) and
+    subject to a backstop at 10x the tier limit. The published limit is
+    enforced by notification and retention, not by rejection; the backstop
+    only fires for runaway or abusive exporters. Fails open on lookup
+    errors so a billing-side problem never breaks ingestion.
 
     Args:
         trace_batch: Batch of OTEL spans to ingest

--- a/apps/backend/src/rhesis/backend/app/services/plan.py
+++ b/apps/backend/src/rhesis/backend/app/services/plan.py
@@ -18,6 +18,14 @@ from __future__ import annotations
 
 __all__ = ["build_plan"]
 
+#: Editions whose public name is not just the title-cased internal one.
+#: ``community`` is advertised on the pricing page as "Free" (see the header
+#: comment in ee/.../licensing/tier_config.yaml and FREE_TIER_LIMITS), so
+#: title-casing the edition string put "Community" in the UI next to limits
+#: the pricing page attributes to "Free". The mapping belongs here because
+#: ``name`` is contractually rendered verbatim by clients.
+_PLAIN_EDITION_NAMES = {"community": "Free"}
+
 
 def build_plan(license_info: dict) -> dict:
     """Build the plan payload a client renders, from a provider's ``info`` dict.
@@ -39,12 +47,21 @@ def build_plan(license_info: dict) -> dict:
     A lapsed paid tier carries the qualifier in ``name``, so the state is
     legible even where styling is not (a screenshot, a narrow column, a
     monochrome theme).
+
+    Editions whose public name differs from their internal one are mapped
+    through :data:`_PLAIN_EDITION_NAMES`; everything else is title-cased.
     """
     edition = str(license_info.get("edition", "community"))
     is_paid = bool(license_info.get("is_paid", False))
     is_active = bool(license_info.get("licensed", False))
 
-    name = edition.replace("_", " ").replace("-", " ").strip().title() or "Unknown"
+    name = (
+        _PLAIN_EDITION_NAMES.get(
+            edition.strip().lower(),
+            edition.replace("_", " ").replace("-", " ").strip().title(),
+        )
+        or "Unknown"
+    )
     if is_paid and not is_active:
         name = f"{name} (inactive)"
 

--- a/apps/backend/src/rhesis/backend/celery/config.py
+++ b/apps/backend/src/rhesis/backend/celery/config.py
@@ -109,6 +109,7 @@ CELERY_CONFIG = {
         "rhesis.backend.jobs.telemetry.evaluate",
         "rhesis.backend.jobs.telemetry.post_ingest",
         "rhesis.backend.jobs.retention",
+        "rhesis.backend.jobs.trace_retention",
     ],
     # Requires a `celery beat` process actually running against this app --
     # not deployed anywhere yet (see jobs/retention.py's own docstring for
@@ -119,6 +120,10 @@ CELERY_CONFIG = {
         "job-retention-sweep": {
             "task": "rhesis.backend.jobs.retention.sweep_expired_jobs",
             "schedule": crontab(hour=3, minute=0),
+        },
+        "trace-retention-sweep": {
+            "task": "rhesis.backend.jobs.trace_retention.sweep_expired_traces",
+            "schedule": crontab(hour=4, minute=0),
         },
     },
 }

--- a/apps/backend/src/rhesis/backend/jobs/trace_retention.py
+++ b/apps/backend/src/rhesis/backend/jobs/trace_retention.py
@@ -29,7 +29,13 @@ from rhesis.backend.celery.core import app
 
 logger = logging.getLogger(__name__)
 
-BACKSTOP_MULTIPLIER = 10
+#: Rows deleted per transaction. The first live run on an org with a long
+#: ingest history would otherwise delete its whole backlog in one statement,
+#: holding row locks and writing one large WAL burst for as long as that
+#: takes. Batching bounds both, at the cost of the sweep no longer being
+#: atomic per org -- which is fine here: a partial sweep just leaves rows for
+#: the next run, and the cutoff is recomputed from scratch each time.
+DELETE_BATCH_SIZE = 5_000
 
 
 def _resolve_retention_days(org: Organization, override_days: int | None) -> int | None:
@@ -45,35 +51,81 @@ def _resolve_retention_days(org: Organization, override_days: int | None) -> int
     return QuotaRegistry.get_policy(org).retention_days
 
 
+def _expired_traces(db, org: Organization, cutoff: datetime):
+    """Query for *org*'s trace rows older than *cutoff*.
+
+    The explicit ``organization_id`` predicate is what keeps the sweep
+    inside this org -- do not remove it. It is load-bearing rather than
+    belt-and-braces because callers run this under
+    :func:`~rhesis.backend.app.scope.bypass_tenant_filter`, so the ORM
+    auto-filter adds nothing of its own.
+    """
+    return db.query(Trace).filter(
+        Trace.organization_id == str(org.id),
+        Trace.created_at < cutoff,
+    )
+
+
+def _delete_in_batches(db, org: Organization, cutoff: datetime) -> int:
+    """Delete *org*'s expired traces in :data:`DELETE_BATCH_SIZE` chunks.
+
+    Returns the total number of rows deleted. Commits per batch, so a
+    failure part-way leaves the batches that already landed deleted and
+    the rest for the next run.
+
+    Selects primary keys first, then deletes by id: Postgres has no
+    ``DELETE ... LIMIT``, and this keeps each statement's row count bounded
+    without a correlated subquery.
+    """
+    total = 0
+    while True:
+        batch = _expired_traces(db, org, cutoff).with_entities(Trace.id).limit(DELETE_BATCH_SIZE)
+        ids = [row[0] for row in batch]
+        if not ids:
+            break
+
+        db.query(Trace).filter(Trace.id.in_(ids)).delete(synchronize_session=False)
+        db.commit()
+        total += len(ids)
+
+        # A short batch means the table had fewer than a full batch left,
+        # so there is nothing to come back for.
+        if len(ids) < DELETE_BATCH_SIZE:
+            break
+    return total
+
+
 def _sweep_organization(
     org: Organization,
     cutoff: datetime,
     *,
     dry_run: bool,
-) -> int:
+) -> int | None:
     """Delete (or count) this org's trace rows past *cutoff*.
 
     Returns the number of rows deleted (or that would be deleted in
-    dry-run mode).
+    dry-run mode), or ``None`` if the sweep failed for this org.
+
+    ``None`` rather than ``0`` on failure so the caller can tell "nothing
+    to delete" apart from "the delete blew up"; both used to report zero,
+    which made a run where every org errored indistinguishable from a
+    clean one.
+
+    Runs under ``bypass_tenant_filter``: the session's scope has no
+    project, so the ORM auto-filter would otherwise add
+    ``project_id IS NULL`` and match no traces at all.
     """
     db = SessionLocal()
     try:
         bind_scope_to_session(db, str(org.id))
         with bypass_tenant_filter():
-            query = db.query(Trace).filter(
-                Trace.organization_id == str(org.id),
-                Trace.created_at < cutoff,
-            )
             if dry_run:
-                count = query.count()
-            else:
-                count = query.delete(synchronize_session=False)
-                db.commit()
-        return count
+                return _expired_traces(db, org, cutoff).count()
+            return _delete_in_batches(db, org, cutoff)
     except Exception:
         db.rollback()
         logger.exception("Trace retention sweep failed for organization %s", org.id)
-        return 0
+        return None
     finally:
         db.close()
 
@@ -89,6 +141,7 @@ def sweep_expired_traces(self) -> dict:
     now = datetime.now(timezone.utc)
     total_deleted = 0
     orgs_swept = 0
+    orgs_failed = 0
 
     db = SessionLocal()
     try:
@@ -104,6 +157,9 @@ def sweep_expired_traces(self) -> dict:
 
             cutoff = now - timedelta(days=retention_days)
             count = _sweep_organization(org, cutoff, dry_run=settings.dry_run)
+            if count is None:
+                orgs_failed += 1
+                continue
             if count > 0:
                 logger.info(
                     "Trace retention %s: org=%s retention=%dd cutoff=%s rows=%d",
@@ -117,17 +173,20 @@ def sweep_expired_traces(self) -> dict:
                 orgs_swept += 1
         except Exception:
             logger.exception("Unexpected error sweeping organization %s", org.id)
+            orgs_failed += 1
             continue
 
     logger.info(
-        "Trace retention sweep complete (%s): %d row(s) across %d org(s)",
+        "Trace retention sweep complete (%s): %d row(s) across %d org(s), %d failed",
         "dry-run" if settings.dry_run else "live",
         total_deleted,
         orgs_swept,
+        orgs_failed,
     )
     return {
         "enabled": True,
         "dry_run": settings.dry_run,
         "traces_affected": total_deleted,
         "orgs_swept": orgs_swept,
+        "orgs_failed": orgs_failed,
     }

--- a/apps/backend/src/rhesis/backend/jobs/trace_retention.py
+++ b/apps/backend/src/rhesis/backend/jobs/trace_retention.py
@@ -1,0 +1,133 @@
+"""Hard-deletes trace (span) rows past each org's tier retention window.
+
+Disabled by default (``TRACE_RETENTION_ENABLED``), and defaults to dry-run
+when first enabled (``TRACE_RETENTION_DRY_RUN``) so the blast radius is
+visible in logs before anything is actually deleted.
+
+Retention days come from the org's resolved ``QuotaPolicy.retention_days``
+(tier catalog + any per-org ``custom_retention_days`` override on the
+license token). ``TRACE_RETENTION_DAYS`` overrides the tier value for all
+orgs when set (useful for self-hosted deployments without the EE tier
+system). An org whose resolved retention is ``None`` (unlimited) is skipped.
+
+Each org is swept in its own session and transaction, same pattern as
+``jobs/retention.py``. See that module's docstring for the rationale on
+explicit ``organization_id`` filters, ``bind_scope_to_session`` for RLS
+GUCs, and per-org error isolation.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from rhesis.backend.app.config.settings import get_trace_retention_settings
+from rhesis.backend.app.database import SessionLocal, bind_scope_to_session
+from rhesis.backend.app.models.organization import Organization
+from rhesis.backend.app.models.trace import Trace
+from rhesis.backend.app.quota import QuotaRegistry
+from rhesis.backend.app.scope import bypass_tenant_filter
+from rhesis.backend.celery.core import app
+
+logger = logging.getLogger(__name__)
+
+BACKSTOP_MULTIPLIER = 10
+
+
+def _resolve_retention_days(org: Organization, override_days: int | None) -> int | None:
+    """Return the effective retention window for *org*, in days.
+
+    If the settings carry a global ``TRACE_RETENTION_DAYS`` override, it
+    wins for every org (self-hosted convenience). Otherwise the tier
+    catalog + any per-org ``custom_retention_days`` on the license token
+    is used.
+    """
+    if override_days is not None:
+        return override_days
+    return QuotaRegistry.get_policy(org).retention_days
+
+
+def _sweep_organization(
+    org: Organization,
+    cutoff: datetime,
+    *,
+    dry_run: bool,
+) -> int:
+    """Delete (or count) this org's trace rows past *cutoff*.
+
+    Returns the number of rows deleted (or that would be deleted in
+    dry-run mode).
+    """
+    db = SessionLocal()
+    try:
+        bind_scope_to_session(db, str(org.id))
+        with bypass_tenant_filter():
+            query = db.query(Trace).filter(
+                Trace.organization_id == str(org.id),
+                Trace.created_at < cutoff,
+            )
+            if dry_run:
+                count = query.count()
+            else:
+                count = query.delete(synchronize_session=False)
+                db.commit()
+        return count
+    except Exception:
+        db.rollback()
+        logger.exception("Trace retention sweep failed for organization %s", org.id)
+        return 0
+    finally:
+        db.close()
+
+
+@app.task(bind=True)
+def sweep_expired_traces(self) -> dict:
+    """Delete trace rows past each org's retention window, org by org."""
+    settings = get_trace_retention_settings()
+    if not settings.enabled:
+        logger.debug("Trace retention sweep disabled (TRACE_RETENTION_ENABLED=false); skipping")
+        return {"enabled": False}
+
+    now = datetime.now(timezone.utc)
+    total_deleted = 0
+    orgs_swept = 0
+
+    db = SessionLocal()
+    try:
+        all_orgs = db.query(Organization).all()
+    finally:
+        db.close()
+
+    for org in all_orgs:
+        try:
+            retention_days = _resolve_retention_days(org, settings.override_days)
+            if retention_days is None:
+                continue
+
+            cutoff = now - timedelta(days=retention_days)
+            count = _sweep_organization(org, cutoff, dry_run=settings.dry_run)
+            if count > 0:
+                logger.info(
+                    "Trace retention %s: org=%s retention=%dd cutoff=%s rows=%d",
+                    "dry-run" if settings.dry_run else "deleted",
+                    org.id,
+                    retention_days,
+                    cutoff.isoformat(),
+                    count,
+                )
+                total_deleted += count
+                orgs_swept += 1
+        except Exception:
+            logger.exception("Unexpected error sweeping organization %s", org.id)
+            continue
+
+    logger.info(
+        "Trace retention sweep complete (%s): %d row(s) across %d org(s)",
+        "dry-run" if settings.dry_run else "live",
+        total_deleted,
+        orgs_swept,
+    )
+    return {
+        "enabled": True,
+        "dry_run": settings.dry_run,
+        "traces_affected": total_deleted,
+        "orgs_swept": orgs_swept,
+    }

--- a/apps/backend/src/rhesis/backend/jobs/trace_retention.py
+++ b/apps/backend/src/rhesis/backend/jobs/trace_retention.py
@@ -10,6 +10,11 @@ license token). ``TRACE_RETENTION_DAYS`` overrides the tier value for all
 orgs when set (useful for self-hosted deployments without the EE tier
 system). An org whose resolved retention is ``None`` (unlimited) is skipped.
 
+That last rule is what makes ``TRACE_RETENTION_DAYS`` the operative knob off
+Rhesis cloud: with ``USAGE_QUOTAS_ENABLED`` false (the default), every policy
+resolves unlimited and so carries ``retention_days=None``, meaning enabling
+the sweep on its own deletes nothing. Set the override too, or leave quotas on.
+
 Each org is swept in its own session and transaction, same pattern as
 ``jobs/retention.py``. See that module's docstring for the rationale on
 explicit ``organization_id`` filters, ``bind_scope_to_session`` for RLS

--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -67,6 +67,13 @@ const nextConfig = {
   // @mui/material/useMediaQuery calls a 'use client' export at module-evaluation
   // time, which fails whenever the module lands in the RSC server graph. That is
   // fixed by patches/@mui+material+7.3.5.patch, which defers the call.
+  //
+  // That patch is why @mui/material is pinned to an exact version in
+  // package.json instead of "^7". postinstall runs `patch-package
+  // --error-on-fail`, and patch files are matched by the version in their
+  // name, so a floating range lets the first `npm install` after any 7.x
+  // release resolve past 7.3.5 and hard-fail the install if MUI has touched
+  // the patched lines. Bump the pin and re-cut the patch together.
 
   // Environment variables available to the client
   // NEXT_PUBLIC_ prefix guarantees availability in client components

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "@icons-pack/react-simple-icons": "^13.12.0",
         "@monaco-editor/react": "^4.7.0",
         "@mui/icons-material": "^7",
-        "@mui/material": "^7",
+        "@mui/material": "7.3.5",
         "@mui/material-nextjs": "^7",
         "@mui/x-charts": "^8.19.0",
         "@mui/x-data-grid": "^7.27.3",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -39,7 +39,7 @@
     "@icons-pack/react-simple-icons": "^13.12.0",
     "@monaco-editor/react": "^4.7.0",
     "@mui/icons-material": "^7",
-    "@mui/material": "^7",
+    "@mui/material": "7.3.5",
     "@mui/material-nextjs": "^7",
     "@mui/x-charts": "^8.19.0",
     "@mui/x-data-grid": "^7.27.3",

--- a/docs/content/docs/deployment/environment-variables.mdx
+++ b/docs/content/docs/deployment/environment-variables.mdx
@@ -192,6 +192,29 @@ See [Telemetry System Documentation](/contribute/telemetry) for what is collecte
 | `CELERY_WORKER_CONCURRENCY` | Worker process concurrency | `8` |
 | `CELERY_WORKER_PREFETCH_MULTIPLIER` | Tasks prefetched per worker process | `4` |
 
+## Data retention
+
+Two scheduled sweeps hard-delete rows past a retention window: one for `job` and `activity_log`
+rows, one for trace (span) rows. Both are off by default, and both run from `celery beat` — with no
+beat process against the backend, enabling either has no effect.
+
+<Callout type="warning">
+These deletes are permanent. Keep `TRACE_RETENTION_DRY_RUN` at `true` for the first run: the sweep
+then logs the row count it would delete per organization, without deleting anything.
+</Callout>
+
+| Variable | Description | Default |
+|---|---|---|
+| `JOB_RETENTION_ENABLED` | Run the `job`/`activity_log` sweep, 03:00 UTC | `false` |
+| `JOB_RETENTION_DAYS` | Age at which those rows are deleted | `90` |
+| `TRACE_RETENTION_ENABLED` | Run the trace sweep, 04:00 UTC | `false` |
+| `TRACE_RETENTION_DRY_RUN` | Count and log instead of deleting | `true` |
+| `TRACE_RETENTION_DAYS` | Retention window for every organization, overriding the per-plan value | *(unset)* |
+
+The trace sweep reads its window from each organization's resolved plan. Self-hosted deployments
+have no usage limits, so every organization resolves to unlimited retention and the sweep deletes
+nothing until `TRACE_RETENTION_DAYS` supplies a window. Set it to put the whole deployment on one.
+
 ## Advanced
 
 Rarely changed; the defaults are correct for most deployments.

--- a/ee/backend/src/rhesis/backend/ee/licensing/cli.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/cli.py
@@ -241,6 +241,7 @@ def cmd_mint(args: argparse.Namespace) -> None:
         kid=args.kid,
         custom_features=custom_features,
         custom_limits=custom_limits,
+        custom_retention_days=args.retention_days,
     )
 
     if args.secret_name:
@@ -297,6 +298,7 @@ def cmd_issue(args: argparse.Namespace) -> None:
             kid=args.kid,
             custom_features=custom_features,
             custom_limits=custom_limits,
+            custom_retention_days=args.retention_days,
         )
         _print_summary(args.org, args.kid, token, dry_run=True)
         return
@@ -325,6 +327,7 @@ def cmd_issue(args: argparse.Namespace) -> None:
             dry_run=False,
             custom_features=custom_features,
             custom_limits=custom_limits,
+            custom_retention_days=args.retention_days,
         )
         # Best-effort: the license write above already succeeded, so a lookup
         # failure here should degrade to an unlabeled summary, not fail the
@@ -472,6 +475,17 @@ def _build_parser() -> argparse.ArgumentParser:
                 "Overlaid on the tier's live limits at enforcement time; resources left "
                 "out keep following the published tier. Use null for unlimited. This is "
                 'how a "custom" enterprise cap is set.'
+            ),
+        )
+        p.add_argument(
+            "--retention-days",
+            default=None,
+            type=int,
+            metavar="DAYS",
+            help=(
+                "Per-org trace retention window in days, overriding the tier's "
+                "published retention_days. Consumed by the trace retention sweep. "
+                "Must be a positive integer; omit to follow the tier."
             ),
         )
 

--- a/ee/backend/src/rhesis/backend/ee/licensing/entitlements.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/entitlements.py
@@ -118,6 +118,9 @@ LIC_LIMITS = "limits"
 #: enforcing it would pin every org to its mint-time numbers and silently
 #: ignore later pricing changes.
 LIC_CUSTOM_LIMITS = "custom_limits"
+#: Per-org retention-days override, present only when explicitly minted.
+#: Overlaid on the tier's ``retention_days`` by ``ConfigQuotaProvider``.
+LIC_CUSTOM_RETENTION_DAYS = "custom_retention_days"
 
 # --- Environment variable names --------------------------------------------
 ENV_TIER_CONFIG = "RHESIS_TIER_CONFIG"
@@ -181,6 +184,12 @@ class Entitlements:
     """Bespoke per-org limit overrides, empty unless explicitly minted. These
     *are* enforced, overlaid on the tier catalog. See :data:`LIC_CUSTOM_LIMITS`.
     Always a read-only mapping, see :meth:`__post_init__`."""
+
+    custom_retention_days: Any = None
+    """Per-org retention-days override, raw value from the token. Validated
+    by :class:`~rhesis.backend.ee.licensing.quota_provider.ConfigQuotaProvider`
+    at resolution time (must be a positive int, not a bool). ``None`` when
+    the claim is absent."""
 
     jti: Optional[str] = None
     """JWT ID for audit logging and future revocation support."""
@@ -256,6 +265,7 @@ __all__ = [
     "LIC_EDITION",
     "LIC_FEATURES",
     "LIC_CUSTOM_LIMITS",
+    "LIC_CUSTOM_RETENTION_DAYS",
     "LIC_LIMITS",
     "LIC_STATUS",
     "REQUIRED_CLAIMS",

--- a/ee/backend/src/rhesis/backend/ee/licensing/mint.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/mint.py
@@ -55,6 +55,7 @@ from rhesis.backend.ee.licensing.entitlements import (
     ENV_LICENSE_PRIVATE_KEY,
     LIC_ALL_FEATURES,
     LIC_CUSTOM_LIMITS,
+    LIC_CUSTOM_RETENTION_DAYS,
     LIC_FEATURES,
     LICENSE_ALGORITHM,
     LICENSE_AUDIENCE,
@@ -133,6 +134,7 @@ def mint_token(
     *,
     custom_features: Optional[list[str]] = None,
     custom_limits: Optional[dict[str, Any]] = None,
+    custom_retention_days: Optional[int] = None,
 ) -> str:
     """Mint and sign a license JWT for *org_id*.
 
@@ -159,10 +161,23 @@ def mint_token(
         tier and a later pricing change still reaches this customer. Use
         ``None`` as a value to make one resource unlimited. This is the
         mechanism behind the pricing page's "custom" enterprise limits.
+    :param custom_retention_days: Bespoke trace-retention window for this org,
+        in days, written to the ``custom_retention_days`` claim. Overrides the
+        tier's published ``retention_days`` at enforcement time (the sweep in
+        ``jobs/trace_retention.py``). Must be a positive int; the resolver
+        ignores anything else and keeps the tier value.
     :returns: Signed JWT string.
     :raises RuntimeError: if the private key is unavailable or invalid, or if
         *edition* is not a sellable tier.
+    :raises ValueError: if *custom_retention_days* is not a positive int.
     """
+    if custom_retention_days is not None and (
+        isinstance(custom_retention_days, bool) or custom_retention_days <= 0
+    ):
+        raise ValueError(
+            f"custom_retention_days must be a positive int, got {custom_retention_days!r}"
+        )
+
     private_key = _load_private_key()
 
     now = int(datetime.now(tz=timezone.utc).timestamp())
@@ -185,6 +200,9 @@ def mint_token(
         # from the tier's own numbers, and enforcing it would pin this org to
         # its mint-time limits for good. See LIC_CUSTOM_LIMITS.
         lic_claim[LIC_CUSTOM_LIMITS] = dict(custom_limits)
+
+    if custom_retention_days is not None:
+        lic_claim[LIC_CUSTOM_RETENTION_DAYS] = custom_retention_days
 
     payload: dict[str, Any] = {
         CLAIM_ISSUER: LICENSE_ISSUER,
@@ -229,6 +247,7 @@ def issue(
     dry_run: bool = False,
     custom_features: Optional[list[str]] = None,
     custom_limits: Optional[dict[str, Any]] = None,
+    custom_retention_days: Optional[int] = None,
 ) -> str:
     """Mint a token and (unless *dry_run*) write it to ``organization.license``.
 
@@ -267,6 +286,7 @@ def issue(
         kid=kid,
         custom_features=custom_features,
         custom_limits=custom_limits,
+        custom_retention_days=custom_retention_days,
     )
 
     if dry_run:

--- a/ee/backend/src/rhesis/backend/ee/licensing/provider.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/provider.py
@@ -156,6 +156,8 @@ class SignedTokenLicenseProvider:
         # the consuming side instead of two cases it has to distinguish.
         if entitlements.custom_limits:
             info["custom_limits"] = dict(entitlements.custom_limits)
+        if entitlements.custom_retention_days is not None:
+            info["custom_retention_days"] = entitlements.custom_retention_days
         return info
 
     # ------------------------------------------------------------------ #

--- a/ee/backend/src/rhesis/backend/ee/licensing/quota_provider.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/quota_provider.py
@@ -32,7 +32,11 @@ from typing import Optional
 
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.quota import QuotaPolicy, limits_from_wire
-from rhesis.backend.ee.licensing.entitlements import LIC_CUSTOM_LIMITS, LicenseEdition
+from rhesis.backend.ee.licensing.entitlements import (
+    LIC_CUSTOM_LIMITS,
+    LIC_CUSTOM_RETENTION_DAYS,
+    LicenseEdition,
+)
 from rhesis.backend.ee.licensing.tiers import resolve_policy
 
 logger = logging.getLogger(__name__)
@@ -101,26 +105,37 @@ class ConfigQuotaProvider:
         policy = resolve_policy(edition)
 
         overrides = limits_from_wire(info.get(LIC_CUSTOM_LIMITS))
-        if not overrides:
-            return policy
+        if overrides:
+            # DEBUG, and resource names without their values. This runs on the
+            # request path -- every quota gate and every hosted-model call resolves
+            # a policy -- so INFO here is one line per request for the orgs that
+            # have overrides. The values are also a customer's negotiated caps,
+            # which is contract detail that should not be sitting in log storage;
+            # the names alone are enough to answer "did an override apply, and to
+            # what" when debugging, and the effective numbers are already visible
+            # on `GET /usage`.
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "Applied %d custom limit override(s) for org %s (edition=%s) on: %s",
+                    len(overrides),
+                    getattr(org, "id", None),
+                    edition.value if edition else None,
+                    ", ".join(sorted(r.value for r in overrides)),
+                )
+            policy = policy.with_limit_overrides(overrides)
 
-        # DEBUG, and resource names without their values. This runs on the
-        # request path -- every quota gate and every hosted-model call resolves
-        # a policy -- so INFO here is one line per request for the orgs that
-        # have overrides. The values are also a customer's negotiated caps,
-        # which is contract detail that should not be sitting in log storage;
-        # the names alone are enough to answer "did an override apply, and to
-        # what" when debugging, and the effective numbers are already visible
-        # on `GET /usage`.
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                "Applied %d custom limit override(s) for org %s (edition=%s) on: %s",
-                len(overrides),
-                getattr(org, "id", None),
-                edition.value if edition else None,
-                ", ".join(sorted(r.value for r in overrides)),
-            )
-        return policy.with_limit_overrides(overrides)
+        custom_retention = info.get(LIC_CUSTOM_RETENTION_DAYS)
+        if isinstance(custom_retention, int) and not isinstance(custom_retention, bool):
+            if custom_retention > 0:
+                policy = policy.with_retention_override(custom_retention)
+            else:
+                logger.warning(
+                    "Ignoring non-positive custom_retention_days %r for org %s",
+                    custom_retention,
+                    getattr(org, "id", None),
+                )
+
+        return policy
 
 
 __all__ = ["ConfigQuotaProvider"]

--- a/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
@@ -138,6 +138,7 @@ class TierSpec:
             limits=dict(self.limits),
             overage=self.overage,
             overage_tolerance_percent=self.overage_tolerance_percent,
+            retention_days=self.retention_days,
         )
 
     def feature_values(self) -> list[str]:

--- a/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
@@ -116,7 +116,10 @@ class TierSpec:
         granted when ``all_features`` is ``False``.
     :param limits: metered resource limits keyed by
         :class:`QuotaResource`.  ``None`` values mean unlimited.
-    :param retention_days: data retention in days for this tier.
+    :param retention_days: data retention in days for this tier, as published
+        on the pricing page. Consumed by the trace retention sweep
+        (``jobs/trace_retention.py``), which hard-deletes trace rows older
+        than this. ``None`` means unlimited (the sweep skips the org).
     :param overage: whether reaching a limit blocks immediately or allows
         the grace band in :attr:`overage_tolerance_percent`.
     :param overage_tolerance_percent: for :attr:`OveragePolicy.SOFT`, how
@@ -128,7 +131,7 @@ class TierSpec:
     all_features: bool = False
     features: frozenset[FeatureName] = frozenset()
     limits: dict[QuotaResource, int | None] = field(default_factory=dict)
-    retention_days: int = 14
+    retention_days: Optional[int] = 14
     overage: OveragePolicy = OveragePolicy.HARD
     overage_tolerance_percent: int = 0
 
@@ -291,6 +294,36 @@ def _parse_overage_tolerance(raw: object) -> int:
     return raw
 
 
+def _parse_retention_days(raw: object) -> Optional[int]:
+    """Validate a raw YAML ``retention_days`` value.
+
+    ``None`` means unlimited, matching this file's ``null = unlimited``
+    convention for limits. Otherwise a positive ``int`` -- ``bool`` is
+    rejected explicitly (it passes ``isinstance(v, int)``), and zero or
+    negative would set a cutoff at or after "now", making the retention
+    sweep delete every trace the org has.
+
+    Validated rather than passed through because the sweep now consumes
+    this value: a string ``"90"`` from a mounted ConfigMap would reach
+    ``timedelta(days="90")`` and raise per org inside the sweep's blanket
+    ``except Exception``, so retention would silently never run for the tier.
+
+    :raises ValueError: if *raw* is neither ``None`` nor a positive ``int``.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise ValueError(
+            f"Invalid retention_days in tier config: {raw!r} "
+            f"({type(raw).__name__}). Expected a positive integer or null."
+        )
+    if raw <= 0:
+        raise ValueError(
+            f"Invalid retention_days in tier config: {raw!r}. Must be positive (or null)."
+        )
+    return raw
+
+
 class _FallbackCatalog(dict):
     """Marks a catalog as the intentional safety-net from :func:`_fallback_catalog`.
 
@@ -403,9 +436,9 @@ def _load_tier_config() -> dict[LicenseEdition, TierSpec]:
         # defaults apply for the rest. Hardcoding e.g. `retention_days=14`
         # here would duplicate TierSpec's default and silently drift from
         # it if that default ever changes.
-        overrides: dict[str, object] = {
-            key: spec_raw[key] for key in ("retention_days",) if key in spec_raw
-        }
+        overrides: dict[str, object] = {}
+        if "retention_days" in spec_raw:
+            overrides["retention_days"] = _parse_retention_days(spec_raw["retention_days"])
         if "all_features" in spec_raw:
             overrides["all_features"] = _parse_all_features(spec_raw["all_features"])
         if "overage" in spec_raw:

--- a/ee/backend/src/rhesis/backend/ee/licensing/verify.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/verify.py
@@ -35,6 +35,7 @@ from rhesis.backend.ee.licensing.entitlements import (
     CLAIM_SUBJECT,
     LIC_ALL_FEATURES,
     LIC_CUSTOM_LIMITS,
+    LIC_CUSTOM_RETENTION_DAYS,
     LIC_EDITION,
     LIC_FEATURES,
     LIC_LIMITS,
@@ -215,6 +216,7 @@ def _payload_to_entitlements(payload: dict) -> Optional[Entitlements]:
             expires_at=expires_at,
             limits=_mapping_claim(lic, LIC_LIMITS),
             custom_limits=_mapping_claim(lic, LIC_CUSTOM_LIMITS),
+            custom_retention_days=lic.get(LIC_CUSTOM_RETENTION_DAYS),
             jti=payload.get(CLAIM_JWT_ID),
         )
     except (KeyError, TypeError, ValueError) as exc:

--- a/tests/backend/app/test_quota_enforcement.py
+++ b/tests/backend/app/test_quota_enforcement.py
@@ -13,7 +13,9 @@ import pytest
 from rhesis.backend.app.models.project import Project
 from rhesis.backend.app.quota import OveragePolicy, QuotaPolicy, QuotaRegistry, QuotaResource
 from rhesis.backend.app.quota.enforcement import (
+    BACKSTOP_MULTIPLIER,
     QuotaExceededError,
+    check_backstop,
     check_quota,
     enforce_quota,
     quota_exceeded_response_body,
@@ -226,3 +228,73 @@ class TestQuotaExceededResponseBody:
         assert body["kind"] == "flow"
         assert body["period_end"] == verdict.period_end
         assert "test runs" in body["message"]
+
+
+class TestCheckBackstopUnlimited:
+    """An unlimited tier (limit is None) is never backstopped."""
+
+    def test_unlimited_is_always_allowed(self, test_db, test_org_id, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.TRACING_SPANS: None}))
+        increment_usage(test_db, test_org_id, QuotaResource.TRACING_SPANS, 999_999_999)
+
+        verdict = check_backstop(test_db, test_org_id, None, QuotaResource.TRACING_SPANS)
+
+        assert verdict.allowed is True
+        assert verdict.limit is None
+
+
+class TestCheckBackstopBoundary:
+    """The backstop fires at BACKSTOP_MULTIPLIER x the tier limit (10x by default).
+
+    With a limit of 100, the backstop ceiling is 1,000. Off-by-one matters:
+    999 is allowed, 1,000 is blocked.
+    """
+
+    def _install_100(self):
+        _install(QuotaPolicy(limits={QuotaResource.TRACING_SPANS: 100}))
+
+    def test_below_backstop_is_allowed(self, test_db, test_org_id, clean_registry):
+        self._install_100()
+        increment_usage(test_db, test_org_id, QuotaResource.TRACING_SPANS, 999)
+
+        verdict = check_backstop(test_db, test_org_id, None, QuotaResource.TRACING_SPANS)
+
+        assert verdict.allowed is True
+
+    def test_at_backstop_is_blocked(self, test_db, test_org_id, clean_registry):
+        self._install_100()
+        backstop = 100 * BACKSTOP_MULTIPLIER
+        increment_usage(test_db, test_org_id, QuotaResource.TRACING_SPANS, backstop)
+
+        verdict = check_backstop(test_db, test_org_id, None, QuotaResource.TRACING_SPANS)
+
+        assert verdict.allowed is False
+        assert verdict.limit == backstop
+
+    def test_above_the_tier_limit_but_below_backstop_is_allowed(
+        self, test_db, test_org_id, clean_registry
+    ):
+        """The backstop is not normal enforcement. Usage past the tier limit
+        but below 10x is allowed -- the published limit is enforced by
+        notifications and retention, not rejection."""
+        self._install_100()
+        increment_usage(test_db, test_org_id, QuotaResource.TRACING_SPANS, 500)
+
+        verdict = check_backstop(test_db, test_org_id, None, QuotaResource.TRACING_SPANS)
+
+        assert verdict.allowed is True
+        assert verdict.over_limit is True
+
+    def test_verdict_limit_is_the_backstop_ceiling_not_the_tier_limit(
+        self, test_db, test_org_id, clean_registry
+    ):
+        """The verdict.limit field carries the backstop ceiling so a 402 body
+        built from it shows the actual threshold that was crossed, not the
+        published tier limit the org passed long ago."""
+        self._install_100()
+        backstop = 100 * BACKSTOP_MULTIPLIER
+        increment_usage(test_db, test_org_id, QuotaResource.TRACING_SPANS, backstop)
+
+        verdict = check_backstop(test_db, test_org_id, None, QuotaResource.TRACING_SPANS)
+
+        assert verdict.limit == backstop

--- a/tests/backend/ee/licensing/conftest.py
+++ b/tests/backend/ee/licensing/conftest.py
@@ -30,6 +30,7 @@ from rhesis.backend.ee.licensing.entitlements import (
     CLAIM_SUBJECT,
     LIC_ALL_FEATURES,
     LIC_CUSTOM_LIMITS,
+    LIC_CUSTOM_RETENTION_DAYS,
     LIC_EDITION,
     LIC_FEATURES,
     LIC_LIMITS,
@@ -42,6 +43,8 @@ from rhesis.backend.ee.licensing.verify import _parse_token
 
 # Test key id baked into every minted token and the patched key map.
 TEST_KID = "test-v1"
+
+_SENTINEL = object()
 
 
 @pytest.fixture(scope="session")
@@ -71,6 +74,7 @@ def mint_token(ed25519_keypair):
         features: Optional[list] = None,
         limits: Optional[dict] = None,
         custom_limits: Optional[dict] = None,
+        custom_retention_days: Any = _SENTINEL,
         exp: Optional[int] = None,
         iss: str = LICENSE_ISSUER,
         aud: str = LICENSE_AUDIENCE,
@@ -90,6 +94,8 @@ def mint_token(ed25519_keypair):
         # in the wild -- no custom_limits claim at all.
         if custom_limits is not None:
             lic[LIC_CUSTOM_LIMITS] = custom_limits
+        if custom_retention_days is not _SENTINEL:
+            lic[LIC_CUSTOM_RETENTION_DAYS] = custom_retention_days
         payload: dict[str, Any] = {
             CLAIM_ISSUER: iss,
             CLAIM_AUDIENCE: aud,

--- a/tests/backend/ee/licensing/test_licensing_loopholes.py
+++ b/tests/backend/ee/licensing/test_licensing_loopholes.py
@@ -46,7 +46,6 @@ from rhesis.backend.ee.licensing.entitlements import (
     CLAIM_SUBJECT,
     LIC_ALL_FEATURES,
     LIC_CUSTOM_LIMITS,
-    LIC_CUSTOM_RETENTION_DAYS,
     LIC_EDITION,
     LIC_FEATURES,
     LIC_LIMITS,

--- a/tests/backend/ee/licensing/test_licensing_loopholes.py
+++ b/tests/backend/ee/licensing/test_licensing_loopholes.py
@@ -46,6 +46,7 @@ from rhesis.backend.ee.licensing.entitlements import (
     CLAIM_SUBJECT,
     LIC_ALL_FEATURES,
     LIC_CUSTOM_LIMITS,
+    LIC_CUSTOM_RETENTION_DAYS,
     LIC_EDITION,
     LIC_FEATURES,
     LIC_LIMITS,
@@ -56,7 +57,7 @@ from rhesis.backend.ee.licensing.entitlements import (
 )
 from rhesis.backend.ee.licensing.provider import SignedTokenLicenseProvider
 from rhesis.backend.ee.licensing.quota_provider import ConfigQuotaProvider
-from rhesis.backend.ee.licensing.tiers import resolve_limits, resolve_tier
+from rhesis.backend.ee.licensing.tiers import resolve_limits, resolve_policy, resolve_tier
 from rhesis.backend.ee.licensing.verify import _parse_token, verify_token
 
 pytestmark = pytest.mark.skipif(
@@ -178,6 +179,10 @@ def _no_env_license():
 
 def _limits_for(quota_provider, org) -> dict:
     return quota_provider.get_policy(org).limits
+
+
+def _retention_for(quota_provider, org) -> int | None:
+    return quota_provider.get_policy(org).retention_days
 
 
 # ---------------------------------------------------------------------------
@@ -656,3 +661,114 @@ class TestLicenseColumnIsNotClientWritable:
                 f"{schema_name} accepts a client-supplied 'license'. That lets an "
                 f"organization install its own license token and pick its own tier."
             )
+
+
+# ---------------------------------------------------------------------------
+# 6. Retention escalation through custom_retention_days
+# ---------------------------------------------------------------------------
+
+
+_COMMUNITY_RETENTION = resolve_policy(None).retention_days
+_ENTERPRISE_RETENTION = resolve_policy(LicenseEdition.ENTERPRISE).retention_days
+
+
+class TestRetentionEscalation:
+    """Escalation attempt: use the custom_retention_days claim to avoid data
+    deletion, or inherit unlimited retention without paying for it.
+
+    ``retention_days`` controls how long trace data is kept before the sweep
+    hard-deletes it. ``None`` means unlimited. An invalid override must fall
+    back to the tier's own value, never to ``None``.
+    """
+
+    @pytest.mark.parametrize(
+        "junk",
+        [
+            "unlimited",
+            True,
+            False,
+            -1,
+            0,
+            1.5,
+            [],
+            {},
+            "365",
+        ],
+        ids=[
+            "string",
+            "bool-true",
+            "bool-false",
+            "negative",
+            "zero",
+            "float",
+            "list",
+            "dict",
+            "numeric-string",
+        ],
+    )
+    def test_an_unparseable_override_keeps_the_tier_retention(
+        self, mint_token, quota_provider, licensed_registry, junk
+    ):
+        """A bad custom_retention_days must not become None (unlimited)."""
+        token = mint_token(sub=_VICTIM_ORG, edition="team", custom_retention_days=junk)
+        org = _make_org(license_token=token)
+        retention = _retention_for(quota_provider, org)
+
+        team_retention = resolve_policy(LicenseEdition.TEAM).retention_days
+        assert retention == team_retention
+        assert retention is not None
+
+    def test_a_valid_override_applies(
+        self, mint_token, quota_provider, licensed_registry
+    ):
+        token = mint_token(sub=_VICTIM_ORG, edition="enterprise", custom_retention_days=180)
+        org = _make_org(license_token=token)
+
+        assert _retention_for(quota_provider, org) == 180
+
+    def test_another_orgs_retention_override_does_not_apply_to_you(
+        self, mint_token, quota_provider, licensed_registry
+    ):
+        token = mint_token(
+            sub=_OTHER_ORG,
+            edition="enterprise",
+            custom_retention_days=730,
+        )
+        org = _make_org(_VICTIM_ORG, license_token=token)
+        assert _retention_for(quota_provider, org) == _COMMUNITY_RETENTION
+
+    def test_retention_override_on_a_revoked_license_does_not_apply(
+        self, mint_token, quota_provider, licensed_registry
+    ):
+        token = mint_token(
+            sub=_VICTIM_ORG,
+            edition="enterprise",
+            status="canceled",
+            custom_retention_days=730,
+        )
+        org = _make_org(license_token=token)
+        retention = _retention_for(quota_provider, org)
+
+        assert retention == _COMMUNITY_RETENTION
+        assert retention is not None
+
+    def test_absent_or_junk_license_gives_finite_community_retention(
+        self, quota_provider, licensed_registry
+    ):
+        org = _make_org(license_token=None)
+        retention = _retention_for(quota_provider, org)
+
+        assert retention == _COMMUNITY_RETENTION
+        assert retention is not None, "unlicensed org must have finite retention"
+
+    def test_expired_enterprise_token_gives_community_retention(
+        self, mint_token, quota_provider, licensed_registry
+    ):
+        import time
+
+        token = mint_token(
+            sub=_VICTIM_ORG, edition="enterprise", exp=int(time.time()) - 3600
+        )
+        org = _make_org(license_token=token)
+
+        assert _retention_for(quota_provider, org) == _COMMUNITY_RETENTION

--- a/tests/backend/ee/licensing/test_mint.py
+++ b/tests/backend/ee/licensing/test_mint.py
@@ -262,6 +262,48 @@ class TestMintTokenOverrides:
         assert ent is not None
         assert dict(ent.custom_limits) == {}
 
+    def test_custom_retention_days_survives_a_mint_verify_round_trip(self, private_key_env):
+        """End-to-end producer check. The read path (verify -> Entitlements ->
+        provider.info -> ConfigQuotaProvider) is only reachable if minting can
+        actually write this claim, which it could not before."""
+        from rhesis.backend.ee.licensing.mint import mint_token
+
+        ent = verify_token(
+            mint_token(
+                self.ORG_ID,
+                LicenseEdition.ENTERPRISE,
+                kid="test-v1",
+                custom_retention_days=180,
+            )
+        )
+        assert ent is not None
+        assert ent.custom_retention_days == 180
+
+    def test_no_custom_retention_days_leaves_the_claim_absent(self, private_key_env):
+        """Absent must stay absent so the resolver keeps the tier's own value
+        instead of seeing an override it was never given."""
+        from rhesis.backend.ee.licensing.mint import mint_token
+
+        ent = verify_token(mint_token(self.ORG_ID, LicenseEdition.ENTERPRISE, kid="test-v1"))
+        assert ent is not None
+        assert ent.custom_retention_days is None
+
+    @pytest.mark.parametrize("bad", [0, -30, True, False])
+    def test_a_non_positive_retention_override_is_refused_at_mint_time(
+        self, private_key_env, bad
+    ):
+        """Caught when the token is issued rather than silently ignored at
+        resolution time, so a bad deal never ships as a signed licence."""
+        from rhesis.backend.ee.licensing.mint import mint_token
+
+        with pytest.raises(ValueError, match="custom_retention_days"):
+            mint_token(
+                self.ORG_ID,
+                LicenseEdition.ENTERPRISE,
+                kid="test-v1",
+                custom_retention_days=bad,
+            )
+
 
 # ---------------------------------------------------------------------------
 # Error cases

--- a/tests/backend/ee/licensing/test_tiers.py
+++ b/tests/backend/ee/licensing/test_tiers.py
@@ -387,6 +387,50 @@ class TestLoadTierConfig:
                 f"  overage: soft\n  overage_tolerance_percent: {value}\n",
             )
 
+    @pytest.mark.parametrize(
+        "value,description",
+        [
+            ('"90"', "string"),
+            ("true", "bool-true"),
+            ("false", "bool-false"),
+            ("0", "zero"),
+            ("-30", "negative"),
+            ("1.5", "float"),
+        ],
+    )
+    def test_invalid_retention_days_values_are_rejected(
+        self, tmp_path, monkeypatch, value, description
+    ):
+        """The retention sweep consumes this value, so a string "90" from a
+        mounted ConfigMap would reach timedelta(days="90") and raise per org
+        inside the sweep's blanket except -- retention would silently never
+        run for the tier. Zero or negative would set a cutoff at or after
+        "now" and delete every trace the org has."""
+        with pytest.raises(ValueError, match="retention_days"):
+            self._load_from(
+                tmp_path,
+                monkeypatch,
+                f"community:\n  limits:\n    seats: 3\n  retention_days: {value}\n",
+            )
+
+    def test_null_retention_days_means_unlimited(self, tmp_path, monkeypatch):
+        """Matches the config's own `null = unlimited` convention; the sweep
+        skips an org whose resolved retention is None."""
+        catalog = self._load_from(
+            tmp_path,
+            monkeypatch,
+            "community:\n  limits:\n    seats: 3\n  retention_days: null\n",
+        )
+        assert catalog[LicenseEdition.COMMUNITY].retention_days is None
+
+    def test_valid_retention_days_is_carried(self, tmp_path, monkeypatch):
+        catalog = self._load_from(
+            tmp_path,
+            monkeypatch,
+            "community:\n  limits:\n    seats: 3\n  retention_days: 45\n",
+        )
+        assert catalog[LicenseEdition.COMMUNITY].retention_days == 45
+
 
 class TestTierSpecToPolicy:
     def test_carries_limits_overage_and_tolerance(self):

--- a/tests/backend/jobs/test_trace_retention.py
+++ b/tests/backend/jobs/test_trace_retention.py
@@ -1,0 +1,296 @@
+"""jobs/trace_retention.py: the sweep is disabled by default, keys trace
+deletion on ``created_at`` per org, and respects per-org retention windows
+resolved from the tier catalog. Integration-style, using
+``real_commit_test_db``: the sweep opens its own ``SessionLocal()``
+connections, so writes must be genuinely committed.
+
+Modelled on ``test_retention.py`` (the job retention sweep), with the
+additions the plan calls out: org-boundary isolation (a missing
+``organization_id`` predicate under ``bypass_tenant_filter`` would silently
+delete another org's data), per-org error isolation, dry-run vs live, and
+the global ``TRACE_RETENTION_DAYS`` override.
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.models.project import Project
+from rhesis.backend.app.models.trace import Trace
+from rhesis.backend.app.quota import QuotaPolicy, QuotaRegistry
+from rhesis.backend.jobs import trace_retention
+from rhesis.backend.jobs.trace_retention import sweep_expired_traces
+from tests.backend.fixtures.test_setup import create_test_organization_and_user
+
+_NOW = datetime.now(timezone.utc)
+_OLD = _NOW - timedelta(days=100)
+_RECENT = _NOW - timedelta(days=1)
+
+
+class _FixedPolicyProvider:
+    def __init__(self, policy: QuotaPolicy):
+        self._policy = policy
+
+    def get_policy(self, org=None) -> QuotaPolicy:
+        return self._policy
+
+
+def _settings(monkeypatch, *, enabled: bool, dry_run: bool = False, override_days=None):
+    monkeypatch.setattr(
+        "rhesis.backend.jobs.trace_retention.get_trace_retention_settings",
+        lambda: SimpleNamespace(enabled=enabled, dry_run=dry_run, override_days=override_days),
+    )
+
+
+def _org(db: Session, name: str, email: str):
+    org, user, _ = create_test_organization_and_user(db, name, email, f"{name} User")
+    user.organization_id = org.id
+    db.commit()
+    return org, user
+
+
+def _project(db: Session, org) -> str:
+    proj = Project(name="retention-test-project", organization_id=org.id)
+    db.add(proj)
+    db.commit()
+    project_id = str(proj.id)
+    db.expunge(proj)
+    return project_id
+
+
+def _trace(db: Session, org, project_id: str, *, created_at) -> str:
+    t = Trace(
+        trace_id="deadbeef" * 4,
+        span_id="abcd1234" * 2,
+        project_id=project_id,
+        organization_id=org.id,
+        environment="test",
+        span_name="test-span",
+        span_kind="INTERNAL",
+        start_time=created_at,
+        end_time=created_at + timedelta(seconds=1),
+        duration_ms=1000.0,
+        status_code="OK",
+        attributes={},
+        events=[],
+        links=[],
+        resource={},
+        created_at=created_at,
+    )
+    db.add(t)
+    db.flush()
+    trace_id = str(t.id)
+    db.execute(
+        text("UPDATE trace SET created_at = :ts WHERE id = :id"),
+        {"ts": created_at, "id": trace_id},
+    )
+    db.commit()
+    db.expunge(t)
+    return trace_id
+
+
+def _trace_exists(db: Session, trace_id: str) -> bool:
+    db.expire_all()
+    return (
+        db.execute(text("SELECT 1 FROM trace WHERE id = :id"), {"id": trace_id}).first()
+        is not None
+    )
+
+
+@pytest.mark.integration
+class TestSweepDisabledByDefault:
+    def test_disabled_deletes_nothing(self, monkeypatch, real_commit_test_db: Session):
+        _settings(monkeypatch, enabled=False)
+        db = real_commit_test_db
+        org, user = _org(db, "Trace Ret Disabled Org", "trace-ret-disabled@test.com")
+        project_id = _project(db, org)
+        old_trace_id = _trace(db, org, project_id, created_at=_OLD)
+
+        result = sweep_expired_traces()
+
+        assert result == {"enabled": False}
+        assert _trace_exists(db, old_trace_id)
+
+
+@pytest.mark.integration
+class TestSweepDeletesPastTheWindow:
+    def test_deletes_old_traces_but_keeps_recent(
+        self, monkeypatch, real_commit_test_db: Session
+    ):
+        _settings(monkeypatch, enabled=True)
+        monkeypatch.setattr(
+            "rhesis.backend.app.quota.get_application_settings",
+            lambda: SimpleNamespace(usage_quotas_enabled=True),
+        )
+        QuotaRegistry.set_quota_provider(
+            _FixedPolicyProvider(QuotaPolicy(limits={}, retention_days=30))
+        )
+        db = real_commit_test_db
+        org, user = _org(db, "Trace Ret Delete Org", "trace-ret-delete@test.com")
+        project_id = _project(db, org)
+
+        old_trace_id = _trace(db, org, project_id, created_at=_OLD)
+        recent_trace_id = _trace(db, org, project_id, created_at=_RECENT)
+
+        try:
+            result = sweep_expired_traces()
+
+            assert result["enabled"] is True
+            assert result["dry_run"] is False
+            assert result["traces_affected"] >= 1
+            assert not _trace_exists(db, old_trace_id)
+            assert _trace_exists(db, recent_trace_id)
+        finally:
+            QuotaRegistry.reset()
+
+
+@pytest.mark.integration
+class TestSweepDryRun:
+    def test_dry_run_counts_without_deleting(
+        self, monkeypatch, real_commit_test_db: Session
+    ):
+        _settings(monkeypatch, enabled=True, dry_run=True)
+        monkeypatch.setattr(
+            "rhesis.backend.app.quota.get_application_settings",
+            lambda: SimpleNamespace(usage_quotas_enabled=True),
+        )
+        QuotaRegistry.set_quota_provider(
+            _FixedPolicyProvider(QuotaPolicy(limits={}, retention_days=30))
+        )
+        db = real_commit_test_db
+        org, user = _org(db, "Trace Ret DryRun Org", "trace-ret-dryrun@test.com")
+        project_id = _project(db, org)
+        old_trace_id = _trace(db, org, project_id, created_at=_OLD)
+
+        try:
+            result = sweep_expired_traces()
+
+            assert result["dry_run"] is True
+            assert result["traces_affected"] >= 1
+            assert _trace_exists(db, old_trace_id), "dry-run must not actually delete"
+        finally:
+            QuotaRegistry.reset()
+
+
+@pytest.mark.integration
+class TestSweepUnlimitedRetention:
+    def test_unlimited_retention_skips_the_org(
+        self, monkeypatch, real_commit_test_db: Session
+    ):
+        """An org whose resolved retention_days is None (unlimited, e.g.
+        enterprise default) is skipped entirely."""
+        _settings(monkeypatch, enabled=True)
+        monkeypatch.setattr(
+            "rhesis.backend.app.quota.get_application_settings",
+            lambda: SimpleNamespace(usage_quotas_enabled=True),
+        )
+        QuotaRegistry.set_quota_provider(
+            _FixedPolicyProvider(QuotaPolicy(limits={}, retention_days=None))
+        )
+        db = real_commit_test_db
+        org, user = _org(db, "Trace Ret Unlimited Org", "trace-ret-unlimited@test.com")
+        project_id = _project(db, org)
+        old_trace_id = _trace(db, org, project_id, created_at=_OLD)
+
+        try:
+            result = sweep_expired_traces()
+
+            assert result["orgs_swept"] == 0
+            assert _trace_exists(db, old_trace_id)
+        finally:
+            QuotaRegistry.reset()
+
+
+@pytest.mark.integration
+class TestSweepGlobalOverride:
+    def test_override_days_supersedes_tier_retention(
+        self, monkeypatch, real_commit_test_db: Session
+    ):
+        """TRACE_RETENTION_DAYS env var overrides the tier-resolved value.
+        With a 200-day override, a 100-day-old trace is kept."""
+        _settings(monkeypatch, enabled=True, override_days=200)
+        monkeypatch.setattr(
+            "rhesis.backend.app.quota.get_application_settings",
+            lambda: SimpleNamespace(usage_quotas_enabled=True),
+        )
+        QuotaRegistry.set_quota_provider(
+            _FixedPolicyProvider(QuotaPolicy(limits={}, retention_days=30))
+        )
+        db = real_commit_test_db
+        org, user = _org(db, "Trace Ret Override Org", "trace-ret-override@test.com")
+        project_id = _project(db, org)
+        old_trace_id = _trace(db, org, project_id, created_at=_OLD)
+
+        try:
+            result = sweep_expired_traces()
+
+            assert _trace_exists(db, old_trace_id), (
+                "100-day-old trace should survive a 200-day override"
+            )
+        finally:
+            QuotaRegistry.reset()
+
+
+@pytest.mark.integration
+class TestSweepOrgIsolation:
+    def test_sweeping_one_org_never_touches_another_orgs_traces(
+        self, monkeypatch, real_commit_test_db: Session
+    ):
+        """Regression guard: _sweep_organization uses an explicit
+        organization_id filter. Without it, the delete under
+        bypass_tenant_filter would wipe every org's expired traces."""
+        _settings(monkeypatch, enabled=True)
+        db = real_commit_test_db
+        org_a, _ = _org(db, "Trace Iso Org A", "trace-iso-a@test.com")
+        org_b, _ = _org(db, "Trace Iso Org B", "trace-iso-b@test.com")
+        proj_a = _project(db, org_a)
+        proj_b = _project(db, org_b)
+
+        trace_a_id = _trace(db, org_a, proj_a, created_at=_OLD)
+        trace_b_id = _trace(db, org_b, proj_b, created_at=_OLD)
+
+        cutoff = _NOW - timedelta(days=30)
+        trace_retention._sweep_organization(org_b, cutoff, dry_run=False)
+
+        assert _trace_exists(db, trace_a_id), "sweeping org_b must not delete org_a's traces"
+        assert not _trace_exists(db, trace_b_id)
+
+    def test_one_organizations_failure_does_not_block_the_rest(
+        self, monkeypatch, real_commit_test_db: Session
+    ):
+        _settings(monkeypatch, enabled=True)
+        monkeypatch.setattr(
+            "rhesis.backend.app.quota.get_application_settings",
+            lambda: SimpleNamespace(usage_quotas_enabled=True),
+        )
+        QuotaRegistry.set_quota_provider(
+            _FixedPolicyProvider(QuotaPolicy(limits={}, retention_days=30))
+        )
+        db = real_commit_test_db
+        org_a, _ = _org(db, "Trace Fail Org A", "trace-fail-a@test.com")
+        org_b, _ = _org(db, "Trace Fail Org B", "trace-fail-b@test.com")
+        proj_a = _project(db, org_a)
+        proj_b = _project(db, org_b)
+
+        trace_a_id = _trace(db, org_a, proj_a, created_at=_OLD)
+        trace_b_id = _trace(db, org_b, proj_b, created_at=_OLD)
+
+        real_sweep = trace_retention._sweep_organization
+
+        def flaky_sweep(org, cutoff, *, dry_run):
+            if str(org.id) == str(org_a.id):
+                raise RuntimeError("simulated failure")
+            return real_sweep(org, cutoff, dry_run=dry_run)
+
+        monkeypatch.setattr(trace_retention, "_sweep_organization", flaky_sweep)
+
+        try:
+            sweep_expired_traces()
+
+            assert _trace_exists(db, trace_a_id), "org_a's failure is swallowed"
+            assert not _trace_exists(db, trace_b_id), "org_b is still swept"
+        finally:
+            QuotaRegistry.reset()

--- a/tests/backend/jobs/test_trace_retention.py
+++ b/tests/backend/jobs/test_trace_retention.py
@@ -38,6 +38,29 @@ class _FixedPolicyProvider:
         return self._policy
 
 
+@pytest.fixture
+def clean_registry():
+    """Reset the registry before each test, restore the real state after.
+
+    Mirrors ``clean_registry`` in ``test_quota_registry.py``, and the
+    save/restore is the whole point. A bare ``QuotaRegistry.reset()`` on
+    teardown is not enough: ``ee.bootstrap()`` installs the config-backed
+    provider once at process import time, so resetting leaves the *default*
+    provider -- with real free-tier integer limits -- for the rest of the
+    suite. A later test that mocks its DB session then reaches
+    ``check_quota``'s ceiling comparison with a Mock usage value and dies on
+    ``Mock < int``, in a file that has nothing to do with quotas.
+    """
+    saved_provider = QuotaRegistry._provider
+    QuotaRegistry.reset()
+    yield
+    QuotaRegistry._provider = saved_provider
+
+
+def _install(policy: QuotaPolicy) -> None:
+    QuotaRegistry.set_quota_provider(_FixedPolicyProvider(policy))
+
+
 def _settings(monkeypatch, *, enabled: bool, dry_run: bool = False, override_days=None):
     monkeypatch.setattr(
         "rhesis.backend.jobs.trace_retention.get_trace_retention_settings",
@@ -118,16 +141,14 @@ class TestSweepDisabledByDefault:
 @pytest.mark.integration
 class TestSweepDeletesPastTheWindow:
     def test_deletes_old_traces_but_keeps_recent(
-        self, monkeypatch, real_commit_test_db: Session
+        self, monkeypatch, real_commit_test_db: Session, clean_registry
     ):
         _settings(monkeypatch, enabled=True)
         monkeypatch.setattr(
             "rhesis.backend.app.quota.get_application_settings",
             lambda: SimpleNamespace(usage_quotas_enabled=True),
         )
-        QuotaRegistry.set_quota_provider(
-            _FixedPolicyProvider(QuotaPolicy(limits={}, retention_days=30))
-        )
+        _install(QuotaPolicy(limits={}, retention_days=30))
         db = real_commit_test_db
         org, user = _org(db, "Trace Ret Delete Org", "trace-ret-delete@test.com")
         project_id = _project(db, org)
@@ -135,50 +156,42 @@ class TestSweepDeletesPastTheWindow:
         old_trace_id = _trace(db, org, project_id, created_at=_OLD)
         recent_trace_id = _trace(db, org, project_id, created_at=_RECENT)
 
-        try:
-            result = sweep_expired_traces()
+        result = sweep_expired_traces()
 
-            assert result["enabled"] is True
-            assert result["dry_run"] is False
-            assert result["traces_affected"] >= 1
-            assert not _trace_exists(db, old_trace_id)
-            assert _trace_exists(db, recent_trace_id)
-        finally:
-            QuotaRegistry.reset()
+        assert result["enabled"] is True
+        assert result["dry_run"] is False
+        assert result["traces_affected"] >= 1
+        assert not _trace_exists(db, old_trace_id)
+        assert _trace_exists(db, recent_trace_id)
 
 
 @pytest.mark.integration
 class TestSweepDryRun:
     def test_dry_run_counts_without_deleting(
-        self, monkeypatch, real_commit_test_db: Session
+        self, monkeypatch, real_commit_test_db: Session, clean_registry
     ):
         _settings(monkeypatch, enabled=True, dry_run=True)
         monkeypatch.setattr(
             "rhesis.backend.app.quota.get_application_settings",
             lambda: SimpleNamespace(usage_quotas_enabled=True),
         )
-        QuotaRegistry.set_quota_provider(
-            _FixedPolicyProvider(QuotaPolicy(limits={}, retention_days=30))
-        )
+        _install(QuotaPolicy(limits={}, retention_days=30))
         db = real_commit_test_db
         org, user = _org(db, "Trace Ret DryRun Org", "trace-ret-dryrun@test.com")
         project_id = _project(db, org)
         old_trace_id = _trace(db, org, project_id, created_at=_OLD)
 
-        try:
-            result = sweep_expired_traces()
+        result = sweep_expired_traces()
 
-            assert result["dry_run"] is True
-            assert result["traces_affected"] >= 1
-            assert _trace_exists(db, old_trace_id), "dry-run must not actually delete"
-        finally:
-            QuotaRegistry.reset()
+        assert result["dry_run"] is True
+        assert result["traces_affected"] >= 1
+        assert _trace_exists(db, old_trace_id), "dry-run must not actually delete"
 
 
 @pytest.mark.integration
 class TestSweepDeletesInBatches:
     def test_all_expired_rows_go_even_when_they_span_several_batches(
-        self, monkeypatch, real_commit_test_db: Session
+        self, monkeypatch, real_commit_test_db: Session, clean_registry
     ):
         """The delete is chunked to bound lock duration and WAL growth, so the
         loop has to come back for the remaining rows. Batch size is patched
@@ -210,7 +223,7 @@ class TestSweepDeletesInBatches:
 @pytest.mark.integration
 class TestSweepUnlimitedRetention:
     def test_unlimited_retention_skips_the_org(
-        self, monkeypatch, real_commit_test_db: Session
+        self, monkeypatch, real_commit_test_db: Session, clean_registry
     ):
         """An org whose resolved retention_days is None (unlimited, e.g.
         enterprise default) is skipped entirely."""
@@ -219,27 +232,22 @@ class TestSweepUnlimitedRetention:
             "rhesis.backend.app.quota.get_application_settings",
             lambda: SimpleNamespace(usage_quotas_enabled=True),
         )
-        QuotaRegistry.set_quota_provider(
-            _FixedPolicyProvider(QuotaPolicy(limits={}, retention_days=None))
-        )
+        _install(QuotaPolicy(limits={}, retention_days=None))
         db = real_commit_test_db
         org, user = _org(db, "Trace Ret Unlimited Org", "trace-ret-unlimited@test.com")
         project_id = _project(db, org)
         old_trace_id = _trace(db, org, project_id, created_at=_OLD)
 
-        try:
-            result = sweep_expired_traces()
+        result = sweep_expired_traces()
 
-            assert result["orgs_swept"] == 0
-            assert _trace_exists(db, old_trace_id)
-        finally:
-            QuotaRegistry.reset()
+        assert result["orgs_swept"] == 0
+        assert _trace_exists(db, old_trace_id)
 
 
 @pytest.mark.integration
 class TestSweepGlobalOverride:
     def test_override_days_supersedes_tier_retention(
-        self, monkeypatch, real_commit_test_db: Session
+        self, monkeypatch, real_commit_test_db: Session, clean_registry
     ):
         """TRACE_RETENTION_DAYS env var overrides the tier-resolved value.
         With a 200-day override, a 100-day-old trace is kept."""
@@ -248,22 +256,17 @@ class TestSweepGlobalOverride:
             "rhesis.backend.app.quota.get_application_settings",
             lambda: SimpleNamespace(usage_quotas_enabled=True),
         )
-        QuotaRegistry.set_quota_provider(
-            _FixedPolicyProvider(QuotaPolicy(limits={}, retention_days=30))
-        )
+        _install(QuotaPolicy(limits={}, retention_days=30))
         db = real_commit_test_db
         org, user = _org(db, "Trace Ret Override Org", "trace-ret-override@test.com")
         project_id = _project(db, org)
         old_trace_id = _trace(db, org, project_id, created_at=_OLD)
 
-        try:
-            sweep_expired_traces()
+        sweep_expired_traces()
 
-            assert _trace_exists(db, old_trace_id), (
-                "100-day-old trace should survive a 200-day override"
-            )
-        finally:
-            QuotaRegistry.reset()
+        assert _trace_exists(db, old_trace_id), (
+            "100-day-old trace should survive a 200-day override"
+        )
 
 
 @pytest.mark.integration
@@ -291,16 +294,14 @@ class TestSweepOrgIsolation:
         assert not _trace_exists(db, trace_b_id)
 
     def test_one_organizations_failure_does_not_block_the_rest(
-        self, monkeypatch, real_commit_test_db: Session
+        self, monkeypatch, real_commit_test_db: Session, clean_registry
     ):
         _settings(monkeypatch, enabled=True)
         monkeypatch.setattr(
             "rhesis.backend.app.quota.get_application_settings",
             lambda: SimpleNamespace(usage_quotas_enabled=True),
         )
-        QuotaRegistry.set_quota_provider(
-            _FixedPolicyProvider(QuotaPolicy(limits={}, retention_days=30))
-        )
+        _install(QuotaPolicy(limits={}, retention_days=30))
         db = real_commit_test_db
         org_a, _ = _org(db, "Trace Fail Org A", "trace-fail-a@test.com")
         org_b, _ = _org(db, "Trace Fail Org B", "trace-fail-b@test.com")
@@ -319,19 +320,16 @@ class TestSweepOrgIsolation:
 
         monkeypatch.setattr(trace_retention, "_sweep_organization", flaky_sweep)
 
-        try:
-            result = sweep_expired_traces()
+        result = sweep_expired_traces()
 
-            assert _trace_exists(db, trace_a_id), "org_a's failure is swallowed"
-            assert not _trace_exists(db, trace_b_id), "org_b is still swept"
-            assert result["orgs_failed"] >= 1, (
-                "a failed org must be counted, not reported as a clean run"
-            )
-        finally:
-            QuotaRegistry.reset()
+        assert _trace_exists(db, trace_a_id), "org_a's failure is swallowed"
+        assert not _trace_exists(db, trace_b_id), "org_b is still swept"
+        assert result["orgs_failed"] >= 1, (
+            "a failed org must be counted, not reported as a clean run"
+        )
 
     def test_a_failed_sweep_is_not_reported_as_a_clean_run(
-        self, monkeypatch, real_commit_test_db: Session
+        self, monkeypatch, real_commit_test_db: Session, clean_registry
     ):
         """_sweep_organization returns None on failure, not 0, so a run where
         every org errored is distinguishable from "nothing to delete" -- the
@@ -341,9 +339,7 @@ class TestSweepOrgIsolation:
             "rhesis.backend.app.quota.get_application_settings",
             lambda: SimpleNamespace(usage_quotas_enabled=True),
         )
-        QuotaRegistry.set_quota_provider(
-            _FixedPolicyProvider(QuotaPolicy(limits={}, retention_days=30))
-        )
+        _install(QuotaPolicy(limits={}, retention_days=30))
         db = real_commit_test_db
         org, _ = _org(db, "Trace AllFail Org", "trace-allfail@test.com")
         project_id = _project(db, org)
@@ -355,12 +351,9 @@ class TestSweepOrgIsolation:
             lambda org, cutoff, *, dry_run: None,
         )
 
-        try:
-            result = sweep_expired_traces()
+        result = sweep_expired_traces()
 
-            assert result["traces_affected"] == 0
-            assert result["orgs_swept"] == 0
-            assert result["orgs_failed"] >= 1
-            assert _trace_exists(db, old_trace_id)
-        finally:
-            QuotaRegistry.reset()
+        assert result["traces_affected"] == 0
+        assert result["orgs_swept"] == 0
+        assert result["orgs_failed"] >= 1
+        assert _trace_exists(db, old_trace_id)

--- a/tests/backend/jobs/test_trace_retention.py
+++ b/tests/backend/jobs/test_trace_retention.py
@@ -176,6 +176,38 @@ class TestSweepDryRun:
 
 
 @pytest.mark.integration
+class TestSweepDeletesInBatches:
+    def test_all_expired_rows_go_even_when_they_span_several_batches(
+        self, monkeypatch, real_commit_test_db: Session
+    ):
+        """The delete is chunked to bound lock duration and WAL growth, so the
+        loop has to come back for the remaining rows. Batch size is patched
+        down to 2 rather than writing DELETE_BATCH_SIZE rows.
+
+        Calls ``_sweep_organization`` directly rather than the task: the task
+        sweeps every org in the database, so a total row count would also pick
+        up whatever other tests in this file left behind.
+        """
+        monkeypatch.setattr(trace_retention, "DELETE_BATCH_SIZE", 2)
+        db = real_commit_test_db
+        org, _ = _org(db, "Trace Batch Org", "trace-batch@test.com")
+        project_id = _project(db, org)
+
+        # 5 expired rows over a batch size of 2: three passes, the last short.
+        old_ids = [_trace(db, org, project_id, created_at=_OLD) for _ in range(5)]
+        recent_id = _trace(db, org, project_id, created_at=_RECENT)
+
+        deleted = trace_retention._sweep_organization(
+            org, _NOW - timedelta(days=30), dry_run=False
+        )
+
+        assert deleted == 5, "every expired row must go, not just the first batch"
+        for trace_id in old_ids:
+            assert not _trace_exists(db, trace_id)
+        assert _trace_exists(db, recent_id), "a recent trace must survive batching"
+
+
+@pytest.mark.integration
 class TestSweepUnlimitedRetention:
     def test_unlimited_retention_skips_the_org(
         self, monkeypatch, real_commit_test_db: Session
@@ -225,7 +257,7 @@ class TestSweepGlobalOverride:
         old_trace_id = _trace(db, org, project_id, created_at=_OLD)
 
         try:
-            result = sweep_expired_traces()
+            sweep_expired_traces()
 
             assert _trace_exists(db, old_trace_id), (
                 "100-day-old trace should survive a 200-day override"
@@ -288,9 +320,47 @@ class TestSweepOrgIsolation:
         monkeypatch.setattr(trace_retention, "_sweep_organization", flaky_sweep)
 
         try:
-            sweep_expired_traces()
+            result = sweep_expired_traces()
 
             assert _trace_exists(db, trace_a_id), "org_a's failure is swallowed"
             assert not _trace_exists(db, trace_b_id), "org_b is still swept"
+            assert result["orgs_failed"] >= 1, (
+                "a failed org must be counted, not reported as a clean run"
+            )
+        finally:
+            QuotaRegistry.reset()
+
+    def test_a_failed_sweep_is_not_reported_as_a_clean_run(
+        self, monkeypatch, real_commit_test_db: Session
+    ):
+        """_sweep_organization returns None on failure, not 0, so a run where
+        every org errored is distinguishable from "nothing to delete" -- the
+        two used to be identical in the returned dict."""
+        _settings(monkeypatch, enabled=True)
+        monkeypatch.setattr(
+            "rhesis.backend.app.quota.get_application_settings",
+            lambda: SimpleNamespace(usage_quotas_enabled=True),
+        )
+        QuotaRegistry.set_quota_provider(
+            _FixedPolicyProvider(QuotaPolicy(limits={}, retention_days=30))
+        )
+        db = real_commit_test_db
+        org, _ = _org(db, "Trace AllFail Org", "trace-allfail@test.com")
+        project_id = _project(db, org)
+        old_trace_id = _trace(db, org, project_id, created_at=_OLD)
+
+        monkeypatch.setattr(
+            trace_retention,
+            "_sweep_organization",
+            lambda org, cutoff, *, dry_run: None,
+        )
+
+        try:
+            result = sweep_expired_traces()
+
+            assert result["traces_affected"] == 0
+            assert result["orgs_swept"] == 0
+            assert result["orgs_failed"] >= 1
+            assert _trace_exists(db, old_trace_id)
         finally:
             QuotaRegistry.reset()

--- a/tests/backend/routes/test_quota_gates.py
+++ b/tests/backend/routes/test_quota_gates.py
@@ -21,7 +21,11 @@ import pytest
 from fastapi import Response, status
 from fastapi.testclient import TestClient
 
-from rhesis.backend.app.auth.quota_gates import QUOTA_WARNING_HEADER, require_quota
+from rhesis.backend.app.auth.quota_gates import (
+    QUOTA_WARNING_HEADER,
+    require_backstop,
+    require_quota,
+)
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.project import Project
 from rhesis.backend.app.quota import OveragePolicy, QuotaPolicy, QuotaRegistry, QuotaResource
@@ -504,3 +508,46 @@ class TestRequireQuotaFlowResourceWarningHeader:
         dep = require_quota(QuotaResource.TEST_EXECUTIONS)
         with pytest.raises(QuotaExceededError):
             dep(response=response, org=authenticated_org, db=test_db)
+
+
+class TestRequireBackstopFailsOpen:
+    """``require_backstop`` guards span ingest, whose contract is that a
+    billing-side problem never breaks ingestion. These call the dependency
+    callable directly: the branches under test are about what the *lookup*
+    returns, so driving them through a real route would mean engineering a
+    broken org row rather than simply handing one over.
+    """
+
+    def _dep(self, resource=QuotaResource.TRACING_SPANS):
+        return require_backstop(resource)
+
+    def test_a_missing_org_row_allows_the_request(self, test_db, test_org_id, clean_registry):
+        """The regression this guards: falling through with ``org=None``
+        resolves the *community* policy, so a possibly-paid org would be
+        backstopped at 10x the free tier and 402 on ingest -- caused purely
+        by a lookup that failed."""
+        _install(QuotaPolicy(limits={QuotaResource.TRACING_SPANS: 1}))
+        increment_usage(test_db, test_org_id, QuotaResource.TRACING_SPANS, 10_000)
+
+        class _NoOrgSession:
+            def get(self, *_args, **_kwargs):
+                return None
+
+        # Returns None (allows) rather than raising QuotaExceededError.
+        assert self._dep()(tenant_context=(test_org_id, None), db=_NoOrgSession()) is None
+
+    def test_no_org_in_context_allows_the_request(self, clean_registry):
+        """Nothing to attribute usage to, so nothing to backstop."""
+        _install(QuotaPolicy(limits={QuotaResource.TRACING_SPANS: 1}))
+
+        assert self._dep()(tenant_context=(None, None), db=None) is None
+
+    def test_a_lookup_that_raises_allows_the_request(self, clean_registry):
+        """Fail-open covers the DB being unreachable, not just a null row."""
+        _install(QuotaPolicy(limits={QuotaResource.TRACING_SPANS: 1}))
+
+        class _BrokenSession:
+            def get(self, *_args, **_kwargs):
+                raise RuntimeError("connection reset")
+
+        assert self._dep()(tenant_context=("some-org", None), db=_BrokenSession()) is None

--- a/tests/backend/services/test_plan.py
+++ b/tests/backend/services/test_plan.py
@@ -17,7 +17,8 @@ class TestLabel:
     @pytest.mark.parametrize(
         ("edition", "expected"),
         [
-            ("community", "Community"),
+            # Not "Community": the pricing page advertises this tier as Free.
+            ("community", "Free"),
             ("team", "Team"),
             ("enterprise", "Enterprise"),
             # Separators become spaces, so a multi-word tier id reads as prose
@@ -41,7 +42,19 @@ class TestLabel:
         empty name as "no plan yet" and show nothing, which would hide the
         plan row entirely rather than showing something is wrong."""
         assert build_plan({"edition": "   "})["name"] == "Unknown"
-        assert build_plan({})["name"] == "Community"
+        assert build_plan({})["name"] == "Free"
+
+    def test_the_free_tier_is_named_as_the_pricing_page_advertises_it(self):
+        """``community`` is the internal id; the pricing page sells it as the
+        Free plan (see FREE_TIER_LIMITS and tier_config.yaml's header). Since
+        ``name`` is rendered verbatim, title-casing the id put "Community" in
+        the sidebar and usage page beside limits published as Free.
+
+        The mapping is an exception list over the title-case default, not a
+        replacement for it, so the unrecognised-tier property above still holds.
+        """
+        assert build_plan({"edition": "community"})["name"] == "Free"
+        assert build_plan({"edition": "COMMUNITY"})["name"] == "Free"
 
 
 class TestLapsedQualifier:
@@ -61,7 +74,7 @@ class TestLapsedQualifier:
         """A free org is not "inactive" -- it has nothing to reactivate. Only a
         tier that was paid for gets the qualifier."""
         plan = build_plan({"edition": "community", "licensed": False, "is_paid": False})
-        assert plan["name"] == "Community"
+        assert plan["name"] == "Free"
         assert plan["is_paid"] is False
         assert plan["is_active"] is False
 


### PR DESCRIPTION
## What this does

Makes `tracing_spans` an enforced resource. The published limit was already metered and notified on, but nothing acted on it, because a 402 on span ingest is silently swallowed by the exporter's `BatchSpanProcessor`. So enforcement takes two other shapes:

- **Tier-based retention.** A nightly sweep hard-deletes trace rows past the org's `retention_days`, resolved from the tier catalog plus any per-org override on the licence token.
- **A backstop on ingest.** Rejection at 10x the tier limit, for runaway or abusive exporters only. It fails open: a billing-side problem must never break ingestion.

Both are off by default. `TRACE_RETENTION_ENABLED` gates the sweep, and it starts in dry-run so the blast radius shows up in logs before anything is deleted.

## Notable details

**The sweep must not cross org boundaries.** It runs under `bypass_tenant_filter()`, which is required rather than incidental: the session's scope has no project, so the ORM auto-filter would otherwise add `project_id IS NULL` and match no traces at all. That makes the explicit `organization_id` predicate load-bearing, and there's a regression test that sweeping one org leaves another's traces alone.

**Deletes are batched** at 5000 rows per transaction. One unbounded `DELETE` would take an org's whole backlog at once on first live run, holding row locks and writing a single large WAL burst.

**The backstop's fail-open is real.** It takes `tenant_context` and looks the org up inside its own `try`, rather than depending on `get_current_organization` — FastAPI resolves sub-dependencies before the function body, so that dependency's own `db.get` could 500 and a missing org row 403s, both from outside the `try`.

**Retention overrides are minted, not just read.** `custom_retention_days` flows JWT → `Entitlements` → `provider.info()` → `ConfigQuotaProvider`, and `--retention-days` on the licence CLI writes it. `retention_days` from the tier YAML is now validated like its siblings; a string `"90"` from a mounted ConfigMap would otherwise reach `timedelta(days="90")` and be swallowed by the sweep's per-org `except`.

## Also in here

Two fixes found while testing this, both user-visible:

- The free tier rendered as **"Community"** in the sidebar, org menu and usage page, while the pricing page advertises those exact limits as the **Free** plan. `plan.name` is rendered verbatim by clients, so the mapping belongs in `build_plan`.
- `@mui/material` was declared `"^7"` while `postinstall` runs `patch-package --error-on-fail` against a patch named for 7.3.5. That patch is load-bearing (it stops `useMediaQuery` crashing at module-evaluation in the RSC graph), so the first `npm install` after any 7.x release could hard-fail the install. Pinned, lockfile regenerated so `npm ci` stays in sync.

## Testing

337 backend tests pass across the licensing, quota, gates and retention suites. New coverage:

- backstop boundary: unlimited never backstopped, off-by-one at 10x, over-limit-but-under-backstop allowed, verdict carries the backstop ceiling not the tier limit
- retention escalation loopholes: unparseable overrides fall back to the tier, cross-org isolation, revoked / expired / unlicensed orgs
- sweep: org isolation, per-org error isolation, dry-run counts without deleting, unlimited retention skips, global override, batching across multiple passes, and a failed sweep reporting `orgs_failed` rather than looking clean
- mint/verify round trip for `custom_retention_days`, and refusal of non-positive values at mint time
- plan naming, including that "(inactive)" is gated on `is_paid` so a free org is never labelled inactive

## Reviewer notes

- `alembic heads` returns a single head. Worth confirming on merge, since a second head aborts every upgrade.
- The free-tier naming fix lives in `services/plan.py`, not `services/usage.py`: `build_plan` moved there in #2683 while this branch was open, so the change was relocated during the rebase and three existing assertions in `tests/backend/services/test_plan.py` were updated from "Community" to "Free".
- The sweep has no `celery beat` process deployed against it yet, same as the existing job retention sweep. The schedule entry is in place for when there is one.

