### PR TITLE
Clear the frontend lint warnings (and one stale-closure bug behind them)

### DIFF
--- a/apps/frontend/scripts/generate-templates.js
+++ b/apps/frontend/scripts/generate-templates.js
@@ -35,8 +35,6 @@ const generateTypeScriptFile = templates => {
     )
     .join('\n');
 
-  const iconMap = iconImports.map(icon => `  ${icon},`).join('\n');
-
   const templatesCode = templates
     .map(template => {
       const topics = JSON.stringify(template.topics);
@@ -61,11 +59,6 @@ const generateTypeScriptFile = templates => {
 
 ${imports}
 import { TestTemplate } from '@/app/(protected)/test-sets/new-generated/components/shared/types';
-
-// Icon mapping for YAML references
-const iconMap: Record<string, React.ComponentType<any>> = {
-${iconMap}
-};
 
 // Generated templates from YAML
 export const TEMPLATES: TestTemplate[] = [

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentRunsTab.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentRunsTab.tsx
@@ -71,7 +71,9 @@ export default function ExperimentRunsTab({
     initialData: initialRuns,
   });
 
-  const runs = data?.items ?? [];
+  // Memoised so the `?? []` fallback does not hand a fresh array to the
+  // filter memo below on every render, which defeated it entirely.
+  const runs = useMemo(() => data?.items ?? [], [data?.items]);
   const error =
     fetchError instanceof Error
       ? fetchError.message

--- a/apps/frontend/src/app/(protected)/explorer/[identifier]/components/ExplorerDetail.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/[identifier]/components/ExplorerDetail.tsx
@@ -34,10 +34,9 @@ import {
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/SettingsOutlined';
 import IosShareOutlinedIcon from '@mui/icons-material/IosShareOutlined';
-import ApiOutlinedIcon from '@mui/icons-material/ApiOutlined';
 import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
-import { alpha, useTheme } from '@mui/material/styles';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
+import { useTheme } from '@mui/material/styles';
+import { BORDER_RADIUS } from '@/styles/theme';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import {
@@ -67,7 +66,6 @@ import DeleteIcon from '@mui/icons-material/DeleteOutlined';
 import PlayArrowIcon from '@mui/icons-material/PlayArrowOutlined';
 import GradingIcon from '@mui/icons-material/GradingOutlined';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesomeOutlined';
-import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
 import { MetricDetailView } from '@/app/(protected)/metrics/[identifier]/MetricDetailView';
 import {
   TestNode,
@@ -1968,7 +1966,6 @@ export default function ExplorerDetail({
   const [deleteSessionDialogOpen, setDeleteSessionDialogOpen] = useState(false);
   const [deleteSessionSubmitting, setDeleteSessionSubmitting] = useState(false);
 
-  const theme = useTheme();
   const { status } = useSession();
   const notifications = useNotifications();
   const searchParams = useSearchParams();

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
@@ -45,10 +45,7 @@ import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import { BetaBadge } from '@/components/common/BetaBadge';
 import PageLoadingState from '@/components/common/PageLoadingState';
-import type {
-  RequirementReference,
-  RequirementWithMetrics,
-} from '@/utils/api-client/interfaces/requirement';
+import type { RequirementWithMetrics } from '@/utils/api-client/interfaces/requirement';
 import type { MetricDetail } from '@/utils/api-client/interfaces/metric';
 import type { Status } from '@/utils/api-client/interfaces/status';
 import type { UUID } from 'crypto';

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailView.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailView.tsx
@@ -626,7 +626,7 @@ export function MetricDetailView({
 
       setEditData(sectionData);
     },
-    [metric, populateFieldRefs, notifications, tagNames, status]
+    [metric, populateFieldRefs, notifications, status]
   );
 
   const handleCancelEdit = React.useCallback(() => {

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/__tests__/MetricDetailView.test.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/__tests__/MetricDetailView.test.tsx
@@ -198,7 +198,9 @@ describe('MetricDetailView — evaluation steps (issue #1045)', () => {
     // debt, out of scope for #1045), so query by icon testid and walk up to
     // the button ancestor.
     const deleteIcons = screen.getAllByTestId('DeleteIcon');
-    const deleteButtons = deleteIcons.map(icon => icon.closest('button')!);
+    const deleteButtons = deleteIcons
+      .map(icon => icon.closest('button'))
+      .filter((button): button is HTMLButtonElement => button !== null);
     // The second step's delete button is the last one rendered before "Add Step".
     await act(async () => {
       fireEvent.click(deleteButtons[deleteButtons.length - 1]);

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectEnvironments.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectEnvironments.tsx
@@ -62,7 +62,6 @@ import {
   BuiltInEnvironment,
   ExperimentRead,
   EnvironmentPointer,
-  ProjectEnvironments as ProjectEnvironmentsShape,
   shortVersion,
 } from '@/utils/api-client/interfaces/parameters';
 import { AddIcon, DeleteIcon, PromoteIcon } from '@/components/icons';
@@ -166,10 +165,12 @@ export default forwardRef<ProjectEnvironmentsHandle, ProjectEnvironmentsProps>(
     const [searchQuery, setSearchQuery] = useState('');
 
     const queryClient = useQueryClient();
-    const environmentsQueryKey = [
-      ...projectKeys.detail(projectId),
-      'environments',
-    ] as const;
+    // Memoised so `refresh` below keeps a stable identity; a fresh array each
+    // render made its useCallback pointless.
+    const environmentsQueryKey = useMemo(
+      () => [...projectKeys.detail(projectId), 'environments'] as const,
+      [projectId]
+    );
     const [pickerEnvironmentName, setPickerEnvironmentName] = useState<
       string | null
     >(null);
@@ -198,7 +199,12 @@ export default forwardRef<ProjectEnvironmentsHandle, ProjectEnvironmentsProps>(
     });
 
     const bindings = envData?.bindings ?? null;
-    const experiments = envData?.experiments ?? [];
+    // Memoised for the same reason as environmentsQueryKey: the `?? []`
+    // fallback otherwise re-ran sharedExperiments and experimentName every render.
+    const experiments = useMemo(
+      () => envData?.experiments ?? [],
+      [envData?.experiments]
+    );
     const error =
       fetchError instanceof Error
         ? fetchError.message

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectParameters.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectParameters.tsx
@@ -18,7 +18,6 @@ import {
   AddIcon,
   KeyboardArrowDownIcon,
   KeyboardArrowUpIcon,
-  TuneIcon,
 } from '@/components/icons';
 import BaseDrawer from '@/components/common/BaseDrawer';
 import FormSectionDivider from '@/components/common/FormSectionDivider';

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/parameter-schema-shared.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/parameter-schema-shared.tsx
@@ -15,7 +15,6 @@ import {
   Typography,
 } from '@mui/material';
 import {
-  AddIcon,
   CategoryIcon,
   LockIcon,
   NotesIcon,

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsTableView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsTableView.tsx
@@ -226,74 +226,81 @@ export default function TestsTableView({
     }
   };
 
-  const handleConfirmReview = async (
-    event: React.MouseEvent,
-    test: TestResultDetail
-  ) => {
-    event.stopPropagation();
-    if (isConfirmingRef.current) return;
-    isConfirmingRef.current = true;
+  // useCallback so the columns memo below can depend on this handler without
+  // being rebuilt on every render. Everything it closes over is either a ref
+  // or a setState (both stable), leaving onTestResultUpdate as the only dep.
+  const handleConfirmReview = useCallback(
+    async (event: React.MouseEvent, test: TestResultDetail) => {
+      event.stopPropagation();
+      if (isConfirmingRef.current) return;
+      isConfirmingRef.current = true;
 
-    try {
-      setIsConfirmingReview(true);
+      try {
+        setIsConfirmingReview(true);
 
-      const clientFactory = new ApiClientFactory();
-      const testResultsClient = clientFactory.getTestResultsClient();
-      const statusClient = clientFactory.getStatusClient();
-      const statuses = await statusClient.getStatuses({
-        entity_type: EntityType.TEST_RESULT,
-      });
+        const clientFactory = new ApiClientFactory();
+        const testResultsClient = clientFactory.getTestResultsClient();
+        const statusClient = clientFactory.getStatusClient();
+        const statuses = await statusClient.getStatuses({
+          entity_type: EntityType.TEST_RESULT,
+        });
 
-      // Confirm the outcome the reviewer is actually looking at. Deriving it
-      // from raw metrics here risked submitting a verdict that contradicted
-      // the chip on screen. The review flow only offers pass/fail, so any
-      // non-Pass outcome is confirmed as a fail.
-      const automatedPassed = getEffectiveTestResultStatus(test) === 'Pass';
+        // Confirm the outcome the reviewer is actually looking at. Deriving it
+        // from raw metrics here risked submitting a verdict that contradicted
+        // the chip on screen. The review flow only offers pass/fail, so any
+        // non-Pass outcome is confirmed as a fail.
+        const automatedPassed = getEffectiveTestResultStatus(test) === 'Pass';
 
-      const targetStatus = findStatusByCategory(
-        statuses,
-        automatedPassed ? 'passed' : 'failed'
-      );
-      if (!targetStatus) return;
+        const targetStatus = findStatusByCategory(
+          statuses,
+          automatedPassed ? 'passed' : 'failed'
+        );
+        if (!targetStatus) return;
 
-      await testResultsClient.createReview(
-        test.id,
-        targetStatus.id,
-        `Confirmed automated ${automatedPassed ? 'pass' : 'fail'} result.`,
-        { type: REVIEW_TARGET_TYPES.TEST_RESULT, reference: null }
-      );
+        await testResultsClient.createReview(
+          test.id,
+          targetStatus.id,
+          `Confirmed automated ${automatedPassed ? 'pass' : 'fail'} result.`,
+          { type: REVIEW_TARGET_TYPES.TEST_RESULT, reference: null }
+        );
 
-      let updatedTest: TestResultDetail | null = null;
-      const delays = [100, 200, 400, 800];
+        let updatedTest: TestResultDetail | null = null;
+        const delays = [100, 200, 400, 800];
 
-      for (const delay of delays) {
-        await new Promise(resolve => setTimeout(resolve, delay));
-        const fetchedTest = await testResultsClient.getTestResult(test.id);
-        if (fetchedTest.last_review) {
-          updatedTest = fetchedTest;
-          break;
+        for (const delay of delays) {
+          await new Promise(resolve => setTimeout(resolve, delay));
+          const fetchedTest = await testResultsClient.getTestResult(test.id);
+          if (fetchedTest.last_review) {
+            updatedTest = fetchedTest;
+            break;
+          }
         }
+
+        updatedTest = await testResultsClient.getTestResult(test.id);
+
+        setLocalTestUpdates(prev => ({
+          ...prev,
+          [updatedTest.id]: updatedTest,
+        }));
+
+        // Updater form rather than reading `selectedTest` from the closure:
+        // the awaits above can span well over a second, by which point a
+        // captured `selectedTest` may name a test the user has already
+        // navigated away from.
+        setSelectedTest(prev =>
+          prev && prev.id === test.id ? updatedTest : prev
+        );
+
+        onTestResultUpdate(updatedTest);
+      } catch (error) {
+        console.error('Failed to confirm review:', error);
+      } finally {
+        setIsConfirmingReview(false);
+        isConfirmingRef.current = false;
       }
-
-      updatedTest = await testResultsClient.getTestResult(test.id);
-
-      setLocalTestUpdates(prev => ({
-        ...prev,
-        [updatedTest.id]: updatedTest,
-      }));
-
-      if (selectedTest && selectedTest.id === test.id) {
-        setSelectedTest(updatedTest);
-      }
-
-      onTestResultUpdate(updatedTest);
-    } catch (error) {
-      console.error('Failed to confirm review:', error);
-    } finally {
-      setIsConfirmingReview(false);
-      isConfirmingRef.current = false;
-    }
-  };
+    },
+    [onTestResultUpdate]
+  );
 
   const openTestDrawer = useCallback((test: TestResultDetail, tabIndex = 0) => {
     setSelectedTest(test);
@@ -683,6 +690,7 @@ export default function TestsTableView({
     isConfirmingReview,
     openTestDrawer,
     requirements,
+    handleConfirmReview,
   ]);
 
   return (

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/__tests__/test-run-summary-utils.test.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/__tests__/test-run-summary-utils.test.ts
@@ -125,9 +125,12 @@ describe('aggregateMetricStats', () => {
       },
     });
 
+    const goalAchievement = result.test_metrics?.metrics?.['Goal Achievement'];
+    expect(goalAchievement).toBeDefined();
+
     expect(
       getEffectiveMetricSuccess(
-        result.test_metrics!.metrics!['Goal Achievement'] as {
+        goalAchievement as {
           is_successful: boolean;
           override?: { original_value: boolean };
         }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/RunClock.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/RunClock.test.tsx
@@ -97,11 +97,27 @@ describe('RunClockProvider', () => {
     const textCb = jest.fn();
     let clockRef: ReturnType<typeof useRunClock> | null = null;
 
+    /** The clock captured during render, or a thrown failure if Capturer
+     *  never ran. A plain `clockRef!` read here would be a non-null
+     *  assertion, and a local guard cannot work: in this scope TypeScript
+     *  narrows clockRef to its `null` initializer, since the only assignment
+     *  is inside Capturer. Reads inside this function use the declared type. */
+    const requireClock = () => {
+      if (!clockRef) {
+        throw new Error('useRunClock was never captured during render');
+      }
+      return clockRef;
+    };
+
     function Capturer() {
       clockRef = useRunClock();
       React.useEffect(() => {
-        const unsubFrame = clockRef!.subscribeFrame(frameCb);
-        const unsubText = clockRef!.subscribeText(textCb);
+        // Read the captured clock once and guard, rather than asserting
+        // non-null twice; useRunClock() above assigns it during render.
+        const clock = clockRef;
+        if (!clock) return;
+        const unsubFrame = clock.subscribeFrame(frameCb);
+        const unsubText = clock.subscribeText(textCb);
         return () => {
           unsubFrame();
           unsubText();
@@ -119,7 +135,7 @@ describe('RunClockProvider', () => {
     frameCb.mockClear();
     textCb.mockClear();
 
-    clockRef!.poke();
+    requireClock().poke();
 
     expect(frameCb).toHaveBeenCalledTimes(1);
     expect(textCb).toHaveBeenCalledTimes(1);

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/useTestRunLive.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/useTestRunLive.test.tsx
@@ -71,6 +71,18 @@ function makeMatrix(overrides: Partial<VerdictMatrix> = {}): VerdictMatrix {
 describe('useTestRunLive', () => {
   let subscribedHandlers: Map<string, (msg: any) => void>;
 
+  /** The handler the hook registered for `eventType`, or a thrown failure if
+   *  it never registered one. Replaces a non-null assertion per call site, so
+   *  a hook that silently stops subscribing fails here by name rather than
+   *  further down on an unrelated expectation. */
+  const requireHandler = (eventType: string) => {
+    const handler = subscribedHandlers.get(eventType);
+    if (!handler) {
+      throw new Error(`useTestRunLive subscribed no handler for ${eventType}`);
+    }
+    return handler;
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsConnected = true;
@@ -109,11 +121,10 @@ describe('useTestRunLive', () => {
     await waitFor(() => expect(result.current.matrix).toBeDefined());
     mockGetVerdictMatrix.mockClear();
 
-    const handler = subscribedHandlers.get(EventType.TEST_RUN_PROGRESSED);
-    expect(handler).toBeDefined();
+    const handler = requireHandler(EventType.TEST_RUN_PROGRESSED);
 
     act(() => {
-      handler!({ channel: 'test_run:other-id' });
+      handler({ channel: 'test_run:other-id' });
     });
 
     // Should not trigger a refetch for a different channel
@@ -126,10 +137,10 @@ describe('useTestRunLive', () => {
     await waitFor(() => expect(result.current.matrix).toBeDefined());
     mockGetVerdictMatrix.mockClear();
 
-    const handler = subscribedHandlers.get(EventType.TEST_RUN_PROGRESSED);
+    const handler = requireHandler(EventType.TEST_RUN_PROGRESSED);
 
     await act(async () => {
-      handler!({ channel: 'test_run:run-1' });
+      handler({ channel: 'test_run:run-1' });
     });
 
     await waitFor(() => expect(mockGetVerdictMatrix).toHaveBeenCalled());
@@ -144,9 +155,9 @@ describe('useTestRunLive', () => {
       makeMatrix({ test_ids: null, version: 2 })
     );
 
-    const handler = subscribedHandlers.get(EventType.TEST_RUN_PROGRESSED);
+    const handler = requireHandler(EventType.TEST_RUN_PROGRESSED);
     await act(async () => {
-      handler!({ channel: 'test_run:run-1' });
+      handler({ channel: 'test_run:run-1' });
     });
 
     await waitFor(() =>
@@ -169,9 +180,9 @@ describe('useTestRunLive', () => {
       makeMatrix({ test_ids: null, version: 2 })
     );
 
-    const handler = subscribedHandlers.get(EventType.TEST_RUN_PROGRESSED);
+    const handler = requireHandler(EventType.TEST_RUN_PROGRESSED);
     await act(async () => {
-      handler!({ channel: 'test_run:run-1' });
+      handler({ channel: 'test_run:run-1' });
     });
 
     await waitFor(() => expect(result.current.matrix?.version).toBe(2));
@@ -187,9 +198,9 @@ describe('useTestRunLive', () => {
     mockGetVerdictMatrix.mockResolvedValue(
       makeMatrix({ test_ids: ['t3', 't4'], version: 2 })
     );
-    const handler = subscribedHandlers.get(EventType.TEST_RUN_PROGRESSED);
+    const handler = requireHandler(EventType.TEST_RUN_PROGRESSED);
     await act(async () => {
-      handler!({ channel: 'test_run:run-1' });
+      handler({ channel: 'test_run:run-1' });
     });
 
     await waitFor(() => expect(result.current.matrix?.version).toBe(2));
@@ -209,11 +220,11 @@ describe('useTestRunLive', () => {
 
     await waitFor(() => expect(result.current.matrix).toBeDefined());
 
-    const handler = subscribedHandlers.get(EventType.SUBSCRIPTION_ERROR);
+    const handler = requireHandler(EventType.SUBSCRIPTION_ERROR);
     expect(handler).toBeDefined();
 
     act(() => {
-      handler!({ channel: 'test_run:run-1' });
+      handler({ channel: 'test_run:run-1' });
     });
 
     // After subscription error, the hook should fall back to polling

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunDetailData.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunDetailData.ts
@@ -59,17 +59,22 @@ function extractRequirementsWithMetrics(results: TestResultDetail[]): {
     const requirement = result.test?.requirement;
     const metrics = result.test_metrics?.metrics ?? {};
 
-    if (requirement && !requirementMap.has(requirement.id as string)) {
-      requirementMap.set(requirement.id as string, {
-        id: requirement.id as string,
-        name: requirement.name,
-        description: requirement.description || undefined,
-        metrics: [],
-      });
-    }
-
     if (requirement) {
-      const entry = requirementMap.get(requirement.id as string)!;
+      const requirementId = requirement.id as string;
+      // Hold the entry rather than re-reading it: the has/set/get round trip
+      // is what forced a non-null assertion, since TypeScript cannot know the
+      // `set` above guarantees this `get`.
+      let entry = requirementMap.get(requirementId);
+      if (!entry) {
+        entry = {
+          id: requirementId,
+          name: requirement.name,
+          description: requirement.description || undefined,
+          metrics: [],
+        };
+        requirementMap.set(requirementId, entry);
+      }
+
       for (const [name, data] of Object.entries(metrics)) {
         if (!entry.metrics.some(m => m.name === name)) {
           entry.metrics.push({

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetMetrics.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetMetrics.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   Typography,
@@ -24,7 +24,6 @@ import AddIcon from '@mui/icons-material/Add';
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { TestSetMetric } from '@/utils/api-client/interfaces/test-set';
 import { useNotifications } from '@/components/common/NotificationContext';
 import SelectMetricsDialog from '@/components/common/SelectMetricsDialog';
 import { useCan } from '@/components/common/Can';

--- a/apps/frontend/src/app/(protected)/tools/components/ToolConnectionDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tools/components/ToolConnectionDrawer.tsx
@@ -17,7 +17,6 @@ import { FilledStatusAlert } from '@/components/common/FilledStatusAlert';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 
-import SmartToyIcon from '@mui/icons-material/SmartToy';
 import { useTheme } from '@mui/material/styles';
 import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -28,10 +27,7 @@ import {
   TypeLookup,
 } from '@/utils/api-client/interfaces/tool';
 import { UUID } from 'crypto';
-import {
-  TOOL_PROVIDER_ICONS,
-  formatToolProviderDisplayName,
-} from '@/config/tool-providers';
+import { formatToolProviderDisplayName } from '@/config/tool-providers';
 import { getErrorMessage } from '@/utils/entity-error-handler';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 
@@ -370,6 +366,7 @@ export function ToolConnectionDrawer({
       setCredentialsModified(false);
       setScopeMetadataModified(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `tool` and `providers` are tracked by value through tool?.id / toolProviderKey / providerIdsKey. Depending on the objects themselves would re-run this whole form reset on any new reference and wipe what the user has typed.
   }, [
     open,
     isEditMode,
@@ -1292,12 +1289,6 @@ export function ToolConnectionDrawer({
       }
     }
   };
-
-  // Determine icon and display name
-  const providerIconKey = provider?.type_value ?? '';
-  const providerIcon = TOOL_PROVIDER_ICONS[providerIconKey] || (
-    <SmartToyIcon sx={{ fontSize: theme => theme.iconSizes.medium }} />
-  );
 
   const displayName = provider?.type_value
     ? formatToolProviderDisplayName(provider.type_value)

--- a/apps/frontend/src/app/(protected)/traces/components/ConversationTraceView.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/ConversationTraceView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
-import { Alert, Box, CircularProgress, Typography } from '@mui/material';
+import { Alert, Box, CircularProgress } from '@mui/material';
 import {
   TraceDetailResponse,
   SpanNode,

--- a/apps/frontend/src/components/common/EntityGrid/EntityGrid.tsx
+++ b/apps/frontend/src/components/common/EntityGrid/EntityGrid.tsx
@@ -199,20 +199,19 @@ export default function EntityGrid<
     [deleteSpec, ambientCanDelete]
   );
 
-  const bulkDeleteFn = useMemo(
-    () =>
-      deleteSpec?.bulk
-        ? (ids: string[]) => deleteSpec.bulk!(new ApiClientFactory(), ids)
-        : undefined,
-    [deleteSpec]
-  );
-  const deleteOneFn = useMemo(
-    () =>
-      deleteSpec?.one
-        ? (id: string) => deleteSpec.one!(new ApiClientFactory(), id)
-        : undefined,
-    [deleteSpec]
-  );
+  // Capture the method in a local before closing over it: narrowing
+  // `deleteSpec?.bulk` does not survive into the returned closure, which is
+  // what the non-null assertions here used to paper over.
+  const bulkDeleteFn = useMemo(() => {
+    const bulk = deleteSpec?.bulk;
+    return bulk
+      ? (ids: string[]) => bulk(new ApiClientFactory(), ids)
+      : undefined;
+  }, [deleteSpec]);
+  const deleteOneFn = useMemo(() => {
+    const one = deleteSpec?.one;
+    return one ? (id: string) => one(new ApiClientFactory(), id) : undefined;
+  }, [deleteSpec]);
 
   const {
     checkboxSelectionMode,

--- a/apps/frontend/src/components/tests/TestExecutionHistorySection.tsx
+++ b/apps/frontend/src/components/tests/TestExecutionHistorySection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Alert, Box, CircularProgress, Paper, Typography } from '@mui/material';
+import { Alert, CircularProgress, Paper, Typography } from '@mui/material';
 import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import TestExecutionHistoryTable from './TestExecutionHistoryTable';

--- a/apps/frontend/src/config/test-templates.generated.ts
+++ b/apps/frontend/src/config/test-templates.generated.ts
@@ -15,22 +15,6 @@ import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import CampaignIcon from '@mui/icons-material/Campaign';
 import { TestTemplate } from '@/app/(protected)/test-sets/new-generated/components/shared/types';
 
-// Icon mapping for YAML references
-const iconMap: Record<string, React.ComponentType<any>> = {
-  BalanceIcon,
-  LanguageIcon,
-  VerifiedUserIcon,
-  PrivacyTipIcon,
-  RecordVoiceOverIcon,
-  PublicIcon,
-  MenuBookIcon,
-  FavoriteIcon,
-  LightbulbIcon,
-  TroubleshootIcon,
-  AccountBalanceIcon,
-  CampaignIcon,
-};
-
 // Generated templates from YAML
 export const TEMPLATES: TestTemplate[] = [
   {

--- a/apps/frontend/src/hooks/useInsightsFailedTestIds.ts
+++ b/apps/frontend/src/hooks/useInsightsFailedTestIds.ts
@@ -109,6 +109,10 @@ export function useInsightsFailedTestIds(
   const queryClient = useQueryClient();
   const isAuthenticated = useIsAuthenticated();
 
+  // Extracted so the dependency array holds a plain value the lint rule can
+  // check statically; the join keeps testRunIds compared by value, not identity.
+  const testRunIdsKey = filters?.testRunIds?.join(',');
+
   const scope = useMemo(
     () => (filters ? toInsightsFailedTestIdsScope(filters) : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- field-level deps; testRunIds by value
@@ -116,7 +120,7 @@ export function useInsightsFailedTestIds(
       filters?.endpointId,
       filters?.runFilterMode,
       filters?.timeRange,
-      filters?.testRunIds?.join(','),
+      testRunIdsKey,
       filters?.requirementId,
       filters?.metricName,
       filters?.topicName,
@@ -128,7 +132,17 @@ export function useInsightsFailedTestIds(
     queryKey: scope
       ? insightsFailedTestIdsKeys.scope(scope)
       : insightsFailedTestIdsKeys.all(),
-    queryFn: () => insightsFailedTestIdsQueryFn(queryClient, filters!),
+    queryFn: () => {
+      // `enabled` below gates on filters?.endpointId, so this cannot run with
+      // null filters. The explicit guard is what lets TypeScript drop the
+      // non-null assertion that used to sit here.
+      if (!filters) {
+        throw new Error(
+          'useInsightsFailedTestIds: queryFn ran without filters'
+        );
+      }
+      return insightsFailedTestIdsQueryFn(queryClient, filters);
+    },
     enabled: enabled && isAuthenticated && !!filters?.endpointId && !!scope,
   });
 }

--- a/apps/frontend/src/utils/api-client/__tests__/tests-client.test.ts
+++ b/apps/frontend/src/utils/api-client/__tests__/tests-client.test.ts
@@ -1,7 +1,5 @@
 import { TestsClient } from '../tests-client';
 
-const BASE_URL = 'http://localhost/api/backend';
-
 function makeFetchResponse(
   body: unknown,
   status = 200,

--- a/apps/frontend/tests/e2e/tests/knowledge-crud.spec.ts
+++ b/apps/frontend/tests/e2e/tests/knowledge-crud.spec.ts
@@ -5,7 +5,6 @@ import { KnowledgePage } from '../pages/KnowledgePage';
 import {
   confirmDeleteDialog,
   expectGridRowVisible,
-  waitForDrawerClosed,
 } from '../helpers/CrudHelper';
 
 interface StubbedSource {

--- a/apps/frontend/tests/e2e/tests/tasks-crud.spec.ts
+++ b/apps/frontend/tests/e2e/tests/tasks-crud.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from '@playwright/test';
 import { TasksPage } from '../pages/TasksPage';
 import {
   confirmDeleteDialog,
-  openDrawer,
   waitForDrawerClosed,
 } from '../helpers/CrudHelper';
 

--- a/ee/frontend/src/api-clients/components/CreateApiClientDrawer.tsx
+++ b/ee/frontend/src/api-clients/components/CreateApiClientDrawer.tsx
@@ -32,7 +32,6 @@
  */
 
 import * as React from 'react';
-import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Checkbox from '@mui/material/Checkbox';
 import FormControl from '@mui/material/FormControl';

--- a/ee/frontend/src/rbac/components/RoleEditorDrawer.tsx
+++ b/ee/frontend/src/rbac/components/RoleEditorDrawer.tsx
@@ -14,7 +14,6 @@ import {
   ROLE_EDITOR_DRAWER_WIDTH,
 } from '@/components/common/drawerFormFieldSx';
 import { useNotifications } from '@/components/common/NotificationContext';
-import { useOrgSettings } from '@/contexts/OrgSettingsContext';
 import { RbacClient } from '../api/rbac-client';
 import { invalidateRoles } from '../api/role-cache';
 import { useActorAuthority } from '../hooks/useActorAuthority';

--- a/ee/frontend/src/rbac/components/RolesTab.tsx
+++ b/ee/frontend/src/rbac/components/RolesTab.tsx
@@ -38,7 +38,6 @@ import {
   sectionCardGridTableInsetSx,
   sectionCardGridTableEdgeCellResetSx,
 } from '@/components/common/GridToolbar';
-import { useOrgSettings } from '@/contexts/OrgSettingsContext';
 import { BORDER_RADIUS } from '@/styles/theme-constants';
 import { RbacClient } from '../api/rbac-client';
 import { fetchRoles, invalidateRoles } from '../api/role-cache';

--- a/ee/frontend/src/rbac/components/__tests__/OrgRoleChip.test.tsx
+++ b/ee/frontend/src/rbac/components/__tests__/OrgRoleChip.test.tsx
@@ -44,7 +44,6 @@ import type { OrgMemberRead } from '../../types';
 
 import OrgRoleChip from '../OrgRoleChip';
 
-const SESSION_TOKEN = 'session-token';
 const USER_ID = 'user-1';
 
 const VIEWER_ROLE = makeRole({

--- a/ee/frontend/src/rbac/components/__tests__/RoleSelectField.test.tsx
+++ b/ee/frontend/src/rbac/components/__tests__/RoleSelectField.test.tsx
@@ -24,8 +24,6 @@ jest.mock('../../api/rbac-client', () => rbacClientMock);
 import { invalidateRoles } from '../../api/role-cache';
 import RoleSelectField from '../RoleSelectField';
 
-const SESSION_TOKEN = 'session-token';
-
 const VIEWER_ROLE = makeRole({
   id: 'role-viewer',
   name: 'viewer',

--- a/ee/frontend/src/rbac/components/__tests__/TokenScopeField.test.tsx
+++ b/ee/frontend/src/rbac/components/__tests__/TokenScopeField.test.tsx
@@ -25,8 +25,6 @@ import { RESOURCE_AREAS, CapabilityLevel } from '../../capability-groups';
 import type { PermissionRead } from '../../types';
 import TokenScopeField from '../TokenScopeField';
 
-const SESSION_TOKEN = 'session-token';
-
 function requireArea(id: string) {
   const area = RESOURCE_AREAS.find(a => a.id === id);
   if (!area) throw new Error(`Unknown resource area: ${id}`);


### PR DESCRIPTION
## What this does

Takes the frontend from 49 ESLint warnings to zero. They were all warnings rather than errors, so `npm run lint` already exited 0 and CI never blocked on them; the effect was that a genuinely new warning had nowhere to stand out.

Nothing here is a behaviour change except one bug fix, called out below.

## The four categories

**Unused imports and variables (24).** Dead icon and component imports, an unused type import, a `const theme = useTheme()` nothing read, and unused constants in three RBAC tests. Removed rather than underscore-prefixed, since none is a positional parameter that has to keep its slot.

**Non-null assertions (16).** Each site now states its assumption instead of suppressing the check. Two get a `require*` helper that throws with a specific message, so a regression fails at the cause rather than further down on an unrelated expectation. `EntityGrid` captures `deleteSpec.bulk`/`.one` in a local, because narrowing does not survive into the returned closure. `useTestRunDetailData` holds the map entry rather than doing a `has`/`set`/`get` round trip, which is what made the assertion necessary in the first place.

**Hook dependencies (8).** Most were pointing at memos that never memoised: a `?? []` fallback or an inline array literal handed a fresh reference to the dependency array every render, so the `useMemo` below it was doing nothing. Wrapping the initialisation is what the rule was asking for.

**A generated file (2).** `test-templates.generated.ts` carried an `iconMap` the output never read, which was also the file's only `any`. The file says "do not edit manually", so the fix is in `scripts/generate-templates.js`, then regenerated.

## One real bug

`TestsTableView.handleConfirmReview` read `selectedTest` from its closure *after* up to 1.5 seconds of awaited retry loop, then wrote to it. If the user selected a different test while those retries were in flight, the stale capture decided what got updated. It now uses the setState updater form, which reads the current value at commit time.

That one surfaced only because the missing-dependency warning pointed at it. The lint rule was right for a reason that had nothing to do with memoisation.

## One warning deliberately kept suppressed

`ToolConnectionDrawer`'s form-reset effect tracks `tool` and `providers` by value, through `tool?.id` / `toolProviderKey` / `providerIdsKey`. Depending on the objects themselves would re-run a 30-field reset on any new reference and wipe whatever the user had typed. The existing code already had a comment saying the dependency array was intentionally stable; this adds the `eslint-disable` with that reason written out, which is the escape hatch `apps/frontend/AGENTS.md` prescribes for exactly this case.

## Testing

- `tsc --noEmit`: clean
- `npm run lint`: 0 problems, in `apps/frontend` and `ee/frontend`
- `npm run format:check`: clean
- `npm test`: 251 suites, 2461 tests, all passing

## Reviewer notes

- `TestsTableView.tsx` shows ~138 changed lines, but `git diff -w` reduces that to 16. The rest is the body re-indenting under `useCallback`.
- Worth a look at the `handleConfirmReview` change specifically, since it is the only place where behaviour differs.
- No test was added for the stale-read fix. Reproducing it needs a test that swaps the selection mid-retry, which the current harness for that component does not set up cheaply. Happy to add one if you would rather not take the fix on inspection.
