### PR TITLE
feat(sdk): prompt for the API key at plugin install

### DIFF
--- a/docs/content/docs/agent-skill/platform.mdx
+++ b/docs/content/docs/agent-skill/platform.mdx
@@ -28,14 +28,19 @@ source, and one copy silently shadows the other.
 /plugin install rhesis@rhesis-ai`}
 </CodeBlock>
 
-**Step 2:** Set your API token, either as a shell environment variable:
+**Step 2:** The install prompts for your API token and stores it in your OS keychain, so there is
+nothing to place by hand. Generate a token at
+[app.rhesis.ai/tokens](https://app.rhesis.ai/tokens).
+
+If you skipped the prompt, set it later with:
 
 <CodeBlock language="bash">
-{`export RHESIS_API_KEY=rhs_your_token_here`}
+{`/plugin configure rhesis@rhesis-ai`}
 </CodeBlock>
 
-or in the `env` block of `~/.claude/settings.json`, which applies to every session without
-touching your shell profile:
+The server also reads `RHESIS_API_KEY` when the prompted value is unset, which suits CI and
+self-hosted setups that manage secrets elsewhere. Either export it, or put it in the `env` block of
+`~/.claude/settings.json` so it applies to every session without touching your shell profile:
 
 <CodeBlock filename="~/.claude/settings.json" language="json">
 {`{
@@ -44,6 +49,8 @@ touching your shell profile:
   }
 }`}
 </CodeBlock>
+
+Either way the token is read at session start, so a running session will not pick up a new one.
 
 **Step 3:** Restart Claude Code, then run `/mcp`. The plugin's server is listed under **Built-in
 MCPs**, named with a `plugin:` prefix rather than plain `rhesis`, with a tool count after it:

--- a/scripts/skill/build_mirror.py
+++ b/scripts/skill/build_mirror.py
@@ -82,6 +82,24 @@ def build_claude_plugin() -> dict:
         # skills/ at the plugin root is scanned by default, so no `skills` field is needed.
         # .mcp.json is not at the plugin root, so that one must be declared.
         "mcpServers": "./skills/rhesis/.mcp.json",
+        # Prompts for the API key at install time and stores it in the OS keychain, so
+        # users no longer have to place it themselves. `sensitive` keeps it out of
+        # settings.json; `description` is required by the manifest schema.
+        #
+        # Deliberately not `required`: the key is also readable from RHESIS_API_KEY, and
+        # marking it required would block anyone already set up that way when the plugin
+        # updates. `.mcp.json` falls back to the environment variable.
+        "userConfig": {
+            "api_key": {
+                "type": "string",
+                "title": "Rhesis API key",
+                "description": (
+                    "Generate one at https://app.rhesis.ai/tokens. Leave blank to use the "
+                    "RHESIS_API_KEY environment variable instead."
+                ),
+                "sensitive": True,
+            }
+        },
     }
 
 

--- a/skills/rhesis/.mcp.json
+++ b/skills/rhesis/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "${RHESIS_MCP_URL:-https://api.rhesis.ai/mcp/}",
       "headers": {
-        "Authorization": "Bearer ${RHESIS_API_KEY}"
+        "Authorization": "Bearer ${user_config.api_key:-${RHESIS_API_KEY}}"
       }
     }
   }

--- a/skills/rhesis/README.md
+++ b/skills/rhesis/README.md
@@ -28,13 +28,26 @@ and one copy silently shadows the other.
 /plugin install rhesis@rhesis-ai
 ```
 
