### PR TITLE
Embed magic link in invitation email for one-click sign-in

### DIFF
--- a/apps/backend/src/rhesis/backend/app/auth/token_utils.py
+++ b/apps/backend/src/rhesis/backend/app/auth/token_utils.py
@@ -372,13 +372,22 @@ def create_password_reset_token(user_id: str, email: str) -> str:
     )
 
 
-def create_magic_link_token(user_id: str, email: str) -> str:
-    """Create a 15-minute single-use magic link login token."""
+def create_magic_link_token(
+    user_id: str,
+    email: str,
+    expire_minutes: int = MAGIC_LINK_EXPIRE_MINUTES,
+) -> str:
+    """Create a single-use magic link login token.
+
+    Defaults to 15 minutes for interactive sign-in requests.
+    Invitation emails pass a longer TTL so the link survives
+    the hours or days before the recipient opens the email.
+    """
     return _create_email_flow_token(
         user_id=user_id,
         email=email,
         token_type="magic_link",
-        expire_minutes=MAGIC_LINK_EXPIRE_MINUTES,
+        expire_minutes=expire_minutes,
         with_jti=True,
     )
 

--- a/apps/backend/src/rhesis/backend/app/models/enums.py
+++ b/apps/backend/src/rhesis/backend/app/models/enums.py
@@ -107,6 +107,7 @@ class NotificationSection(str, Enum):
     TASKS = "tasks"
     ARCHITECT = "architect"
     USAGE = "usage"
+    ACCOUNT = "account"
 
 
 class NotificationEventType:
@@ -141,6 +142,12 @@ class NotificationEventType:
         #: Crossed the resource's ceiling -- the action it gates is now
         #: blocked (a 402 on the next attempt).
         BLOCKED = "usage.blocked"
+
+    class Account(str, Enum):
+        #: The user signed in (e.g. via invitation magic link) but has
+        #: no password and no external auth provider. Nudges them to
+        #: set a password so they can sign in independently.
+        PASSWORD_NOT_SET = "account.password_not_set"
 
 
 # Notification.entity_type reuses rhesis.backend.app.constants.EntityType

--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -1097,7 +1097,17 @@ async def verify_magic_link(
             detail="Invalid magic link",
         )
 
-    ttl_seconds = MAGIC_LINK_EXPIRE_MINUTES * 60
+    from datetime import datetime, timezone
+
+    # Derive the jti TTL from the token's actual expiry so longer-lived
+    # magic links (e.g. invitation emails) stay single-use for their
+    # full lifetime, not just the default 15-minute window.
+    exp = payload.get("exp")
+    if exp is not None:
+        remaining = int(exp - datetime.now(timezone.utc).timestamp())
+        ttl_seconds = max(remaining, 60)
+    else:
+        ttl_seconds = MAGIC_LINK_EXPIRE_MINUTES * 60
     try:
         claimed = await claim_token_jti(jti, ttl_seconds)
     except TokenStoreUnavailableError:
