### PR TITLE
fix(frontend): show mapping tab read-only for SDK endpoints and fix table styling

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointMappingTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointMappingTab.tsx
@@ -19,6 +19,7 @@ import {
 import EditableSection from '@/components/common/EditableSection';
 import { SectionCard } from '@/components/common/SectionCard';
 import { useNotifications } from '@/components/common/NotificationContext';
+import { CODE_FONT_SIZE } from '@/styles/theme-constants';
 import { AutoConfigureResult } from '@/utils/api-client/interfaces/endpoint';
 import { testEndpointMapping } from '@/actions/endpoints';
 import MappingEditor from '../../components/MappingEditor';
@@ -53,7 +54,7 @@ const codeSx = {
   overflow: 'auto',
   fontFamily: (theme: import('@mui/material/styles').Theme) =>
     theme.typography.fontFamilyCode,
-  fontSize: 13,
+  fontSize: CODE_FONT_SIZE,
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-word',
 };

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointMappingTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointMappingTab.tsx
@@ -45,6 +45,47 @@ function mappingFromEndpoint(endpoint: {
   };
 }
 
+const codeSx = {
+  m: 0,
+  p: 2,
+  bgcolor: 'action.hover',
+  borderRadius: 1,
+  overflow: 'auto',
+  fontFamily: (theme: import('@mui/material/styles').Theme) =>
+    theme.typography.fontFamilyCode,
+  fontSize: 13,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+};
+
+function SdkMappingReadOnly() {
+  const { endpoint } = useEndpointDetailContext();
+  const mapping = mappingFromEndpoint(endpoint);
+
+  return (
+    <SectionCard title="Mapping">
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        <Box>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Request mapping
+          </Typography>
+          <Typography component="pre" variant="body2" sx={codeSx}>
+            {mapping.reqBody || '{}'}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Response mapping
+          </Typography>
+          <Typography component="pre" variant="body2" sx={codeSx}>
+            {mapping.resBody || '{}'}
+          </Typography>
+        </Box>
+      </Box>
+    </SectionCard>
+  );
+}
+
 export default function EndpointMappingTab() {
   const { endpoint, saveFields } = useEndpointDetailContext();
   const canEditEndpoint = useCan(Capability.Endpoint.UPDATE);
@@ -66,7 +107,7 @@ export default function EndpointMappingTab() {
   );
 
   if (endpoint.connection_type === 'SDK') {
-    return null;
+    return <SdkMappingReadOnly />;
   }
 
   const handleAutoConfigureApply = async (result: AutoConfigureResult) => {
@@ -259,21 +300,7 @@ export default function EndpointMappingTab() {
                   <Typography variant="subtitle2" sx={{ mb: 1 }}>
                     Request mapping
                   </Typography>
-                  <Typography
-                    component="pre"
-                    variant="body2"
-                    sx={{
-                      m: 0,
-                      p: 2,
-                      bgcolor: 'action.hover',
-                      borderRadius: 1,
-                      overflow: 'auto',
-                      fontFamily: 'monospace',
-                      fontSize: 13,
-                      whiteSpace: 'pre-wrap',
-                      wordBreak: 'break-word',
-                    }}
-                  >
+                  <Typography component="pre" variant="body2" sx={codeSx}>
                     {draft.reqBody || '{}'}
                   </Typography>
                 </Box>
@@ -281,21 +308,7 @@ export default function EndpointMappingTab() {
                   <Typography variant="subtitle2" sx={{ mb: 1 }}>
                     Response mapping
                   </Typography>
-                  <Typography
-                    component="pre"
-                    variant="body2"
-                    sx={{
-                      m: 0,
-                      p: 2,
-                      bgcolor: 'action.hover',
-                      borderRadius: 1,
-                      overflow: 'auto',
-                      fontFamily: 'monospace',
-                      fontSize: 13,
-                      whiteSpace: 'pre-wrap',
-                      wordBreak: 'break-word',
-                    }}
-                  >
+                  <Typography component="pre" variant="body2" sx={codeSx}>
                     {draft.resBody || '{}'}
                   </Typography>
                 </Box>

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointSdkConnectionPanel.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointSdkConnectionPanel.tsx
@@ -84,13 +84,19 @@ export default function EndpointSdkConnectionPanel() {
             {/* Function Parameters */}
             {endpoint.endpoint_metadata.function_schema?.parameters && (
               <Grid size={12}>
+                <Typography
+                  variant="subtitle2"
+                  color="text.secondary"
+                  sx={{ mb: 1 }}
+                >
+                  Function Parameters
+                </Typography>
                 {parameterRows.length === 0 ? (
                   <Typography variant="body2" color="text.secondary">
                     No parameters
                   </Typography>
                 ) : (
                   <BaseTable<ParameterRow>
-                    title="Function Parameters"
                     columns={[
                       {
                         id: 'name',

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointSdkConnectionPanel.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointSdkConnectionPanel.tsx
@@ -64,7 +64,10 @@ export default function EndpointSdkConnectionPanel() {
                     endpoint.endpoint_metadata.sdk_connection.function_name
                   }
                   bgcolor="transparent"
-                  inputSx={{ fontFamily: 'monospace', fontWeight: 500 }}
+                  inputSx={{
+                    fontFamily: theme => theme.typography.fontFamilyCode,
+                    fontWeight: 500,
+                  }}
                 />
               </Grid>
             )}
@@ -81,67 +84,66 @@ export default function EndpointSdkConnectionPanel() {
             {/* Function Parameters */}
             {endpoint.endpoint_metadata.function_schema?.parameters && (
               <Grid size={12}>
-                <Typography
-                  variant="subtitle2"
-                  color="text.secondary"
-                  sx={{ mb: 1 }}
-                >
-                  Function Parameters
-                </Typography>
-                <Paper
-                  variant="outlined"
-                  sx={{ p: 2, bgcolor: 'background.default' }}
-                >
-                  {parameterRows.length === 0 ? (
-                    <Typography variant="body2" color="text.secondary">
-                      No parameters
-                    </Typography>
-                  ) : (
-                    <BaseTable<ParameterRow>
-                      columns={[
-                        {
-                          id: 'name',
-                          label: 'Parameter',
-                          render: row => (
-                            <Typography
-                              variant="body2"
-                              sx={{ fontFamily: 'monospace', fontWeight: 500 }}
-                            >
-                              {row.name}
-                            </Typography>
-                          ),
-                        },
-                        {
-                          id: 'type',
-                          label: 'Type',
-                          render: row => (
-                            <Typography
-                              variant="caption"
-                              sx={{ fontFamily: 'monospace' }}
-                              color="text.secondary"
-                            >
-                              {row.type}
-                            </Typography>
-                          ),
-                        },
-                        {
-                          id: 'default',
-                          label: 'Default',
-                          render: row => (
-                            <Typography
-                              variant="caption"
-                              sx={{ fontFamily: 'monospace' }}
-                              color="text.secondary"
-                            >
-                              {row.defaultValue}
-                            </Typography>
-                          ),
-                        },
-                      ]}
-                      data={parameterRows}
-                    />
-                  )}
-                </Paper>
+                {parameterRows.length === 0 ? (
+                  <Typography variant="body2" color="text.secondary">
+                    No parameters
+                  </Typography>
+                ) : (
+                  <BaseTable<ParameterRow>
+                    title="Function Parameters"
+                    columns={[
+                      {
+                        id: 'name',
+                        label: 'Parameter',
+                        render: row => (
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              fontFamily: theme =>
+                                theme.typography.fontFamilyCode,
+                              fontWeight: 500,
+                            }}
+                          >
+                            {row.name}
+                          </Typography>
+                        ),
+                      },
+                      {
+                        id: 'type',
+                        label: 'Type',
+                        render: row => (
+                          <Typography
+                            variant="caption"
+                            sx={{
+                              fontFamily: theme =>
+                                theme.typography.fontFamilyCode,
+                            }}
+                            color="text.secondary"
+                          >
+                            {row.type}
+                          </Typography>
+                        ),
+                      },
+                      {
+                        id: 'default',
+                        label: 'Default',
+                        render: row => (
+                          <Typography
+                            variant="caption"
+                            sx={{
+                              fontFamily: theme =>
+                                theme.typography.fontFamilyCode,
+                            }}
+                            color="text.secondary"
+                          >
+                            {row.defaultValue}
+                          </Typography>
+                        ),
+                      },
+                    ]}
+                    data={parameterRows}
+                  />
+                )}
               </Grid>
             )}
 

--- a/apps/frontend/src/app/(protected)/endpoints/components/HeadersEditor.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/HeadersEditor.tsx
@@ -5,6 +5,7 @@ import { Box, CircularProgress, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import dynamic from 'next/dynamic';
 import type { OnMount } from '@monaco-editor/react';
+import { CODE_FONT_SIZE } from '@/styles/theme-constants';
 import { editorContainerSx } from './endpoint-styles';
 
 // Shared with RequestBodyEditor — colours {{ ... }} tokens inside Monaco
@@ -250,7 +251,7 @@ export default function HeadersEditor({
           scrollBeyondLastLine: false,
           automaticLayout: true,
           padding: { top: 8, bottom: 8 },
-          fontSize: 13,
+          fontSize: CODE_FONT_SIZE,
           wordWrap: 'on',
         }}
       />

--- a/apps/frontend/src/app/(protected)/endpoints/components/RequestBodyEditor.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/RequestBodyEditor.tsx
@@ -11,6 +11,7 @@ import {
 import dynamic from 'next/dynamic';
 import type { OnMount, BeforeMount } from '@monaco-editor/react';
 import { useTheme } from '@mui/material/styles';
+import { CODE_FONT_SIZE } from '@/styles/theme-constants';
 import { editorContainerSx } from './endpoint-styles';
 import VariableChip from './VariableChip';
 
@@ -272,7 +273,7 @@ export default function RequestBodyEditor({
           scrollBeyondLastLine: false,
           automaticLayout: true,
           padding: { top: 8, bottom: 8 },
-          fontSize: 13,
+          fontSize: CODE_FONT_SIZE,
           wordWrap: 'on',
           tabSize: 2,
           formatOnType: true,

--- a/apps/frontend/src/app/(protected)/jobs/[identifier]/components/ActivityLogViewer.tsx
+++ b/apps/frontend/src/app/(protected)/jobs/[identifier]/components/ActivityLogViewer.tsx
@@ -13,6 +13,7 @@ import {
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import type { ActivityLogEntry } from '@/utils/api-client/interfaces/job';
 import { ACTIVITY_LEVEL_COLOR } from '@/constants/jobs';
+import { CODE_FONT_SIZE } from '@/styles/theme-constants';
 import { BORDER_RADIUS } from '@/styles/theme';
 
 interface ActivityLogViewerProps {
@@ -114,8 +115,8 @@ export default function ActivityLogViewer({
         sx={{
           maxHeight: 480,
           overflowY: 'auto',
-          fontFamily: 'monospace',
-          fontSize: 13,
+          fontFamily: theme => theme.typography.fontFamilyCode,
+          fontSize: CODE_FONT_SIZE,
           p: 1.5,
         }}
       >

--- a/apps/frontend/src/app/(protected)/tokens/components/TokenDisplay.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokenDisplay.tsx
@@ -6,6 +6,7 @@ import { TokenResponse } from '@/utils/api-client/interfaces/token';
 import { useNotifications } from '@/components/common/NotificationContext';
 import BaseDrawer from '@/components/common/BaseDrawer';
 import { formatDate } from '@/utils/date';
+import { CODE_FONT_SIZE } from '@/styles/theme-constants';
 
 interface TokenDisplayProps {
   open: boolean;
@@ -75,7 +76,7 @@ export default function TokenDisplay({
                 variant="outlined"
                 InputProps={{ readOnly: true }}
                 inputProps={{
-                  style: { fontFamily: 'monospace', fontSize: 13 },
+                  style: { fontFamily: 'monospace', fontSize: CODE_FONT_SIZE },
                 }}
               />
               <IconButton

--- a/apps/frontend/src/styles/theme-constants.ts
+++ b/apps/frontend/src/styles/theme-constants.ts
@@ -108,6 +108,9 @@ export const BACKDROP_COLORS = {
   filter: 'rgba(0, 101, 140, 0.8)',
 } as const;
 
+/** Font size for monospace / code blocks (px). */
+export const CODE_FONT_SIZE = 13;
+
 /** Horizontal gap between FAB buttons in a page-header action group (Figma) */
 export const FAB_GROUP_GAP = '20px';
 


### PR DESCRIPTION
## Summary
- SDK endpoints now show the Mapping tab with a read-only view of request/response mappings instead of a blank panel
- Removed double Paper wrapper around the Function Parameters table in the SDK connection panel, which was causing excessively rounded corners
- Extracted duplicated `codeSx` style object for the mapping code blocks

## Test plan
- [ ] Open an SDK endpoint detail page and verify the Function Parameters table no longer has overly rounded corners
- [ ] Click the Mapping tab on an SDK endpoint and verify it shows request/response mappings in read-only mode (no edit, auto-configure, or test controls)
- [ ] Verify REST endpoint Mapping tab still works normally (editable, auto-configure, test)