-Then set your API token, either in your shell:
+The install prompts for your API token and stores it in your OS keychain, so there is nothing to
+place by hand. Generate a token at [app.rhesis.ai/tokens](https://app.rhesis.ai/tokens).
+
+If you skipped the prompt, set it later with:
+
+```
+/plugin configure rhesis@rhesis-ai
+```
+
+<details>
+<summary>Setting the token as an environment variable instead</summary>
+
+The server also reads `RHESIS_API_KEY` when the prompted value is unset, which is the better fit
+for CI and for self-hosted setups that already manage secrets elsewhere. Either export it:
 
 ```bash
 export RHESIS_API_KEY=rhs_your_token_here
 ```
 
-or in the `env` block of `~/.claude/settings.json`, which applies to every session without
+or put it in the `env` block of `~/.claude/settings.json`, which applies to every session without
 touching your shell profile:
 
 ```json
@@ -44,6 +57,10 @@ touching your shell profile:
   }
 }
 ```
+
+Environment variables are read at session start, so a running session will not pick up a new one.
+
+</details>
 
 Restart Claude Code and run `/mcp`. The plugin's server is listed under **Built-in MCPs**, named
 with a `plugin:` prefix rather than plain `rhesis`, with a tool count after it:


### PR DESCRIPTION
Placing the API key by hand was the main setup failure in the skill's first-run path. It had to be exported or written into `~/.claude/settings.json`, is read only at session start, and when it was missing the skill offered an unrelated OAuth connector rather than reporting that the server was unconfigured. #2694 fixed the docs around that; this removes the step.

## Change

Declare the key as plugin `userConfig`, so Claude Code prompts for it at install and stores it in the OS keychain:

```json
"userConfig": {
  "api_key": {
    "type": "string",
    "title": "Rhesis API key",
    "description": "Generate one at https://app.rhesis.ai/tokens. Leave blank to use the RHESIS_API_KEY environment variable instead.",
    "sensitive": true
  }
}
```

and reference it from the bundled MCP config, which uses a different placeholder syntax than the environment variable:

```json
"Authorization": "Bearer ${user_config.api_key:-${RHESIS_API_KEY}}"
```

`/plugin configure rhesis@rhesis-ai` sets it later if the prompt was skipped.

## Deliberately not `required`

The header falls back to `RHESIS_API_KEY`, so anyone already set up that way keeps working when the plugin updates. Marking the key required would have blocked them. Verified the difference:

```
optional  → "1 userConfig option not yet set" and install succeeds
required  → "2 userConfig options not yet set (1 required)"
```

The environment variable stays documented for CI and self-hosted setups that manage secrets elsewhere, just no longer as the primary path.

## What I verified

Against a probe plugin, since the published docs do not describe this behaviour:

| Check | Result |
|---|---|
| `userConfig` block accepted by the manifest schema | yes — note `description` is **required** per key, omitting it fails validation |
| Generated mirror plugin validates | passes (only the deliberate no-`version` warning) |
| `${user_config.KEY}` and the `:-` fallback forms validate | all three accepted |
| Optional key does not block install | confirmed, message above |
| Sensitive value stays out of `settings.json` | confirmed earlier — 0 occurrences; non-sensitive values land in `pluginConfigs.<plugin>.options` |
| `scripts/skill/validate.py` | passes |

## What I could not verify, and why it matters

**Whether `${user_config.api_key:-${RHESIS_API_KEY}}` actually falls back at runtime.** `claude plugin validate` only checks JSON shape, and resolution happens when the MCP server connects at session start, which I cannot trigger from inside a session. All three placeholder forms validate, so validation tells us nothing about which resolve.

This matters because `skills/rhesis/**` mirrors to `rhesis-ai/skills` on merge and reaches every user on their next plugin update. If the fallback does not resolve, existing environment-variable users would see the server fail to connect until they run `/plugin configure`.

Suggested check before merging: build the mirror locally, install it as a plugin, restart, and confirm `/mcp` still shows `plugin:rhesis:rhesis · ✔ connected` with only `RHESIS_API_KEY` set and no prompted value.

```bash
python scripts/skill/build_mirror.py --out /tmp/skills-mirror
```

If the fallback turns out not to work, the alternative is to drop it and document that existing users run `/plugin configure` once.
