### PR TITLE
fix: correct the skill install path and MCP URL

### DIFF
--- a/docs/content/docs/agent-skill/for-agents.mdx
+++ b/docs/content/docs/agent-skill/for-agents.mdx
@@ -46,7 +46,7 @@ This page is for **AI agents** (Cursor, Claude Code, Telemachus, MCP). Humans sh
 
 ## Coding agents
 
-Install: `npx skills add rhesis-ai/rhesis -g`
+Install: `npx skills add rhesis-ai/skills -g`
 
 `SKILL.md` routes to these docs and to `skills/rhesis/references/` in the repo. Connect the Rhesis MCP server for tool calls.
 

--- a/docs/content/docs/agent-skill/for-agents.mdx
+++ b/docs/content/docs/agent-skill/for-agents.mdx
@@ -46,7 +46,9 @@ This page is for **AI agents** (Cursor, Claude Code, Telemachus, MCP). Humans sh
 
 ## Coding agents
 
-Install: `npx skills add rhesis-ai/skills -g`
+Install: `/plugin marketplace add rhesis-ai/skills` then `/plugin install rhesis@rhesis-ai` in
+Claude Code, which brings the MCP server with it. Any other agent: `npx skills add rhesis-ai/skills -g`,
+then connect the MCP server separately.
 
 `SKILL.md` routes to these docs and to `skills/rhesis/references/` in the repo. Connect the Rhesis MCP server for tool calls.
 

--- a/docs/content/docs/agent-skill/index.mdx
+++ b/docs/content/docs/agent-skill/index.mdx
@@ -29,11 +29,21 @@ If you already paste a spec or name an endpoint, the menu is skipped.
 
 ## Quick install
 
+Claude Code installs the skill and the MCP server together, as a plugin:
+
+<CodeBlock language="bash">
+{`/plugin marketplace add rhesis-ai/skills
+/plugin install rhesis@rhesis-ai`}
+</CodeBlock>
+
+Every other agent installs the skill on its own, then connects the MCP server separately:
+
 <CodeBlock language="bash">
 {`npx skills add rhesis-ai/skills -g`}
 </CodeBlock>
 
