### PR TITLE
Fix credit-burn blind spot and per-env Vertex credentials

### DIFF
--- a/.github/actions/tf-setup/action.yml
+++ b/.github/actions/tf-setup/action.yml
@@ -66,7 +66,18 @@ runs:
                      echo "service_account=$TF_SA_PRD" >> "$GITHUB_OUTPUT" ;;
           wireguard) echo "project_id=$TF_PROJECT_ID_WIREGUARD" >> "$GITHUB_OUTPUT"
                      echo "service_account=$TF_SA_WIREGUARD" >> "$GITHUB_OUTPUT" ;;
-          *)         echo "::error::Unknown environment '$ENV' -- expected dev, stg, prd, or wireguard/admin."
+          # envs/billing manages billing-account budgets. It reuses the admin
+          # project and terraform-wireguard rather than taking its own secrets:
+          # the notification channels live in rhesis-platform-admin anyway, and
+          # terraform-wireguard is the only SA there GitHub Actions can
+          # impersonate (terraform-deployer holds billing.user but its only
+          # workloadIdentityUser members are KSAs in the deleted rhesis-worker
+          # clusters). Budgets need roles/billing.costsManager, granted to
+          # terraform-wireguard out-of-band on 2026-09-03 -- Terraform cannot
+          # grant itself the permission it needs to run.
+          billing)   echo "project_id=$TF_PROJECT_ID_WIREGUARD" >> "$GITHUB_OUTPUT"
+                     echo "service_account=$TF_SA_WIREGUARD" >> "$GITHUB_OUTPUT" ;;
+          *)         echo "::error::Unknown environment '$ENV' -- expected dev, stg, prd, wireguard/admin, or billing."
                      exit 1 ;;
         esac
 

--- a/.github/workflows/terraform-infrastructure.yml
+++ b/.github/workflows/terraform-infrastructure.yml
@@ -7,7 +7,7 @@ on:
         description: 'Target environment'
         required: true
         type: choice
-        options: [dev, stg, prd, admin]
+        options: [dev, stg, prd, admin, billing]
         default: dev
       action:
         description: 'Terraform action'
@@ -47,6 +47,12 @@ jobs:
   # wireguard/admin is intentionally excluded: it takes bespoke inputs
   # (wireguard_envs/wireguard_peers) that don't have sane defaults for an
   # automatic plan, and it changes far less often than dev/stg/prd.
+  # billing IS planned automatically: every variable has a default, and
+  # terraform-wireguard (the admin SA this root reuses) was granted
+  # roles/billing.costsManager on 2026-09-03, which is what planning budgets
+  # needs. Auto-planning it is the point -- a budget edited by hand in the
+  # console is exactly the kind of invisible billing drift that let 4,700
+  # EUR/month of credit burn go unnoticed.
   compute-matrix:
     name: Compute plan matrix
     runs-on: ubuntu-latest
@@ -58,7 +64,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo 'environments=["${{ inputs.environment }}"]' >> "$GITHUB_OUTPUT"
           else
-            echo 'environments=["dev","stg","prd"]' >> "$GITHUB_OUTPUT"
+            echo 'environments=["dev","stg","prd","billing"]' >> "$GITHUB_OUTPUT"
           fi
 
   plan:

--- a/.github/workflows/terraform-infrastructure.yml
+++ b/.github/workflows/terraform-infrastructure.yml
@@ -116,7 +116,14 @@ jobs:
 
       - name: Plan
         working-directory: terraform/infrastructure/envs/${{ steps.tf_setup.outputs.target_env }}
-        run: terraform plan -input=false -out=tfplan -no-color 2>&1 | tee plan.txt
+        # pipefail is required, not stylistic. GitHub's default shell is `bash -e {0}`,
+        # which has -e but NOT -o pipefail, so `terraform plan | tee` exits with tee's
+        # status and a failed plan reported the job as passing. That masked a real 403 on
+        # the billing plan in PR #2690: the plan errored, the check went green.
+        shell: bash
+        run: |
+          set -o pipefail
+          terraform plan -input=false -out=tfplan -no-color 2>&1 | tee plan.txt
         env:
           TF_VAR_project_id: ${{ steps.tf_setup.outputs.project_id }}
           TF_VAR_region: ${{ secrets.TF_REGION }}

--- a/charts/rhesis/values-dev.yaml
+++ b/charts/rhesis/values-dev.yaml
@@ -43,8 +43,9 @@ config:
   authDisposableEmailExtraDomains: ""
   authDefaultSsoOrganization: ""
 
-  # GCP
-  vertexAiProject: "playground-437609"
+  # vertexAiProject is deliberately not set: it derives from the service account
+  # key delivered as GOOGLE_APPLICATION_CREDENTIALS, so rotating the key moves
+  # identity and project together. See values.yaml.
 
   # AI model — Vertex defaults in dev (GOOGLE_APPLICATION_CREDENTIALS in ESO);
   # avoids requiring RHESIS_API_KEY for rhesis/rhesis

--- a/charts/rhesis/values-prd.yaml
+++ b/charts/rhesis/values-prd.yaml
@@ -52,10 +52,14 @@ config:
   authDisposableEmailExtraDomains: ""
   authDefaultSsoOrganization: ""
 
-  # GCP
-  # TODO: migrate to rhesis-prd. Currently shared with dev for Vertex AI quota/billing.
-  # Audit logs and quota are split across projects until this is resolved.
-  vertexAiProject: "playground-437609"
+  # vertexAiProject is deliberately not set: it derives from the service account
+  # key delivered as GOOGLE_APPLICATION_CREDENTIALS, so rotating the key moves
+  # identity and project together. See values.yaml.
+  #
+  # This retires the "TODO: migrate to rhesis-prd" that sat here: prd no longer
+  # pins playground-437609, so the move happens when the key is rotated to
+  # rhesis-vertex-prd@rhesis-prd. Until that rotation, the old key still resolves
+  # to playground-437609, so removing the pin changes nothing on its own.
 
   # AI / Vertex
   defaultGenerationModel: "vertex_ai/gemini-3.1-flash-lite"

--- a/charts/rhesis/values-stg.yaml
+++ b/charts/rhesis/values-stg.yaml
@@ -48,8 +48,9 @@ config:
   authDisposableEmailExtraDomains: ""
   authDefaultSsoOrganization: ""
 
-  # GCP
-  vertexAiProject: "playground-437609"
+  # vertexAiProject is deliberately not set: it derives from the service account
+  # key delivered as GOOGLE_APPLICATION_CREDENTIALS, so rotating the key moves
+  # identity and project together. See values.yaml.
 
   # AI / Vertex (same model stack as dev; override per staging policy if needed)
   defaultGenerationModel: "vertex_ai/gemini-3.1-flash-lite"

--- a/charts/rhesis/values.yaml
+++ b/charts/rhesis/values.yaml
@@ -130,6 +130,14 @@ config:
   # Embeddings need a concrete region: text-embedding-* is not served from the
   # "eu" multi-region endpoint that Gemini accepts.
   vertexAiEmbeddingLocation: "europe-west4"
+  # Leave empty on purpose. Empty means the SDK takes the project from the
+  # service account key's own project_id, so identity and target project are a
+  # single artifact and cannot disagree. Setting it makes them two independent
+  # sources of truth that travel by different routes (this value via the
+  # ConfigMap and GitOps, the key via Secret Manager and ESO), and then changing
+  # one without the other is a guaranteed 403: the new key has no role in the old
+  # project, and the old key has none in the new one. Only set this if a
+  # deployment genuinely must call a project other than the key's owner.
   vertexAiProject: ""
 
   # Chatbot

--- a/infrastructure/config/gsm-secrets-sync.sh
+++ b/infrastructure/config/gsm-secrets-sync.sh
@@ -11,6 +11,12 @@
 #   ./gsm-secrets-sync.sh --project <GCP_PROJECT_ID> --dry-run
 #   ./gsm-secrets-sync.sh --project <GCP_PROJECT_ID> --secret-key SSO_ENCRYPTION_KEY
 #   ./infrastructure/config/gsm-secrets-sync.sh --project <GCP_PROJECT_ID> --json-env stg --eso-sa-email <ESO_SERVICE_ACCOUNT_EMAIL> --secret-key SSO_ENCRYPTION_KEY --dry-run
+#
+# Vertex AI credential rotation is the one value this script generates rather than reads,
+# via --mint-vertex-key. See the block above VERTEX_SECRET_KEY for why, and the runbook in
+# terraform/infrastructure/modules/vertex-ai/gcp/README.md for the surrounding steps:
+#   ./gsm-secrets-sync.sh --project rhesis-dev-494712 --json-env dev --mint-vertex-key --dry-run
+#   ./gsm-secrets-sync.sh --project rhesis-dev-494712 --json-env dev --mint-vertex-key
 
 set -euo pipefail
 
@@ -24,6 +30,13 @@ PROJECT=""
 ESO_SA_EMAIL=""
 DRY_RUN=0
 ONLY_SECRET_KEY=""
