### PR TITLE
Mint the Vertex key without writing it to disk

### DIFF
--- a/infrastructure/config/gsm-secrets-sync.sh
+++ b/infrastructure/config/gsm-secrets-sync.sh
@@ -188,8 +188,12 @@ cleanup_vertex_key() {
 }
 trap cleanup_vertex_key EXIT INT TERM
 
+# VERTEX_KEY_FILE must already be set by the CALLER. This function is invoked inside a
+# command substitution to capture its stdout, and that runs in a subshell, so anything it
+# assigned would be invisible to the parent -- which is exactly how an earlier version left
+# a live private key behind in $TMPDIR: cleanup_vertex_key and the EXIT trap both saw an
+# empty path and silently did nothing.
 mint_vertex_key_b64() {
-  VERTEX_KEY_FILE="$(mktemp -t vertex-key-XXXXXX.json)"
   gcloud iam service-accounts keys create "${VERTEX_KEY_FILE}" \
     --iam-account="${VERTEX_SA}" --project="${PROJECT}" >/dev/null
   # tr -d '\n' guards against a base64 build that line-wraps (GNU coreutils wraps at 76
@@ -271,6 +275,9 @@ while read -r secret_key gsm_key; do
       continue
     fi
     echo -e "${BLUE}Mint${NC} GSM ${gsm_key} <- new key for ${VERTEX_SA}"
+    # Created here, not inside mint_vertex_key_b64: the assignment has to happen in this
+    # shell so cleanup_vertex_key and the EXIT trap can actually find the file.
+    VERTEX_KEY_FILE="$(mktemp -t vertex-key-XXXXXX.json)"
     value="$(mint_vertex_key_b64)"
   else
     value="$(

--- a/infrastructure/config/gsm-secrets-sync.sh
+++ b/infrastructure/config/gsm-secrets-sync.sh
@@ -32,10 +32,9 @@ DRY_RUN=0
 ONLY_SECRET_KEY=""
 MINT_VERTEX_KEY=0
 VERTEX_SA=""
-VERTEX_KEY_FILE=""
 
-# Any key material this script writes to disk must be owner-only from the moment it
-# exists, not chmod'ed afterwards.
+# Nothing here writes key material to disk (see mint_vertex_key_b64), but keep the tight
+# umask so a future change that does write a file cannot default to group/world readable.
 umask 077
 
 RED=''
@@ -181,25 +180,31 @@ if [[ "${MINT_VERTEX_KEY}" -eq 1 ]]; then
   fi
 fi
 
-cleanup_vertex_key() {
-  [[ -n "${VERTEX_KEY_FILE}" && -f "${VERTEX_KEY_FILE}" ]] || return 0
-  # shred where available; rm is the fallback and still removes the file.
-  shred -u "${VERTEX_KEY_FILE}" 2>/dev/null || rm -f "${VERTEX_KEY_FILE}"
-}
-trap cleanup_vertex_key EXIT INT TERM
-
-# VERTEX_KEY_FILE must already be set by the CALLER. This function is invoked inside a
-# command substitution to capture its stdout, and that runs in a subshell, so anything it
-# assigned would be invisible to the parent -- which is exactly how an earlier version left
-# a live private key behind in $TMPDIR: cleanup_vertex_key and the EXIT trap both saw an
-# empty path and silently did nothing.
+# Mints via the IAM REST API rather than `gcloud iam service-accounts keys create`, because
+# that command takes a file path and pre-checks write permission on it, so it cannot emit to
+# stdout. The API's privateKeyData field is already single-line base64 of the JSON key,
+# which is exactly the stored format, so the key material only ever exists in a pipe: no
+# temp file, no local base64 step, and nothing to clean up.
+#
+# That is a deliberate simplification after a bug. The previous version wrote the key to
+# mktemp and relied on an EXIT trap to shred it, but the trap saw an empty path (the
+# variable was assigned inside a command substitution, which runs in a subshell) and the dev
+# rotation left a live private key in $TMPDIR. Not writing the file removes that whole class
+# of failure instead of fixing one instance of it.
 mint_vertex_key_b64() {
-  gcloud iam service-accounts keys create "${VERTEX_KEY_FILE}" \
-    --iam-account="${VERTEX_SA}" --project="${PROJECT}" >/dev/null
-  # tr -d '\n' guards against a base64 build that line-wraps (GNU coreutils wraps at 76
-  # chars; BSD/macOS does not). upsert_secret_value pipes with printf '%s', so no newline
-  # is added on the way out either.
-  base64 < "${VERTEX_KEY_FILE}" | tr -d '\n'
+  curl -sS -X POST \
+    -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+    -H "Content-Type: application/json" \
+    "https://iam.googleapis.com/v1/projects/${PROJECT}/serviceAccounts/${VERTEX_SA}/keys" \
+    -d '{"privateKeyType":"TYPE_GOOGLE_CREDENTIALS_FILE","keyAlgorithm":"KEY_ALG_RSA_2048"}' \
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+if 'error' in d:
+    sys.exit('mint failed: ' + str(d['error'].get('message', ''))[:300])
+# Written with no trailing newline; upsert_secret_value pipes it with printf '%s'.
+sys.stdout.write(d['privateKeyData'])
+"
 }
 
 verify_vertex_credential() {
@@ -275,9 +280,6 @@ while read -r secret_key gsm_key; do
       continue
     fi
     echo -e "${BLUE}Mint${NC} GSM ${gsm_key} <- new key for ${VERTEX_SA}"
-    # Created here, not inside mint_vertex_key_b64: the assignment has to happen in this
-    # shell so cleanup_vertex_key and the EXIT trap can actually find the file.
-    VERTEX_KEY_FILE="$(mktemp -t vertex-key-XXXXXX.json)"
     value="$(mint_vertex_key_b64)"
   else
     value="$(
@@ -298,7 +300,6 @@ while read -r secret_key gsm_key; do
   bind_eso_accessor "${gsm_key}"
   if [[ "${MINT_VERTEX_KEY}" -eq 1 ]]; then
     verify_vertex_credential "${gsm_key}"
-    cleanup_vertex_key
   fi
   SYNCED=1
 done < <(


### PR DESCRIPTION
Follow-up to #2690, found while running the dev rotation.

## The bug

`mint_vertex_key_b64` assigned `VERTEX_KEY_FILE`, but it is called inside a command
substitution to capture its stdout, and that runs in a **subshell**. The assignment never
reached the parent shell, so both `cleanup_vertex_key` and the `EXIT` trap saw an empty path
and silently did nothing.

The dev rotation therefore left a live service account private key in `$TMPDIR`. It was
owner-only (`-rw-------`, from `umask 077`) and has been shredded, but it should not have
survived the run. Worth noting how quiet it was: the script printed success, reported its own
verification as passing, and the key looked cleaned up. Only checking `$TMPDIR` afterwards
revealed it.

## The fix, in two commits

The first commit moves the `mktemp` into the calling shell so both cleanup paths can find
the file. That is the narrow fix.

The second commit **removes the file entirely**, which is the better answer: if the key
never touches disk, there is nothing to clean up and no trap to get wrong.

`gcloud iam service-accounts keys create` takes a file path and pre-checks write permission
on it, so it cannot emit to stdout. The IAM REST API can, and its `privateKeyData` field is
already single-line base64 of the JSON key, which is exactly the format the secret stores.
So the key only ever exists in a pipe.

That deletes the `mktemp`, the `shred`, the `EXIT/INT/TERM` trap, the `VERTEX_KEY_FILE`
variable and the explicit cleanup call. It also drops the local `base64 | tr -d '\n'` step
and the line-wrapping risk that guarded against. The subshell bug becomes structurally
impossible rather than merely fixed.

## Verified for real, not just dry-run

The dry-run path does not mint, so I ran it against dev end to end:

```
mint -> version 5 published
script's own round-trip assertion: rhesis-vertex-dev@rhesis-dev-494712 -> rhesis-dev-494712
$TMPDIR: nothing written
ESO force-sync -> in-cluster key_id 040c4b11...
rollout restart -> backend 1/1, worker-default 4/4, chatbot 1/1, polyphemus 1/1
pods confirmed on 040c4b11...
```

Then cleaned up after it: secret version 4 disabled and its key deleted, so
`rhesis-vertex-dev` holds exactly one key. Version 4 was disabled *before* deleting its key,
so no enabled version references a key that no longer exists. Versions 1-3 remain enabled,
which is the real rollback target if the whole migration needs undoing, since those hold the
old `gemini-vertex-sa` credential.

I also verified before restarting that `gemini-3.1-flash-lite` at `eu` and
`text-embedding-005` at `europe-west4` both resolve in `rhesis-dev-494712`, since publisher
model availability is per project. That is a step in the runbook I skipped on the first pass.

## Note for stg and prd

Rotate those with this version, not the one merged in #2690.