### PR TITLE
fix(backend): honor batch_size for multi-turn generation

### DIFF
--- a/apps/backend/src/rhesis/backend/jobs/test_set.py
+++ b/apps/backend/src/rhesis/backend/jobs/test_set.py
@@ -533,6 +533,7 @@ def generate_and_save_test_set(
         elif test_type == TestSetType.MULTI_TURN.value:
             synthesizer = MultiTurnSynthesizer(
                 config=generation_config,
+                batch_size=batch_size,
                 model=model,
             )
         else:


### PR DESCRIPTION
One-line fix. `MultiTurnSynthesizer` was constructed without `batch_size`, so a request's value was silently ignored and multi-turn generation always used the SDK default of 10.

```python
# jobs/test_set.py, before
synthesizer = MultiTurnSynthesizer(
    config=generation_config,
    model=model,
)
```

Every sibling call in the same function passes it, including the single-turn branch immediately above (`ConfigSynthesizer`, line 529) and the two calls at 510 and 546.

## Behaviour change worth naming

The job's own default is `batch_size: int = 20`, so a caller that never set it now generates multi-turn tests in batches of 20 rather than 10. That is what the single-turn path already did, so this aligns the two rather than introducing a new value — but it does change the number of model calls for an unchanged request.

Batch size does not affect how many tests are produced (`num_tests` governs that), only how many are requested per model call.

## Verification

`tests/backend/jobs` — 609 passed. Ruff clean.

Found while reviewing the multi-turn path for #2693; noted there but deliberately left out of that PR as unrelated.