+MINT_VERTEX_KEY=0
+VERTEX_SA=""
+VERTEX_KEY_FILE=""
+
+# Any key material this script writes to disk must be owner-only from the moment it
+# exists, not chmod'ed afterwards.
+umask 077
 
 RED=''
 GREEN=''
@@ -47,10 +60,15 @@ ${BLUE}Usage:${NC} $0 --project GCP_PROJECT_ID [options]
 
 ${BLUE}Options:${NC}
   -p, --project ID     GCP project (required)
-      --json-env NAME  Key in gsm-secrets.json (default: stg). Use dev, prod, etc.
+      --json-env NAME  Key in gsm-secrets.json (default: stg). One of dev, stg, prd --
+                       it also derives the ESO and Vertex service account names.
   -s, --eso-sa-email   ESO service account (default: eso-<json-env>@<project>.iam.gserviceaccount.com)
   -k, --secret-key NAME  Only sync this one secretKey (e.g. SSO_ENCRYPTION_KEY)
                          instead of every entry in the manifest
+      --mint-vertex-key  Mint a fresh key for rhesis-vertex-<json-env>@<project> and
+                         publish it as GOOGLE_APPLICATION_CREDENTIALS, instead of
+                         reading that value from gsm-secrets.json. Implies
+                         --secret-key GOOGLE_APPLICATION_CREDENTIALS.
       --dry-run        Print only; no gcloud
   -h, --help
 
@@ -76,6 +94,10 @@ while [[ $# -gt 0 ]]; do
       ONLY_SECRET_KEY="$2"
       shift 2
       ;;
+    --mint-vertex-key)
+      MINT_VERTEX_KEY=1
+      shift
+      ;;
     --dry-run)
       DRY_RUN=1
       shift
@@ -99,7 +121,10 @@ if [[ -z "${PROJECT}" ]]; then
   usage >&2
   exit 1
 fi
-if [[ ! -f "${SECRETS_JSON}" ]]; then
+# --mint-vertex-key generates its value instead of reading one, so it needs neither the
+# local secrets file nor jq. Better that way: it means rotating a credential never requires
+# a plaintext file of every other secret to be sitting on disk.
+if [[ "${MINT_VERTEX_KEY}" -eq 0 && ! -f "${SECRETS_JSON}" ]]; then
   echo -e "${RED}Error:${NC} missing ${SECRETS_JSON}" >&2
   exit 1
 fi
@@ -107,7 +132,7 @@ if [[ ! -f "${EXTERNAL_SECRET_YAML}" ]]; then
   echo -e "${RED}Error:${NC} missing ${EXTERNAL_SECRET_YAML}" >&2
   exit 1
 fi
-if ! command -v jq &>/dev/null; then
+if [[ "${MINT_VERTEX_KEY}" -eq 0 ]] && ! command -v jq &>/dev/null; then
   echo -e "${RED}Error:${NC} jq is required" >&2
   exit 1
 fi
@@ -120,6 +145,72 @@ if [[ -z "${ESO_SA_EMAIL}" ]]; then
   ESO_SA_EMAIL="eso-${JSON_ENV}@${PROJECT}.iam.gserviceaccount.com"
 fi
 IAM_MEMBER="serviceAccount:${ESO_SA_EMAIL}"
+
+# ── Vertex key minting (--mint-vertex-key) ───────────────────────────
+# The Vertex service account is Terraform-managed (modules/vertex-ai/gcp) but its KEY
+# deliberately is not: google_service_account_key stores private_key in Terraform state in
+# plaintext, and every CI service account holds storage.objectAdmin on the whole state
+# bucket with no per-prefix isolation, so a key in one environment's state is readable by
+# the others. Minting here keeps it out of state entirely.
+#
+# This mode exists rather than pasting a base64 blob into gsm-secrets.json because two
+# mistakes break auth on every pod and neither is visible where it is made:
+#   1. A trailing newline. The SDK decodes with base64.b64decode(..., validate=True),
+#      which rejects one outright.
+#   2. A key from the wrong project. vertexAiProject is unset in the chart, so the SDK
+#      derives the target project from the key's own project_id; a mismatched key now
+#      succeeds silently against the wrong project instead of failing with a 403.
+# verify_vertex_credential re-reads the published version and checks both.
+
+VERTEX_SECRET_KEY="GOOGLE_APPLICATION_CREDENTIALS"
+
+if [[ "${MINT_VERTEX_KEY}" -eq 1 ]]; then
+  VERTEX_SA="rhesis-vertex-${JSON_ENV}@${PROJECT}.iam.gserviceaccount.com"
+
+  if [[ -n "${ONLY_SECRET_KEY}" && "${ONLY_SECRET_KEY}" != "${VERTEX_SECRET_KEY}" ]]; then
+    echo -e "${RED}Error:${NC} --mint-vertex-key only applies to ${VERTEX_SECRET_KEY}, not '${ONLY_SECRET_KEY}'" >&2
+    exit 1
+  fi
+  ONLY_SECRET_KEY="${VERTEX_SECRET_KEY}"
+
+  # Fail before minting, so a missing prerequisite never leaves an orphaned key behind.
+  if ! gcloud iam service-accounts describe "${VERTEX_SA}" --project="${PROJECT}" &>/dev/null; then
+    echo -e "${RED}Error:${NC} service account does not exist: ${VERTEX_SA}" >&2
+    echo "Apply the Terraform first: envs/${JSON_ENV} includes module vertex_ai_${JSON_ENV}." >&2
+    exit 1
+  fi
+fi
+
+cleanup_vertex_key() {
+  [[ -n "${VERTEX_KEY_FILE}" && -f "${VERTEX_KEY_FILE}" ]] || return 0
+  # shred where available; rm is the fallback and still removes the file.
+  shred -u "${VERTEX_KEY_FILE}" 2>/dev/null || rm -f "${VERTEX_KEY_FILE}"
+}
+trap cleanup_vertex_key EXIT INT TERM
+
+mint_vertex_key_b64() {
+  VERTEX_KEY_FILE="$(mktemp -t vertex-key-XXXXXX.json)"
+  gcloud iam service-accounts keys create "${VERTEX_KEY_FILE}" \
+    --iam-account="${VERTEX_SA}" --project="${PROJECT}" >/dev/null
+  # tr -d '\n' guards against a base64 build that line-wraps (GNU coreutils wraps at 76
+  # chars; BSD/macOS does not). upsert_secret_value pipes with printf '%s', so no newline
+  # is added on the way out either.
+  base64 < "${VERTEX_KEY_FILE}" | tr -d '\n'
+}
+
+verify_vertex_credential() {
+  local secret_id="$1"
+  gcloud secrets versions access latest --secret="${secret_id}" --project="${PROJECT}" \
+    | SA="${VERTEX_SA}" PROJ="${PROJECT}" python3 -c "
+import sys, os, base64, json
+raw = sys.stdin.read()
+assert '\n' not in raw and '\r' not in raw, 'published value contains a newline; the SDK would reject it'
+d = json.loads(base64.b64decode(raw, validate=True))   # the exact call the SDK makes
+assert d['client_email'] == os.environ['SA'], f\"wrong service account: {d['client_email']}\"
+assert d['project_id'] == os.environ['PROJ'], f\"wrong project: {d['project_id']}\"
+print('  verified:', d['client_email'], '->', d['project_id'])
+"
+}
 
 upsert_secret_value() {
   local secret_id="$1"
@@ -173,21 +264,35 @@ while read -r secret_key gsm_key; do
   fi
   FOUND_IN_MANIFEST=1
 
-  value="$(
-    jq -r --arg env "${JSON_ENV}" --arg k "${secret_key}" \
-      '.[$env] // {} | .[$k] // empty' "${SECRETS_JSON}"
-  )"
-  if [[ "${value}" == "null" ]]; then
-    value=""
-  fi
-  if [[ -z "${value}" ]]; then
-    echo -e "${YELLOW}Skip:${NC} ${gsm_key} (no .${JSON_ENV}.${secret_key} in $(basename "${SECRETS_JSON}"))"
-    continue
+  if [[ "${MINT_VERTEX_KEY}" -eq 1 ]]; then
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+      echo -e "${YELLOW}[dry-run]${NC} would mint a key for ${VERTEX_SA} -> ${gsm_key}"
+      SYNCED=1
+      continue
+    fi
+    echo -e "${BLUE}Mint${NC} GSM ${gsm_key} <- new key for ${VERTEX_SA}"
+    value="$(mint_vertex_key_b64)"
+  else
+    value="$(
+      jq -r --arg env "${JSON_ENV}" --arg k "${secret_key}" \
+        '.[$env] // {} | .[$k] // empty' "${SECRETS_JSON}"
+    )"
+    if [[ "${value}" == "null" ]]; then
+      value=""
+    fi
+    if [[ -z "${value}" ]]; then
+      echo -e "${YELLOW}Skip:${NC} ${gsm_key} (no .${JSON_ENV}.${secret_key} in $(basename "${SECRETS_JSON}"))"
+      continue
+    fi
+    echo -e "${BLUE}Sync${NC} GSM ${gsm_key} <- JSON .${JSON_ENV}.${secret_key}"
   fi
 
