### PR TITLE
fix(frontend): show email on settings page when server prefetch fails

### DIFF
--- a/apps/frontend/src/app/(protected)/settings/components/ProfileForm.tsx
+++ b/apps/frontend/src/app/(protected)/settings/components/ProfileForm.tsx
@@ -134,7 +134,7 @@ export default function ProfileForm({ userSettings }: ProfileFormProps) {
           <Grid size={{ xs: 12, md: 6 }}>
             <ViewField
               label="Email"
-              value={userSettings?.email}
+              value={userSettings?.email ?? session?.user?.email}
               helperText="Your login email address"
             />
           </Grid>

--- a/apps/frontend/src/app/(protected)/settings/page.tsx
+++ b/apps/frontend/src/app/(protected)/settings/page.tsx
@@ -21,8 +21,8 @@ export default async function SettingsPage() {
   try {
     const factory = await createServerApiFactory();
     userSettings = await factory.getUsersClient().getUserSettings();
-  } catch {
-    // Render the page without prefilled values.
+  } catch (err) {
+    console.warn('[settings] failed to prefetch user settings:', err);
   }
 
   const breadcrumbs = [{ label: 'Settings', href: '/settings' }];


### PR DESCRIPTION
## Summary

- The settings page email field shows "—" on first load when the server-side `getUserSettings()` prefetch fails silently. The empty `catch` block swallows the error, leaving `userSettings` undefined.
- Falls back to the NextAuth session email (`session?.user?.email`), which is always available on a protected page. No new props or imports needed since `ProfileForm` already destructures `session` from `useSession()`.
- Logs the prefetch error with `console.warn` instead of silently swallowing it, so the root cause of the fetch failure can be traced in server logs.

## Test plan

- [ ] Invite a new user to an organization, have them log in, and navigate to Settings. Email should be visible immediately.
- [ ] Existing users visiting Settings should see no change in behavior.
- [ ] After editing and saving profile fields, email should still display correctly.