### PR TITLE
fix(frontend): type metric score fields as text and validate them as numbers

### DIFF
--- a/apps/frontend/src/app/(protected)/metrics/new/components/NewMetricForm.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/new/components/NewMetricForm.tsx
@@ -41,6 +41,7 @@ import { TEST_TYPES } from '@/constants/test-types';
 import { SCORE_TYPES, ScoreTypeValue } from '@/constants/score-types';
 import { useTypeLookups } from '@/hooks/useLookups';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { validateScore } from '@/utils/validation';
 
 interface MetricFormData {
   name: string;
@@ -85,9 +86,6 @@ const initialFormData: MetricFormData = {
 const steps = ['Metric Information and Criteria', 'Confirmation'];
 
 const STEP_SEPARATOR = '\n---\n';
-
-/** A required score field is unset while it holds no non-whitespace text. */
-const isBlank = (value: string) => value.trim() === '';
 
 interface NewMetricFormProps {
   type: string;
@@ -186,6 +184,17 @@ export default function NewMetricForm({
     }));
   };
 
+  // Only rendered for numeric metrics, so computing them unconditionally is harmless.
+  const minScoreError = showErrors
+    ? validateScore(formData.min_score, 'Minimum Score').message
+    : undefined;
+  const maxScoreError = showErrors
+    ? validateScore(formData.max_score, 'Maximum Score').message
+    : undefined;
+  const thresholdError = showErrors
+    ? validateScore(formData.threshold, 'Threshold Value').message
+    : undefined;
+
   const isStepValid = React.useCallback((): boolean => {
     // Common required fields
     if (!formData.name.trim()) return false;
@@ -194,9 +203,9 @@ export default function NewMetricForm({
 
     // Score type conditional validation
     if (formData.score_type === SCORE_TYPES.NUMERIC) {
-      if (isBlank(formData.min_score)) return false;
-      if (isBlank(formData.max_score)) return false;
-      if (isBlank(formData.threshold)) return false;
+      if (!validateScore(formData.min_score).isValid) return false;
+      if (!validateScore(formData.max_score).isValid) return false;
+      if (!validateScore(formData.threshold).isValid) return false;
     }
 
     if (formData.score_type === SCORE_TYPES.CATEGORICAL) {
@@ -274,17 +283,19 @@ export default function NewMetricForm({
             ? formData.passing_categories
             : undefined,
         // Numeric metric fields
+        // Number, not parseFloat: validateScore rejects what Number rejects, so
+        // the two agree on what reaches the API. parseFloat would accept more.
         min_score:
           formData.score_type === SCORE_TYPES.NUMERIC
-            ? parseFloat(formData.min_score)
+            ? Number(formData.min_score)
             : undefined,
         max_score:
           formData.score_type === SCORE_TYPES.NUMERIC
-            ? parseFloat(formData.max_score)
+            ? Number(formData.max_score)
             : undefined,
         threshold:
           formData.score_type === SCORE_TYPES.NUMERIC
-            ? parseFloat(formData.threshold)
+            ? Number(formData.threshold)
             : undefined,
         threshold_operator:
           formData.score_type === SCORE_TYPES.NUMERIC
@@ -684,12 +695,8 @@ export default function NewMetricForm({
                 label="Minimum Score"
                 value={formData.min_score}
                 onChange={handleChange('min_score')}
-                error={showErrors && isBlank(formData.min_score)}
-                helperText={
-                  showErrors && isBlank(formData.min_score)
-                    ? 'Required'
-                    : undefined
-                }
+                error={minScoreError !== undefined}
+                helperText={minScoreError}
                 fullWidth
               />
               <TextField
@@ -698,12 +705,8 @@ export default function NewMetricForm({
                 label="Maximum Score"
                 value={formData.max_score}
                 onChange={handleChange('max_score')}
-                error={showErrors && isBlank(formData.max_score)}
-                helperText={
-                  showErrors && isBlank(formData.max_score)
-                    ? 'Required'
-                    : undefined
-                }
+                error={maxScoreError !== undefined}
+                helperText={maxScoreError}
                 fullWidth
               />
             </Box>
@@ -719,12 +722,8 @@ export default function NewMetricForm({
                   label="Threshold Value"
                   value={formData.threshold}
                   onChange={handleChange('threshold')}
-                  error={showErrors && isBlank(formData.threshold)}
-                  helperText={
-                    showErrors && isBlank(formData.threshold)
-                      ? 'Required'
-                      : undefined
-                  }
+                  error={thresholdError !== undefined}
+                  helperText={thresholdError}
                   fullWidth
                 />
                 <FormControl fullWidth>

--- a/apps/frontend/src/app/(protected)/metrics/new/components/NewMetricForm.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/new/components/NewMetricForm.tsx
@@ -52,9 +52,11 @@ interface MetricFormData {
   score_type: ScoreTypeValue;
   categories: string[];
   passing_categories: string[];
-  min_score?: number;
-  max_score?: number;
-  threshold?: number;
+  // Raw text from the number inputs, not numbers: a partially typed value
+  // ('', '-', '0.') has no numeric form. Parsed once in handleSubmit.
+  min_score: string;
+  max_score: string;
+  threshold: string;
   threshold_operator: ThresholdOperator;
   explanation: string;
   model_id: string;
@@ -71,6 +73,9 @@ const initialFormData: MetricFormData = {
   score_type: SCORE_TYPES.NUMERIC,
   categories: [],
   passing_categories: [],
+  min_score: '',
+  max_score: '',
+  threshold: '',
   threshold_operator: '>=',
   explanation: '',
   model_id: '',
@@ -80,6 +85,9 @@ const initialFormData: MetricFormData = {
 const steps = ['Metric Information and Criteria', 'Confirmation'];
 
 const STEP_SEPARATOR = '\n---\n';
+
+/** A required score field is unset while it holds no non-whitespace text. */
+const isBlank = (value: string) => value.trim() === '';
 
 interface NewMetricFormProps {
   type: string;
@@ -186,12 +194,9 @@ export default function NewMetricForm({
 
     // Score type conditional validation
     if (formData.score_type === SCORE_TYPES.NUMERIC) {
-      if (formData.min_score == null || String(formData.min_score) === '')
-        return false;
-      if (formData.max_score == null || String(formData.max_score) === '')
-        return false;
-      if (formData.threshold == null || String(formData.threshold) === '')
-        return false;
+      if (isBlank(formData.min_score)) return false;
+      if (isBlank(formData.max_score)) return false;
+      if (isBlank(formData.threshold)) return false;
     }
 
     if (formData.score_type === SCORE_TYPES.CATEGORICAL) {
@@ -271,15 +276,15 @@ export default function NewMetricForm({
         // Numeric metric fields
         min_score:
           formData.score_type === SCORE_TYPES.NUMERIC
-            ? parseFloat(String(formData.min_score))
+            ? parseFloat(formData.min_score)
             : undefined,
         max_score:
           formData.score_type === SCORE_TYPES.NUMERIC
-            ? parseFloat(String(formData.max_score))
+            ? parseFloat(formData.max_score)
             : undefined,
         threshold:
           formData.score_type === SCORE_TYPES.NUMERIC
-            ? parseFloat(String(formData.threshold))
+            ? parseFloat(formData.threshold)
             : undefined,
         threshold_operator:
           formData.score_type === SCORE_TYPES.NUMERIC
@@ -677,17 +682,11 @@ export default function NewMetricForm({
                 required
                 type="number"
                 label="Minimum Score"
-                value={formData.min_score || ''}
+                value={formData.min_score}
                 onChange={handleChange('min_score')}
-                error={
-                  showErrors &&
-                  (formData.min_score == null ||
-                    String(formData.min_score) === '')
-                }
+                error={showErrors && isBlank(formData.min_score)}
                 helperText={
-                  showErrors &&
-                  (formData.min_score == null ||
-                    String(formData.min_score) === '')
+                  showErrors && isBlank(formData.min_score)
                     ? 'Required'
                     : undefined
                 }
@@ -697,17 +696,11 @@ export default function NewMetricForm({
                 required
                 type="number"
                 label="Maximum Score"
-                value={formData.max_score || ''}
+                value={formData.max_score}
                 onChange={handleChange('max_score')}
-                error={
-                  showErrors &&
-                  (formData.max_score == null ||
-                    String(formData.max_score) === '')
-                }
+                error={showErrors && isBlank(formData.max_score)}
                 helperText={
-                  showErrors &&
-                  (formData.max_score == null ||
-                    String(formData.max_score) === '')
+                  showErrors && isBlank(formData.max_score)
                     ? 'Required'
                     : undefined
                 }
@@ -724,17 +717,11 @@ export default function NewMetricForm({
                   required
                   type="number"
                   label="Threshold Value"
-                  value={formData.threshold || ''}
+                  value={formData.threshold}
                   onChange={handleChange('threshold')}
-                  error={
-                    showErrors &&
-                    (formData.threshold == null ||
-                      String(formData.threshold) === '')
-                  }
+                  error={showErrors && isBlank(formData.threshold)}
                   helperText={
-                    showErrors &&
-                    (formData.threshold == null ||
-                      String(formData.threshold) === '')
+                    showErrors && isBlank(formData.threshold)
                       ? 'Required'
                       : undefined
                   }

--- a/apps/frontend/src/utils/__tests__/validation.test.ts
+++ b/apps/frontend/src/utils/__tests__/validation.test.ts
@@ -9,6 +9,7 @@ import {
   validatePassword,
   validatePasswordConfirmation,
   validateLength,
+  validateScore,
   validateFields,
   DEFAULT_PASSWORD_POLICY,
 } from '../validation';
@@ -251,6 +252,47 @@ describe('validateLength', () => {
 
   it('trims whitespace before checking length', () => {
     expect(validateLength('  hi  ', 5).isValid).toBe(false);
+  });
+});
+
+describe('validateScore', () => {
+  it('accepts ordinary numbers', () => {
+    expect(validateScore('1.5').isValid).toBe(true);
+    expect(validateScore('-2').isValid).toBe(true);
+    expect(validateScore(' 3 ').isValid).toBe(true);
+  });
+
+  it('accepts zero, which a falsy check would reject', () => {
+    expect(validateScore('0').isValid).toBe(true);
+  });
+
+  it('rejects blank input', () => {
+    expect(validateScore('').isValid).toBe(false);
+    expect(validateScore('   ').isValid).toBe(false);
+    expect(validateScore('', 'Minimum Score').message).toBe(
+      'Minimum Score is required'
+    );
+  });
+
+  it('rejects a lone minus sign, which parseFloat reads as NaN', () => {
+    const result = validateScore('-', 'Threshold');
+    expect(result.isValid).toBe(false);
+    expect(result.message).toBe('Threshold must be a number');
+  });
+
+  it('rejects overflow literals that parseFloat turns into Infinity', () => {
+    // '1e999' is a valid floating-point literal, so it survives the number
+    // input's own sanitization, then serializes to null over JSON.
+    expect(validateScore('1e999').isValid).toBe(false);
+    expect(validateScore('-1e999').isValid).toBe(false);
+  });
+
+  it('rejects partial numbers that parseFloat would silently truncate', () => {
+    // parseFloat('1.2.3') is 1.2 and parseFloat('12abc') is 12, so these would
+    // submit a wrong value rather than fail.
+    expect(validateScore('1.2.3').isValid).toBe(false);
+    expect(validateScore('12abc').isValid).toBe(false);
+    expect(validateScore('1e').isValid).toBe(false);
   });
 });
 

--- a/apps/frontend/src/utils/validation.ts
+++ b/apps/frontend/src/utils/validation.ts
@@ -299,6 +299,29 @@ export const validatePasswordConfirmation = (
 };
 
 /**
+ * Numeric score validation for metric score fields.
+ *
+ * Uses `Number` rather than `parseFloat`, which stops at the first invalid
+ * character and so silently reads '1.2.3' as 1.2 and '12abc' as 12. The
+ * isFinite check additionally rejects '1e999': a valid floating-point literal
+ * that overflows to Infinity, which JSON serializes as null.
+ */
+export const validateScore = (
+  value: string,
+  fieldName: string = 'Score'
+): ValidationResult => {
+  if (!value.trim()) {
+    return { isValid: false, message: `${fieldName} is required` };
+  }
+
+  if (!Number.isFinite(Number(value))) {
+    return { isValid: false, message: `${fieldName} must be a number` };
+  }
+
+  return { isValid: true };
+};
+
+/**
  * Generic length validation
  */
 export const validateLength = (


### PR DESCRIPTION
Two commits on the metric creation form. The first makes the score field types honest; the second fixes a validation hole that the first one exposed. #2702 was merged into this branch, so both ship together here.

```
1367ddd2b fix(frontend): reject non-numeric metric score input (#2702)
e4528ab48 refactor(frontend): type score fields as text
```

## 1. The score fields were typed as numbers but always held strings

`MetricFormData` declared them `number`:

```ts
min_score?: number;
max_score?: number;
threshold?: number;
```

But `handleChange` assigns `event.target.value` through a computed key, which hides the mismatch from `tsc`:

```ts
setFormData(prev => ({ ...prev, [field]: value }));
```

So the state has always held strings while claiming numbers, and every reader worked around it with `String(...)` or a falsy guard.

They are now typed `string`, which is what a number input produces, defaulted to `''`, and parsed once at submit. A partially typed value (`''`, `'-'`, `'0.'`) has no numeric form, so `string` is the only type the editing state can honestly have.

This removed **9 copies** of `x == null || String(x) === ''`, the `String()` wrappers around the three `parseFloat` calls, and the `value={formData.x || ''}` coercion that turned a numeric `0` into an empty field. No code path could actually produce that `0` today, so it was latent rather than a live bug, but the declared `number` type invited it and `tsc` now prevents it.

## 2. Non-numeric input could reach the API

Raised by peqy on the first commit. `isStepValid` only checked non-blank, so whatever the number input let through reached `parseFloat` unvalidated:

```
parseFloat('-')      ->  NaN       ->  JSON null
parseFloat('1e999')  ->  Infinity  ->  JSON null
parseFloat('1.2.3')  ->  1.2       ->  silently the wrong number
```

The first is browser-dependent: `type="number"` sanitizes its value, and MDN documents that browsers vary in how strictly ("Some browsers allow invalid characters, others do not", citing Firefox bug 1398528). The other two are not. `1e999` is a **valid** floating-point literal, so it survives sanitization everywhere, and `parseFloat` stops at the first invalid character rather than rejecting, so `'1.2.3'` submits `1.2` and `'12abc'` submits `12`. A plausible wrong number is harder to notice than a `null`.

Adds `validateScore` to `src/utils/validation.ts`, following the `ValidationResult` idiom already used there, driving both the step guard and the field messages. Submit moves from `parseFloat` to `Number` so parsing and validation agree on what is acceptable.

Worth knowing, since it is the opposite of what you might expect: **`Number('')` is `0`**, so the finite check cannot replace the blank check, only follow it.

```js
Number.isFinite(Number(''))   // true
Number.isFinite(Number(' '))  // true
```

## Behavior change

The first commit alone changed nothing observable. The second does:

- The `Next` button stays disabled for non-numeric input where it previously advanced.
- Field errors distinguish `"Minimum Score is required"` from `"Minimum Score must be a number"`, where both previously showed `"Required"`.

## Testing

- `npm test`: 255 suites, 2521 tests, all passing
- `npm run type-check` (app + ee): passes
- `npx eslint` and `npx prettier --check` on all changed files: clean

Six new cases in `src/utils/__tests__/validation.test.ts` cover ordinary numbers, zero (which a falsy check would reject), blank and whitespace, the lone minus sign, the `1e999` / `-1e999` overflow forms, and the `'1.2.3'` / `'12abc'` / `'1e'` truncation forms.

`MetricFormData` is local to this file and not exported, so the type change reaches one component.