-  echo -e "${BLUE}Sync${NC} GSM ${gsm_key} <- JSON .${JSON_ENV}.${secret_key}"
   upsert_secret_value "${gsm_key}" "${value}"
   bind_eso_accessor "${gsm_key}"
+  if [[ "${MINT_VERTEX_KEY}" -eq 1 ]]; then
+    verify_vertex_credential "${gsm_key}"
+    cleanup_vertex_key
+  fi
   SYNCED=1
 done < <(
   awk '

--- a/sdk/src/rhesis/sdk/agents/architect/agent.py
+++ b/sdk/src/rhesis/sdk/agents/architect/agent.py
@@ -125,7 +125,7 @@ class ArchitectAgent(BaseAgent):
     Usage::
 
         architect = ArchitectAgent(
-            model="vertex_ai/gemini-2.0-flash",
+            model="vertex_ai/gemini-3.1-flash-lite",
             tools=[*get_rhesis_tools(), extra_tool],
             event_handlers=[WebSocketHandler(ws.send_json)],
         )

--- a/sdk/src/rhesis/sdk/agents/events.py
+++ b/sdk/src/rhesis/sdk/agents/events.py
@@ -16,7 +16,7 @@ Usage::
             await self._send({"type": "tool_start", "tool": tool_name})
 
     architect = ArchitectAgent(
-        model="vertex_ai/gemini-2.0-flash",
+        model="vertex_ai/gemini-3.1-flash-lite",
         tools=[...],
         event_handlers=[WebSocketHandler(ws.send_json)],
     )

--- a/sdk/src/rhesis/sdk/agents/tools.py
+++ b/sdk/src/rhesis/sdk/agents/tools.py
@@ -66,7 +66,7 @@ class ExploreEndpointTool(BaseTool):
         target_factory: ``(endpoint_id) -> Target`` callable that
             creates a target for any endpoint (unbound mode).
         model: Model for Penelope to use during exploration. Accepts a
-            model string (e.g. ``"vertex_ai/gemini-2.0-flash"``) or a
+            model string (e.g. ``"vertex_ai/gemini-3.1-flash-lite"``) or a
             ``BaseLLM`` instance. If ``None``, Penelope uses its default.
         max_turns: Maximum conversation turns for each exploration.
             Defaults to 5.

--- a/sdk/src/rhesis/sdk/models/defaults.py
+++ b/sdk/src/rhesis/sdk/models/defaults.py
@@ -1,7 +1,7 @@
 """
 Canonical default model identifiers in unified provider/name form.
 
-All defaults are stored as full model ids (e.g. "vertex_ai/gemini-2.0-flash").
+All defaults are stored as full model ids (e.g. "vertex_ai/gemini-3.1-flash-lite").
 Use _model_name(full_id) to get the name part when calling provider constructors.
 """
 
@@ -29,7 +29,7 @@ DEFAULT_LANGUAGE_MODELS = {
     "polyphemus": "polyphemus/polyphemus-default",
     "replicate": "replicate/llama-2-70b-chat",
     "together_ai": "together_ai/togethercomputer/llama-2-70b-chat",
-    "vertex_ai": "vertex_ai/gemini-2.0-flash",
+    "vertex_ai": "vertex_ai/gemini-3.1-flash-lite",
     "azure_ai": "azure_ai/command-r-plus",
     "azure": "azure/gpt-4o",
 }
@@ -47,10 +47,10 @@ def parse_model_id(full_id: str) -> tuple[str, str]:
     """Split a full model id into (provider, model_name).
 
     Args:
-        full_id: Unified model id, e.g. "vertex_ai/gemini-2.0-flash"
+        full_id: Unified model id, e.g. "vertex_ai/gemini-3.1-flash-lite"
 
     Returns:
-        (provider, model_name), e.g. ("vertex_ai", "gemini-2.0-flash")
+        (provider, model_name), e.g. ("vertex_ai", "gemini-3.1-flash-lite")
     """
     if not full_id:
         return "", ""

--- a/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
+++ b/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
@@ -5,10 +5,15 @@ This provider enables access to Google's Vertex AI models (including Gemini) via
 It supports regional deployment and automatic credential detection (base64 or file path).
 
 
-Regional availability:
-    • gemini-2.0-flash: Available in us-central1, us-east4, us-west1,
-      europe-west1, europe-west4 (NOT in europe-west3)
-    • gemini-2.5-flash: Available in all regions
+Regional availability (verified 2026-09-02):
+    • gemini-3.1-flash-lite: eu, europe-west1, europe-west4 — the current default
+    • gemini-2.5-flash, gemini-2.5-pro: europe-west4
+    • text-embedding-005: eu, europe-west4 (embeddings use :predict, not :generateContent)
+    • gemini-2.0-flash: RETIRED. Returns 404 "Publisher model was not found".
+
+Note that "eu" is a valid VERTEX_AI_LOCATION multi-region, and is what the deployed
+environments use; it routes to whichever European region has capacity, so a single
+request can bill in europe-west1 while another bills in europe-west4.
 
 For detailed usage and configuration options, see VertexAILLM class documentation.
 """
@@ -243,7 +248,8 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
         with regional deployment support and automatic credential detection.
 
         Args:
-            model_name (str): The name of the Vertex AI model to use (default: "gemini-2.0-flash").
+            model_name (str): The name of the Vertex AI model to use
+                (default: "gemini-3.1-flash-lite").
             credentials (Optional[str]): Service account credentials (auto-detected format)
                 - Base64-encoded JSON string (for K8s/production)
                 - Or file path to JSON file (standard for local development)
@@ -267,12 +273,12 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
 
         Examples:
             >>> # Using environment variables (recommended)
-            >>> llm = VertexAILLM(model_name="gemini-2.0-flash")
+            >>> llm = VertexAILLM(model_name="gemini-3.1-flash-lite")
             >>> result = llm.generate("Tell me a joke.")
 
             >>> # Passing credentials directly (for Berlin/Europe)
             >>> llm = VertexAILLM(
-            ...     model_name="gemini-2.0-flash",
+            ...     model_name="gemini-3.1-flash-lite",
             ...     credentials="/path/to/service-account.json",
             ...     location="europe-west4",  # Netherlands - best for Europe
             ...     project="my-gcp-project"

--- a/terraform/infrastructure/envs/billing/README.md
+++ b/terraform/infrastructure/envs/billing/README.md
@@ -19,8 +19,11 @@ because it already holds `roles/billing.user`, but it is **not** usable: its onl
 `workloadIdentityUser` members are Kubernetes service accounts in the deleted
 `rhesis-worker{,-dev,-stg}` Autopilot clusters. That binding is Cloud Run era leftover.
 
-Managing budgets needs `roles/billing.costsManager`; `billing.user` is not enough. Granted
-on 2026-09-03:
+Two grants are needed, both applied 2026-09-03. They stay out-of-band on purpose: Terraform
+cannot grant itself the permissions it needs in order to run.
+
+Budgets need `roles/billing.costsManager` on the billing account; `billing.user` is not
+enough. Only a `billing.admin` (harry@, nicolai@) can grant it:
 
 ```bash
 gcloud billing accounts add-iam-policy-binding 01F632-DCD99F-C6AD14 \
@@ -28,8 +31,18 @@ gcloud billing accounts add-iam-policy-binding 01F632-DCD99F-C6AD14 \
   --role="roles/billing.costsManager"
 ```
 
-This stays out-of-band on purpose: Terraform cannot grant itself the permission it needs to
-run, and only a `billing.admin` (harry@, nicolai@) can grant it.
+The notification channels are a separate permission surface, easy to miss because it is not
+a billing role at all. Without it the plan fails at the import step with
+`Error 403 ... MonitoringNotificationChannel`, not at the budgets:
+
+```bash
+gcloud projects add-iam-policy-binding rhesis-platform-admin \
+  --member="serviceAccount:terraform-wireguard@rhesis-platform-admin.iam.gserviceaccount.com" \
+  --role="roles/monitoring.notificationChannelEditor"
+```
+
+`notificationChannelEditor` rather than `monitoring.editor`: Terraform manages these
+channels so read-only is not enough, but it needs nothing else in Monitoring.
 
 ## Applying
 

--- a/terraform/infrastructure/envs/billing/README.md
+++ b/terraform/infrastructure/envs/billing/README.md
@@ -44,6 +44,26 @@ gcloud projects add-iam-policy-binding rhesis-platform-admin \
 `notificationChannelEditor` rather than `monitoring.editor`: Terraform manages these
 channels so read-only is not enough, but it needs nothing else in Monitoring.
 
+## Prerequisite: two APIs
+
+`billingbudgets.googleapis.com` and `monitoring.googleapis.com` must be on in
+`rhesis-platform-admin`. Both are declared in `main.tf`, but that cannot bootstrap this
+root: Terraform refreshes and imports the existing budgets before it would create those
+resources, so the first plan needs them already enabled. Enabled out-of-band 2026-09-03:
+
+```bash
+gcloud services enable billingbudgets.googleapis.com monitoring.googleapis.com \
+  --project=rhesis-platform-admin
+```
+
+Symptom when `billingbudgets` is missing, which names the project by number rather than id
+and does not mention budgets in the resource path, so it reads like an IAM problem:
+
+```
+Error 403: Cloud Billing Budget API has not been used in project 211583725977
+  before or it is disabled
+```
+
 ## Applying
 
 Plans run automatically on any PR touching `terraform/**`. To apply, dispatch

--- a/terraform/infrastructure/envs/billing/README.md
+++ b/terraform/infrastructure/envs/billing/README.md
@@ -1,0 +1,80 @@
+# envs/billing
+
+Billing-account guardrails: the Cloud Monitoring notification channels for budget
+alerts, and the budgets themselves.
+
+Separate root because budgets are billing-account resources rather than project ones, so
+they do not belong in any single environment's state. The provider targets
+`rhesis-platform-admin`, which is where the notification channels live.
+
+## Identity and the one out-of-band IAM grant
+
+CI reuses the admin service account, `terraform-wireguard@rhesis-platform-admin`
+(`TF_SA_WIREGUARD`), rather than taking its own secrets. It is the only service account in
+the admin project with a `principalSet://.../workloadIdentityPools/github-actions/`
+binding, so it is the only one GitHub Actions can actually impersonate.
+
+Note that `terraform-deployer@rhesis-platform-admin` looks like the natural candidate
+because it already holds `roles/billing.user`, but it is **not** usable: its only
+`workloadIdentityUser` members are Kubernetes service accounts in the deleted
+`rhesis-worker{,-dev,-stg}` Autopilot clusters. That binding is Cloud Run era leftover.
+
+Managing budgets needs `roles/billing.costsManager`; `billing.user` is not enough. Granted
+on 2026-09-03:
+
+```bash
+gcloud billing accounts add-iam-policy-binding 01F632-DCD99F-C6AD14 \
+  --member="serviceAccount:terraform-wireguard@rhesis-platform-admin.iam.gserviceaccount.com" \
+  --role="roles/billing.costsManager"
+```
+
+This stays out-of-band on purpose: Terraform cannot grant itself the permission it needs to
+run, and only a `billing.admin` (harry@, nicolai@) can grant it.
+
+## Applying
+
+Plans run automatically on any PR touching `terraform/**`. To apply, dispatch
+`Terraform Infrastructure [Deploy]` with environment `billing` and action `apply`.
+
+The first apply adopts four resources created by hand on 2026-09-02 (two channels, two
+budgets) through `import` blocks in `main.tf`, so expect the plan to show adoption rather
+than creation. If it proposes to *create* a budget that already exists, the import ID is
+wrong: stop, because applying would leave two budgets alerting on the same thing. Verify
+IDs with:
+
+```bash
+gcloud billing budgets list --billing-account=01F632-DCD99F-C6AD14 \
+  --format="table(name,displayName,amount.specifiedAmount.units,budgetFilter.creditTypesTreatment)"
+```
+
+Delete the `import` blocks after the first successful apply; Terraform ignores them once
+the resources are in state.
+
+## Why two budgets
+
+They measure different things, and only one of them would have caught the August 2026
+invoice.
+
+| Budget | `credit_types_treatment` | Measures | Catches |
+|---|---|---|---|
+| Credit burn, 1500 EUR | `EXCLUDE_ALL_CREDITS` | gross spend | credit pool draining, runaway usage |
+| Uncovered spend, 5 EUR | `INCLUDE_ALL_CREDITS` | net invoice | spend credits refuse to cover |
+
+Startup credits run to February 2027 and do not cover third-party Marketplace publisher
+SKUs, such as Anthropic models served through Vertex AI Model Garden. So gross spend can
+run at thousands per month while the invoice reads 0.00, and a few euros of Marketplace
+usage can appear while everything Google-owned is fully credited. The two pre-existing
+budgets on this account both use `INCLUDE_ALL_CREDITS`, which is why 4,700 EUR/month of
+credit burn was invisible.
+
+## What a budget cannot do
+
+Budgets notify; they never block a request. A GCP quota cap cannot bound monthly cost here
+either: measured Vertex usage is bursty (median 10 requests/min, peak 226) at roughly
+EUR 0.0046 per prediction request, so any rate limit high enough for normal evaluation runs
+still permits thousands of euros a day if sustained. Holding a sustained runaway under
+1500 EUR/month would need about 7.5 requests/min, far below the legitimate peak.
+
+The `FORECASTED_SPEND` rule on the credit-burn budget is therefore the important one: it
+fires on projected overspend within hours rather than after the fact. Actually stopping a
+runaway tenant is application-level per-organisation quotas, not anything in this root.

--- a/terraform/infrastructure/envs/billing/main.tf
+++ b/terraform/infrastructure/envs/billing/main.tf
@@ -31,6 +31,26 @@ provider "google" {
   region  = var.region
 }
 
+# ── APIs ─────────────────────────────────────────────────────────────
+# Declared for durability, but note they cannot bootstrap this root: Terraform refreshes
+# and imports the existing budgets before it would create these resources, so the very
+# first plan needs both APIs already on. They were enabled out-of-band on 2026-09-03 after
+# the first plan failed with:
+#   Error 403: Cloud Billing Budget API has not been used in project 211583725977
+# Keeping them here stops a later `terraform destroy` or a disabled API silently breaking
+# budget management, and records the dependency where someone will look for it.
+resource "google_project_service" "billingbudgets" {
+  project            = var.project_id
+  service            = "billingbudgets.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "monitoring" {
+  project            = var.project_id
+  service            = "monitoring.googleapis.com"
+  disable_on_destroy = false
+}
+
 # ── Notification channels ────────────────────────────────────────────
 # Budget alerts also reach billing-account admins by default (that default is
 # left on deliberately, so removing a channel cannot silence alerts entirely).

--- a/terraform/infrastructure/envs/billing/main.tf
+++ b/terraform/infrastructure/envs/billing/main.tf
@@ -1,0 +1,174 @@
+# Billing guardrails for the whole billing account.
+#
+# Separate root because budgets are billing-account resources, not project ones:
+# they sit above dev/stg/prd and a change here is not scoped to any single
+# environment's state. The provider still needs a project to bill API calls to
+# and to hold the Cloud Monitoring notification channels, which is
+# rhesis-platform-admin.
+#
+# The two budgets cover the two independent axes, which is the point of having
+# both. Startup credits run to February 2027, and they do NOT cover third-party
+# Marketplace publisher SKUs (Anthropic models via Vertex AI Model Garden, for
+# one). So gross spend can run at thousands per month while the invoice reads
+# 0.00, and separately a few euros of uncovered Marketplace usage can appear
+# while everything Google-owned is fully credited. A budget measures one or the
+# other depending on credit_types_treatment, never both.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+  backend "gcs" {
+    prefix = "terraform/infrastructure/envs/billing"
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# ── Notification channels ────────────────────────────────────────────
+# Budget alerts also reach billing-account admins by default (that default is
+# left on deliberately, so removing a channel cannot silence alerts entirely).
+resource "google_monitoring_notification_channel" "budget_alerts" {
+  for_each = toset(var.budget_alert_emails)
+
+  project      = var.project_id
+  display_name = "Budget alerts (${each.key})"
+  type         = "email"
+  enabled      = true
+
+  labels = {
+    email_address = each.key
+  }
+}
+
+locals {
+  budget_channels = [for c in google_monitoring_notification_channel.budget_alerts : c.id]
+}
+
+# ── Credit burn: gross spend, credits excluded ───────────────────────
+# EXCLUDE_ALL_CREDITS is what makes this measure credit consumption rather than
+# the invoice. Without it the budget reads ~0 while credits are active and tells
+# you nothing until they run out.
+#
+# The FORECASTED_SPEND rule is the one that catches a runaway. A GCP quota cap
+# cannot bound monthly cost here: measured usage is bursty (median 10 req/min,
+# peak 226) at roughly EUR 0.0046 per prediction request, so any rate limit high
+# enough for normal evaluation runs still allows thousands of euros a day if
+# sustained. Detection, not prevention, is this budget's job.
+resource "google_billing_budget" "credit_burn" {
+  billing_account = var.billing_account_id
+  display_name    = "Credit burn - ${var.credit_burn_budget_eur} EUR/month (gross)"
+
+  budget_filter {
+    calendar_period        = "MONTH"
+    credit_types_treatment = "EXCLUDE_ALL_CREDITS"
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "EUR"
+      units         = tostring(var.credit_burn_budget_eur)
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 0.5
+  }
+  threshold_rules {
+    threshold_percent = 0.8
+  }
+  threshold_rules {
+    threshold_percent = 1.0
+  }
+  threshold_rules {
+    threshold_percent = 1.0
+    spend_basis       = "FORECASTED_SPEND"
+  }
+
+  all_updates_rule {
+    monitoring_notification_channels = local.budget_channels
+  }
+}
+
+# ── Uncovered spend: net billed cost, credits included ───────────────
+# While credits are active, any non-zero billed cost is by definition something
+# the credits refused to cover, so the useful threshold is "almost zero" rather
+# than a real budget. 5 EUR with a 20% first rule trips at 1 EUR. The August 2026
+# invoice was 3.16 EUR of Anthropic-on-Vertex usage that no existing budget could
+# have caught, because both then-existing budgets used INCLUDE_ALL_CREDITS with
+# limits of 1000 and 1500.
+resource "google_billing_budget" "uncovered_spend" {
+  billing_account = var.billing_account_id
+  display_name    = "Uncovered spend - ${var.uncovered_spend_budget_eur} EUR/month (net billed)"
+
+  budget_filter {
+    calendar_period        = "MONTH"
+    credit_types_treatment = "INCLUDE_ALL_CREDITS"
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "EUR"
+      units         = tostring(var.uncovered_spend_budget_eur)
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 0.2
+  }
+  threshold_rules {
+    threshold_percent = 0.6
+  }
+  threshold_rules {
+    threshold_percent = 1.0
+  }
+
+  all_updates_rule {
+    monitoring_notification_channels = local.budget_channels
+  }
+}
+
+# ── Adopt the resources already created by hand ──────────────────────
+# These four were created with gcloud on 2026-09-02 so the protection existed
+# the same day, before this root existed. Import blocks adopt them instead of
+# creating duplicates; the first apply should show changes only where the
+# gcloud-created config differs from the code above.
+#
+# Terraform removes an import block once it has been applied, so these can be
+# deleted after the first successful apply.
+import {
+  to = google_monitoring_notification_channel.budget_alerts["hello@rhesis.ai"]
+  id = "projects/rhesis-platform-admin/notificationChannels/10717083289590599537"
+}
+
+import {
+  to = google_monitoring_notification_channel.budget_alerts["engineering@rhesis.ai"]
+  id = "projects/rhesis-platform-admin/notificationChannels/11505341684286712947"
+}
+
+import {
+  to = google_billing_budget.credit_burn
+  id = "billingAccounts/01F632-DCD99F-C6AD14/budgets/6cd240d3-8bfb-428c-a854-618d84630431"
+}
+
+import {
+  to = google_billing_budget.uncovered_spend
+  id = "billingAccounts/01F632-DCD99F-C6AD14/budgets/3ba74fdb-e0a1-4dc2-bdfc-0de8f8aa1c3e"
+}
+
+# Not managed here yet: two older budgets on the same account, both
+# INCLUDE_ALL_CREDITS, so neither can see credit burn.
+#
+#   5f1e6d74-977a-4329-9dfa-f36c5d22f916  Gemini API Monthly Budget - 1000 EUR
+#   5fabdd8a-54cf-4ec0-b328-2f54c1709662  All projects - post-cleanup guardrail
+#
+# google_billing_budget is not authoritative over the account, so leaving them
+# out is safe; they simply stay unmanaged. Adopting them is a follow-up, and
+# worth doing together with deciding whether the 1000 EUR Gemini one still
+# earns its place now that the credit-burn budget exists.

--- a/terraform/infrastructure/envs/billing/outputs.tf
+++ b/terraform/infrastructure/envs/billing/outputs.tf
@@ -1,0 +1,14 @@
+output "budget_alert_channel_ids" {
+  description = "Cloud Monitoring notification channel IDs receiving budget alerts; reuse these for any further budget added to this account"
+  value       = local.budget_channels
+}
+
+output "credit_burn_budget_name" {
+  description = "Resource name of the gross-spend (credit burn) budget"
+  value       = google_billing_budget.credit_burn.name
+}
+
+output "uncovered_spend_budget_name" {
+  description = "Resource name of the net-billed-cost (uncovered spend) budget"
+  value       = google_billing_budget.uncovered_spend.name
+}

--- a/terraform/infrastructure/envs/billing/variables.tf
+++ b/terraform/infrastructure/envs/billing/variables.tf
@@ -1,0 +1,47 @@
+variable "project_id" {
+  description = "GCP project the provider bills API calls to and that holds the notification channels (rhesis-platform-admin)"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "billing_account_id" {
+  description = "Billing account the budgets attach to, bare ID form (no 'billingAccounts/' prefix)"
+  type        = string
+  default     = "01F632-DCD99F-C6AD14"
+
+  validation {
+    condition     = can(regex("^[0-9A-F]{6}-[0-9A-F]{6}-[0-9A-F]{6}$", var.billing_account_id))
+    error_message = "Must be a bare billing account ID, e.g. 01F632-DCD99F-C6AD14."
+  }
+}
+
+variable "budget_alert_emails" {
+  description = "Addresses that receive budget threshold alerts, in addition to the billing-account admins who always get them"
+  type        = list(string)
+  default     = ["hello@rhesis.ai", "engineering@rhesis.ai"]
+}
+
+variable "credit_burn_budget_eur" {
+  description = <<-EOT
+    Monthly gross spend (credits excluded) that triggers alerts. This is credit
+    consumption, not the invoice. Post-cleanup run rate is roughly 615 EUR/month,
+    so 1500 leaves headroom while still catching a runaway well before it drains
+    the credit pool.
+  EOT
+  type        = number
+  default     = 1500
+}
+
+variable "uncovered_spend_budget_eur" {
+  description = <<-EOT
+    Monthly net billed cost (credits included) that triggers alerts. Expected
+    value is 0.00 while credits are active, so this is a leak detector rather
+    than a budget: keep it small enough that the 20% rule trips on a euro.
+  EOT
+  type        = number
+  default     = 5
+}

--- a/terraform/infrastructure/envs/dev/main.tf
+++ b/terraform/infrastructure/envs/dev/main.tf
@@ -64,9 +64,13 @@ module "gke_dev" {
   wireguard_cidr         = local.cidrs.wireguard.network
   # e2-medium (~940m allocatable CPU/node) cannot fit the rhesis stack (~1400m requests)
   # plus platform DaemonSets; causes OOM, probe timeouts, and failed scale-up.
-  # Match stg sizing; keep min 2 nodes so cluster-autoscaler does not pack everything on one VM.
+  #
+  # min_node_count is PER ZONE on a regional cluster, so 1 already floors this at 3 nodes,
+  # one per zone. That satisfies the "don't let the autoscaler pack everything onto one VM"
+  # concern this was previously raised to 2 for, while 2 would mean a 6-node floor. Keeping
+  # a node in every zone is also what lets pods with zonal persistent disks reschedule.
   machine_type           = "e2-standard-2"
-  min_node_count         = 2
+  min_node_count         = 1
   max_node_count         = 6
   deletion_protection    = var.gke_deletion_protection
 

--- a/terraform/infrastructure/envs/dev/main.tf
+++ b/terraform/infrastructure/envs/dev/main.tf
@@ -96,6 +96,15 @@ module "eso_dev" {
   depends_on = [module.gke_dev]
 }
 
+# Vertex AI identity owned by this project, so dev's Gemini traffic stops billing
+# into playground-437609 via the shared gemini-vertex-sa key.
+module "vertex_ai_dev" {
+  source = "../../modules/vertex-ai/gcp"
+
+  project_id  = var.project_id
+  environment = "dev"
+}
+
 module "external_dns_dev" {
   source = "../../modules/external-dns/gcp"
 

--- a/terraform/infrastructure/envs/prd/main.tf
+++ b/terraform/infrastructure/envs/prd/main.tf
@@ -121,6 +121,15 @@ module "eso_prd" {
   depends_on = [module.gke_prd]
 }
 
+# Vertex AI identity owned by this project, so prd's Gemini traffic stops billing
+# into playground-437609 via the shared gemini-vertex-sa key.
+module "vertex_ai_prd" {
+  source = "../../modules/vertex-ai/gcp"
+
+  project_id  = var.project_id
+  environment = "prd"
+}
+
 module "external_dns_prd" {
   source = "../../modules/external-dns/gcp"
 

--- a/terraform/infrastructure/envs/stg/main.tf
+++ b/terraform/infrastructure/envs/stg/main.tf
@@ -99,6 +99,15 @@ module "eso_stg" {
   depends_on = [module.gke_stg]
 }
 
+# Vertex AI identity owned by this project, so stg's Gemini traffic stops billing
+# into playground-437609 via the shared gemini-vertex-sa key.
+module "vertex_ai_stg" {
+  source = "../../modules/vertex-ai/gcp"
+
+  project_id  = var.project_id
+  environment = "stg"
+}
+
 module "external_dns_stg" {
   source = "../../modules/external-dns/gcp"
 

--- a/terraform/infrastructure/modules/kubernetes/gcp/cluster.tf
+++ b/terraform/infrastructure/modules/kubernetes/gcp/cluster.tf
@@ -45,5 +45,20 @@ resource "google_container_cluster" "cluster" {
     channel = var.release_channel
   }
 
+  # Declared so these stop being invisible drift: they were trimmed with gcloud during the
+  # 2026-08 cost work and nothing in Terraform owned them, meaning any future change here
+  # would silently re-enable paid metric collection. Defaults match what all three clusters
+  # already run, so adding this is a no-op on apply.
+  monitoring_config {
+    enable_components = var.monitoring_enable_components
+    managed_prometheus {
+      enabled = var.enable_managed_prometheus
+    }
+  }
+
+  logging_config {
+    enable_components = var.logging_enable_components
+  }
+
   deletion_protection = var.deletion_protection
 }

--- a/terraform/infrastructure/modules/kubernetes/gcp/variables.tf
+++ b/terraform/infrastructure/modules/kubernetes/gcp/variables.tf
@@ -98,6 +98,28 @@ variable "release_channel" {
   default     = "STABLE"
 }
 
+variable "monitoring_enable_components" {
+  description = <<-EOT
+    GKE metrics sent to Cloud Monitoring. SYSTEM_COMPONENTS only by default: the in-cluster
+    kube-prometheus-stack is the source of truth, so adding POD/CADVISOR/KUBELET/DCGM here
+    pays Cloud Monitoring per sample for data we already collect ourselves.
+  EOT
+  type        = list(string)
+  default     = ["SYSTEM_COMPONENTS"]
+}
+
+variable "enable_managed_prometheus" {
+  description = "Run Google Managed Prometheus. Off: kube-prometheus-stack already covers this in-cluster, and running both bills twice for the same samples."
+  type        = bool
+  default     = false
+}
+
+variable "logging_enable_components" {
+  description = "Log sources sent to Cloud Logging"
+  type        = list(string)
+  default     = ["SYSTEM_COMPONENTS", "WORKLOADS"]
+}
+
 variable "machine_type" {
   description = "GCE machine type for node pool"
   type        = string

--- a/terraform/infrastructure/modules/vertex-ai/gcp/README.md
+++ b/terraform/infrastructure/modules/vertex-ai/gcp/README.md
@@ -77,18 +77,25 @@ gcloud secrets versions access latest \
       print(d['client_email'], d['project_id'])"
 ```
 
-### 4. Repoint the chart
+### 4. Nothing to change in the chart
 
-`vertexAiProject` is pinned per environment and is **not** auto-extracted from the key, so
-this step is required:
+The key is the only thing that moves. `vertexAiProject` is intentionally unset in every
+values file, so the SDK derives the project from the key's own `project_id`
+(`sdk/src/rhesis/sdk/models/providers/vertex_ai.py:219` only overrides it when the env var
+is truthy). Identity and target project are therefore a single artifact and cannot drift
+apart.
 
-```
-charts/rhesis/values-dev.yaml   vertexAiProject: "rhesis-dev-494712"
-charts/rhesis/values-stg.yaml   vertexAiProject: "rhesis-stg-494712"
-charts/rhesis/values-prd.yaml   vertexAiProject: "rhesis-prd"
-```
+This is deliberate. When the project was pinned separately it travelled by a different
+route from the key (ConfigMap and GitOps versus Secret Manager and ESO), which made the
+cutover a two-place change where either half alone guarantees a 403: a new key has no role
+in the old project, and the old key has none in the new one.
 
-The ExternalSecret needs no edit: the secret name is unchanged, only a new version is added.
+The ExternalSecret needs no edit either. The secret name is unchanged; only a new version
+is added, and `eso-<env>@` already holds `roles/secretmanager.secretAccessor` on it.
+
+The one thing this gives up: a wrong-project key used to fail loudly with a 403, and now it
+would silently succeed against the wrong project. Catch that with the round-trip check in
+step 3 and the per-project billing breakdown, not with a pinned value.
 
 ### 5. Refresh and restart
 
@@ -124,10 +131,24 @@ confirms it a day later.
 
 ## Rollback
 
-The previous secret version is retained, so rollback is: revert `vertexAiProject` in the
-values file, re-add the old key as a new version, force-sync, restart. Do not disable
-`aiplatform.googleapis.com` in `playground-437609` as a rollback step; that is what caused
-the outage.
+One command, because the project follows the key. Secret Manager's `latest` resolves to the
+newest *enabled* version, so disabling the version you just added reverts to the previous
+key, and the project reverts with it:
+
+```bash
+ENV=dev
+PROJECT=rhesis-dev-494712
+gcloud secrets versions disable <new-version> \
+  --secret="${ENV}-rhesis-google-application-credentials" --project="${PROJECT}"
+# then force-sync and restart as in step 5
+```
+
+No need to re-upload the old key, and no chart revert.
+
+Do **not** disable `aiplatform.googleapis.com` in `playground-437609` as a rollback step.
+That is what caused the 2026-09-02 outage: all three environments authenticate into that
+project until their rotation is done, so toggling the API there takes down dev, stg and prd
+at once.
 
 ## Follow-up: drop the keys entirely
 

--- a/terraform/infrastructure/modules/vertex-ai/gcp/README.md
+++ b/terraform/infrastructure/modules/vertex-ai/gcp/README.md
@@ -47,35 +47,45 @@ done
 
 ### 3. Mint the key and write it to Secret Manager
 
-The value must be **single-line base64 of the JSON, with no trailing newline**. The SDK calls
-`base64.b64decode(..., validate=True)`, which rejects a newline outright, so a stray `\n`
-breaks auth on every pod.
+Use `--mint-vertex-key` on the existing secrets sync script; do not do this by hand:
 
 ```bash
-ENV=dev
-PROJECT=rhesis-dev-494712
-SA="rhesis-vertex-${ENV}@${PROJECT}.iam.gserviceaccount.com"
-KEY=$(mktemp)
-
-gcloud iam service-accounts keys create "${KEY}" --iam-account="${SA}" --project="${PROJECT}"
-
-# tr -d '\n' guards against a base64 build that line-wraps (GNU coreutils wraps at 76 chars).
-base64 < "${KEY}" | tr -d '\n' \
-  | gcloud secrets versions add "${ENV}-rhesis-google-application-credentials" \
-      --project="${PROJECT}" --data-file=-
-
-shred -u "${KEY}" 2>/dev/null || rm -f "${KEY}"
+S=infrastructure/config/gsm-secrets-sync.sh
+bash "$S" --project rhesis-dev-494712 --json-env dev --mint-vertex-key --dry-run
+bash "$S" --project rhesis-dev-494712 --json-env dev --mint-vertex-key
 ```
 
-Verify it round-trips exactly as the SDK will read it:
+That script already owned publishing to Secret Manager, including the `printf '%s'` upsert
+that avoids a trailing newline and the `secretmanager.secretAccessor` binding for ESO. The
+flag changes only where the value comes from: instead of reading
+`GOOGLE_APPLICATION_CREDENTIALS` out of `gsm-secrets.json`, it mints a fresh key for
+`rhesis-vertex-<env>@<project>`. It then reads the published version back and decodes it
+with the exact call the SDK makes, asserting `client_email` and `project_id`.
 
-```bash
-gcloud secrets versions access latest \
-  --secret="${ENV}-rhesis-google-application-credentials" --project="${PROJECT}" \
-  | python3 -c "import sys,base64,json; \
-      d=json.loads(base64.b64decode(sys.stdin.read(), validate=True)); \
-      print(d['client_email'], d['project_id'])"
-```
+In this mode the script needs neither `gsm-secrets.json` nor `jq`, so rotating a credential
+does not require a plaintext file of every other secret to be on disk.
+
+Two failure modes are why this is a script rather than copy-paste steps, because both break
+auth on every pod and neither is visible at the point of the mistake:
+
+- The value must be **single-line base64 with no trailing newline**. The SDK calls
+  `base64.b64decode(..., validate=True)`, which rejects a newline outright. GNU `base64`
+  line-wraps at 76 characters (BSD/macOS does not), and a shell redirect adds a newline, so
+  the script uses `tr -d '\n'` and `printf '%s'`.
+- The key must belong to the environment's own project, since the project is derived from
+  the key (see step 4). A key from the wrong project now succeeds silently against that
+  project instead of failing with a 403.
+
+The key never enters Terraform state, deliberately. `google_service_account_key` stores
+`private_key` in state in plaintext, and all four CI service accounts hold
+`storage.objectAdmin` on the entire state bucket with no per-prefix isolation, so a key in
+one environment's state would be readable by the others. That also matches the existing
+practice for the prd Cloudflare token, which is fetched in the CI action so it never reaches
+state.
+
+Preflight fails before minting anything if the service account does not exist, the secret
+does not exist, or `eso-<env>@` lacks `secretmanager.secretAccessor` on it. The key file is
+written with `umask 077` and shredded on exit, including on interrupt.
 
 ### 4. Nothing to change in the chart
 

--- a/terraform/infrastructure/modules/vertex-ai/gcp/README.md
+++ b/terraform/infrastructure/modules/vertex-ai/gcp/README.md
@@ -1,0 +1,142 @@
+# vertex-ai/gcp
+
+Per-environment Vertex AI identity: enables `aiplatform.googleapis.com`, creates
+`rhesis-vertex-<env>`, and grants it `roles/aiplatform.user` in its own project.
+
+## Why
+
+Every environment used to authenticate as `gemini-vertex-sa@playground-437609` from a single
+shared JSON key, and `vertexAiProject` was pinned to `playground-437609` in all three chart
+value files. So dev, stg and prd all ran their Gemini traffic inside the retired Cloud Run
+project. On 2026-09-02 disabling `aiplatform.googleapis.com` there took Vertex down in all
+three environments at once for about 14 minutes.
+
+## Cutover runbook
+
+Terraform creates the identity but deliberately does not create the key, because
+`google_service_account_key` writes the private key into Terraform state in plaintext.
+
+Run one environment at a time, in the order dev, stg, prd, and verify before moving on.
+
+### 1. Apply the Terraform
+
+Merge the change and let `.github/workflows/terraform-infrastructure.yml` apply it. This
+enables the API and creates the service account. It changes no traffic on its own.
+
+### 2. Check the models exist in the new project
+
+Model availability is per project and per location, so confirm before cutting over. Note
+`VERTEX_AI_LOCATION` is `eu` (a multi-region), not `europe-west4`, while
+`VERTEX_AI_EMBEDDING_LOCATION` is `europe-west4`.
+
+```bash
+PROJECT=rhesis-dev-494712
+TOKEN=$(gcloud auth print-access-token)
+# Braces matter: in zsh, "$m:generateContent" parses as a history modifier and mangles the URL.
+for m in gemini-3.1-flash-lite; do
+  curl -s -o /dev/null -w "${m} %{http_code}\n" -X POST \
+    -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+    "https://aiplatform.googleapis.com/v1/projects/${PROJECT}/locations/eu/publishers/google/models/${m}:generateContent" \
+    -d '{"contents":[{"role":"user","parts":[{"text":"ping"}]}],"generationConfig":{"maxOutputTokens":5}}'
+done
+```
+
+`gemini-2.0-flash` is retired and returns 404. It is still the SDK default in
+`sdk/src/rhesis/sdk/models/defaults.py`, so anything relying on the default rather than the
+`DEFAULT_*_MODEL` config will fail. Track that separately.
+
+### 3. Mint the key and write it to Secret Manager
+
+The value must be **single-line base64 of the JSON, with no trailing newline**. The SDK calls
+`base64.b64decode(..., validate=True)`, which rejects a newline outright, so a stray `\n`
+breaks auth on every pod.
+
+```bash
+ENV=dev
+PROJECT=rhesis-dev-494712
+SA="rhesis-vertex-${ENV}@${PROJECT}.iam.gserviceaccount.com"
+KEY=$(mktemp)
+
+gcloud iam service-accounts keys create "${KEY}" --iam-account="${SA}" --project="${PROJECT}"
+
+# tr -d '\n' guards against a base64 build that line-wraps (GNU coreutils wraps at 76 chars).
+base64 < "${KEY}" | tr -d '\n' \
+  | gcloud secrets versions add "${ENV}-rhesis-google-application-credentials" \
+      --project="${PROJECT}" --data-file=-
+
+shred -u "${KEY}" 2>/dev/null || rm -f "${KEY}"
+```
+
+Verify it round-trips exactly as the SDK will read it:
+
+```bash
+gcloud secrets versions access latest \
+  --secret="${ENV}-rhesis-google-application-credentials" --project="${PROJECT}" \
+  | python3 -c "import sys,base64,json; \
+      d=json.loads(base64.b64decode(sys.stdin.read(), validate=True)); \
+      print(d['client_email'], d['project_id'])"
+```
+
+### 4. Repoint the chart
+
+`vertexAiProject` is pinned per environment and is **not** auto-extracted from the key, so
+this step is required:
+
+```
+charts/rhesis/values-dev.yaml   vertexAiProject: "rhesis-dev-494712"
+charts/rhesis/values-stg.yaml   vertexAiProject: "rhesis-stg-494712"
+charts/rhesis/values-prd.yaml   vertexAiProject: "rhesis-prd"
+```
+
+The ExternalSecret needs no edit: the secret name is unchanged, only a new version is added.
+
+### 5. Refresh and restart
+
+ESO has `refreshInterval: 1h`, and the secret reaches pods via `secretRef envFrom`, so env
+vars are fixed at pod start. Both a resync and a restart are needed:
+
+```bash
+CTX=connectgateway_rhesis-dev-494712_global_dev
+kubectl --context="${CTX}" -n rhesis annotate externalsecret rhesis-app-secrets \
+  force-sync="$(date +%s)" --overwrite
+kubectl --context="${CTX}" -n rhesis rollout restart \
+  deploy/backend deploy/worker-default deploy/chatbot deploy/polyphemus
+```
+
+Deployment names are `backend`, `chatbot`, `docs`, `frontend`, `otel-collector`, `polyphemus`,
+`telemetry-processor`, `worker-default`. Every one of them receives `rhesis-app-secrets` via
+`envFrom`, but only the four above are expected to call Vertex; confirm against the new
+project's invocation metric and widen the restart if any traffic is missing.
+
+### 6. Verify, then move on
+
+Confirm calls now bill to the new project and are succeeding:
+
+```bash
+gcloud logging read 'protoPayload.serviceName="aiplatform.googleapis.com"' \
+  --project="${PROJECT}" --freshness=15m --limit=5
+```
+
+The authoritative signal is the metric
+`aiplatform.googleapis.com/publisher/online_serving/model_invocation_count` in the **new**
+project starting to record invocations while the old project's goes quiet. Billing export
+confirms it a day later.
+
+## Rollback
+
+The previous secret version is retained, so rollback is: revert `vertexAiProject` in the
+values file, re-add the old key as a new version, force-sync, restart. Do not disable
+`aiplatform.googleapis.com` in `playground-437609` as a rollback step; that is what caused
+the outage.
+
+## Follow-up: drop the keys entirely
+
+Workload Identity would remove the JSON keys, as `modules/cnpg-barman-sa-gcp` already does.
+Two things block it:
+
+1. The chart sets no `serviceAccountName` and defines no `ServiceAccount`, so every pod runs
+   as the namespace `default` KSA. Binding that would grant Vertex access to all eight
+   components, so per-component KSAs are needed first.
+2. `sdk/src/rhesis/sdk/models/providers/vertex_ai.py` raises when
+   `GOOGLE_APPLICATION_CREDENTIALS` is unset instead of falling back to ADC. LiteLLM
+   underneath does support ADC, so the change is small but it is a code change.

--- a/terraform/infrastructure/modules/vertex-ai/gcp/main.tf
+++ b/terraform/infrastructure/modules/vertex-ai/gcp/main.tf
@@ -1,0 +1,54 @@
+# Per-environment Vertex AI identity.
+#
+# Before this module, dev, stg and prd all authenticated as
+# gemini-vertex-sa@playground-437609 from one shared JSON key, and VERTEX_AI_PROJECT
+# was left empty so the project was auto-extracted from that key. Every environment's
+# Gemini traffic therefore billed into the retired Cloud Run project, and disabling
+# aiplatform.googleapis.com there on 2026-09-02 took Vertex down in all three
+# environments at once for ~14 minutes.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+# disable_on_destroy = false is load-bearing: turning this API off stops every Gemini
+# call in the environment, so destroying this module must not take Vertex with it.
+resource "google_project_service" "aiplatform" {
+  project            = var.project_id
+  service            = "aiplatform.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_service_account" "vertex" {
+  project      = var.project_id
+  account_id   = "rhesis-vertex-${var.environment}"
+  display_name = "Rhesis ${var.environment} Vertex AI"
+  description  = "Calls Vertex AI (Gemini) for the ${var.environment} stack; scoped to this project only"
+
+  depends_on = [google_project_service.aiplatform]
+}
+
+# aiplatform.user grants invoke (predict / generateContent) and nothing else.
+# Deliberately not aiplatform.admin: the old shared account held admin, which is why
+# deleting one service account was not enough to stop Model Garden publisher models
+# being reachable.
+resource "google_project_iam_member" "vertex_user" {
+  project = var.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.vertex.email}"
+}
+
+# No google_service_account_key resource here on purpose: Terraform stores the private
+# key in plaintext in state. Keys are minted out of band and piped straight into Secret
+# Manager as single-line base64 (see the runbook in this module's README).
+#
+# The better end state is Workload Identity, which needs no key at all, as
+# modules/cnpg-barman-sa-gcp already does. That is blocked on two things: the chart
+# gives every pod the namespace default KSA (no serviceAccountName anywhere), and
+# sdk/src/rhesis/sdk/models/providers/vertex_ai.py raises if
+# GOOGLE_APPLICATION_CREDENTIALS is unset instead of falling back to ADC.

--- a/terraform/infrastructure/modules/vertex-ai/gcp/main.tf
+++ b/terraform/infrastructure/modules/vertex-ai/gcp/main.tf
@@ -43,9 +43,16 @@ resource "google_project_iam_member" "vertex_user" {
   member  = "serviceAccount:${google_service_account.vertex.email}"
 }
 
-# No google_service_account_key resource here on purpose: Terraform stores the private
-# key in plaintext in state. Keys are minted out of band and piped straight into Secret
-# Manager as single-line base64 (see the runbook in this module's README).
+# No google_service_account_key resource here on purpose. It stores private_key in
+# Terraform state in plaintext, and all four CI service accounts hold
+# storage.objectAdmin on the whole rhesis-platform-admin-tfstate bucket with no
+# per-prefix isolation, so a key in one environment's state is readable by the
+# others. Same reasoning as the prd Cloudflare token, which envs/prd fetches in CI
+# so it never reaches state.
+#
+# Keys are minted out of band by
+# `infrastructure/config/gsm-secrets-sync.sh --mint-vertex-key`, which also verifies
+# the published value decodes exactly as the SDK reads it.
 #
 # The better end state is Workload Identity, which needs no key at all, as
 # modules/cnpg-barman-sa-gcp already does. That is blocked on two things: the chart

--- a/terraform/infrastructure/modules/vertex-ai/gcp/outputs.tf
+++ b/terraform/infrastructure/modules/vertex-ai/gcp/outputs.tf
@@ -1,0 +1,9 @@
+output "service_account_email" {
+  description = "Email of the per-environment Vertex AI service account; mint the key for GOOGLE_APPLICATION_CREDENTIALS against this"
+  value       = google_service_account.vertex.email
+}
+
+output "project_id" {
+  description = "Project the Vertex AI calls are billed to and quota-limited in"
+  value       = var.project_id
+}

--- a/terraform/infrastructure/modules/vertex-ai/gcp/variables.tf
+++ b/terraform/infrastructure/modules/vertex-ai/gcp/variables.tf
@@ -1,0 +1,9 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, stg, prd)"
+  type        = string
+}

--- a/tests/sdk/integration/metrics/test_metrics.py
+++ b/tests/sdk/integration/metrics/test_metrics.py
@@ -389,7 +389,7 @@ def test_goal_achievement_judge_evaluate_real(sample_conversation):
     from rhesis.sdk.models import VertexAILLM
 
     judge = GoalAchievementJudge(
-        model=VertexAILLM(model_name="gemini-2.0-flash"),
+        model=VertexAILLM(model_name="gemini-3.1-flash-lite"),
         threshold=0.7,
     )
 

--- a/tests/sdk/models/providers/test_vertex_ai.py
+++ b/tests/sdk/models/providers/test_vertex_ai.py
@@ -18,7 +18,7 @@ from rhesis.sdk.models.providers.vertex_ai import (
 def test_vertex_ai_defaults():
     """Test default constants."""
     assert VertexAILLM.PROVIDER == "vertex_ai"
-    assert DEFAULT_MODEL_NAME == "gemini-2.0-flash"
+    assert DEFAULT_MODEL_NAME == "gemini-3.1-flash-lite"
 
 
 class TestVertexAILLMInitialization:


### PR DESCRIPTION
Follow-up to the GCP cost work. Started from an invoice that was non-zero when it should have
been zero under startup credits, and ended up covering the reason it was invisible, the reason
it could happen again, and a live dependency that made the cleanup dangerous.

## Why the invoice was not zero

Credits do not cover **third-party Marketplace publisher SKUs**. Every line item was
`PublisherName = Anthropic`: Claude models invoked through Vertex AI Model Garden. Meanwhile the
credits absorbed essentially all of the list cost across Google's own services down to
approximately zero.

Both budgets that existed used `INCLUDE_ALL_CREDITS`, so both measured the invoice and neither
could see credit burn. That is why the monthly gross spend was invisible.

## What is in here

| Commit | |
|---|---|
| `fix(sdk)` | `gemini-2.0-flash` is retired and 404s; it was still the Vertex provider default |
| `feat(dev)` | per-environment Vertex service accounts (Terraform) |
| `feat(dev)` | `envs/billing` root, adopting the budgets via `import` blocks |
| `refactor(dev)` | derive the Vertex project from the key instead of pinning it separately |
| `feat(dev)` | `--mint-vertex-key` on the existing secrets sync script |
| `fix(dev)` | reconcile two `gcloud` edits back into Terraform |
| `fix(dev)` | stop Terraform plan failures reporting as passing CI |

Two budgets now, covering both axes, notifying hello@ and engineering@:

- **Credit burn**, `EXCLUDE_ALL_CREDITS` — gross spend, so it sees the credit pool draining. Has a
  `FORECASTED_SPEND` rule so a runaway trips mid-month rather than after the fact.
- **Uncovered spend**, `INCLUDE_ALL_CREDITS` — the net invoice, set near zero so it trips on
  anything credits refuse to cover, with a low first threshold.

## Disclosure: I caused a 14 minute production outage doing this

All three environments authenticate as `gemini-vertex-sa@playground-437609` from one shared key,
and `vertexAiProject` pinned that same project in every values file. So dev, stg and prd all ran
their Gemini traffic inside the retired Cloud Run project. I disabled `aiplatform.googleapis.com`
there believing the project was dead for Vertex, and took Vertex down in all three at once,
**09:33:16–09:47:42 UTC on 2026-09-02**, visible as a gap in
`aiplatform.googleapis.com/publisher/online_serving/model_invocation_count`. Recovered, all
response codes since are 200, and the 13 tuned models in that project survived.

That dependency is the reason for the per-environment service accounts, and it is recorded in the
module README so nobody repeats it.

## Plan results

`terraform` is not installed locally, so CI is the first real validation of this HCL; I only
checked it structurally. All four plans now pass, and `pass` is trustworthy again after the CI fix
below.

- **dev / stg / prd**: `4 to add, 0 to change, 0 to destroy` — the API enable, service account and
  IAM member, plus the generated `cluster.env` local file. `0 to change` is the important part: no
  node pool diff, so the drift reconciliation took, and no monitoring/logging diff, so those
  defaults match the live clusters.
- **billing**: `4 to import, 2 to add, 2 to change, 0 to destroy`.
  - **4 to import** is the condition that mattered: both budgets and both notification channels
    are adopted, not recreated, so there is no risk of two budgets alerting on the same threshold.
  - **2 to add** are the two `google_project_service` resources, already enabled, so no-ops.
  - **2 to change** is only `monitoring_notification_channels` on each budget, a list reorder.
    Both channels end up attached; no threshold, amount, credit treatment or name moves. It
    resolves on first apply.

Getting there took two out-of-band grants and two APIs that Terraform cannot bootstrap for itself,
all now documented in the billing README. Worth knowing the failure mode was misleading: the
budget API error names the project by number and does not mention budgets in the resource path, so
it reads like an IAM problem.

That billing failure is also why the CI fix commit exists. The check first reported **pass** while
the plan exited 1, because the step was `terraform plan ... | tee plan.txt` and GitHub's default
shell sets `-e` but not `-o pipefail`. Every Terraform plan failure on every PR has been invisible
the same way.

## Rollout (nothing is applied by merging)

Applying is `workflow_dispatch` only, so merging changes nothing. Per environment, dev first:

```
1. dispatch Terraform Infrastructure [Deploy]: environment=dev, action=apply
2. bash infrastructure/config/gsm-secrets-sync.sh \
        --project rhesis-dev-494712 --json-env dev --mint-vertex-key --dry-run   # then for real
3. force-sync ESO, restart: backend, worker-default, chatbot, polyphemus
4. verify model_invocation_count starts in rhesis-dev-494712 and stops in playground-437609
```

The restart list is verified, not guessed: `worker-default` runs `rhesis.backend.worker` and
`rhesis.backend.jobs.*`, so it executes the backend's Vertex code even though `apps/worker` has no
model references of its own. `frontend`, `otel-collector` and `telemetry-processor` have none.

Runbook: `terraform/infrastructure/modules/vertex-ai/gcp/README.md`.

## Design notes worth a look

**No `google_service_account_key` in Terraform.** It stores `private_key` in state in plaintext,
and all four CI service accounts hold `storage.objectAdmin` on the whole state bucket with no
per-prefix isolation, so a key in one environment's state is readable by the others. Same reasoning
as the prd Cloudflare token. Keys are minted out of band instead, and the script verifies the
published value by decoding it with the exact call the SDK makes.

**The project now derives from the key.** Previously identity and target project were two sources
of truth travelling by different routes (ConfigMap/GitOps vs Secret Manager/ESO), which made
cutover a two-place change where either half alone guarantees a 403. Verified as a no-op before
landing: the live prd ConfigMap and the credential both resolve to `playground-437609`. This also
retires the `TODO: migrate to rhesis-prd` that was already in `values-prd.yaml`.

**`billing` reuses `terraform-wireguard`, not `terraform-deployer`.** The latter already holds
`roles/billing.user` and looks like the obvious choice, but its only `workloadIdentityUser`
members are service accounts in the deleted `rhesis-worker{,-dev,-stg}` clusters, so CI cannot
impersonate it. Two grants to `terraform-wireguard` are out of band, since Terraform cannot grant
itself the permissions it needs to run.

## Not done

- **A quota cap.** Worth knowing a rate cap cannot bound monthly cost here: measured usage is
  bursty (median 10 req/min, peak 226), so any limit high enough for normal evaluation runs still
  permits a very large daily spend if sustained. Holding a sustained runaway under the alert
  threshold would need roughly 7.5 req/min, far below the legitimate peak. Stopping a runaway
  tenant is application-level per-org quotas, not a GCP quota.
- **429 retry behaviour** unchecked, which gates any quota cap: a cap on a hard-retrying client
  makes things worse.
- `defaults.py:19` still points at `gemini/gemini-2.0-flash` for the **Gemini API** provider. Left
  alone because I did not verify whether that model is retired on that API surface too.
- The two older budgets are left unmanaged, IDs recorded in a comment.
- `gsm-secrets-sync.sh` is mode `100644` while documenting `./` usage; unrelated, left alone.
