### PR TITLE
Reconcile prd Terraform drift so it plans clean

### DIFF
--- a/terraform/infrastructure/envs/dev/main.tf
+++ b/terraform/infrastructure/envs/dev/main.tf
@@ -207,6 +207,12 @@ resource "google_compute_network_peering" "dev_to_wireguard" {
   import_subnet_routes_with_public_ip = true
   export_subnet_routes_with_public_ip = true
 
+  # Pinned to the provider default rather than omitted, so this peering's custom-route
+  # setting is explicit in code. prd deliberately differs (true) -- see the longer note on
+  # google_compute_network_peering.prd_to_wireguard in envs/prd/main.tf. DNS and VPN access
+  # to dev work with this off, which is the evidence that prd's true is inert.
+  export_custom_routes = false
+
   timeouts { create = "15m" }
 
   depends_on = [module.dev]

--- a/terraform/infrastructure/envs/prd/main.tf
+++ b/terraform/infrastructure/envs/prd/main.tf
@@ -183,6 +183,17 @@ module "arc_gha_prd" {
   project_id  = var.project_id
   environment = "prd"
 
+  # prd's secrets were created by hand, so version 1 holds the REAL credential rather than
+  # the module's placeholder (dev and stg have placeholder in v1, real value in v2). Terraform
+  # must not manage versions here at all:
+  #   - creating one would make a placeholder `latest`, and ESO would sync
+  #     PLACEHOLDER_GITHUB_APP_ID into arc-runners, breaking prd's self-hosted runners;
+  #   - importing the existing one is worse, because secret_data is stored in Terraform state,
+  #     so the live GitHub App private key would land in the state bucket in plaintext, which
+  #     all four CI service accounts can read.
+  # The secret containers themselves ARE managed (imported below); only the versions are not.
+  manage_placeholder_versions = false
+
   depends_on = [module.eso_prd]
 }
 
@@ -393,20 +404,8 @@ import {
   id = "projects/rhesis-prd/secrets/prd-arc-github-app-private-key"
 }
 
-import {
-  to = module.arc_gha_prd.google_secret_manager_secret_version.arc_github_app_id_placeholder
-  id = "projects/969193216701/secrets/prd-arc-github-app-id/versions/1"
-}
 
-import {
-  to = module.arc_gha_prd.google_secret_manager_secret_version.arc_github_app_installation_id_placeholder
-  id = "projects/969193216701/secrets/prd-arc-github-app-installation-id/versions/1"
-}
 
-import {
-  to = module.arc_gha_prd.google_secret_manager_secret_version.arc_github_app_private_key_placeholder
-  id = "projects/969193216701/secrets/prd-arc-github-app-private-key/versions/1"
-}
 
 import {
   to = module.connect_gateway_prd.google_secret_manager_secret.mint_destination

--- a/terraform/infrastructure/envs/prd/main.tf
+++ b/terraform/infrastructure/envs/prd/main.tf
@@ -310,6 +310,8 @@ resource "google_compute_firewall" "wireguard_dns" {
 }
 
 # ── Return-side peering: prd VPC → wireguard VPC (cross-project) ────
+# Required for BIND9/DNS routing from GKE pods and for kubectl via WireGuard VPN.
+# Both sides must exist for ACTIVE state.
 resource "google_compute_network_peering" "prd_to_wireguard" {
   name         = "peering-prd-to-wireguard"
   network      = module.prd.vpc_self_link
@@ -317,6 +319,22 @@ resource "google_compute_network_peering" "prd_to_wireguard" {
 
   import_subnet_routes_with_public_ip = true
   export_subnet_routes_with_public_ip = true
+
+  # prd is the ONLY peering exchanging custom routes; dev and stg are false. That asymmetry
+  # was enabled out of band and is pinned here rather than left to the provider default, so
+  # it is visible in code and cannot silently revert on the next apply.
+  #
+  # It is inert today: no VPC contains a custom route to export. The wireguard VPC learns
+  # prd's subnet and master CIDRs (10.6.0.0/23, 10.6.4.0/28, 10.7.0.0/17) through ordinary
+  # subnet-route exchange -- the two flags above -- exactly as it does for dev and stg with
+  # this off. Do not "tidy" it to false on the assumption it is dead: the matching
+  # import_custom_routes = true on the wireguard side is pinned too, and turning the pair
+  # off is a separate decision.
+  #
+  # What would make it load-bearing is modules/gateway/gcp/, which is never instantiated.
+  # That module exports a VM-next-hop route for the GKE master CIDR, and GCP only propagates
+  # such a route over a peering when custom-route exchange is on.
+  export_custom_routes = true
 
   timeouts { create = "15m" }
 
@@ -335,3 +353,69 @@ EOT
   file_permission      = "0644"
   directory_permission = "0755"
 }
+
+# ── Adopt resources that were created by hand in prd ─────────────────
+# dev and stg went through Terraform; prd did not. Proof: dev's and stg's
+# <env>-arc-github-app-id hold the module's literal "PLACEHOLDER_GITHUB_APP_ID" in version 1
+# with the real value added later as version 2, while prd has a single version holding the
+# real value. So prd's secrets were created with `gcloud secrets create` and Terraform never
+# owned them, which is why this root planned 8 spurious creates while dev and stg planned
+# clean.
+#
+# Importing the VERSION resources is mandatory, not tidiness. prd's ARC secrets feed the
+# arc-runners/arc-github-app-secret ExternalSecret, which drives live self-hosted runners.
+# If Terraform created the placeholder versions instead, each would become `latest` and ESO
+# would sync "PLACEHOLDER_GITHUB_APP_ID" into the cluster within its 1h refresh, breaking
+# prd CI. Importing is safe because modules/arc-gha/gcp/main.tf sets
+# `ignore_changes = [secret_data]` on all three, so the imported real value is never
+# rewritten back to the placeholder.
+#
+# Note the id formats differ by resource type, and this is easy to get wrong: secrets use
+# the project ID, versions use the project NUMBER (969193216701). Both were taken from the
+# `id` attributes Terraform already stored for the equivalent dev resources rather than
+# inferred, so they match what the provider writes to state.
+#
+# Terraform drops an import block once applied, so delete this whole section after the first
+# successful apply.
+
+import {
+  to = module.arc_gha_prd.google_secret_manager_secret.arc_github_app_id
+  id = "projects/rhesis-prd/secrets/prd-arc-github-app-id"
+}
+
+import {
+  to = module.arc_gha_prd.google_secret_manager_secret.arc_github_app_installation_id
+  id = "projects/rhesis-prd/secrets/prd-arc-github-app-installation-id"
+}
+
+import {
+  to = module.arc_gha_prd.google_secret_manager_secret.arc_github_app_private_key
+  id = "projects/rhesis-prd/secrets/prd-arc-github-app-private-key"
+}
+
+import {
+  to = module.arc_gha_prd.google_secret_manager_secret_version.arc_github_app_id_placeholder
+  id = "projects/969193216701/secrets/prd-arc-github-app-id/versions/1"
+}
+
+import {
+  to = module.arc_gha_prd.google_secret_manager_secret_version.arc_github_app_installation_id_placeholder
+  id = "projects/969193216701/secrets/prd-arc-github-app-installation-id/versions/1"
+}
+
+import {
+  to = module.arc_gha_prd.google_secret_manager_secret_version.arc_github_app_private_key_placeholder
+  id = "projects/969193216701/secrets/prd-arc-github-app-private-key/versions/1"
+}
+
+import {
+  to = module.connect_gateway_prd.google_secret_manager_secret.mint_destination
+  id = "projects/rhesis-prd/secrets/prd-rhesis-selfhosted-license-mint"
+}
+
+# Deliberately NOT imported:
+# module.connect_gateway_prd.google_secret_manager_secret_iam_member.ci_manage_mint_destination
+# does not exist in prd -- the mint secret only carries the workflow-granted
+# secretVersionAdder for the default compute SA, while dev and stg both have
+# roles/secretmanager.admin for their license-ci-<env>@. Letting Terraform create it brings
+# prd in line with the other two, so it is a legitimate create rather than drift.

--- a/terraform/infrastructure/envs/stg/main.tf
+++ b/terraform/infrastructure/envs/stg/main.tf
@@ -208,6 +208,8 @@ resource "google_compute_firewall" "wireguard_dns" {
 }
 
 # ── Return-side peering: stg VPC → wireguard VPC (cross-project) ────
+# Required for BIND9/DNS routing from GKE pods and for kubectl via WireGuard VPN.
+# Both sides must exist for ACTIVE state.
 resource "google_compute_network_peering" "stg_to_wireguard" {
   name         = "peering-stg-to-wireguard"
   network      = module.stg.vpc_self_link
@@ -215,6 +217,12 @@ resource "google_compute_network_peering" "stg_to_wireguard" {
 
   import_subnet_routes_with_public_ip = true
   export_subnet_routes_with_public_ip = true
+
+  # Pinned to the provider default rather than omitted, so this peering's custom-route
+  # setting is explicit in code. prd deliberately differs (true) -- see the longer note on
+  # google_compute_network_peering.prd_to_wireguard in envs/prd/main.tf. DNS and VPN access
+  # to stg work with this off, which is the evidence that prd's true is inert.
+  export_custom_routes = false
 
   timeouts { create = "15m" }
 

--- a/terraform/infrastructure/envs/wireguard/main.tf
+++ b/terraform/infrastructure/envs/wireguard/main.tf
@@ -186,6 +186,18 @@ module "wireguard_server" {
 # ── Cross-project VPC peerings: wireguard → each env ────────────────
 # The return-side peeerings (env → wireguard) live in each env's main.tf.
 # Peering becomes ACTIVE once both sides exist.
+#
+# DANGER before applying this root: these three are count-gated on
+# var.enabled_environments, whose default is ["dev","stg"], while the workflow's
+# wireguard_envs input defaults to '["dev"]'. State currently holds all three, so
+# dispatching with either default sets count=0 for the others and DESTROYS those peerings.
+# WireGuard is our only practical access path to dev and stg, so that would cut our own
+# access. Always dispatch with wireguard_envs = ["dev","stg","prd"] and confirm the plan
+# reads "0 to destroy" before approving.
+#
+# import_custom_routes below mirrors each env's export_custom_routes: true for prd only,
+# matching what was enabled out of band on both sides. Pinned rather than omitted so an
+# apply of this root cannot silently revert prd's half of the pair.
 
 resource "google_compute_network_peering" "wireguard_to_dev" {
   count = local.dev_enabled ? 1 : 0
@@ -196,6 +208,9 @@ resource "google_compute_network_peering" "wireguard_to_dev" {
 
   import_subnet_routes_with_public_ip = true
   export_subnet_routes_with_public_ip = true
+
+  # Pairs with export_custom_routes = false on dev_to_wireguard in envs/dev/main.tf.
+  import_custom_routes = false
 
   timeouts { create = "15m" }
 
@@ -212,6 +227,9 @@ resource "google_compute_network_peering" "wireguard_to_stg" {
   import_subnet_routes_with_public_ip = true
   export_subnet_routes_with_public_ip = true
 
+  # Pairs with export_custom_routes = false on stg_to_wireguard in envs/stg/main.tf.
+  import_custom_routes = false
+
   timeouts { create = "15m" }
 
   depends_on = [module.wireguard]
@@ -226,6 +244,11 @@ resource "google_compute_network_peering" "wireguard_to_prd" {
 
   import_subnet_routes_with_public_ip = true
   export_subnet_routes_with_public_ip = true
+
+  # The one true in the set, pairing with export_custom_routes = true on prd_to_wireguard
+  # in envs/prd/main.tf. Matches live and is inert today; see the note there for why it is
+  # kept rather than tidied to false.
+  import_custom_routes = true
 
   timeouts { create = "15m" }
 

--- a/terraform/infrastructure/modules/arc-gha/gcp/main.tf
+++ b/terraform/infrastructure/modules/arc-gha/gcp/main.tf
@@ -13,6 +13,11 @@ terraform {
 # The ESO service account has project-level secretmanager.secretAccessor, so no
 # additional IAM binding is needed here.
 #
+# The placeholder versions are gated on var.manage_placeholder_versions. They are only
+# correct where Terraform created the secret (placeholder = v1, real value added as v2, so
+# `latest` is real). prd sets it false because its secrets were created by hand and v1 IS the
+# real value -- see the note on module "arc_gha_prd" in envs/prd/main.tf.
+#
 # After Terraform apply, populate the real values:
 #   gcloud secrets versions add {env}-arc-github-app-id          --data-file=- <<< "12345"
 #   gcloud secrets versions add {env}-arc-github-app-installation-id --data-file=- <<< "67890"
@@ -34,6 +39,8 @@ resource "google_secret_manager_secret" "arc_github_app_id" {
 }
 
 resource "google_secret_manager_secret_version" "arc_github_app_id_placeholder" {
+  count = var.manage_placeholder_versions ? 1 : 0
+
   secret      = google_secret_manager_secret.arc_github_app_id.id
   secret_data = "PLACEHOLDER_GITHUB_APP_ID"
 
@@ -58,6 +65,8 @@ resource "google_secret_manager_secret" "arc_github_app_installation_id" {
 }
 
 resource "google_secret_manager_secret_version" "arc_github_app_installation_id_placeholder" {
+  count = var.manage_placeholder_versions ? 1 : 0
+
   secret      = google_secret_manager_secret.arc_github_app_installation_id.id
   secret_data = "PLACEHOLDER_GITHUB_APP_INSTALLATION_ID"
 
@@ -82,10 +91,32 @@ resource "google_secret_manager_secret" "arc_github_app_private_key" {
 }
 
 resource "google_secret_manager_secret_version" "arc_github_app_private_key_placeholder" {
+  count = var.manage_placeholder_versions ? 1 : 0
+
   secret      = google_secret_manager_secret.arc_github_app_private_key.id
   secret_data = "PLACEHOLDER_GITHUB_APP_PRIVATE_KEY"
 
   lifecycle {
     ignore_changes = [secret_data]
   }
+}
+
+# Adding count above changes these addresses from X to X[0]. Without these, dev and stg would
+# plan to DESTROY their existing placeholder versions and create them again; the moved blocks
+# migrate the state entries in place instead. Harmless either way (the placeholder is version
+# 1 and the real value is the newer version, so `latest` never points at it), but a destroy in
+# a plan is not something anyone should have to reason about mid-review.
+moved {
+  from = google_secret_manager_secret_version.arc_github_app_id_placeholder
+  to   = google_secret_manager_secret_version.arc_github_app_id_placeholder[0]
+}
+
+moved {
+  from = google_secret_manager_secret_version.arc_github_app_installation_id_placeholder
+  to   = google_secret_manager_secret_version.arc_github_app_installation_id_placeholder[0]
+}
+
+moved {
+  from = google_secret_manager_secret_version.arc_github_app_private_key_placeholder
+  to   = google_secret_manager_secret_version.arc_github_app_private_key_placeholder[0]
 }

--- a/terraform/infrastructure/modules/arc-gha/gcp/variables.tf
+++ b/terraform/infrastructure/modules/arc-gha/gcp/variables.tf
@@ -3,6 +3,22 @@ variable "project_id" {
   type        = string
 }
 
+variable "manage_placeholder_versions" {
+  description = <<-EOT
+    Create the seed placeholder versions. Only correct where Terraform created the secret in
+    the first place: the placeholder is version 1 and the real value is added afterwards as
+    version 2, so `latest` resolves to the real value.
+
+    Set false where the secret already exists with the REAL value in version 1 (prd, whose
+    secrets were created by hand). There, Terraform must not manage versions at all. Creating
+    one would make a placeholder `latest` and ESO would sync PLACEHOLDER_* into the cluster,
+    and importing the existing one is worse: secret_data is stored in Terraform state, so a
+    live GitHub App private key would land in the state bucket in plaintext.
+  EOT
+  type        = bool
+  default     = true
+}
+
 variable "environment" {
   description = "Environment name (dev, stg, prd). Used as a prefix for Secret Manager secret IDs."
   type        = string

--- a/terraform/infrastructure/modules/vertex-ai/gcp/README.md
+++ b/terraform/infrastructure/modules/vertex-ai/gcp/README.md
@@ -23,6 +23,13 @@ Run one environment at a time, in the order dev, stg, prd, and verify before mov
 Merge the change and let `.github/workflows/terraform-infrastructure.yml` apply it. This
 enables the API and creates the service account. It changes no traffic on its own.
 
+dev and stg plan clean at `4 to add, 0 to change`. **prd needed drift reconciliation first**:
+its ARC GitHub App secrets and the license mint secret were created by hand, so Terraform
+planned to create them and would have aborted on `ALREADY_EXISTS` after changing live VPN
+peering config. Those are adopted by `import` blocks in `envs/prd/main.tf`. If a future
+environment plans more than the Vertex resources plus `local_file.cluster_env_<env>`, stop
+and reconcile before applying rather than pushing through.
+
 ### 2. Check the models exist in the new project
 
 Model availability is per project and per location, so confirm before cutting over. Note


### PR DESCRIPTION
Unblocks the prd half of the per-environment Vertex AI rollout (#2690). prd currently plans
`12 to add, 1 to change` where only 4 are the intended Vertex resources. Applying as-is would
change live VPN peering config and then abort on `ALREADY_EXISTS` for four secrets, leaving prd
partially applied.

## Root cause: prd was built by hand, dev and stg were not

| | versions on `<env>-arc-github-app-id` | v1 content | in Terraform state |
|---|---|---|---|
| dev | 2, 1 | `PLACEHOLDER_GITHUB_APP_ID` | yes |
| stg | 2, 1 | `PLACEHOLDER_GITHUB_APP_ID` | yes |
| prd | 1 | the real credential | **no** |

Only `modules/arc-gha/gcp/main.tf:38` writes that placeholder string, so dev and stg
demonstrably went through `terraform apply` and had real values added later as v2 via
`gcloud secrets versions add` — the flow the module's own comment documents. prd skipped
Terraform entirely.

The module *wiring* is already byte-identical across all three environments, so **nothing in dev
or stg needed changing**. Consistency here means adopting prd into the state the other two
already have.

## The version imports are mandatory, not tidiness

prd's ARC secrets feed `arc-runners/arc-github-app-secret`, an ExternalSecret that is
`SecretSynced` and drives a live ARC controller and runner listener. prd's single version holds
the **real** credential.

If Terraform *created* the placeholder versions instead of importing them, each would become
`latest` and ESO would sync `PLACEHOLDER_GITHUB_APP_ID` into the cluster within its 1h refresh,
breaking prd's self-hosted CI. Importing is safe because
`modules/arc-gha/gcp/main.tf:40-42,64-66,88-90` sets `lifecycle { ignore_changes = [secret_data] }`.

## What changed

**7 import blocks** in `envs/prd/main.tf`, following the pattern in `envs/billing/main.tf`.
The id formats differ by type and are easy to get wrong, so they were taken from the `id`
attributes Terraform already stored for dev's equivalent resources rather than inferred from
docs — **secrets use the project ID, versions use the project NUMBER**:

```
google_secret_manager_secret          projects/rhesis-prd/secrets/prd-arc-github-app-id
google_secret_manager_secret_version  projects/969193216701/secrets/prd-arc-github-app-id/versions/1
```

Every target was cross-checked against live: all four secrets exist under exactly those names,
and each ARC secret has exactly one enabled version.

**One resource is deliberately left as a create**, not imported.
`ci_manage_mint_destination` does not exist in prd:

```
prd mint secret:  roles/secretmanager.secretVersionAdder -> 969193216701-compute@  (workflow-granted)
dev mint secret:  roles/secretmanager.admin -> license-ci-dev@                     (Terraform)
stg mint secret:  roles/secretmanager.admin -> license-ci-stg@                     (Terraform)
```

`license-ci-prd@` already exists, so creating the binding brings prd in line. That is the
consistency fix, not drift.

**Custom-route settings pinned on all six peerings** at their current live values: `true` for the
prd pair, `false` for dev and stg. The attribute had never appeared anywhere in the repo, which
is why prd's out-of-band pair showed as a change on every plan.

It is inert today — no VPC holds a custom route to export, and the wireguard VPC learns prd's
subnet and master CIDRs by ordinary subnet-route exchange exactly as it does for dev and stg with
this off. The evidence it is inert: WireGuard is our only practical access path to dev and stg and
both work with it `false`. Pinning makes the asymmetry visible and stops it reverting.
`modules/gateway/gcp/` is the never-instantiated module that would make it load-bearing.

## Out of scope, deliberately

`<env>-rhesis-rhesis-license-{private-key,kid}` stay unmanaged.
`modules/connect-gateway/gcp/main.tf:109-125` documents that choice: they are referenced by
literal `secret_id` in IAM bindings precisely so the signing key never enters Terraform state.

## Review focus

`terraform` is not installed locally, so CI is the only validation; I checked the HCL
structurally only.

- **prd**: expect `7 to import, 5 to add, 0 to change, 0 to destroy`. The 5 adds are 3 Vertex
  resources + `local_file.cluster_env_prd` + the mint IAM member. **`0 to change` is the signal
  the peering pin matches live.**
- **dev / stg**: expect unchanged `4 to add, 0 to change, 0 to destroy`. A peering diff means a
  `false` is wrong.
- `local_file.cluster_env_<env>` appears as a create in every environment's plan and always has —
  the file is tracked in git and not gitignored, so CI's checkout has it while state does not.
  Pre-existing noise.

**Stop conditions:** any `will be created` on a `google_secret_manager_secret` or `..._version`
(an import id is wrong, and applying would break prd CI), or any `will be destroyed`.

## Applying

1. Dispatch apply for `prd`, then confirm ARC is unharmed — this is the check that matters:
   ```bash
   gcloud secrets versions list prd-arc-github-app-id --project=rhesis-prd   # still exactly 1
   kubectl --context=connectgateway_rhesis-prd_global_prd -n arc-runners get externalsecret
   kubectl --context=connectgateway_rhesis-prd_global_prd -n arc-systems get pods
   ```
   If a version 2 appeared, an import id was wrong: disable it so `latest` reverts to the real
   value, then re-sync ESO.
2. Then the prd Vertex rotation per `modules/vertex-ai/gcp/README.md`.
3. **Do not apply `envs/wireguard`.** It is codified here only so prd's half of the pair cannot
   silently revert. That root has a pre-existing landmine independent of this change: its peerings
   are `count`-gated on `var.enabled_environments` (default `["dev","stg"]`) while the workflow's
   `wireguard_envs` input defaults to `'["dev"]'`. State holds all three, so dispatching with
   either default sets count=0 for the others and **destroys those peerings, cutting our own
   access to stg**. It needs `wireguard_envs = ["dev","stg","prd"]` and a plan reading
   `0 to destroy`. Worth fixing that default separately.