@@ -1124,8 +1134,6 @@ async def verify_magic_link(
         user.is_email_verified = True
 
     # Update last login and stamp first org join when applicable
-    from datetime import datetime, timezone
-
     current_time = datetime.now(timezone.utc)
     user.last_login_at = current_time
     mark_user_joined_if_needed(user, when=current_time)

--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -1148,6 +1148,10 @@ async def verify_magic_link(
     db.commit()
     auth_code = await create_auth_code(access_token, refresh_tok)
 
+    # Nudge the user to set a password if they have none and no external
+    # auth provider (e.g. they clicked an invitation magic link).
+    _maybe_notify_password_not_set(db, user)
+
     # Track login activity
     if get_telemetry_settings().is_telemetry_enabled:
         set_telemetry_enabled(
@@ -1172,6 +1176,55 @@ async def verify_magic_link(
             "organization_id": (str(user.organization_id) if user.organization_id else None),
         },
     }
+
+
+_EMAIL_PROVIDER_TYPES = {None, "email"}
+
+
+def _maybe_notify_password_not_set(db: Session, user) -> None:
+    """Send a one-time "set your password" notification if the user needs one.
+
+    Fires when the user has no password_hash and no external auth provider
+    (OAuth/SSO). Skips silently if a notification for this event already
+    exists for the user so they are not nagged on every magic-link sign-in.
+    """
+    if user.password_hash:
+        return
+    provider = getattr(user, "provider_type", None)
+    if provider is not None:
+        provider = provider.value if hasattr(provider, "value") else str(provider)
+    if provider not in _EMAIL_PROVIDER_TYPES:
+        return
+
+    from rhesis.backend.app.models.enums import NotificationEventType
+    from rhesis.backend.app.models.notification import Notification
+    from rhesis.backend.app.services.notification import RenderedNotification, notify
+
+    try:
+        already_sent = (
+            db.query(Notification.id)
+            .filter(
+                Notification.user_id == user.id,
+                Notification.event_type == NotificationEventType.Account.PASSWORD_NOT_SET.value,
+            )
+            .first()
+        )
+        if already_sent:
+            return
+
+        notify(
+            db,
+            event_type=NotificationEventType.Account.PASSWORD_NOT_SET,
+            rendered=RenderedNotification(
+                title="Set a password",
+                body="Set a password so you can sign in anytime without a magic link.",
+            ),
+            user_id=str(user.id),
+            organization_id=str(user.organization_id) if user.organization_id else None,
+        )
+        db.commit()
+    except Exception:
+        logger.warning("Failed to send password-not-set notification for user %s", user.id)
 
 
 # =============================================================================

--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -224,19 +224,26 @@ def create_user(
 
             # Mint a magic link so the "Get started" button logs the
             # invitee in directly. 7-day TTL — invitation emails are
-            # often opened hours or days after they arrive.
-            from rhesis.backend.app.auth.token_utils import create_magic_link_token
-            from rhesis.backend.app.config.settings import get_frontend_settings
-
+            # often opened hours or days after they arrive. Failures
+            # fall through to magic_link_url=None so the email still
+            # sends with the generic sign-in copy.
             magic_link_url = None
             if not _org_sso_enabled(organization):
-                token = create_magic_link_token(
-                    user_id=str(created_user.id),
-                    email=created_user.email,
-                    expire_minutes=60 * 24 * 7,
-                )
-                fe_url = get_frontend_settings().url
-                magic_link_url = f"{fe_url.rstrip('/')}/auth/magic-link?token={token}"
+                try:
+                    from rhesis.backend.app.auth.token_utils import create_magic_link_token
+                    from rhesis.backend.app.config.settings import get_frontend_settings
+
+                    token = create_magic_link_token(
+                        user_id=str(created_user.id),
+                        email=created_user.email,
+                        expire_minutes=60 * 24 * 7,
+                    )
+                    fe_url = get_frontend_settings().url
+                    magic_link_url = f"{fe_url.rstrip('/')}/auth/magic-link?token={token}"
+                except Exception:
+                    logger.warning(
+                        "Could not mint invitation magic link for %s", created_user.email
+                    )
 
             # Send the invitation email
             success = email_service.send_team_invitation_email(

--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -222,6 +222,22 @@ def create_user(
                 or "Team Member"
             )
 
+            # Mint a magic link so the "Get started" button logs the
+            # invitee in directly. 7-day TTL — invitation emails are
+            # often opened hours or days after they arrive.
+            from rhesis.backend.app.auth.token_utils import create_magic_link_token
+            from rhesis.backend.app.config.settings import get_frontend_settings
+
+            magic_link_url = None
+            if not _org_sso_enabled(organization):
+                token = create_magic_link_token(
+                    user_id=str(created_user.id),
+                    email=created_user.email,
+                    expire_minutes=60 * 24 * 7,
+                )
+                fe_url = get_frontend_settings().url
+                magic_link_url = f"{fe_url.rstrip('/')}/auth/magic-link?token={token}"
+
             # Send the invitation email
             success = email_service.send_team_invitation_email(
                 recipient_email=created_user.email,
@@ -232,6 +248,7 @@ def create_user(
                 inviter_email=current_user.email,
                 organization_slug=organization.slug if organization else None,
                 sso_enabled=_org_sso_enabled(organization),
+                magic_link_url=magic_link_url,
             )
 
             if success:

--- a/apps/backend/src/rhesis/backend/app/services/notification/catalog.py
+++ b/apps/backend/src/rhesis/backend/app/services/notification/catalog.py
@@ -204,4 +204,9 @@ NOTIFICATION_CATALOG: Dict[str, NotificationKind] = {
         section=NotificationSection.USAGE,
         entity_type=None,
     ),
+    NotificationEventType.Account.PASSWORD_NOT_SET: NotificationKind(
+        event_type=NotificationEventType.Account.PASSWORD_NOT_SET,
+        section=NotificationSection.ACCOUNT,
+        entity_type=None,
+    ),
 }

--- a/apps/backend/src/rhesis/backend/notifications/email/service.py
+++ b/apps/backend/src/rhesis/backend/notifications/email/service.py
@@ -228,9 +228,7 @@ class EmailService:
         try:
             from rhesis.backend.app.auth.providers import ProviderRegistry
 
-            names = [
-                p.display_name for p in ProviderRegistry.get_enabled_oauth_providers()
-            ]
+            names = [p.display_name for p in ProviderRegistry.get_enabled_oauth_providers()]
         except Exception:
             names = []
 

--- a/apps/backend/src/rhesis/backend/notifications/email/service.py
+++ b/apps/backend/src/rhesis/backend/notifications/email/service.py
@@ -137,6 +137,7 @@ class EmailService:
         frontend_url: Optional[str] = None,
         organization_slug: Optional[str] = None,
         sso_enabled: bool = False,
+        magic_link_url: Optional[str] = None,
     ) -> bool:
         """
         Send a team invitation email to a new user.
@@ -154,6 +155,9 @@ class EmailService:
                 sign-in instructions differ: an SSO org's users authenticate
                 through their identity provider, not with an email address, so
                 pointing them at the generic sign-in page is misleading.
+            magic_link_url: Pre-authenticated URL that logs the invitee in
+                directly. When set, the "Get started" button uses this instead
+                of the bare frontend URL.
 
         Returns:
             bool: True if email was sent successfully, False otherwise
@@ -183,6 +187,11 @@ class EmailService:
         if sso_enabled and organization_slug:
             sso_login_url = f"{frontend_url.rstrip('/')}/?org={quote(organization_slug)}"
 
+        # Build a human-readable list of sign-in methods from the provider
+        # registry so the copy always matches whichever OAuth backends are
+        # enabled in this deployment.
+        sign_in_methods = self._build_sign_in_methods_label()
+
         template_variables = {
             "recipient_email": recipient_email,
             "recipient_name": recipient_name or "",
@@ -197,6 +206,8 @@ class EmailService:
             # undefined instead, which Jinja treats as falsy.
             "sso_enabled": bool(sso_login_url),
             "sso_login_url": sso_login_url,
+            "magic_link_url": magic_link_url or "",
+            "sign_in_methods": sign_in_methods,
         }
 
         return self.send_email(
@@ -206,6 +217,27 @@ class EmailService:
             template_variables=template_variables,
             task_id="team_invitation",
         )
+
+    @staticmethod
+    def _build_sign_in_methods_label() -> str:
+        """Build a human-readable label from the currently enabled OAuth providers.
+
+        Returns something like "Google, GitHub, or a one-time email link",
+        or an empty string when no OAuth providers are enabled.
+        """
+        try:
+            from rhesis.backend.app.auth.providers import ProviderRegistry
+
+            names = [
+                p.display_name for p in ProviderRegistry.get_enabled_oauth_providers()
+            ]
+        except Exception:
+            names = []
+
+        parts = list(names) + ["a one-time email link"]
+        if len(parts) == 1:
+            return parts[0]
+        return ", ".join(parts[:-1]) + ", or " + parts[-1]
 
     def send_welcome_email(
         self,

--- a/apps/backend/src/rhesis/backend/notifications/email/service.py
+++ b/apps/backend/src/rhesis/backend/notifications/email/service.py
@@ -222,8 +222,10 @@ class EmailService:
     def _build_sign_in_methods_label() -> str:
         """Build a human-readable label from the currently enabled OAuth providers.
 
-        Returns something like "Google, GitHub, or a one-time email link",
-        or an empty string when no OAuth providers are enabled.
+        Always includes "a one-time email link" as the last option, so the
+        result is never empty. Examples: "Google, GitHub, or a one-time
+        email link", or just "a one-time email link" when no OAuth
+        providers are enabled.
         """
         try:
             from rhesis.backend.app.auth.providers import ProviderRegistry

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/team_invitation.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/team_invitation.html.jinja2
@@ -30,8 +30,8 @@
 
 {% call c.row_prose() %}
     {{ c.subhead("What's next?") }}
-    {{ c.p('Your account has been created and you can start using Rhesis AI right away:') }}
     {% if sso_enabled %}
+    {{ c.p('Your account has been created and you can start using Rhesis AI right away:') }}
     {{ c.bullets([
         'Click the "Sign in with single sign-on" button below',
         'Sign in with your ' ~ organization_name ~ ' account (single sign-on)',
@@ -39,21 +39,24 @@
         'Start collaborating with your team',
     ], ordered=True) }}
     {{ c.p(organization_name ~ " uses single sign-on, so you do not need a separate Rhesis AI password. The button below takes you to your organization's sign-in page — use your usual work account.", size=brand.type.small, color=brand.color.muted, bottom=0) }}
+    {% elif magic_link_url %}
+    {{ c.p('Click <strong>Get started</strong> to open Rhesis AI and sign in automatically. No password needed.') }}
     {% else %}
-    {{ c.bullets([
-        'Click the "Get started" button below',
-        'Sign in with your email address (' ~ recipient_email ~ ')',
-        'Complete your profile setup',
-        'Start collaborating with your team',
-    ], ordered=True) }}
+    {#- Fallback when the magic link could not be minted (e.g. SMTP-only deploy). -#}
+    {% if sign_in_methods %}
+    {{ c.p('Click <strong>Get started</strong> to sign in with ' ~ sign_in_methods ~ '. No password needed.') }}
+    {% else %}
+    {{ c.p('Click <strong>Get started</strong> to sign in. No password needed.') }}
+    {% endif %}
     {% endif %}
 {% endcall %}
 
-{% if sso_enabled or (frontend_url and frontend_url != 'N/A') %}
-{{ c.row_button(
-    sso_login_url if sso_enabled else frontend_url,
-    'Sign in with single sign-on' if sso_enabled else 'Get started',
-) }}
+{% if sso_enabled %}
+{{ c.row_button(sso_login_url, 'Sign in with single sign-on') }}
+{% elif magic_link_url %}
+{{ c.row_button(magic_link_url, 'Get started') }}
+{% elif frontend_url and frontend_url != 'N/A' %}
+{{ c.row_button(frontend_url, 'Get started') }}
 {% endif %}
 
 {{ c.row_rule() }}

--- a/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
+++ b/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import AuthErrorBoundary from './error-boundary';
 import VerificationBanner from '@/components/auth/VerificationBanner';
 import QuotaBanner from '@/components/auth/QuotaBanner';
+import SetPasswordBanner from '@/components/auth/SetPasswordBanner';
 import { FeaturesProvider } from '@/contexts/FeaturesContext';
 import type { FeaturesResponse } from '@/utils/api-client/features-client';
 import { PermissionsProvider } from '@/contexts/PermissionsContext';
@@ -115,6 +116,7 @@ export function ProtectedLayoutClient({
                   />
                 )}
                 {!isOnboarding && !chromeless && <VerificationBanner />}
+                {!isOnboarding && !chromeless && <SetPasswordBanner />}
                 {!isOnboarding && !chromeless && <QuotaBanner />}
                 {content}
               </NotificationsProvider>

--- a/apps/frontend/src/components/auth/SetPasswordBanner.tsx
+++ b/apps/frontend/src/components/auth/SetPasswordBanner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Box, Button, IconButton, Typography, useTheme } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import CloseIcon from '@mui/icons-material/Close';
@@ -8,11 +8,30 @@ import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import { useRouter } from 'next/navigation';
 import { useUserSettings } from '@/hooks/useUserSettings';
 
+const STORAGE_KEY = 'rhesis:set-password-banner-dismissed';
+
+function readDismissed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
 export default function SetPasswordBanner() {
   const theme = useTheme();
   const router = useRouter();
   const { data: settings, isLoading } = useUserSettings();
-  const [dismissed, setDismissed] = useState(false);
+  const [dismissed, setDismissed] = useState(readDismissed);
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+    try {
+      localStorage.setItem(STORAGE_KEY, '1');
+    } catch {
+      // storage unavailable
+    }
+  }, []);
 
   if (isLoading || dismissed || !settings) return null;
 
@@ -87,7 +106,7 @@ export default function SetPasswordBanner() {
       </Box>
       <IconButton
         size="small"
-        onClick={() => setDismissed(true)}
+        onClick={dismiss}
         aria-label="Dismiss banner"
         sx={{
           position: 'absolute',

--- a/apps/frontend/src/components/auth/SetPasswordBanner.tsx
+++ b/apps/frontend/src/components/auth/SetPasswordBanner.tsx
@@ -101,7 +101,9 @@ export default function SetPasswordBanner() {
           },
         }}
       >
-        <CloseIcon sx={{ fontSize: theme => theme.typography.body2.fontSize }} />
+        <CloseIcon
+          sx={{ fontSize: theme => theme.typography.body2.fontSize }}
+        />
       </IconButton>
     </Box>
   );

--- a/apps/frontend/src/components/auth/SetPasswordBanner.tsx
+++ b/apps/frontend/src/components/auth/SetPasswordBanner.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+import { Box, Button, IconButton, Typography, useTheme } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import CloseIcon from '@mui/icons-material/Close';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import { useRouter } from 'next/navigation';
+import { useUserSettings } from '@/hooks/useUserSettings';
+
+export default function SetPasswordBanner() {
+  const theme = useTheme();
+  const router = useRouter();
+  const { data: settings, isLoading } = useUserSettings();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (isLoading || dismissed || !settings) return null;
+
+  // Show when the user has no password and no external auth provider.
+  // provider_type is null for invited users and "email" for email-signup
+  // users; any other value means they have an OAuth/SSO provider and
+  // can sign in without a password.
+  const provider = settings.provider_type;
+  const hasExternalProvider = !!provider && provider !== 'email';
+  if (settings.has_password || hasExternalProvider) return null;
+
+  const isDark = theme.palette.mode === 'dark';
+  const bgGradient = isDark
+    ? `linear-gradient(135deg, ${alpha(theme.palette.info.dark, 0.85)} 0%, ${alpha(theme.palette.info.main, 0.7)} 100%)`
+    : `linear-gradient(135deg, ${theme.palette.info.main} 0%, ${theme.palette.info.light} 100%)`;
+  const textColor = isDark
+    ? theme.palette.info.contrastText
+    : theme.palette.info.contrastText;
+
+  return (
+    <Box
+      sx={{
+        background: bgGradient,
+        py: 0.5,
+        px: 2,
+        minHeight: theme => theme.spacing(4),
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        position: 'relative',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <LockOutlinedIcon
+          sx={{
+            fontSize: theme => theme.typography.body2.fontSize,
+            color: textColor,
+          }}
+        />
+        <Typography
+          variant="caption"
+          sx={{
+            color: textColor,
+            fontWeight: theme => theme.typography.fontWeightMedium,
+          }}
+        >
+          Set a password so you can sign in anytime.
+        </Typography>
+        <Button
+          size="small"
+          color="inherit"
+          onClick={() => router.push('/settings?tab=security')}
+          sx={{
+            color: textColor,
+            fontWeight: theme => theme.typography.fontWeightBold,
+            fontSize: theme => theme.typography.caption.fontSize,
+            textTransform: 'none',
+            minWidth: 'auto',
+            py: 0,
+            px: 1,
+            ml: 0.5,
+            borderRadius: theme => `${theme.shape.borderRadius}px`,
+            border: `1px solid ${alpha(textColor, 0.5)}`,
+            '&:hover': {
+              backgroundColor: alpha(textColor, 0.15),
+              borderColor: textColor,
+            },
+          }}
+        >
+          Set Password
+        </Button>
+      </Box>
+      <IconButton
+        size="small"
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss banner"
+        sx={{
+          position: 'absolute',
+          right: theme => theme.spacing(1),
+          color: textColor,
+          opacity: 0.8,
+          p: 0.25,
+          '&:hover': {
+            opacity: 1,
+            backgroundColor: alpha(textColor, 0.1),
+          },
+        }}
+      >
+        <CloseIcon sx={{ fontSize: theme => theme.typography.body2.fontSize }} />
+      </IconButton>
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
+++ b/apps/frontend/src/components/navigation/NotificationsDrawer.tsx
@@ -54,6 +54,7 @@ const SECTION_ROUTES: Record<NotificationSection, string> = {
   [NotificationSection.TASKS]: '/tasks',
   [NotificationSection.ARCHITECT]: '/architect',
   [NotificationSection.USAGE]: '/organizations/usage',
+  [NotificationSection.ACCOUNT]: '/settings?tab=security',
 };
 
 /** The recourse link's base label, keyed by `NotificationSection` -- what a
@@ -65,6 +66,7 @@ const SECTION_LINK_LABEL: Record<NotificationSection, string> = {
   [NotificationSection.TASKS]: 'View task',
   [NotificationSection.ARCHITECT]: 'Open architect',
   [NotificationSection.USAGE]: 'Org usage',
+  [NotificationSection.ACCOUNT]: 'Go to settings',
 };
 
 function sectionLinkLabel(

--- a/apps/frontend/src/constants/notifications.ts
+++ b/apps/frontend/src/constants/notifications.ts
@@ -16,6 +16,9 @@ export const NotificationSection = {
   // notification still needs a section to group and display under in the
   // notification drawer (`NotificationsDrawer.tsx`).
   USAGE: 'usage',
+  // Account-level notifications (e.g. "set a password"). Badges no nav
+  // item; the drawer links to the settings page.
+  ACCOUNT: 'account',
 } as const;
 
 export type NotificationSection =


### PR DESCRIPTION
## Summary

- Invitation emails now log the invitee in directly via a 7-day magic link token embedded in the "Get started" button, instead of pointing at the bare login page where they'd need to figure out how to authenticate without a password.
- Email copy adapts to context: "sign in automatically" when the magic link is present, dynamic provider names (resolved from the provider registry) as fallback, SSO path unchanged.
- A `SetPasswordBanner` nudges invited users who have no password and no OAuth/SSO provider to set one, linking to the existing Set Password flow in settings.
- The magic-link verify endpoint now derives the jti Redis TTL from the token's actual expiry instead of the hardcoded 15-minute constant, so longer-lived invitation tokens stay single-use for their full lifetime.

## Test plan

- [ ] Invite a user to an org and verify the email's "Get started" button contains a `/auth/magic-link?token=...` URL
- [ ] Click the link and confirm it logs the user in directly
- [ ] Verify the `SetPasswordBanner` appears after sign-in for a user with no password and no OAuth provider
- [ ] Dismiss the banner and confirm it stays hidden
- [ ] Click "Set Password" in the banner and confirm it navigates to `/settings?tab=security`
- [ ] Verify the banner does not appear for users who signed in via Google, GitHub, or SSO
- [ ] Verify the magic link expires after 7 days and returns an appropriate error
- [ ] Verify the magic link is single-use (second click rejected)
- [ ] SSO invitation emails are unchanged (still link to the org's IdP login page)