### PR TITLE
fix(backend): key entity reuse on a mapped content column

### DIFF
--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -1000,8 +1000,11 @@ def _build_search_filters_for_model(model: Type[T], search_data: Dict[str, Any])
                     model.type_value == search_data["type_value"],
                 ]
             )
-    elif hasattr(model, "content"):
-        # Models using content as identifier
+    elif "content" in columns:
+        # Models using content as identifier. Keyed on a mapped column, not
+        # hasattr: Test exposes `content` as a hybrid property proxying its
+        # prompt, so hasattr sent it down this branch even though there is no
+        # content column to filter on.
         if "content" in search_data:
             search_filters.append(model.content == search_data["content"])
 
@@ -1030,12 +1033,18 @@ def _has_identifying_field(model: Type[T], search_data: Dict[str, Any]) -> bool:
     so a non-empty filter list is not evidence that we can pick out one row. Reusing
     the filter count as that evidence means a blank name matches the org's first row
     and silently returns an unrelated entity.
+
+    The branching here must stay identical to ``_build_search_filters_for_model``.
+    If this function reports that a row is identifiable via a field the filter
+    builder never turns into a predicate, the lookup runs on the organization
+    predicate alone and ``.first()`` returns an unrelated row — the exact failure
+    this guard exists to prevent.
     """
     columns = inspect(model).columns.keys()
 
     if model.__name__ == "TypeLookup":
         return bool(search_data.get("type_name")) and bool(search_data.get("type_value"))
-    if hasattr(model, "content"):
+    if "content" in columns:
         return bool(search_data.get("content"))
     return any(field in columns and search_data.get(field) for field in IDENTIFYING_FIELDS)
 

--- a/tests/backend/utils/test_crud_utils.py
+++ b/tests/backend/utils/test_crud_utils.py
@@ -644,6 +644,56 @@ class TestHasIdentifyingField:
             is False
         )
 
+    def test_branching_agrees_with_the_filter_builder(self):
+        """The guard and the filter builder must never disagree about a branch.
+
+        If the guard reports a row is identifiable via a field the filter builder
+        never turns into a predicate, the lookup runs on the organization predicate
+        alone and ``.first()`` returns an unrelated row.
+
+        ``Test`` is the case that made this concrete: it exposes ``content`` as a
+        hybrid property proxying its prompt, so a ``hasattr`` check sent it down the
+        content branch even though there is no content column to filter on.
+        """
+        search_data = {"nano_id": "abc123", "organization_id": str(uuid.uuid4())}
+
+        assert crud_utils._has_identifying_field(models.Test, search_data) is True
+        filters = crud_utils._build_search_filters_for_model(models.Test, search_data)
+        assert any("nano_id" in str(f) for f in filters), (
+            "guard vouched for nano_id but the filter builder emitted no predicate for it"
+        )
+
+    def test_no_model_branches_on_a_non_column_content_attribute(self):
+        """Guards against reintroducing the hasattr check on either function."""
+        from sqlalchemy import inspect as sa_inspect
+
+        for name in dir(models):
+            model = getattr(models, name)
+            if not hasattr(model, "__tablename__"):
+                continue
+            try:
+                columns = set(sa_inspect(model).columns.keys())
+            except Exception:
+                continue
+            if "content" not in columns and hasattr(model, "content"):
+                # A content-less model must fall through to the identifying fields,
+                # not be treated as content-keyed.
+                assert crud_utils._has_identifying_field(model, {"nano_id": "x"}) is True
+
+    def test_test_without_an_identifying_field_is_not_reused(self):
+        """Org seeding passes neither content nor an identifying field."""
+        search_data = {
+            "prompt_id": str(uuid.uuid4()),
+            "test_type_id": str(uuid.uuid4()),
+            "organization_id": str(uuid.uuid4()),
+        }
+
+        assert crud_utils._has_identifying_field(models.Test, search_data) is False
+
+    def test_content_keyed_models_still_key_on_content(self):
+        assert crud_utils._has_identifying_field(models.Prompt, {"content": "hello"}) is True
+        assert crud_utils._has_identifying_field(models.Prompt, {"content": ""}) is False
+
     def test_blank_name_still_builds_the_org_filter(self):
         """Documents why the count-based check was wrong: filters are non-empty even
         when nothing identifies a row."""

--- a/tests/backend/utils/test_crud_utils.py
+++ b/tests/backend/utils/test_crud_utils.py
@@ -664,9 +664,16 @@ class TestHasIdentifyingField:
         )
 
     def test_no_model_branches_on_a_non_column_content_attribute(self):
-        """Guards against reintroducing the hasattr check on either function."""
+        """Guards against reintroducing the hasattr check on either function.
+
+        Asserted on the content branch itself rather than via a substitute
+        identifying field: some models (the stats views) have no ``nano_id`` and no
+        identifying field at all, so keying the assertion on one of those would fail
+        for a future content-hybrid model even while the branching stayed correct.
+        """
         from sqlalchemy import inspect as sa_inspect
 
+        checked = []
         for name in dir(models):
             model = getattr(models, name)
             if not hasattr(model, "__tablename__"):
@@ -675,10 +682,25 @@ class TestHasIdentifyingField:
                 columns = set(sa_inspect(model).columns.keys())
             except Exception:
                 continue
-            if "content" not in columns and hasattr(model, "content"):
-                # A content-less model must fall through to the identifying fields,
-                # not be treated as content-keyed.
-                assert crud_utils._has_identifying_field(model, {"nano_id": "x"}) is True
+            if "content" in columns or not hasattr(model, "content"):
+                continue
+
+            checked.append(model.__name__)
+            search_data = {"content": "x", "organization_id": str(uuid.uuid4())}
+
+            # `content` cannot identify a row it is not a column of.
+            assert crud_utils._has_identifying_field(model, search_data) is False, (
+                f"{model.__name__} treats a non-column content attribute as identifying"
+            )
+            # And no predicate may be built from it.
+            filters = crud_utils._build_search_filters_for_model(model, search_data)
+            assert not any("content" in str(f) for f in filters), (
+                f"{model.__name__} emitted a content predicate for a non-column attribute"
+            )
+
+        # Test is the one such model today; if that changes the loop covers it, but an
+        # empty loop would make this test silently vacuous.
+        assert "Test" in checked
 
     def test_test_without_an_identifying_field_is_not_reused(self):
         """Org seeding passes neither content nor an identifying field."""


### PR DESCRIPTION
Follow-up to #2693, promised on [this review thread](https://github.com/rhesis-ai/rhesis/pull/2693#discussion_r3923582894). Kept separate because it changes existing reuse behaviour rather than fixing the requirement-attribution bug.

## Problem

`_build_search_filters_for_model` and `_has_identifying_field` both decided whether a model is content-keyed with `hasattr(model, "content")`. That also matches a hybrid property, and `Test` is exactly that case:

```
hasattr(Test, "content")            = True   # hybrid_propertyProxy over its prompt
"content" in inspect(Test).columns  = False
```

`Test` is the **only** model in the repo where the two disagree, so the blast radius is small — but the shape of the bug is not.

`_has_identifying_field` exists to stop `get_or_create_entity` reusing an arbitrary row when nothing in the data identifies one. It can only do that if it branches the same way as the filter builder. Key one on columns and the other on `hasattr`, and the guard vouches for a field the builder never turns into a predicate, leaving the lookup running on the organization predicate alone and `.first()` returning an unrelated row.

That is what peqy's original suggestion would have caused had it been applied to the guard alone:

```
Test lookup carrying a nano_id, guard on columns / builder on hasattr:
  guard   -> True
  filters -> ['test.organization_id = :organization_id_1']     ← no nano_id predicate
```

## Change

Both functions now test for a mapped column, so they cannot diverge by construction. The docstring on `_has_identifying_field` states the invariant, since it is not obvious from either function in isolation.

## Behaviour change

`Test` falls through to the identifying-field loop and matches on `nano_id` when one is supplied, instead of being treated as content-keyed and matching nothing:

```
before:  guard -> False,  filters -> [organization_id]
after:   guard -> True,   filters -> [organization_id, nano_id]
```

A `Test` with no identifying field is still created rather than reused, so org seeding (`services/organization.py:279`, which passes neither `content` nor an identifying field) is unaffected. Content-keyed models such as `Prompt` have a real `content` column and behave exactly as before.

## Verification

| Check | Result |
|---|---|
| `tests/backend/utils/test_crud_utils.py` | 35 passed (4 new) |
| org seeding, tenant isolation, test service, services routes | 88 passed, 1 skipped |
| ruff | clean (the 3 pre-existing errors in that test file are unchanged from `main` — same count, same lines 8/198/526, none in the added range) |

New tests: the guard and the filter builder agree on the `Test`-with-`nano_id` case; no model branches on a non-column `content` attribute (this one fails if either function goes back to `hasattr`); a `Test` with no identifying field is not reused; content-keyed models still key on content.
