### PR TITLE
fix(frontend): reject non-numeric metric score input

### DIFF
--- a/apps/frontend/src/app/(protected)/metrics/new/components/NewMetricForm.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/new/components/NewMetricForm.tsx
@@ -41,6 +41,7 @@ import { TEST_TYPES } from '@/constants/test-types';
 import { SCORE_TYPES, ScoreTypeValue } from '@/constants/score-types';
 import { useTypeLookups } from '@/hooks/useLookups';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { validateScore } from '@/utils/validation';
 
 interface MetricFormData {
   name: string;
@@ -85,9 +86,6 @@ const initialFormData: MetricFormData = {
 const steps = ['Metric Information and Criteria', 'Confirmation'];
 
 const STEP_SEPARATOR = '\n---\n';
-
-/** A required score field is unset while it holds no non-whitespace text. */
-const isBlank = (value: string) => value.trim() === '';
 
 interface NewMetricFormProps {
   type: string;
@@ -186,6 +184,17 @@ export default function NewMetricForm({
     }));
   };
 
+  // Only rendered for numeric metrics, so computing them unconditionally is harmless.
+  const minScoreError = showErrors
+    ? validateScore(formData.min_score, 'Minimum Score').message
+    : undefined;
+  const maxScoreError = showErrors
+    ? validateScore(formData.max_score, 'Maximum Score').message
+    : undefined;
+  const thresholdError = showErrors
+    ? validateScore(formData.threshold, 'Threshold Value').message
+    : undefined;
+
   const isStepValid = React.useCallback((): boolean => {
     // Common required fields
     if (!formData.name.trim()) return false;
@@ -194,9 +203,9 @@ export default function NewMetricForm({
 
     // Score type conditional validation
     if (formData.score_type === SCORE_TYPES.NUMERIC) {
-      if (isBlank(formData.min_score)) return false;
-      if (isBlank(formData.max_score)) return false;
-      if (isBlank(formData.threshold)) return false;
+      if (!validateScore(formData.min_score).isValid) return false;
+      if (!validateScore(formData.max_score).isValid) return false;
+      if (!validateScore(formData.threshold).isValid) return false;
     }
 
     if (formData.score_type === SCORE_TYPES.CATEGORICAL) {
@@ -274,17 +283,19 @@ export default function NewMetricForm({
             ? formData.passing_categories
             : undefined,
         // Numeric metric fields
+        // Number, not parseFloat: validateScore rejects what Number rejects, so
+        // the two agree on what reaches the API. parseFloat would accept more.
         min_score:
           formData.score_type === SCORE_TYPES.NUMERIC
-            ? parseFloat(formData.min_score)
+            ? Number(formData.min_score)
             : undefined,
         max_score:
           formData.score_type === SCORE_TYPES.NUMERIC
-            ? parseFloat(formData.max_score)
+            ? Number(formData.max_score)
             : undefined,
         threshold:
           formData.score_type === SCORE_TYPES.NUMERIC
-            ? parseFloat(formData.threshold)
+            ? Number(formData.threshold)
             : undefined,
         threshold_operator:
           formData.score_type === SCORE_TYPES.NUMERIC
@@ -684,12 +695,8 @@ export default function NewMetricForm({
                 label="Minimum Score"
                 value={formData.min_score}
                 onChange={handleChange('min_score')}
-                error={showErrors && isBlank(formData.min_score)}
-                helperText={
-                  showErrors && isBlank(formData.min_score)
-                    ? 'Required'
-                    : undefined
-                }
+                error={minScoreError !== undefined}
+                helperText={minScoreError}
                 fullWidth
               />
               <TextField
@@ -698,12 +705,8 @@ export default function NewMetricForm({
                 label="Maximum Score"
                 value={formData.max_score}
                 onChange={handleChange('max_score')}
-                error={showErrors && isBlank(formData.max_score)}
-                helperText={
-                  showErrors && isBlank(formData.max_score)
-                    ? 'Required'
-                    : undefined
-                }
+                error={maxScoreError !== undefined}
+                helperText={maxScoreError}
                 fullWidth
               />
             </Box>
@@ -719,12 +722,8 @@ export default function NewMetricForm({
                   label="Threshold Value"
                   value={formData.threshold}
                   onChange={handleChange('threshold')}
-                  error={showErrors && isBlank(formData.threshold)}
-                  helperText={
-                    showErrors && isBlank(formData.threshold)
-                      ? 'Required'
-                      : undefined
-                  }
+                  error={thresholdError !== undefined}
+                  helperText={thresholdError}
                   fullWidth
                 />
                 <FormControl fullWidth>

--- a/apps/frontend/src/utils/__tests__/validation.test.ts
+++ b/apps/frontend/src/utils/__tests__/validation.test.ts
@@ -9,6 +9,7 @@ import {
   validatePassword,
   validatePasswordConfirmation,
   validateLength,
+  validateScore,
   validateFields,
   DEFAULT_PASSWORD_POLICY,
 } from '../validation';
@@ -251,6 +252,47 @@ describe('validateLength', () => {
 
   it('trims whitespace before checking length', () => {
     expect(validateLength('  hi  ', 5).isValid).toBe(false);
+  });
+});
+
+describe('validateScore', () => {
+  it('accepts ordinary numbers', () => {
+    expect(validateScore('1.5').isValid).toBe(true);
+    expect(validateScore('-2').isValid).toBe(true);
+    expect(validateScore(' 3 ').isValid).toBe(true);
+  });
+
+  it('accepts zero, which a falsy check would reject', () => {
+    expect(validateScore('0').isValid).toBe(true);
+  });
+
+  it('rejects blank input', () => {
+    expect(validateScore('').isValid).toBe(false);
+    expect(validateScore('   ').isValid).toBe(false);
+    expect(validateScore('', 'Minimum Score').message).toBe(
+      'Minimum Score is required'
+    );
+  });
+
+  it('rejects a lone minus sign, which parseFloat reads as NaN', () => {
+    const result = validateScore('-', 'Threshold');
+    expect(result.isValid).toBe(false);
+    expect(result.message).toBe('Threshold must be a number');
+  });
+
+  it('rejects overflow literals that parseFloat turns into Infinity', () => {
+    // '1e999' is a valid floating-point literal, so it survives the number
+    // input's own sanitization, then serializes to null over JSON.
+    expect(validateScore('1e999').isValid).toBe(false);
+    expect(validateScore('-1e999').isValid).toBe(false);
+  });
+
+  it('rejects partial numbers that parseFloat would silently truncate', () => {
+    // parseFloat('1.2.3') is 1.2 and parseFloat('12abc') is 12, so these would
+    // submit a wrong value rather than fail.
+    expect(validateScore('1.2.3').isValid).toBe(false);
+    expect(validateScore('12abc').isValid).toBe(false);
+    expect(validateScore('1e').isValid).toBe(false);
   });
 });
 

--- a/apps/frontend/src/utils/validation.ts
+++ b/apps/frontend/src/utils/validation.ts
@@ -299,6 +299,29 @@ export const validatePasswordConfirmation = (
 };
 
 /**
+ * Numeric score validation for metric score fields.
+ *
+ * Uses `Number` rather than `parseFloat`, which stops at the first invalid
+ * character and so silently reads '1.2.3' as 1.2 and '12abc' as 12. The
+ * isFinite check additionally rejects '1e999': a valid floating-point literal
+ * that overflows to Infinity, which JSON serializes as null.
+ */
+export const validateScore = (
+  value: string,
+  fieldName: string = 'Score'
+): ValidationResult => {
+  if (!value.trim()) {
+    return { isValid: false, message: `${fieldName} is required` };
+  }
+
+  if (!Number.isFinite(Number(value))) {
+    return { isValid: false, message: `${fieldName} must be a number` };
+  }
+
+  return { isValid: true };
+};
+
+/**
  * Generic length validation
  */
 export const validateLength = (


### PR DESCRIPTION
Follow-up to #2699, from [peqy's review](https://github.com/rhesis-ai/rhesis/pull/2699#discussion_r3924515517).

**Stacked on #2699**, so it is based on that branch and the diff here shows only the validation change. GitHub will retarget it to `main` once #2699 merges.

## The problem

`isStepValid` only checked that the score fields were non-blank, so whatever the number input let through reached `parseFloat` unvalidated. Three ways that went wrong, all ending in bad data rather than an error:

```
parseFloat('-')      ->  NaN       ->  JSON null
parseFloat('1e999')  ->  Infinity  ->  JSON null
parseFloat('1.2.3')  ->  1.2       ->  silently the wrong number
```

peqy raised the first. It depends on the browser: `type="number"` runs a value sanitization algorithm, and MDN documents that browsers vary in how strictly they apply it ("Some browsers allow invalid characters, others do not", citing Firefox bug 1398528).

The other two do not depend on the browser, which is why the guard is worth adding regardless:

- `1e999` is a **valid** floating-point literal, so it survives sanitization everywhere and overflows to `Infinity`.
- `parseFloat` stops at the first invalid character rather than rejecting, so `'1.2.3'` submits `1.2` and `'12abc'` submits `12`. A plausible wrong number is harder to notice than a `null`.

## The fix

Adds `validateScore` to `src/utils/validation.ts`, following the `ValidationResult` idiom already used there by `validateEmail`, `validateLength` and friends. It drives both the step guard and the per-field messages.

One subtlety worth flagging, since it is the opposite of what you might expect: **`Number('')` is `0`**, so the finite check cannot replace the blank check, only follow it.

```js
Number.isFinite(Number(''))   // true
Number.isFinite(Number(' '))  // true
```

The submit path also moves from `parseFloat` to `Number`, so parsing and validation agree on what is acceptable. `parseFloat` is the more permissive of the two, and that gap is exactly what let these values through.

## User-visible change

Field errors now distinguish `"Minimum Score is required"` from `"Minimum Score must be a number"`, where both previously showed `"Required"`. The `Next` button stays disabled for non-numeric input where it did not before.

## Testing

Six new cases in `src/utils/__tests__/validation.test.ts`, covering ordinary numbers, zero (which a falsy check would reject), blank and whitespace, the lone minus sign, the `1e999` and `-1e999` overflow forms, and the `'1.2.3'` / `'12abc'` / `'1e'` truncation forms.

- `npm test`: 255 suites, 2521 tests, all passing (up 6)
- `npm run type-check` (app + ee): passes
- `npx eslint` and `npx prettier --check` on all three files: clean