-Connect the MCP server in your agent — see [Install in Cursor](/docs/agent-skill/platform#install-in-cursor).
+Either way you need an API token. See [Install](/docs/agent-skill/platform#install-in-claude-code)
+for the token setup, how to verify the connection, and per-agent MCP configuration.
 
 ## Examples
 

--- a/docs/content/docs/agent-skill/index.mdx
+++ b/docs/content/docs/agent-skill/index.mdx
@@ -30,7 +30,7 @@ If you already paste a spec or name an endpoint, the menu is skipped.
 ## Quick install
 
 <CodeBlock language="bash">
-{`npx skills add rhesis-ai/rhesis -g`}
+{`npx skills add rhesis-ai/skills -g`}
 </CodeBlock>
 
 Connect the MCP server in your agent — see [Install in Cursor](/docs/agent-skill/platform#install-in-cursor).

--- a/docs/content/docs/agent-skill/platform.mdx
+++ b/docs/content/docs/agent-skill/platform.mdx
@@ -73,11 +73,16 @@ touching your shell profile:
 }`}
 </CodeBlock>
 
-**Step 3:** Restart Claude Code, then run `/mcp` to confirm the connection:
+**Step 3:** Restart Claude Code, then run `/mcp`. Under the built-in servers you should see
+`rhesis` connected, with a tool count after it:
 
 <CodeBlock language="text">
 {`plugin:rhesis:rhesis · ✔ connected · 52 tools`}
 </CodeBlock>
+
+That line is the only confirmation that matters. The skill on its own does nothing — every
+platform operation it performs is a call to this server, so an installed skill with no connected
+server cannot explore an endpoint, create anything, or run a test.
 
 <Callout type="warning">
   **If `/mcp` asks you to authenticate a connector named "Rhesis AI", the plugin's server is not

--- a/docs/content/docs/agent-skill/platform.mdx
+++ b/docs/content/docs/agent-skill/platform.mdx
@@ -20,20 +20,20 @@ The **Rhesis agent skill** (`rhesis`) packages platform knowledge into one porta
 The fastest way to install across Claude Code, Cursor, Codex, Gemini CLI, and 40+ other AI interfaces:
 
 <CodeBlock language="bash">
-{`npx skills add rhesis-ai/rhesis`}
+{`npx skills add rhesis-ai/skills`}
 </CodeBlock>
 
 The CLI detects your installed agents and asks where to place the skill. Add `-g` for a global install, or omit it for a project-level install.
 
 <CodeBlock language="bash">
 {`# Global install — available in all projects
-npx skills add rhesis-ai/rhesis -g
+npx skills add rhesis-ai/skills -g
 
 # Install only for selected agents
-npx skills add rhesis-ai/rhesis -a cursor -a claude-code -g
+npx skills add rhesis-ai/skills -a cursor -a claude-code -g
 
 # Preview install targets without writing files
-npx skills add rhesis-ai/rhesis --list`}
+npx skills add rhesis-ai/skills --list`}
 </CodeBlock>
 
 After installing the skill, connect the MCP server for your specific agent. The skill instructions and MCP connection are separate for most agents.
@@ -45,7 +45,7 @@ Claude Code uses a plugin system that bundles the skill and MCP server configura
 **Step 1:** Add the Rhesis marketplace and install the plugin:
 
 <CodeBlock language="bash">
-{`/plugin marketplace add rhesis-ai/rhesis
+{`/plugin marketplace add rhesis-ai/skills
 /plugin install rhesis@rhesis-ai`}
 </CodeBlock>
 
@@ -60,7 +60,7 @@ The plugin reads `RHESIS_API_KEY` automatically. On next session start, the `rhe
 **Self-hosted backend:**
 
 <CodeBlock language="bash">
-{`export RHESIS_MCP_URL=http://localhost:8080/mcp
+{`export RHESIS_MCP_URL=http://localhost:8080/mcp/
 export RHESIS_API_KEY=your_local_token`}
 </CodeBlock>
 
@@ -74,7 +74,7 @@ Add the following to `.cursor/mcp.json` (project-level) or `~/.cursor/mcp.json` 
 {`{
   "mcpServers": {
     "rhesis": {
-      "url": "https://api.rhesis.ai/mcp",
+      "url": "https://api.rhesis.ai/mcp/",
       "headers": {
         "Authorization": "Bearer YOUR_RHESIS_API_KEY"
       }
@@ -85,14 +85,14 @@ Add the following to `.cursor/mcp.json` (project-level) or `~/.cursor/mcp.json` 
 
 Replace `YOUR_RHESIS_API_KEY` with your actual token. Restart Cursor after editing.
 
-For self-hosted backends, replace `https://api.rhesis.ai/mcp` with `http://localhost:8080/mcp`.
+For self-hosted backends, replace `https://api.rhesis.ai/mcp/` with `http://localhost:8080/mcp/`.
 
 ### Install the skill
 
 Use the universal installer:
 
 <CodeBlock language="bash">
-{`npx skills add rhesis-ai/rhesis -a cursor -g`}
+{`npx skills add rhesis-ai/skills -a cursor -g`}
 </CodeBlock>
 
 Cursor loads the skill automatically on the next session. If you prefer a project-level install, omit `-g` and run the command from the project where the skill should be available.
@@ -148,7 +148,7 @@ Use the native Architect for maximum structural control. Use this skill when you
 **MCP server not connecting**
 
 - Verify your API token is valid and has not expired — regenerate at [app.rhesis.ai/tokens](https://app.rhesis.ai/tokens)
-- Test connectivity: `curl -H "Authorization: Bearer $RHESIS_API_KEY" https://api.rhesis.ai/mcp`
+- Test connectivity: `curl -H "Authorization: Bearer $RHESIS_API_KEY" https://api.rhesis.ai/mcp/`
 - In Cursor, restart the IDE after editing `.cursor/mcp.json`
 
 **Skill not activating (Cursor)**

--- a/docs/content/docs/agent-skill/platform.mdx
+++ b/docs/content/docs/agent-skill/platform.mdx
@@ -15,39 +15,11 @@ The **Rhesis agent skill** (`rhesis`) packages platform knowledge into one porta
 - A Rhesis account at [app.rhesis.ai](https://app.rhesis.ai) (or a self-hosted backend)
 - An API token — generate one at [app.rhesis.ai/tokens](https://app.rhesis.ai/tokens)
 
-## Install (any agent except Claude Code)
-
-<Callout type="warning">
-  **Using Claude Code? Skip to [Install in Claude Code](#install-in-claude-code) and do not run
-  `npx skills add`.** The plugin already includes the skill. Running both installs it twice, from
-  two sources that update through different channels, and one silently shadows the other.
-</Callout>
-
-Installs the skill across Cursor, Codex, Gemini CLI, and 40+ other AI interfaces:
-
-<CodeBlock language="bash">
-{`npx skills add rhesis-ai/skills`}
-</CodeBlock>
-
-The CLI detects your installed agents and asks where to place the skill. Add `-g` for a global install, or omit it for a project-level install.
-
-<CodeBlock language="bash">
-{`# Global install — available in all projects
-npx skills add rhesis-ai/skills -g
-
-# Install only for selected agents
-npx skills add rhesis-ai/skills -a cursor -a claude-code -g
-
-# Preview install targets without writing files
-npx skills add rhesis-ai/skills --list`}
-</CodeBlock>
-
-After installing the skill, connect the MCP server for your specific agent. The skill instructions and MCP connection are separate for most agents.
-
 ## Install in Claude Code
 
-The plugin bundles the skill and the MCP server configuration, so it is the only install step. Do
-not also run `npx skills add`.
+The plugin carries both the skill and the MCP server configuration, so it is the only install
+step. Do not also run `npx skills add` — that installs the skill a second time from a different
+source, and one copy silently shadows the other.
 
 **Step 1:** Add the marketplace and install the plugin:
 
@@ -98,6 +70,27 @@ server cannot explore an endpoint, create anything, or run a test.
 {`export RHESIS_MCP_URL=http://localhost:8080/mcp/
 export RHESIS_API_KEY=your_local_token`}
 </CodeBlock>
+
+## Install in other agents
+
+For Cursor, Codex, Gemini CLI, and 40+ other AI interfaces, the skill and the MCP server are two
+separate installs.
+
+**Step 1 — the skill.** The CLI detects your installed agents and asks where to place it. Add `-g`
+for a global install, or omit it for a project-level install.
+
+<CodeBlock language="bash">
+{`npx skills add rhesis-ai/skills -g
+
+# Install only for selected agents
+npx skills add rhesis-ai/skills -a cursor -a codex -g
+
+# Preview install targets without writing files
+npx skills add rhesis-ai/skills --list`}
+</CodeBlock>
+
+**Step 2 — the MCP server.** `npx skills` installs the skill instructions only, and the skill
+cannot do anything without the server. Configure it for your agent below.
 
 ## Install in Cursor
 

--- a/docs/content/docs/agent-skill/platform.mdx
+++ b/docs/content/docs/agent-skill/platform.mdx
@@ -15,9 +15,15 @@ The **Rhesis agent skill** (`rhesis`) packages platform knowledge into one porta
 - A Rhesis account at [app.rhesis.ai](https://app.rhesis.ai) (or a self-hosted backend)
 - An API token — generate one at [app.rhesis.ai/tokens](https://app.rhesis.ai/tokens)
 
-## Install (any agent)
+## Install (any agent except Claude Code)
 
-The fastest way to install across Claude Code, Cursor, Codex, Gemini CLI, and 40+ other AI interfaces:
+<Callout type="warning">
+  **Using Claude Code? Skip to [Install in Claude Code](#install-in-claude-code) and do not run
+  `npx skills add`.** The plugin already includes the skill. Running both installs it twice, from
+  two sources that update through different channels, and one silently shadows the other.
+</Callout>
+
+Installs the skill across Cursor, Codex, Gemini CLI, and 40+ other AI interfaces:
 
 <CodeBlock language="bash">
 {`npx skills add rhesis-ai/skills`}
@@ -40,22 +46,46 @@ After installing the skill, connect the MCP server for your specific agent. The 
 
 ## Install in Claude Code
 
-Claude Code uses a plugin system that bundles the skill and MCP server configuration together.
+The plugin bundles the skill and the MCP server configuration, so it is the only install step. Do
+not also run `npx skills add`.
 
-**Step 1:** Add the Rhesis marketplace and install the plugin:
+**Step 1:** Add the marketplace and install the plugin:
 
 <CodeBlock language="bash">
 {`/plugin marketplace add rhesis-ai/skills
 /plugin install rhesis@rhesis-ai`}
 </CodeBlock>
 
-**Step 2:** Set your API token:
+**Step 2:** Set your API token, either as a shell environment variable:
 
 <CodeBlock language="bash">
 {`export RHESIS_API_KEY=rhs_your_token_here`}
 </CodeBlock>
 
-The plugin reads `RHESIS_API_KEY` automatically. On next session start, the `rhesis` MCP server is connected and the skill is active.
+or in the `env` block of `~/.claude/settings.json`, which applies to every session without
+touching your shell profile:
+
+<CodeBlock filename="~/.claude/settings.json" language="json">
+{`{
+  "env": {
+    "RHESIS_API_KEY": "rhs_your_token_here"
+  }
+}`}
+</CodeBlock>
+
+**Step 3:** Restart Claude Code, then run `/mcp` to confirm the connection:
+
+<CodeBlock language="text">
+{`plugin:rhesis:rhesis · ✔ connected · 52 tools`}
+</CodeBlock>
+
+<Callout type="warning">
+  **If `/mcp` asks you to authenticate a connector named "Rhesis AI", the plugin's server is not
+  connected.** That is a separate claude.ai cloud connector using OAuth, and the skill will offer
+  it when the plugin's own server is missing. Do not authenticate it. Fix the plugin server
+  instead: confirm `RHESIS_API_KEY` is set, restart, and check `/mcp` again. When the plugin server
+  is connected, that connector correctly stays under "unused connectors".
+</Callout>
 
 **Self-hosted backend:**
 
@@ -157,9 +187,27 @@ Use the native Architect for maximum structural control. Use this skill when you
 - Verify `~/.cursor/skills/rhesis/SKILL.md` exists
 - Try explicitly invoking: type `/rhesis` in the chat
 
-**Claude Code skill loading issues**
+**Claude Code: the skill asks you to authenticate a "Rhesis AI" connector**
 
-- There is a known issue with `~/.claude/skills/` filesystem discovery in some versions of Claude Code. Use the plugin install path (`/plugin install rhesis@rhesis-ai`) instead — this uses a supported installation mechanism.
+The plugin's MCP server is not connected, so the skill is falling back to the claude.ai cloud
+connector, which uses OAuth instead of your API token. Do not authenticate it. Run `/mcp` and
+check for `plugin:rhesis:rhesis`:
+
+- Not listed at all — the plugin is not installed or not enabled. Check `claude plugin list`.
+- Listed but failed — `RHESIS_API_KEY` is unset or invalid. Set it (see step 2 above) and restart.
+  Environment variables are read at session start, so a running session will not pick up a new one.
+
+**Claude Code: `rhesis` appears twice, or edits to the skill have no effect**
+
+The skill is installed from two sources, usually because `npx skills add` was run alongside the
+plugin. One shadows the other, and they update through different channels. Remove the standalone
+copy and keep the plugin:
+
+<CodeBlock language="bash">
+{`rm ~/.claude/skills/rhesis`}
+</CodeBlock>
+
+This leaves `~/.agents/skills/rhesis` in place, so Cursor and Codex keep working.
 
 ## Source
 

--- a/docs/content/docs/agent-skill/platform.mdx
+++ b/docs/content/docs/agent-skill/platform.mdx
@@ -45,8 +45,8 @@ touching your shell profile:
 }`}
 </CodeBlock>
 
-**Step 3:** Restart Claude Code, then run `/mcp`. Under the built-in servers you should see
-`rhesis` connected, with a tool count after it:
+**Step 3:** Restart Claude Code, then run `/mcp`. The plugin's server is listed under **Built-in
+MCPs**, named with a `plugin:` prefix rather than plain `rhesis`, with a tool count after it:
 
 <CodeBlock language="text">
 {`plugin:rhesis:rhesis · ✔ connected · 52 tools`}

--- a/docs/content/docs/agent-skill/spec.mdx
+++ b/docs/content/docs/agent-skill/spec.mdx
@@ -5,7 +5,7 @@ Build a **test foundation** — Requirements, custom metrics, tags, and generate
 Everything created lives in **your Rhesis organization** — reusable and refinable.
 
 <Callout type="info">
-  This is a **workflow inside the Rhesis agent skill**, not a separate install. Install once with `npx skills add rhesis-ai/rhesis`, then paste your spec or PRD, or say you want to build a test foundation.
+  This is a **workflow inside the Rhesis agent skill**, not a separate install. Install once with `npx skills add rhesis-ai/skills`, then paste your spec or PRD, or say you want to build a test foundation.
 </Callout>
 
 ## What you get
@@ -32,7 +32,7 @@ Everything created lives in **your Rhesis organization** — reusable and refina
 Same as the [platform workflow](/docs/agent-skill/platform):
 
 ```bash
-npx skills add rhesis-ai/rhesis -g
+npx skills add rhesis-ai/skills -g
 ```
 
 Connect the MCP server — see [Install in Cursor](/docs/agent-skill/platform#install-in-cursor).

--- a/skills/rhesis/.mcp.json
+++ b/skills/rhesis/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rhesis": {
       "type": "http",
-      "url": "${RHESIS_MCP_URL:-https://api.rhesis.ai/mcp}",
+      "url": "${RHESIS_MCP_URL:-https://api.rhesis.ai/mcp/}",
       "headers": {
         "Authorization": "Bearer ${RHESIS_API_KEY}"
       }

--- a/skills/rhesis/README.md
+++ b/skills/rhesis/README.md
@@ -17,51 +17,71 @@ This skill teaches your agent how to explore an AI endpoint's capabilities, desi
 
 ---
 
-## Install the skill (any agent)
+## Install in Claude Code
 
-The fastest way to install across Claude Code, Cursor, Codex, Gemini CLI, and 40+ other AI interfaces:
-
-```bash
-npx skills add rhesis-ai/skills
-```
-
-The CLI detects which agents you have installed and asks where to place the skill. Use `-g` for a global install (available in all projects) or omit it for project-level.
-
-```bash
-# Global install — available everywhere
-npx skills add rhesis-ai/skills -g
-
-# Install to specific agents only
-npx skills add rhesis-ai/skills -a cursor -a claude-code -g
-
-# See where it would be installed without installing
-npx skills add rhesis-ai/skills --list
-```
-
-> `npx skills` installs the skill instructions. The MCP server (which the skill uses to talk to Rhesis) is configured separately — see the sections below for your agent.
-
----
-
-## Connect the MCP server
-
-The skill needs the Rhesis MCP server connected to call platform tools. Set this up once per agent.
-
-### Claude Code
-
-```bash
-export RHESIS_API_KEY=rhs_your_token_here
-# Optional — defaults to https://api.rhesis.ai/mcp/
-export RHESIS_MCP_URL=http://localhost:8080/mcp/
-```
-
-The skill is bundled as a Claude Code plugin that includes the MCP config. To install via plugin (MCP + skill together):
+The plugin carries both the skill and the MCP server config, so it is the only install step. **Do
+not also run `npx skills add`** — that installs the skill a second time from a different source,
+and one copy silently shadows the other.
 
 ```
 /plugin marketplace add rhesis-ai/skills
 /plugin install rhesis@rhesis-ai
 ```
 
-Then set `RHESIS_API_KEY` as above.
+Then set your API token, either in your shell:
+
+```bash
+export RHESIS_API_KEY=rhs_your_token_here
+```
+
+or in the `env` block of `~/.claude/settings.json`, which applies to every session without
+touching your shell profile:
+
+```json
+{
+  "env": {
+    "RHESIS_API_KEY": "rhs_your_token_here"
+  }
+}
+```
+
+Restart Claude Code and run `/mcp`. You should see:
+
+```
+plugin:rhesis:rhesis · ✔ connected · 52 tools
+```
+
+If instead you are asked to authenticate a connector named "Rhesis AI", the plugin's server is not
+connected — see [Troubleshooting](#troubleshooting).
+
+For a self-hosted backend, also set `RHESIS_MCP_URL=http://localhost:8080/mcp/`.
+
+---
+
+## Install in other agents
+
+For Cursor, Codex, Gemini CLI, and 40+ other AI interfaces, the skill and the MCP server are two
+separate steps.
+
+**Step 1 — the skill.** The CLI detects which agents you have and asks where to place it. Use `-g`
+for a global install, or omit it for project-level.
+
+```bash
+npx skills add rhesis-ai/skills -g
+
+# Install to specific agents only
+npx skills add rhesis-ai/skills -a cursor -a codex -g
+
+# See where it would be installed without installing
+npx skills add rhesis-ai/skills --list
+```
+
+**Step 2 — the MCP server.** `npx skills` installs the skill instructions only. Configure the
+server for your agent using the sections below.
+
+---
+
+## Connect the MCP server
 
 ### Cursor
 
@@ -163,10 +183,20 @@ Use the native Architect when you want maximum structural control. Use this skil
 - Test connectivity: `curl -H "Authorization: Bearer $RHESIS_API_KEY" https://api.rhesis.ai/mcp/`
 - In Cursor, restart the IDE after editing `.cursor/mcp.json`
 
-**Skill not activating:**
+**Claude Code asks you to authenticate a "Rhesis AI" connector:**
+- The plugin's MCP server is not connected, so the skill is falling back to the claude.ai cloud connector, which uses OAuth rather than your API token. Don't authenticate it.
+- Run `/mcp` and look for `plugin:rhesis:rhesis`. Missing entirely means the plugin isn't installed or enabled — check `claude plugin list`. Present but failed means `RHESIS_API_KEY` is unset or invalid.
+- Environment variables are read at session start, so set the token and restart; a running session won't pick up a new one.
+- Once the plugin's server is connected, that connector correctly stays under "unused connectors".
+
+**`rhesis` appears twice in Claude Code, or skill edits have no effect:**
+- The skill is installed from two sources, usually because `npx skills add` was run alongside the plugin. One shadows the other and they update through different channels.
+- Remove the standalone copy with `rm ~/.claude/skills/rhesis` and keep the plugin. This leaves `~/.agents/skills/rhesis` in place, so Cursor and Codex keep working.
+
+**Skill not activating (other agents):**
 - Run `npx skills list` to verify the skill is installed and shows the correct path
 - In Cursor, verify `~/.cursor/skills/rhesis/SKILL.md` exists
-- In Claude Code, try `/rhesis` explicitly; if the filesystem skill loading bug affects your version, use the plugin install path instead
+- Try invoking it explicitly by typing `/rhesis`
 
 **Tool-name collisions:**
 - If you have other MCP servers with generic tool names (e.g., `list_test_runs`), they may conflict. In Claude Code, Rhesis tools are prefixed by server name; in Cursor, check `.cursor/mcp.json` for conflicts.

--- a/skills/rhesis/README.md
+++ b/skills/rhesis/README.md
@@ -45,11 +45,15 @@ touching your shell profile:
 }
 ```
 
-Restart Claude Code and run `/mcp`. You should see:
+Restart Claude Code and run `/mcp`. Under the built-in servers you should see `rhesis` connected,
+with a tool count after it:
 
 ```
 plugin:rhesis:rhesis · ✔ connected · 52 tools
 ```
+
+That line is the only confirmation that matters. The skill on its own does nothing — every
+operation it performs is a call to this server.
 
 If instead you are asked to authenticate a connector named "Rhesis AI", the plugin's server is not
 connected — see [Troubleshooting](#troubleshooting).
@@ -152,7 +156,7 @@ You can also use it for direct operations without the full workflow:
 | `skills/rhesis/SKILL.md` | Skill instructions — loaded by all compatible agents |
 | `skills/rhesis/.mcp.json` | MCP server config bundled with the Claude Code plugin |
 | `skills/rhesis/references/workflow-index.md` | Router — read first, points at everything below |
-| `skills/rhesis/references/tool-catalog.md` | All 48 MCP tools with parameters and common mistakes |
+| `skills/rhesis/references/tool-catalog.md` | Every MCP tool with parameters and common mistakes |
 | `skills/rhesis/references/odata-patterns.md` | `$filter`, `$select`, navigation properties, batched lookups |
 | `skills/rhesis/references/exploration-strategies.md` | Domain probing, capability mapping, boundary discovery |
 | `skills/rhesis/references/result-analysis.md` | Single-run summaries, run comparison, failure patterns |

--- a/skills/rhesis/README.md
+++ b/skills/rhesis/README.md
@@ -50,8 +50,8 @@ The skill needs the Rhesis MCP server connected to call platform tools. Set this
 
 ```bash
 export RHESIS_API_KEY=rhs_your_token_here
-# Optional — defaults to https://api.rhesis.ai/mcp
-export RHESIS_MCP_URL=http://localhost:8080/mcp
+# Optional — defaults to https://api.rhesis.ai/mcp/
+export RHESIS_MCP_URL=http://localhost:8080/mcp/
 ```
 
 The skill is bundled as a Claude Code plugin that includes the MCP config. To install via plugin (MCP + skill together):
@@ -67,7 +67,7 @@ Then set `RHESIS_API_KEY` as above.
 
 **One click** — click the badge to install the MCP server config automatically:
 
-[![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=rhesis&config=eyJ1cmwiOiJodHRwczovL2FwaS5yaGVzaXMuYWkvbWNwIiwiaGVhZGVycyI6eyJBdXRob3JpemF0aW9uIjoiQmVhcmVyIFlPVVJfUkhFU0lTX0FQSV9LRVkifX0K)
+[![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=rhesis&config=eyJ1cmwiOiJodHRwczovL2FwaS5yaGVzaXMuYWkvbWNwLyIsImhlYWRlcnMiOnsiQXV0aG9yaXphdGlvbiI6IkJlYXJlciBZT1VSX1JIRVNJU19BUElfS0VZIn19)
 
 After clicking, edit `.cursor/mcp.json` to replace `YOUR_RHESIS_API_KEY` with your actual token. Restart Cursor.
 
@@ -77,7 +77,7 @@ After clicking, edit `.cursor/mcp.json` to replace `YOUR_RHESIS_API_KEY` with yo
 {
   "mcpServers": {
     "rhesis": {
-      "url": "https://api.rhesis.ai/mcp",
+      "url": "https://api.rhesis.ai/mcp/",
       "headers": {
         "Authorization": "Bearer YOUR_RHESIS_API_KEY"
       }
@@ -90,7 +90,7 @@ After clicking, edit `.cursor/mcp.json` to replace `YOUR_RHESIS_API_KEY` with yo
 
 Add the Rhesis MCP server to your agent's MCP config file. The connection details are:
 
-- **URL:** `https://api.rhesis.ai/mcp` (or `http://localhost:8080/mcp` for self-hosted)
+- **URL:** `https://api.rhesis.ai/mcp/` (or `http://localhost:8080/mcp/` for self-hosted)
 - **Auth header:** `Authorization: Bearer <your-api-token>`
 
 Refer to your agent's documentation for the exact config file location and format.
@@ -160,7 +160,7 @@ Use the native Architect when you want maximum structural control. Use this skil
 
 **MCP server not connecting:**
 - Verify `RHESIS_API_KEY` is set and the token hasn't expired — regenerate at [app.rhesis.ai/tokens](https://app.rhesis.ai/tokens)
-- Test connectivity: `curl -H "Authorization: Bearer $RHESIS_API_KEY" https://api.rhesis.ai/mcp`
+- Test connectivity: `curl -H "Authorization: Bearer $RHESIS_API_KEY" https://api.rhesis.ai/mcp/`
 - In Cursor, restart the IDE after editing `.cursor/mcp.json`
 
 **Skill not activating:**

--- a/skills/rhesis/README.md
+++ b/skills/rhesis/README.md
@@ -45,8 +45,8 @@ touching your shell profile:
 }
 ```
 
-Restart Claude Code and run `/mcp`. Under the built-in servers you should see `rhesis` connected,
-with a tool count after it:
+Restart Claude Code and run `/mcp`. The plugin's server is listed under **Built-in MCPs**, named
+with a `plugin:` prefix rather than plain `rhesis`, with a tool count after it:
 
 ```
 plugin:rhesis:rhesis · ✔ connected · 52 tools

--- a/skills/rhesis/SKILL.md
+++ b/skills/rhesis/SKILL.md
@@ -19,7 +19,7 @@ Platform operations use the `rhesis` MCP server. **Read `references/workflow-ind
 
 - Rhesis MCP connected — [install guide](https://github.com/rhesis-ai/rhesis/tree/main/skills/rhesis#connect-the-mcp-server)
 - API token at [app.rhesis.ai/tokens](https://app.rhesis.ai/tokens)
-- Self-hosted: `RHESIS_MCP_URL=http://localhost:8080/mcp`
+- Self-hosted: `RHESIS_MCP_URL=http://localhost:8080/mcp/`
 
 ## Shared skeleton
 

--- a/skills/rhesis/SKILL.md
+++ b/skills/rhesis/SKILL.md
@@ -17,9 +17,18 @@ Platform operations use the `rhesis` MCP server. **Read `references/workflow-ind
 
 ## Prerequisites
 
-- Rhesis MCP connected — [install guide](https://github.com/rhesis-ai/rhesis/tree/main/skills/rhesis#connect-the-mcp-server)
+Every platform operation in this skill is an `rhesis` MCP tool call. Without that server the skill
+can do nothing — there is no offline mode and no substitute.
+
+- Rhesis MCP connected — [install guide](https://github.com/rhesis-ai/rhesis/tree/main/skills/rhesis#install-in-claude-code)
 - API token at [app.rhesis.ai/tokens](https://app.rhesis.ai/tokens)
 - Self-hosted: `RHESIS_MCP_URL=http://localhost:8080/mcp/`
+
+**If the `rhesis` MCP tools are not available, stop and say so.** Tell the user to install the
+plugin and set `RHESIS_API_KEY`, then restart. Do not improvise from memory, do not answer platform
+questions without the tools, and **do not authenticate a different MCP server or connector that
+happens to be named after Rhesis** — an OAuth connector of a similar name is not this server, and
+authenticating it does not make these tools appear.
 
 ## Shared skeleton
 


### PR DESCRIPTION
Two bugs on the first-run path of the published agent skill, found while installing it from the
docs as written. Unrelated to #2693.

## 1. Install instructions name the wrong repository

The docs told users to run:

```
npx skills add rhesis-ai/rhesis
/plugin marketplace add rhesis-ai/rhesis
```

Both name the monorepo. Verified what each actually does:

- **The plugin command fails.** `scripts/skill/build_mirror.py` generates `.claude-plugin/` into
  the mirror, and the monorepo has no such directory (`GET /repos/rhesis-ai/rhesis/contents/.claude-plugin`
  returns 404). There is no marketplace manifest to add.
- **The npx command works, but wastefully.** The monorepo is public and carries
  `skills/rhesis/SKILL.md`, so the CLI resolves it. It just clones the entire monorepo instead of
  the roughly thirty file mirror, which is the reason the mirror exists at all.

Fixed to `rhesis-ai/skills` in `platform.mdx`, `for-agents.mdx`, `index.mdx` and `spec.mdx`.

Left alone: source links such as `github.com/rhesis-ai/rhesis/tree/main/skills/rhesis`, which
correctly point at the monorepo, and the historical changelog entry, which records what shipped.

## 2. The bundled MCP URL is not the canonical one

`skills/rhesis/.mcp.json` defaulted to `https://api.rhesis.ai/mcp`. The MCP app is a Starlette
`Mount` at `/mcp` (`mcp_server/server.py:255`), so `/mcp/` is canonical and the slashless form
answers 307.

This was not a hard break. Clients that follow a redirect on POST connected fine, which is why it
went unnoticed. It did cost a redirect on every connection, and left anything that does not follow
redirects, or drops the `Authorization` header across one, unable to connect with no useful error.

Measured against production:

```
POST https://api.rhesis.ai/mcp/   ->  HTTP 200, redirects=0
POST https://api.rhesis.ai/mcp    ->  HTTP 200, redirects=1
```

Updated the bundled default, the documented URLs (including the self-hosted
`http://localhost:8080/mcp/`), the `curl` connectivity check, and the base64 payload behind the
Cursor install badge, which carried the same URL.

## Verification

| Check | Result |
|---|---|
| `.mcp.json` parses | valid |
| `scripts/skill/validate.py` | passed |
| `scripts/skill/build_mirror.py` | builds |
| canonical URL reaches the server | 200, 0 redirects |
| no install command still names the monorepo | confirmed |
| monorepo source links intact | confirmed |

## Note

`skills/rhesis/**` mirrors to [`rhesis-ai/skills`](https://github.com/rhesis-ai/skills) on merge to
`main`, so the second commit reaches users on the next sync.


---

## 3. The setup docs led Claude Code users into a broken state

Added after the first two fixes, because installing from the docs as written is what exposed them.

The page led with `npx skills add` as the path for **every** agent, then described the plugin lower
down as a separate Claude Code section. Following it top to bottom, a Claude Code user runs both
and ends up with the skill installed twice, from two sources that update through different
channels, one silently shadowing the other. The README went further and offered `-a claude-code`
as an example. `npx skills add` also installs no MCP server, so the skill loads but has no tools,
and then offers the OAuth cloud connector instead.

Claude Code now gets its own complete path stated first, with the plugin as the only step and an
explicit warning not to also run `npx skills add`. Other agents keep the two-step flow, which is
genuinely two steps for them.

Three things that cost real debugging time and were documented nowhere:

- **How to verify it worked** — run `/mcp`, expect `plugin:rhesis:rhesis · ✔ connected · 52 tools`.
- **The connector collision** — a claude.ai cloud connector named "Rhesis AI" uses OAuth instead
  of the API token, and the skill offers it whenever the plugin's own server is not connected.
  Authenticating it is the wrong fix. The docs now say so and give the actual diagnosis path.
- **Where the token can live** — the `env` block of `~/.claude/settings.json` works and applies to
  every session without touching a shell profile. Either way it is read at session start, so a
  running session will not pick up a new one.

The old "there is a known issue with `~/.claude/skills/` filesystem discovery" troubleshooting
entry is replaced by the two failures users actually hit, with how to tell them apart.

Touches `platform.mdx`, `index.mdx`, `for-agents.mdx` and the skill's own `README.md`, which ships
to users on the mirror.
