### PR TITLE
Surface trace tokens and cost, and fix the totals behind them

### DIFF
--- a/apps/backend/src/rhesis/backend/app/constants.py
+++ b/apps/backend/src/rhesis/backend/app/constants.py
@@ -251,7 +251,14 @@ class AISpanAttributes:
 
     OPERATION_TYPE = "ai.operation.type"
     MODEL_NAME = "ai.model.name"
+    TOKENS_INPUT = "ai.llm.tokens.input"
+    TOKENS_OUTPUT = "ai.llm.tokens.output"
     TOKENS_TOTAL = "ai.llm.tokens.total"
+
+    # Only spans with this operation type carry countable token usage. Agent-run
+    # spans repeat their children's tokens as an aggregate, so counting them too
+    # double-counts the trace.
+    OPERATION_LLM_INVOKE = "llm.invoke"
 
 
 # Keys inside Trace.enriched_data (JSONB) populated by the enrichment service.
@@ -261,6 +268,12 @@ class EnrichedDataKeys:
     COSTS = "costs"
     TOTAL_COST_USD = "total_cost_usd"
     TOTAL_COST_EUR = "total_cost_eur"
+    TOTAL_TOKENS = "total_tokens"
+    TOTAL_INPUT_TOKENS = "total_input_tokens"
+    TOTAL_OUTPUT_TOKENS = "total_output_tokens"
+    BREAKDOWN = "breakdown"
+    SPAN_ID = "span_id"
+    MODEL_NAME = "model_name"
 
 
 # Test Execution Context Constants

--- a/apps/backend/src/rhesis/backend/app/constants.py
+++ b/apps/backend/src/rhesis/backend/app/constants.py
@@ -258,6 +258,10 @@ class AISpanAttributes:
     # Only spans with this operation type carry countable token usage. Agent-run
     # spans repeat their children's tokens as an aggregate, so counting them too
     # double-counts the trace.
+    #
+    # This also excludes embedding spans, which carry ai.llm.tokens.* but map to
+    # embedding.create. That is deliberate: enrichment never priced embeddings, so
+    # counting their tokens would put tokens and cost back out of step.
     OPERATION_LLM_INVOKE = "llm.invoke"
 
 

--- a/apps/backend/src/rhesis/backend/app/crud/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/crud/telemetry.py
@@ -910,17 +910,61 @@ def get_trace_metrics_aggregated(
 
     base = db.query(T).filter(*filters).subquery()
 
-    # JSONB extraction expressions for tokens and costs
-    tokens_expr = base.c.attributes[AISpanAttributes.TOKENS_TOTAL].as_float()
-    cost_expr = base.c.enriched_data[EnrichedDataKeys.COSTS][
-        EnrichedDataKeys.TOTAL_COST_USD
-    ].as_float()
+    # Tokens and costs aggregate per *trace*, not per span row.
+    #
+    # enriched_data is a trace-level blob that mark_trace_processed writes onto every
+    # span of the trace, so summing it across span rows multiplies the real figure by
+    # the span count. Collapse to one row per trace first: MAX is exact for the
+    # enriched columns precisely because every row carries the same value.
+    #
+    # raw_tokens is the pre-enrichment fallback, summed over llm.invoke spans only --
+    # the same filter enrichment applies, so an unenriched trace reports the number it
+    # will keep once enrichment lands. Cost has no fallback; it cannot be derived from
+    # span attributes.
+    per_trace = (
+        db.query(
+            base.c.trace_id.label("trace_id"),
+            func.max(
+                base.c.enriched_data[EnrichedDataKeys.COSTS][
+                    EnrichedDataKeys.TOTAL_TOKENS
+                ].as_float()
+            ).label("enriched_tokens"),
+            func.max(
+                base.c.enriched_data[EnrichedDataKeys.COSTS][
+                    EnrichedDataKeys.TOTAL_COST_USD
+                ].as_float()
+            ).label("cost_usd"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (
+                            base.c.attributes[AISpanAttributes.OPERATION_TYPE].as_string()
+                            == AISpanAttributes.OPERATION_LLM_INVOKE,
+                            base.c.attributes[AISpanAttributes.TOKENS_TOTAL].as_float(),
+                        ),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("raw_tokens"),
+        )
+        .group_by(base.c.trace_id)
+        .subquery()
+    )
+
+    token_cost_agg = db.query(
+        func.coalesce(
+            func.sum(
+                func.coalesce(per_trace.c.enriched_tokens, per_trace.c.raw_tokens, 0),
+            ),
+            0,
+        ).label("total_tokens"),
+        func.coalesce(func.sum(per_trace.c.cost_usd), 0).label("total_cost_usd"),
+    ).one()
 
     agg = db.query(
         func.count(func.distinct(base.c.trace_id)).label("total_traces"),
         func.count(base.c.id).label("total_spans"),
-        func.coalesce(func.sum(tokens_expr), 0).label("total_tokens"),
-        func.coalesce(func.sum(cost_expr), 0).label("total_cost_usd"),
         func.count(case((base.c.status_code == "ERROR", 1))).label("error_count"),
         func.coalesce(func.avg(base.c.duration_ms), 0).label("avg_duration_ms"),
         func.coalesce(sqlfunc.percentile_cont(0.5).within_group(base.c.duration_ms), 0).label(
@@ -954,8 +998,8 @@ def get_trace_metrics_aggregated(
     return {
         "total_traces": agg.total_traces or 0,
         "total_spans": total_spans,
-        "total_tokens": int(agg.total_tokens or 0),
-        "total_cost_usd": round(float(agg.total_cost_usd or 0), 6),
+        "total_tokens": int(token_cost_agg.total_tokens or 0),
+        "total_cost_usd": round(float(token_cost_agg.total_cost_usd or 0), 6),
         "error_rate": round(error_count / total_spans, 4) if total_spans else 0,
         "avg_duration_ms": round(float(agg.avg_duration_ms or 0), 2),
         "p50_duration_ms": round(float(agg.p50_duration_ms or 0), 2),

--- a/apps/backend/src/rhesis/backend/app/crud/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/crud/telemetry.py
@@ -16,7 +16,11 @@ from sqlalchemy import and_, desc, func, or_, select
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models
-from rhesis.backend.app.constants import TestExecutionContext
+from rhesis.backend.app.constants import (
+    AISpanAttributes,
+    EnrichedDataKeys,
+    TestExecutionContext,
+)
 from rhesis.backend.app.schemas.telemetry import (
     OTELSpanCreate,
     StatusCode,
@@ -40,6 +44,9 @@ class TraceRow(NamedTuple):
     total: int
     tags_count: int
     comments_count: int
+    # Summed over the trace's llm.invoke spans. Only used when the trace has not
+    # been enriched yet -- see services/telemetry/token_totals.py.
+    llm_tokens: int
 
 
 # ============================================================================
@@ -332,7 +339,30 @@ def query_traces(
         .scalar_subquery()
     )
 
-    # -- Column 3: total — total matching rows *before* LIMIT/OFFSET
+    # -- Column 3: llm_tokens — tokens over this trace's llm.invoke spans.
+    #    The pre-enrichment fallback: enrichment is dispatched asynchronously after
+    #    ingest, so a freshly ingested trace has no enriched_data and would
+    #    otherwise list as 0 while the detail endpoint reported the real figure.
+    #    The llm.invoke filter is the same one enrichment applies, so the two
+    #    numbers agree instead of double-counting aggregate-reporting frameworks.
+    llm_tokens_col = (
+        select(
+            func.coalesce(
+                func.sum(InnerTrace.attributes[AISpanAttributes.TOKENS_TOTAL].as_float()), 0
+            )
+        )
+        .where(
+            and_(
+                InnerTrace.trace_id == models.Trace.trace_id,
+                InnerTrace.organization_id == org_uuid,
+                InnerTrace.attributes[AISpanAttributes.OPERATION_TYPE].as_string()
+                == AISpanAttributes.OPERATION_LLM_INVOKE,
+            )
+        )
+        .scalar_subquery()
+    )
+
+    # -- Column 4: total — total matching rows *before* LIMIT/OFFSET
     #    Uses a window function so pagination total comes from the same query.
     total_col = func.count().over().label("total_count")
 
@@ -360,7 +390,14 @@ def query_traces(
     )
 
     query = (
-        db.query(models.Trace, span_count_col, total_col, tags_count_col, comments_count_col)
+        db.query(
+            models.Trace,
+            span_count_col,
+            total_col,
+            tags_count_col,
+            comments_count_col,
+            llm_tokens_col,
+        )
         .filter(models.Trace.organization_id == org_uuid)
         .options(
             # Scoped to what the loop below actually reads off this chain (existence
@@ -511,7 +548,14 @@ def query_traces(
 
     results = query.order_by(desc(models.Trace.start_time)).limit(limit).offset(offset).all()
     return [
-        TraceRow(trace=r[0], span_count=r[1], total=r[2], tags_count=r[3], comments_count=r[4])
+        TraceRow(
+            trace=r[0],
+            span_count=r[1],
+            total=r[2],
+            tags_count=r[3],
+            comments_count=r[4],
+            llm_tokens=int(r[5] or 0),
+        )
         for r in results
     ]
 
@@ -849,8 +893,6 @@ def get_trace_metrics_aggregated(
 
     from sqlalchemy import case, literal_column
     from sqlalchemy.sql import functions as sqlfunc
-
-    from rhesis.backend.app.constants import AISpanAttributes, EnrichedDataKeys
 
     T = models.Trace
 

--- a/apps/backend/src/rhesis/backend/app/crud/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/crud/telemetry.py
@@ -12,7 +12,7 @@ from enum import Enum
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 from uuid import UUID
 
-from sqlalchemy import and_, desc, func, or_, select
+from sqlalchemy import and_, asc, desc, func, or_, select
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models
@@ -49,6 +49,87 @@ def span_total_tokens_expr(attributes):
         + func.coalesce(attributes[AISpanAttributes.TOKENS_OUTPUT].as_float(), 0.0),
         0.0,
     )
+
+
+# Grid fields the traces list can sort by, mapped to how each is ordered in SQL.
+#
+# Deliberately a whitelist: the columns left out (conversation_input, endpoint_name,
+# trace_metrics_status) have no SQL sort key -- they come from a JSONB attribute, a
+# three-hop join and a relationship -- so the grid marks them unsortable rather than
+# sorting one page of rows and calling it ordered.
+TRACE_SORT_FIELDS = frozenset(
+    {
+        "start_time",
+        "duration_ms",
+        "trace_id",
+        "environment",
+        "root_operation",
+        "span_count",
+        "total_tokens",
+        "total_cost_usd",
+    }
+)
+
+
+def _trace_sort_clauses(
+    sort_by: Optional[str], sort_order: str, span_count_col, llm_tokens_col
+) -> list:
+    """ORDER BY clauses for the traces list.
+
+    Sorting is server-side so a page of results is genuinely the top N of the whole
+    filtered set, not the newest N reshuffled in the browser.
+
+    Always ends with start_time then id. Without a tiebreaker the many rows tied at
+    zero cost have no defined order between pages, and pagination silently repeats
+    and skips rows.
+    """
+    from fastapi import HTTPException
+
+    if sort_by and sort_by not in TRACE_SORT_FIELDS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Cannot sort traces by '{sort_by}'. "
+                f"Sortable fields: {', '.join(sorted(TRACE_SORT_FIELDS))}"
+            ),
+        )
+
+    columns = {
+        "start_time": models.Trace.start_time,
+        "duration_ms": models.Trace.duration_ms,
+        "trace_id": models.Trace.trace_id,
+        "environment": models.Trace.environment,
+        "root_operation": models.Trace.span_name,
+        "span_count": span_count_col,
+        # Mirrors what the response actually shows: the enriched total when the trace
+        # has been priced, the llm.invoke sum until then.
+        "total_tokens": func.coalesce(
+            models.Trace.enriched_data[EnrichedDataKeys.COSTS][
+                EnrichedDataKeys.TOTAL_TOKENS
+            ].as_float(),
+            llm_tokens_col,
+            0,
+        ),
+        # Cost has no pre-enrichment fallback, so unpriced traces sort last rather
+        # than leading a "most expensive first" list on a NULLS FIRST default.
+        "total_cost_usd": models.Trace.enriched_data[EnrichedDataKeys.COSTS][
+            EnrichedDataKeys.TOTAL_COST_USD
+        ].as_float(),
+    }
+
+    descending = sort_order.lower() != "asc"
+    clauses = []
+
+    if sort_by:
+        expression = columns[sort_by]
+        ordered = desc(expression) if descending else asc(expression)
+        clauses.append(ordered.nullslast())
+
+    if sort_by != "start_time":
+        clauses.append(desc(models.Trace.start_time))
+    clauses.append(desc(models.Trace.id))
+
+    return clauses
 
 
 class TraceRow(NamedTuple):
@@ -303,6 +384,8 @@ def query_traces(
     test_id: Optional[str] = None,
     conversation_id: Optional[str] = None,
     trace_metrics_status: Optional[str] = None,
+    sort_by: Optional[str] = None,
+    sort_order: str = "desc",
     limit: int = 100,
     offset: int = 0,
 ) -> List[TraceRow]:
@@ -561,7 +644,11 @@ def query_traces(
         )
         query = query.filter(models.Trace.trace_metrics_status_id.in_(matching_status_ids))
 
-    results = query.order_by(desc(models.Trace.start_time)).limit(limit).offset(offset).all()
+    query = query.order_by(
+        *_trace_sort_clauses(sort_by, sort_order, span_count_col, llm_tokens_col)
+    )
+
+    results = query.limit(limit).offset(offset).all()
     return [
         TraceRow(
             trace=r[0],

--- a/apps/backend/src/rhesis/backend/app/crud/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/crud/telemetry.py
@@ -32,6 +32,25 @@ from rhesis.backend.app.utils.query_utils import QueryBuilder, include, resolve_
 logger = logging.getLogger(__name__)
 
 
+def span_total_tokens_expr(attributes):
+    """Per-span token total in SQL, matching ``_span_token_counts`` in enrichment/core.py.
+
+    Falls back to ``input + output`` when no total was reported, and treats a reported
+    zero as missing when either side is non-zero. That combination is contradictory and
+    only reachable through hand-set OTLP attributes or ``create_llm_attributes`` with a
+    single side, never through a shipped integration; trusting the zero would undercount.
+
+    Each side is coalesced separately because ``NULL + 100`` is ``NULL`` in SQL, which
+    would otherwise drop a span that reported only one of the two.
+    """
+    return func.coalesce(
+        func.nullif(attributes[AISpanAttributes.TOKENS_TOTAL].as_float(), 0.0),
+        func.coalesce(attributes[AISpanAttributes.TOKENS_INPUT].as_float(), 0.0)
+        + func.coalesce(attributes[AISpanAttributes.TOKENS_OUTPUT].as_float(), 0.0),
+        0.0,
+    )
+
+
 class TraceRow(NamedTuple):
     """A single row returned by query_traces.
 
@@ -346,11 +365,7 @@ def query_traces(
     #    The llm.invoke filter is the same one enrichment applies, so the two
     #    numbers agree instead of double-counting aggregate-reporting frameworks.
     llm_tokens_col = (
-        select(
-            func.coalesce(
-                func.sum(InnerTrace.attributes[AISpanAttributes.TOKENS_TOTAL].as_float()), 0
-            )
-        )
+        select(func.coalesce(func.sum(span_total_tokens_expr(InnerTrace.attributes)), 0))
         .where(
             and_(
                 InnerTrace.trace_id == models.Trace.trace_id,
@@ -940,7 +955,7 @@ def get_trace_metrics_aggregated(
                         (
                             base.c.attributes[AISpanAttributes.OPERATION_TYPE].as_string()
                             == AISpanAttributes.OPERATION_LLM_INVOKE,
-                            base.c.attributes[AISpanAttributes.TOKENS_TOTAL].as_float(),
+                            span_total_tokens_expr(base.c.attributes),
                         ),
                         else_=0,
                     )

--- a/apps/backend/src/rhesis/backend/app/models/trace.py
+++ b/apps/backend/src/rhesis/backend/app/models/trace.py
@@ -179,11 +179,6 @@ class Trace(
         """Extract model name from attributes."""
         return self.attributes.get(AISpanAttributes.MODEL_NAME)
 
-    @property
-    def total_tokens(self) -> int | None:
-        """Extract total tokens from attributes."""
-        return self.attributes.get(AISpanAttributes.TOKENS_TOTAL)
-
     def to_searchable_text(self) -> str:
         """
         Generate searchable text from trace fields for embeddings and full-text search.

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -54,6 +54,11 @@ from rhesis.backend.app.services.review import (
     get_review_status_details,
     update_review_metadata,
 )
+from rhesis.backend.app.services.telemetry.token_totals import (
+    trace_cost_usd,
+    trace_summary_totals,
+    trace_token_totals,
+)
 from rhesis.backend.app.services.trace_review_override import (
     apply_review_override as trace_apply_review_override,
 )
@@ -394,13 +399,13 @@ def list_traces(
         for row in rows:
             trace = row.trace
             has_errors = trace.status_code == StatusCode.ERROR.value
-            total_tokens = trace.total_tokens or 0
-            total_cost_usd = 0.0
-            total_cost_eur = 0.0
-            costs = (trace.enriched_data or {}).get(EnrichedDataKeys.COSTS, {})
-            if costs:
-                total_cost_usd = costs.get(EnrichedDataKeys.TOTAL_COST_USD, 0.0)
-                total_cost_eur = costs.get(EnrichedDataKeys.TOTAL_COST_EUR, 0.0)
+            (
+                total_input_tokens,
+                total_output_tokens,
+                total_tokens,
+                total_cost_usd,
+                total_cost_eur,
+            ) = trace_summary_totals(trace.enriched_data, row.llm_tokens)
 
             # Get endpoint information from eagerly loaded relationships
             trace_endpoint_id = None
@@ -449,6 +454,8 @@ def list_traces(
                 endpoint_id=trace_endpoint_id,
                 endpoint_name=trace_endpoint_name,
                 total_tokens=total_tokens if total_tokens > 0 else None,
+                total_input_tokens=total_input_tokens if total_input_tokens > 0 else None,
+                total_output_tokens=total_output_tokens if total_output_tokens > 0 else None,
                 total_cost_usd=total_cost_usd if total_cost_usd > 0 else None,
                 total_cost_eur=total_cost_eur if total_cost_eur > 0 else None,
                 has_errors=has_errors,
@@ -594,20 +601,25 @@ def get_trace(
         # Build proper span tree
         from rhesis.backend.app.services.telemetry.tree_builder import build_span_tree
 
-        root_spans = build_span_tree(spans)
+        # enriched_data is trace-level and written onto every span, so any span
+        # carries the whole breakdown. Index it once for the tree builder.
+        costs = (spans[0].enriched_data or {}).get(EnrichedDataKeys.COSTS) or {}
+        cost_by_span_id = {
+            entry[EnrichedDataKeys.SPAN_ID]: entry
+            for entry in costs.get(EnrichedDataKeys.BREAKDOWN) or []
+            if entry.get(EnrichedDataKeys.SPAN_ID)
+        }
+
+        root_spans = build_span_tree(spans, cost_by_span_id)
 
         # Calculate trace-level metrics
         total_duration = max(span.end_time for span in spans) - min(
             span.start_time for span in spans
         )
-        total_tokens = sum(span.total_tokens or 0 for span in spans)
+        total_input_tokens, total_output_tokens, total_tokens = trace_token_totals(spans)
         error_count = sum(1 for span in spans if span.status_code == StatusCode.ERROR.value)
 
-        # Extract costs from enriched data
-        total_cost = 0.0
-        costs = (spans[0].enriched_data or {}).get(EnrichedDataKeys.COSTS, {})
-        if costs:
-            total_cost = costs.get(EnrichedDataKeys.TOTAL_COST_USD, 0.0)
+        total_cost = trace_cost_usd(spans[0].enriched_data)
 
         # Build relationship objects from first span
         from rhesis.backend.app.schemas.endpoint import Endpoint
@@ -678,6 +690,8 @@ def get_trace(
             span_count=len(spans),
             error_count=error_count,
             total_tokens=total_tokens,
+            total_input_tokens=total_input_tokens,
+            total_output_tokens=total_output_tokens,
             total_cost_usd=total_cost,
             root_spans=root_spans,
             trace_metrics_status=trace_metrics_status_name,

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -309,6 +309,15 @@ def list_traces(
         True,
         description=("Return only root spans (one per trace). Set to false to return all spans."),
     ),
+    sort_by: Optional[str] = Query(
+        None,
+        description=(
+            "Field to sort by. One of: "
+            "start_time, duration_ms, trace_id, environment, root_operation, "
+            "span_count, total_tokens, total_cost_usd."
+        ),
+    ),
+    sort_order: str = Query("desc", pattern="^(asc|desc)$", description="Sort direction"),
     limit: int = Query(100, ge=1, le=1000, description="Results per page"),
     offset: int = Query(0, ge=0, description="Pagination offset"),
     db: Session = Depends(get_tenant_db_session),
@@ -381,6 +390,8 @@ def list_traces(
             test_id=test_id,
             conversation_id=conversation_id,
             trace_metrics_status=(trace_metrics_status.value if trace_metrics_status else None),
+            sort_by=sort_by,
+            sort_order=sort_order,
             limit=limit,
             offset=offset,
         )
@@ -481,6 +492,9 @@ def list_traces(
             offset=offset,
         )
 
+    except HTTPException:
+        # A deliberate 4xx, such as an unsortable sort_by, must not become a 500.
+        raise
     except Exception as e:
         # Check if it's a database permission error
         error_msg = str(e).lower()

--- a/apps/backend/src/rhesis/backend/app/routers/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_run.py
@@ -11,7 +11,6 @@ from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.principal import resolve_principal_from_request
 from rhesis.backend.app.auth.rbac import authorize_object, project_id_from_scope
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
-from rhesis.backend.app.constants import EnrichedDataKeys
 from rhesis.backend.app.crud import test_run as test_run_crud
 from rhesis.backend.app.crud.telemetry import query_traces
 from rhesis.backend.app.dependencies import (
@@ -22,6 +21,7 @@ from rhesis.backend.app.models.user import User
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.telemetry import TraceListResponse, TraceSource, TraceSummary
 from rhesis.backend.app.services import test_run as services_test_run
+from rhesis.backend.app.services.telemetry.token_totals import trace_summary_totals
 from rhesis.backend.app.services.test_run import (
     get_test_results_for_test_run,
     rescore_test_run,
@@ -550,13 +550,13 @@ def get_test_run_traces(
     for row in rows:
         trace = row.trace
         has_errors = trace.status_code == "ERROR"
-        total_tokens = trace.total_tokens or 0
-        total_cost_usd = 0.0
-        total_cost_eur = 0.0
-        costs = (trace.enriched_data or {}).get(EnrichedDataKeys.COSTS, {})
-        if costs:
-            total_cost_usd = costs.get(EnrichedDataKeys.TOTAL_COST_USD, 0.0)
-            total_cost_eur = costs.get(EnrichedDataKeys.TOTAL_COST_EUR, 0.0)
+        (
+            total_input_tokens,
+            total_output_tokens,
+            total_tokens,
+            total_cost_usd,
+            total_cost_eur,
+        ) = trace_summary_totals(trace.enriched_data, row.llm_tokens)
 
         conversation_input = None
         if isinstance(trace.attributes, dict):
@@ -576,6 +576,8 @@ def get_test_run_traces(
             status_code=trace.status_code,
             has_errors=has_errors,
             total_tokens=total_tokens if total_tokens > 0 else None,
+            total_input_tokens=total_input_tokens if total_input_tokens > 0 else None,
+            total_output_tokens=total_output_tokens if total_output_tokens > 0 else None,
             total_cost_usd=total_cost_usd if total_cost_usd > 0 else None,
             total_cost_eur=total_cost_eur if total_cost_eur > 0 else None,
             test_run_id=str(trace.test_run_id) if trace.test_run_id else None,

--- a/apps/backend/src/rhesis/backend/app/schemas/enrichment.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/enrichment.py
@@ -12,6 +12,12 @@ class CostBreakdown(BaseModel):
     model_name: str = Field(..., description="Model name used")
     input_tokens: int = Field(..., ge=0, description="Number of input tokens")
     output_tokens: int = Field(..., ge=0, description="Number of output tokens")
+    total_tokens: int = Field(
+        0,
+        ge=0,
+        description="Total tokens for this span, as reported rather than derived: "
+        "Google ADK folds cache-read tokens in, so it can exceed input + output",
+    )
     input_cost_usd: float = Field(..., ge=0, description="Cost of input tokens in USD")
     output_cost_usd: float = Field(..., ge=0, description="Cost of output tokens in USD")
     total_cost_usd: float = Field(..., ge=0, description="Total cost for this span in USD")
@@ -25,6 +31,11 @@ class TokenCosts(BaseModel):
 
     total_cost_usd: float = Field(..., ge=0, description="Total cost across all spans in USD")
     total_cost_eur: float = Field(..., ge=0, description="Total cost across all spans in EUR")
+    total_input_tokens: int = Field(0, ge=0, description="Input tokens across all llm.invoke spans")
+    total_output_tokens: int = Field(
+        0, ge=0, description="Output tokens across all llm.invoke spans"
+    )
+    total_tokens: int = Field(0, ge=0, description="Total tokens across all llm.invoke spans")
     breakdown: List[CostBreakdown] = Field(..., description="Per-span cost breakdown")
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/telemetry.py
@@ -103,6 +103,8 @@ class TraceSummary(BaseModel):
     root_operation: str
     status_code: str
     total_tokens: Optional[int] = None
+    total_input_tokens: Optional[int] = None
+    total_output_tokens: Optional[int] = None
     total_cost_usd: Optional[float] = None
     total_cost_eur: Optional[float] = None
     has_errors: bool
@@ -189,6 +191,10 @@ class SpanNode(BaseModel):
     status_code: str
     status_message: Optional[str]
     attributes: Dict[str, Any]
+    # Priced by enrichment, which the frontend cannot reach any other way: the raw
+    # attributes carry tokens but never a cost.
+    cost_usd: Optional[float] = None
+    model_name: Optional[str] = None
     events: List[Dict[str, Any]]
     children: List["SpanNode"] = Field(default_factory=list)
 
@@ -226,6 +232,8 @@ class TraceDetailResponse(BaseModel):
     span_count: int
     error_count: int
     total_tokens: int
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
     total_cost_usd: float
     root_spans: List[SpanNode]
 

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/core.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/core.py
@@ -25,58 +25,49 @@ for _logger_name in ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy"):
 
 logger = logging.getLogger(__name__)
 
+# Stands in for a missing ai.llm.model.name so the span's tokens still get recorded.
+UNKNOWN_MODEL_NAME = "unknown"
 
-def calculate_token_costs(spans: List[Trace]) -> Optional[TokenCosts]:
+
+def _span_token_counts(span: Trace) -> tuple[int, int, int]:
+    """Input, output and total tokens for a span.
+
+    The reported total is trusted rather than derived: Google ADK folds cache-read
+    tokens into ``ai.llm.tokens.total``, so for its spans the total legitimately
+    exceeds ``input + output``. Only fall back to the sum when no total was sent.
     """
-    Calculate token costs for LLM spans using LiteLLM's pricing database.
+    input_tokens = int(span.attributes.get(AIAttributes.LLM_TOKENS_INPUT, 0) or 0)
+    output_tokens = int(span.attributes.get(AIAttributes.LLM_TOKENS_OUTPUT, 0) or 0)
+    reported_total = span.attributes.get(AIAttributes.LLM_TOKENS_TOTAL)
+    if reported_total is None:
+        return input_tokens, output_tokens, input_tokens + output_tokens
+    return input_tokens, output_tokens, int(reported_total)
 
-    Costs are calculated in both USD and EUR for European operations.
 
-    Args:
-        spans: List of trace spans
+def _price_span(span: Trace, usd_to_eur: float) -> CostBreakdown:
+    """Price a single ``llm.invoke`` span.
 
-    Returns:
-        TokenCosts model with cost breakdown or None if no LLM spans
+    Always returns a breakdown: tokens are known even when the price is not, so an
+    unpriced model (self-hosted, or missing from LiteLLM) is recorded at zero cost
+    rather than dropped. Dropping it would make a trace that mixes priced and
+    unpriced spans undercount its tokens.
     """
-    total_cost_usd = 0.0
-    total_cost_eur = 0.0
-    cost_breakdown = []
+    input_tokens, output_tokens, total_tokens = _span_token_counts(span)
+    model_name = span.attributes.get(AIAttributes.MODEL_NAME)
 
-    # Get exchange rate for EUR conversion
-    usd_to_eur = get_usd_to_eur_rate()
+    if input_tokens == 0 and output_tokens == 0:
+        logger.warning(
+            f"⚠️  Zero tokens for span {span.span_id}! "
+            f"Available attributes: {list(span.attributes.keys())}"
+        )
 
-    logger.info(f"🔍 Calculating costs for {len(spans)} spans")
+    input_cost_usd = 0.0
+    output_cost_usd = 0.0
 
-    for span in spans:
-        # Only process LLM invocation spans (use semantic layer constant)
-        operation_type = span.attributes.get(AIAttributes.OPERATION_TYPE)
-        logger.debug(f"Span {span.span_id}: operation_type={operation_type}")
-
-        if operation_type != AIAttributes.OPERATION_LLM_INVOKE:
-            logger.debug(f"⏭️  Skipping span {span.span_id}: not an LLM invocation")
-            continue
-
-        model_name = span.attributes.get(AIAttributes.MODEL_NAME)
-        logger.info(f"📊 Processing LLM span {span.span_id}: model={model_name}")
-
-        if not model_name:
-            logger.warning(f"⚠️  Skipping span {span.span_id}: no model name")
-            continue
-
-        # Get token counts (use semantic layer constants for token attributes)
-        input_tokens = span.attributes.get(AIAttributes.LLM_TOKENS_INPUT, 0)
-        output_tokens = span.attributes.get(AIAttributes.LLM_TOKENS_OUTPUT, 0)
-
-        logger.info(f"🎯 Span {span.span_id} tokens: input={input_tokens}, output={output_tokens}")
-
-        # Log all attributes for debugging
-        if input_tokens == 0 and output_tokens == 0:
-            logger.warning(
-                f"⚠️  Zero tokens for span {span.span_id}! "
-                f"Available attributes: {list(span.attributes.keys())}"
-            )
-
-        # Use LiteLLM's cost_per_token (maintains up-to-date pricing for all providers)
+    if not model_name:
+        logger.warning(f"⚠️  Span {span.span_id} has no model name: recording tokens at zero cost")
+        model_name = UNKNOWN_MODEL_NAME
+    else:
         try:
             # Returns tuple: (prompt_cost_usd, completion_cost_usd)
             input_cost_usd, output_cost_usd = litellm.cost_per_token(
@@ -84,49 +75,63 @@ def calculate_token_costs(spans: List[Trace]) -> Optional[TokenCosts]:
                 prompt_tokens=input_tokens,
                 completion_tokens=output_tokens,
             )
-
-            span_cost_usd = input_cost_usd + output_cost_usd
-
-            # Convert to EUR
-            span_cost_eur = span_cost_usd * usd_to_eur
-            input_cost_eur = input_cost_usd * usd_to_eur
-            output_cost_eur = output_cost_usd * usd_to_eur
-
-            logger.info(
-                f"💰 Calculated costs for {model_name}: "
-                f"${span_cost_usd:.6f} USD, €{span_cost_eur:.6f} EUR"
-            )
-
         except Exception as e:
-            # If LiteLLM doesn't have pricing for this model, log and skip
             logger.warning(
                 f"❌ LiteLLM cost calculation failed for model {model_name}: {e}. "
-                f"Tokens: input={input_tokens}, output={output_tokens}"
+                f"Recording tokens at zero cost: input={input_tokens}, output={output_tokens}"
             )
-            continue
 
-        total_cost_usd += span_cost_usd
-        total_cost_eur += span_cost_eur
+    span_cost_usd = input_cost_usd + output_cost_usd
 
-        # Create Pydantic model for breakdown
-        cost_breakdown.append(
-            CostBreakdown(
-                span_id=span.span_id,
-                model_name=model_name,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                input_cost_usd=round(input_cost_usd, 6),
-                output_cost_usd=round(output_cost_usd, 6),
-                total_cost_usd=round(span_cost_usd, 6),
-                input_cost_eur=round(input_cost_eur, 6),
-                output_cost_eur=round(output_cost_eur, 6),
-                total_cost_eur=round(span_cost_eur, 6),
-            )
-        )
+    return CostBreakdown(
+        span_id=span.span_id,
+        model_name=model_name,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        input_cost_usd=round(input_cost_usd, 6),
+        output_cost_usd=round(output_cost_usd, 6),
+        total_cost_usd=round(span_cost_usd, 6),
+        input_cost_eur=round(input_cost_usd * usd_to_eur, 6),
+        output_cost_eur=round(output_cost_usd * usd_to_eur, 6),
+        total_cost_eur=round(span_cost_usd * usd_to_eur, 6),
+    )
+
+
+def calculate_token_costs(spans: List[Trace]) -> Optional[TokenCosts]:
+    """
+    Calculate token counts and costs for LLM spans using LiteLLM's pricing database.
+
+    Only ``llm.invoke`` spans are counted. That filter is what keeps the totals
+    correct: frameworks like pydantic-ai report aggregated usage on the agent-run
+    span *and* per-call usage on its child model-call spans, so summing every span
+    would double-count them.
+
+    Costs are calculated in both USD and EUR for European operations.
+
+    Args:
+        spans: List of trace spans
+
+    Returns:
+        TokenCosts model with token totals and cost breakdown, or None if the trace
+        has no LLM invocation spans at all.
+    """
+    usd_to_eur = get_usd_to_eur_rate()
+
+    logger.info(f"🔍 Calculating costs for {len(spans)} spans")
+
+    cost_breakdown = [
+        _price_span(span, usd_to_eur)
+        for span in spans
+        if span.attributes.get(AIAttributes.OPERATION_TYPE) == AIAttributes.OPERATION_LLM_INVOKE
+    ]
 
     if not cost_breakdown:
-        logger.warning("⚠️  No cost breakdown calculated - no LLM spans with valid tokens found")
+        logger.warning("⚠️  No cost breakdown calculated - trace has no llm.invoke spans")
         return None
+
+    total_cost_usd = sum(span.total_cost_usd for span in cost_breakdown)
+    total_cost_eur = sum(span.total_cost_eur for span in cost_breakdown)
 
     logger.info(
         f"✅ Cost calculation complete: {len(cost_breakdown)} spans, "
@@ -136,6 +141,9 @@ def calculate_token_costs(spans: List[Trace]) -> Optional[TokenCosts]:
     return TokenCosts(
         total_cost_usd=round(total_cost_usd, 6),
         total_cost_eur=round(total_cost_eur, 6),
+        total_input_tokens=sum(span.input_tokens for span in cost_breakdown),
+        total_output_tokens=sum(span.output_tokens for span in cost_breakdown),
+        total_tokens=sum(span.total_tokens for span in cost_breakdown),
         breakdown=cost_breakdown,
     )
 

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/core.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/core.py
@@ -34,12 +34,14 @@ def _span_token_counts(span: Trace) -> tuple[int, int, int]:
 
     The reported total is trusted rather than derived: Google ADK folds cache-read
     tokens into ``ai.llm.tokens.total``, so for its spans the total legitimately
-    exceeds ``input + output``. Only fall back to the sum when no total was sent.
+    exceeds ``input + output``. Fall back to the sum when no total was sent, and also
+    when a zero total arrives alongside non-zero input or output, which is
+    contradictory and only reachable through hand-set attributes.
     """
     input_tokens = int(span.attributes.get(AIAttributes.LLM_TOKENS_INPUT, 0) or 0)
     output_tokens = int(span.attributes.get(AIAttributes.LLM_TOKENS_OUTPUT, 0) or 0)
     reported_total = span.attributes.get(AIAttributes.LLM_TOKENS_TOTAL)
-    if reported_total is None:
+    if reported_total is None or int(reported_total) == 0:
         return input_tokens, output_tokens, input_tokens + output_tokens
     return input_tokens, output_tokens, int(reported_total)
 
@@ -130,8 +132,8 @@ def calculate_token_costs(spans: List[Trace]) -> Optional[TokenCosts]:
         logger.warning("⚠️  No cost breakdown calculated - trace has no llm.invoke spans")
         return None
 
-    total_cost_usd = sum(span.total_cost_usd for span in cost_breakdown)
-    total_cost_eur = sum(span.total_cost_eur for span in cost_breakdown)
+    total_cost_usd = sum(entry.total_cost_usd for entry in cost_breakdown)
+    total_cost_eur = sum(entry.total_cost_eur for entry in cost_breakdown)
 
     logger.info(
         f"✅ Cost calculation complete: {len(cost_breakdown)} spans, "
@@ -141,9 +143,9 @@ def calculate_token_costs(spans: List[Trace]) -> Optional[TokenCosts]:
     return TokenCosts(
         total_cost_usd=round(total_cost_usd, 6),
         total_cost_eur=round(total_cost_eur, 6),
-        total_input_tokens=sum(span.input_tokens for span in cost_breakdown),
-        total_output_tokens=sum(span.output_tokens for span in cost_breakdown),
-        total_tokens=sum(span.total_tokens for span in cost_breakdown),
+        total_input_tokens=sum(entry.input_tokens for entry in cost_breakdown),
+        total_output_tokens=sum(entry.output_tokens for entry in cost_breakdown),
+        total_tokens=sum(entry.total_tokens for entry in cost_breakdown),
         breakdown=cost_breakdown,
     )
 

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/token_totals.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/token_totals.py
@@ -1,0 +1,132 @@
+"""Trace-level token totals.
+
+One definition of "how many tokens did this trace use", shared by every read path
+so the traces list, the trace detail drawer, the test-run trace list and the
+project metrics endpoint can never disagree again.
+"""
+
+from typing import Optional, Sequence, Tuple
+
+from rhesis.backend.app.constants import AISpanAttributes, EnrichedDataKeys
+from rhesis.backend.app.models.trace import Trace
+
+# input, output, total
+TokenTotals = Tuple[int, int, int]
+
+ZERO_TOKENS: TokenTotals = (0, 0, 0)
+
+
+def token_totals_from_enriched(enriched_data: Optional[dict]) -> Optional[TokenTotals]:
+    """Trace-level input/output/total tokens from an enrichment blob.
+
+    Returns ``None`` when the trace has not been enriched yet, which the caller
+    should treat as "unknown" and fall back on — not as zero.
+
+    Any span of the trace works as the source: ``mark_trace_processed`` writes the
+    same trace-level blob onto every span row.
+    """
+    costs = (enriched_data or {}).get(EnrichedDataKeys.COSTS) or {}
+    if not costs:
+        return None
+
+    # A pre-existing enrichment blob predates the token fields; treat it as unknown
+    # so the caller falls back to the spans rather than reporting a confident zero.
+    if EnrichedDataKeys.TOTAL_TOKENS not in costs:
+        return None
+
+    return (
+        int(costs.get(EnrichedDataKeys.TOTAL_INPUT_TOKENS, 0) or 0),
+        int(costs.get(EnrichedDataKeys.TOTAL_OUTPUT_TOKENS, 0) or 0),
+        int(costs.get(EnrichedDataKeys.TOTAL_TOKENS, 0) or 0),
+    )
+
+
+def token_totals_from_spans(spans: Sequence[Trace]) -> TokenTotals:
+    """Sum tokens over a trace's ``llm.invoke`` spans.
+
+    The fallback for a trace whose enrichment has not run yet — it is dispatched
+    asynchronously after ingest, so a trace opened immediately has no enriched
+    data. The ``llm.invoke`` filter is the same one enrichment applies, which is
+    what keeps the two paths agreeing: pydantic-ai reports aggregated usage on the
+    agent-run span *and* per-call usage on its children, so summing every span
+    would roughly double the real figure.
+    """
+    totals = [0, 0, 0]
+    for span in spans:
+        attributes = span.attributes or {}
+        if attributes.get(AISpanAttributes.OPERATION_TYPE) != (
+            AISpanAttributes.OPERATION_LLM_INVOKE
+        ):
+            continue
+        input_tokens = int(attributes.get(AISpanAttributes.TOKENS_INPUT, 0) or 0)
+        output_tokens = int(attributes.get(AISpanAttributes.TOKENS_OUTPUT, 0) or 0)
+        reported_total = attributes.get(AISpanAttributes.TOKENS_TOTAL)
+        totals[0] += input_tokens
+        totals[1] += output_tokens
+        # Trust the reported total; Google ADK folds cache-read tokens into it, so
+        # deriving it from input + output would quietly discard those.
+        totals[2] += input_tokens + output_tokens if reported_total is None else int(reported_total)
+
+    return (totals[0], totals[1], totals[2])
+
+
+def trace_token_totals(spans: Sequence[Trace]) -> TokenTotals:
+    """Trace-level input/output/total tokens for a full span set.
+
+    Prefers the enrichment breakdown and falls back to the spans themselves when
+    enrichment has not run yet. Returns zeros for a trace with no LLM spans rather
+    than raising.
+    """
+    if not spans:
+        return ZERO_TOKENS
+
+    enriched = token_totals_from_enriched(spans[0].enriched_data)
+    if enriched is not None:
+        return enriched
+
+    return token_totals_from_spans(spans)
+
+
+def trace_cost_usd(enriched_data: Optional[dict]) -> float:
+    """Trace-level cost in USD, or 0.0 when the trace has not been enriched.
+
+    Unlike tokens, cost has no fallback: it cannot be derived from span attributes.
+    """
+    costs = (enriched_data or {}).get(EnrichedDataKeys.COSTS) or {}
+    return float(costs.get(EnrichedDataKeys.TOTAL_COST_USD, 0.0) or 0.0)
+
+
+def trace_summary_totals(
+    enriched_data: Optional[dict], llm_tokens_fallback: int
+) -> Tuple[int, int, int, float, float]:
+    """Token and cost totals for a trace list row.
+
+    Shared by the traces list and the test-run trace list, which build the same
+    ``TraceSummary`` from the same ``query_traces`` rows and each used to read
+    tokens off the root span alone -- a span that is usually not an LLM span, so
+    both reported zero.
+
+    A list row is one span, not the whole trace, so the span-set fallback is not
+    available here; ``llm_tokens_fallback`` is ``TraceRow.llm_tokens``, the same
+    figure computed in SQL. The input/output split stays zero before enrichment:
+    only the drawer shows it, and the drawer reads the detail endpoint, which has
+    the full span set.
+
+    Returns:
+        ``(input_tokens, output_tokens, total_tokens, cost_usd, cost_eur)``
+    """
+    costs = (enriched_data or {}).get(EnrichedDataKeys.COSTS) or {}
+
+    enriched = token_totals_from_enriched(enriched_data)
+    if enriched is None:
+        input_tokens, output_tokens, total_tokens = 0, 0, llm_tokens_fallback
+    else:
+        input_tokens, output_tokens, total_tokens = enriched
+
+    return (
+        input_tokens,
+        output_tokens,
+        total_tokens,
+        float(costs.get(EnrichedDataKeys.TOTAL_COST_USD, 0.0) or 0.0),
+        float(costs.get(EnrichedDataKeys.TOTAL_COST_EUR, 0.0) or 0.0),
+    )

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/token_totals.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/token_totals.py
@@ -64,8 +64,13 @@ def token_totals_from_spans(spans: Sequence[Trace]) -> TokenTotals:
         totals[0] += input_tokens
         totals[1] += output_tokens
         # Trust the reported total; Google ADK folds cache-read tokens into it, so
-        # deriving it from input + output would quietly discard those.
-        totals[2] += input_tokens + output_tokens if reported_total is None else int(reported_total)
+        # deriving it from input + output would quietly discard those. A zero total
+        # next to non-zero input or output is contradictory, so treat it as missing.
+        totals[2] += (
+            input_tokens + output_tokens
+            if reported_total is None or int(reported_total) == 0
+            else int(reported_total)
+        )
 
     return (totals[0], totals[1], totals[2])
 

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/tree_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/tree_builder.py
@@ -2,13 +2,16 @@
 Utility for building hierarchical span trees from flat span lists.
 """
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
+from rhesis.backend.app.constants import EnrichedDataKeys
 from rhesis.backend.app.models.trace import Trace
 from rhesis.backend.app.schemas.telemetry import SpanNode
 
 
-def build_span_tree(spans: List[Trace]) -> List[SpanNode]:
+def build_span_tree(
+    spans: List[Trace], cost_by_span_id: Optional[Dict[str, dict]] = None
+) -> List[SpanNode]:
     """
     Build hierarchical span tree from flat span list.
 
@@ -18,6 +21,8 @@ def build_span_tree(spans: List[Trace]) -> List[SpanNode]:
 
     Args:
         spans: List of Trace models from database
+        cost_by_span_id: Per-span cost breakdown from enrichment, keyed by span_id.
+            Absent for a trace that has not been enriched yet.
 
     Returns:
         List of root SpanNode objects with children populated recursively
@@ -47,9 +52,11 @@ def build_span_tree(spans: List[Trace]) -> List[SpanNode]:
 
     # Create span map for O(1) lookup
     span_map: Dict[str, SpanNode] = {}
+    costs = cost_by_span_id or {}
 
     # Convert all spans to SpanNode objects
     for span in spans:
+        span_cost = costs.get(span.span_id) or {}
         node = SpanNode(
             id=str(span.id),
             span_id=span.span_id,
@@ -61,6 +68,8 @@ def build_span_tree(spans: List[Trace]) -> List[SpanNode]:
             status_code=span.status_code,
             status_message=span.status_message,
             attributes=span.attributes or {},
+            cost_usd=span_cost.get(EnrichedDataKeys.TOTAL_COST_USD),
+            model_name=span_cost.get(EnrichedDataKeys.MODEL_NAME),
             events=span.events or [],
             trace_metrics=span.trace_metrics,
             # server_default only lands at INSERT, so a span that has not

--- a/apps/frontend/src/app/(protected)/traces/components/SpanDetailsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/SpanDetailsPanel.tsx
@@ -31,6 +31,7 @@ import FileAttachmentList from '@/components/common/FileAttachmentList';
 import { MentionOption } from '@/components/common/MentionTextInput';
 import { format } from 'date-fns';
 import { formatDuration } from '@/utils/format-duration';
+import { formatCost, formatTokenCount, spanUsage } from '@/utils/trace-utils';
 import TestResultTab from './TestResultTab';
 import TraceMetricsTab from './TraceMetricsTab';
 import TraceReviewsTab from './TraceReviewsTab';
@@ -316,12 +317,17 @@ export default function SpanDetailsPanel({
     ? parseIfJSON(String(agentOutput))
     : null;
 
-  // Filter out agent I/O from LLM attributes (displayed separately)
+  // Filter out agent I/O and token counts from LLM attributes (displayed separately)
   const {
     'ai.agent.input': _____,
     'ai.agent.output': ______,
+    'ai.llm.tokens.input': _______,
+    'ai.llm.tokens.output': ________,
+    'ai.llm.tokens.total': _________,
     ...otherLlmAttributes
   } = llmAttributes;
+
+  const usage = spanUsage(span);
 
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -437,6 +443,49 @@ export default function SpanDetailsPanel({
                       )}
                     </Box>
                   </Box>
+
+                  {/* Usage - omitted entirely for the tool and function spans
+                      that have neither tokens nor a cost. */}
+                  {usage && (
+                    <Box>
+                      <Typography variant="caption" color="text.secondary">
+                        Usage
+                      </Typography>
+                      <Stack
+                        direction="row"
+                        spacing={1}
+                        sx={{ mt: 0.5, flexWrap: 'wrap', rowGap: 1 }}
+                      >
+                        {usage.total > 0 && (
+                          <GridBadge
+                            size="detail"
+                            label={`${formatTokenCount(usage.total)} tokens`}
+                          />
+                        )}
+                        {usage.input > 0 && (
+                          <GridBadge
+                            size="detail"
+                            label={`${formatTokenCount(usage.input)} input`}
+                          />
+                        )}
+                        {usage.output > 0 && (
+                          <GridBadge
+                            size="detail"
+                            label={`${formatTokenCount(usage.output)} output`}
+                          />
+                        )}
+                        {usage.costUsd !== null && (
+                          <GridBadge
+                            size="detail"
+                            label={formatCost(usage.costUsd)}
+                          />
+                        )}
+                        {span.model_name && (
+                          <GridBadge size="detail" label={span.model_name} />
+                        )}
+                      </Stack>
+                    </Box>
+                  )}
                 </Stack>
               </CardContent>
             </Card>

--- a/apps/frontend/src/app/(protected)/traces/components/SpanDetailsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/SpanDetailsPanel.tsx
@@ -31,7 +31,11 @@ import FileAttachmentList from '@/components/common/FileAttachmentList';
 import { MentionOption } from '@/components/common/MentionTextInput';
 import { format } from 'date-fns';
 import { formatDuration } from '@/utils/format-duration';
-import { formatCost, formatTokenCount, spanUsage } from '@/utils/trace-utils';
+import {
+  formatCost,
+  formatTokenCount,
+  subtreeUsage,
+} from '@/utils/trace-utils';
 import TestResultTab from './TestResultTab';
 import TraceMetricsTab from './TraceMetricsTab';
 import TraceReviewsTab from './TraceReviewsTab';
@@ -327,7 +331,7 @@ export default function SpanDetailsPanel({
     ...otherLlmAttributes
   } = llmAttributes;
 
-  const usage = spanUsage(span);
+  const usage = subtreeUsage(span);
 
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -444,46 +448,39 @@ export default function SpanDetailsPanel({
                     </Box>
                   </Box>
 
-                  {/* Usage - omitted entirely for the tool and function spans
-                      that have neither tokens nor a cost. */}
+                  {/* Usage. Rolled up over the subtree, because only the
+                      ai.llm.invoke leaves carry token attributes and a container
+                      span would otherwise show nothing. */}
                   {usage && (
                     <Box>
                       <Typography variant="caption" color="text.secondary">
                         Usage
                       </Typography>
-                      <Stack
-                        direction="row"
-                        spacing={1}
-                        sx={{ mt: 0.5, flexWrap: 'wrap', rowGap: 1 }}
+                      <Typography
+                        variant="caption"
+                        display="block"
+                        sx={{ mt: 0.5 }}
                       >
-                        {usage.total > 0 && (
-                          <GridBadge
-                            size="detail"
-                            label={`${formatTokenCount(usage.total)} tokens`}
-                          />
-                        )}
-                        {usage.input > 0 && (
-                          <GridBadge
-                            size="detail"
-                            label={`${formatTokenCount(usage.input)} input`}
-                          />
-                        )}
-                        {usage.output > 0 && (
-                          <GridBadge
-                            size="detail"
-                            label={`${formatTokenCount(usage.output)} output`}
-                          />
-                        )}
-                        {usage.costUsd !== null && (
-                          <GridBadge
-                            size="detail"
-                            label={formatCost(usage.costUsd)}
-                          />
-                        )}
-                        {span.model_name && (
-                          <GridBadge size="detail" label={span.model_name} />
-                        )}
-                      </Stack>
+                        Tokens: {formatTokenCount(usage.total)}
+                        {(usage.input > 0 || usage.output > 0) &&
+                          ` (${formatTokenCount(usage.input)} input \u00b7 ${formatTokenCount(usage.output)} output)`}
+                      </Typography>
+                      {usage.costUsd !== null && (
+                        <Typography variant="caption" display="block">
+                          Cost: {formatCost(usage.costUsd)}
+                        </Typography>
+                      )}
+                      {usage.llmSpanCount > 0 && (
+                        <Typography variant="caption" display="block">
+                          Rolled up from {usage.llmSpanCount} LLM{' '}
+                          {usage.llmSpanCount === 1 ? 'span' : 'spans'}
+                        </Typography>
+                      )}
+                      {span.model_name && (
+                        <Typography variant="caption" display="block">
+                          Model: {span.model_name}
+                        </Typography>
+                      )}
                     </Box>
                   )}
                 </Stack>

--- a/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
@@ -25,6 +25,11 @@ import {
   toMentionId,
 } from '@/components/common/MentionTextInput';
 import { formatDuration } from '@/utils/format-duration';
+import {
+  formatCost,
+  formatTokenCount,
+  tokenSplitLabel,
+} from '@/utils/trace-utils';
 import { shortVersion } from '@/utils/api-client/interfaces/parameters';
 import { experimentHref } from '@/utils/experiment-links';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
@@ -603,6 +608,21 @@ export default function TraceDrawer({
             <GridBadge label={`${trace.span_count} spans`} size="grid" />
             <GridBadge label={formatDuration(trace.duration_ms)} size="grid" />
             <GridBadge label={trace.environment} size="grid" />
+            {trace.total_tokens > 0 && (
+              <GridBadge
+                label={`${formatTokenCount(trace.total_tokens)} tokens`}
+                size="grid"
+                // Native title rather than MUI Tooltip: GridBadge is not a
+                // forwardRef component, so Tooltip cannot anchor to it.
+                title={tokenSplitLabel(
+                  trace.total_input_tokens,
+                  trace.total_output_tokens
+                )}
+              />
+            )}
+            {trace.total_cost_usd > 0 && (
+              <GridBadge label={formatCost(trace.total_cost_usd)} size="grid" />
+            )}
             {trace.error_count > 0 && (
               <GridBadge
                 label={`${trace.error_count} errors`}

--- a/apps/frontend/src/app/(protected)/traces/components/TraceMetricsSummary.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceMetricsSummary.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Box, Grid, Typography } from '@mui/material';
+import AccountTreeIcon from '@mui/icons-material/AccountTree';
+import LayersIcon from '@mui/icons-material/Layers';
+import PaidIcon from '@mui/icons-material/Paid';
+import TokenIcon from '@mui/icons-material/Token';
+import { SummaryCard } from '@/components/common/SummaryCard';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import type { TraceMetricsResponse } from '@/utils/api-client/interfaces/telemetry';
+import { formatCost, formatTokenCount } from '@/utils/trace-utils';
+
+interface TraceMetricsSummaryProps {
+  projectId: string | null;
+  environment?: string;
+  startTimeAfter?: string;
+  startTimeBefore?: string;
+  /**
+   * True when a filter the metrics endpoint cannot honor is active (endpoint,
+   * trace source, evaluation status, search, ...). The tiles then cover more
+   * traces than the table lists, and say so rather than appearing to disagree.
+   */
+  hasUnsupportedFilters?: boolean;
+  /** Bumped by the refresh control, to re-fetch alongside the table. */
+  refreshTrigger?: number;
+}
+
+/**
+ * Project-level totals above the traces table.
+ *
+ * Fetched with useEffect rather than react-query: the traces page has no query
+ * cache (useList/usePaginatedList are hand-rolled), so there would be no key to
+ * invalidate. Mirrors how TraceDrawer fetches a single trace.
+ */
+export default function TraceMetricsSummary({
+  projectId,
+  environment,
+  startTimeAfter,
+  startTimeBefore,
+  hasUnsupportedFilters = false,
+  refreshTrigger,
+}: TraceMetricsSummaryProps) {
+  const [metrics, setMetrics] = useState<TraceMetricsResponse | null>(null);
+
+  useEffect(() => {
+    if (!projectId) {
+      setMetrics(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const client = new ApiClientFactory(
+          undefined,
+          projectId
+        ).getTelemetryClient();
+        const result = await client.getMetrics({
+          project_id: projectId,
+          ...(environment ? { environment } : {}),
+          ...(startTimeAfter ? { start_time_after: startTimeAfter } : {}),
+          ...(startTimeBefore ? { start_time_before: startTimeBefore } : {}),
+        });
+        if (!cancelled) {
+          setMetrics(result);
+        }
+      } catch {
+        // The tiles are supplementary; a failure here must not take the table
+        // down with it, and the table surfaces its own errors.
+        if (!cancelled) {
+          setMetrics(null);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, environment, startTimeAfter, startTimeBefore, refreshTrigger]);
+
+  if (!metrics) {
+    return null;
+  }
+
+  const scope = hasUnsupportedFilters
+    ? 'Whole project, not narrowed by the active filters'
+    : undefined;
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      <Grid container spacing={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <SummaryCard
+            title="Traces"
+            value={metrics.total_traces.toLocaleString()}
+            subtitle={scope}
+            icon={<AccountTreeIcon />}
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <SummaryCard
+            title="Spans"
+            value={metrics.total_spans.toLocaleString()}
+            subtitle={scope}
+            icon={<LayersIcon />}
+            color="info"
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <SummaryCard
+            title="Tokens"
+            value={formatTokenCount(metrics.total_tokens)}
+            subtitle={scope}
+            icon={<TokenIcon />}
+            color="success"
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <SummaryCard
+            title="Cost"
+            value={formatCost(metrics.total_cost_usd)}
+            subtitle={scope}
+            icon={<PaidIcon />}
+            color="warning"
+          />
+        </Grid>
+      </Grid>
+      {hasUnsupportedFilters && (
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ display: 'block', mt: 1 }}
+        >
+          Totals cover the whole project for the selected environment and time
+          range. The table below is narrowed further by the active filters.
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
@@ -5,12 +5,14 @@ import { useRouter, usePathname } from 'next/navigation';
 import { Alert, Box, Typography } from '@mui/material';
 import TracesTable from './TracesTable';
 import TraceDrawer from './TraceDrawer';
+import TraceMetricsSummary from './TraceMetricsSummary';
 import { useList } from '@/hooks/useList';
 import { tracesList } from './list';
 import type { TraceSummary } from '@/utils/api-client/interfaces/telemetry';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { readActiveProjectId } from '@/utils/active-project';
 import {
+  buildTraceQueryParams,
   EMPTY_TRACE_DRAWER_FILTERS,
   hasActiveTraceDrawerFilters,
   sanitizeTraceDrawerFiltersForTestRunScope,
@@ -192,6 +194,26 @@ export default function TracesClient({
   const showFilteredEmpty =
     !listLoading && traces.length === 0 && totalCount === 0;
 
+  // GET /telemetry/metrics only narrows by project, environment and time, so any
+  // other active filter makes the rollup broader than the listed rows. Tell it,
+  // rather than letting the two silently disagree.
+  const rollupProjectId = drawerFilters.projectId || scopedProjectId;
+  const hasUnsupportedRollupFilters = Boolean(
+    searchQuery.trim() ||
+    (typeFilter && typeFilter !== 'all') ||
+    drawerFilters.endpointId ||
+    drawerFilters.traceSource ||
+    drawerFilters.traceMetricsStatus ||
+    drawerFilters.testRunId ||
+    drawerFilters.testResultId ||
+    drawerFilters.testId ||
+    fixedTestRunId
+  );
+  const rollupTimeParams = useMemo(
+    () => buildTraceQueryParams(drawerFilters, '', 'all'),
+    [drawerFilters]
+  );
+
   return (
     <>
       {error && (
@@ -199,6 +221,15 @@ export default function TracesClient({
           {error}
         </Alert>
       )}
+
+      <TraceMetricsSummary
+        projectId={rollupProjectId}
+        environment={drawerFilters.environment ?? undefined}
+        startTimeAfter={rollupTimeParams.start_time_after}
+        startTimeBefore={rollupTimeParams.start_time_before}
+        hasUnsupportedFilters={hasUnsupportedRollupFilters}
+        refreshTrigger={refreshTrigger}
+      />
 
       <TracesTable
         traces={traces}

--- a/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
@@ -114,6 +114,8 @@ export default function TracesClient({
     rowsPerPage: pageSize,
     onPageChange,
     onRowsPerPageChange,
+    sortModel,
+    onSortModelChange,
   } = useList(descriptor, {
     filters,
     enabled: !projectLoading && !!scopedProjectId,
@@ -256,6 +258,8 @@ export default function TracesClient({
           onFilterDrawerOpen={() => setFilterDrawerOpen(true)}
           onFilterDrawerClose={() => setFilterDrawerOpen(false)}
           fixedTestRunId={fixedTestRunId}
+          sortModel={sortModel}
+          onSortModelChange={onSortModelChange}
         />
 
         {showFilteredEmpty && (

--- a/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
-import { Alert, Box, Typography } from '@mui/material';
+import { Alert, Box, Paper, Typography } from '@mui/material';
+import { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
 import TracesTable from './TracesTable';
 import TraceDrawer from './TraceDrawer';
 import TraceMetricsSummary from './TraceMetricsSummary';
@@ -206,8 +207,7 @@ export default function TracesClient({
     drawerFilters.traceMetricsStatus ||
     drawerFilters.testRunId ||
     drawerFilters.testResultId ||
-    drawerFilters.testId ||
-    fixedTestRunId
+    drawerFilters.testId
   );
   const rollupTimeParams = useMemo(
     () => buildTraceQueryParams(drawerFilters, '', 'all'),
@@ -216,53 +216,60 @@ export default function TracesClient({
 
   return (
     <>
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
-          {error}
-        </Alert>
+      {/* Project totals sit above the grid card, not inside it. Skipped on a test
+          run's Traces tab: the metrics endpoint cannot filter by test run, so the
+          tiles there would count the whole project next to a dozen listed rows. */}
+      {!fixedTestRunId && (
+        <TraceMetricsSummary
+          projectId={rollupProjectId}
+          environment={drawerFilters.environment ?? undefined}
+          startTimeAfter={rollupTimeParams.start_time_after}
+          startTimeBefore={rollupTimeParams.start_time_before}
+          hasUnsupportedFilters={hasUnsupportedRollupFilters}
+          refreshTrigger={refreshTrigger}
+        />
       )}
 
-      <TraceMetricsSummary
-        projectId={rollupProjectId}
-        environment={drawerFilters.environment ?? undefined}
-        startTimeAfter={rollupTimeParams.start_time_after}
-        startTimeBefore={rollupTimeParams.start_time_before}
-        hasUnsupportedFilters={hasUnsupportedRollupFilters}
-        refreshTrigger={refreshTrigger}
-      />
+      <Paper sx={GRID_PAPER_SX}>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
+            {error}
+          </Alert>
+        )}
 
-      <TracesTable
-        traces={traces}
-        loading={listLoading}
-        onRowClick={handleRowClick}
-        totalCount={totalCount}
-        page={page}
-        pageSize={pageSize}
-        onPageChange={onPageChange}
-        onPageSizeChange={onRowsPerPageChange}
-        searchQuery={searchQuery}
-        onSearchQueryChange={setSearchQuery}
-        typeFilter={typeFilter}
-        onTypeFilterChange={setTypeFilter}
-        drawerFilters={drawerFilters}
-        onApplyDrawerFilters={handleApplyDrawerFilters}
-        filterDrawerOpen={filterDrawerOpen}
-        onFilterDrawerOpen={() => setFilterDrawerOpen(true)}
-        onFilterDrawerClose={() => setFilterDrawerOpen(false)}
-        fixedTestRunId={fixedTestRunId}
-      />
+        <TracesTable
+          traces={traces}
+          loading={listLoading}
+          onRowClick={handleRowClick}
+          totalCount={totalCount}
+          page={page}
+          pageSize={pageSize}
+          onPageChange={onPageChange}
+          onPageSizeChange={onRowsPerPageChange}
+          searchQuery={searchQuery}
+          onSearchQueryChange={setSearchQuery}
+          typeFilter={typeFilter}
+          onTypeFilterChange={setTypeFilter}
+          drawerFilters={drawerFilters}
+          onApplyDrawerFilters={handleApplyDrawerFilters}
+          filterDrawerOpen={filterDrawerOpen}
+          onFilterDrawerOpen={() => setFilterDrawerOpen(true)}
+          onFilterDrawerClose={() => setFilterDrawerOpen(false)}
+          fixedTestRunId={fixedTestRunId}
+        />
 
-      {showFilteredEmpty && (
-        <Box sx={{ py: 6, textAlign: 'center' }}>
-          <Typography variant="h6" gutterBottom>
-            No traces found
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Try adjusting your filters or check back after running tests or
-            invoking endpoints.
-          </Typography>
-        </Box>
-      )}
+        {showFilteredEmpty && (
+          <Box sx={{ py: 6, textAlign: 'center' }}>
+            <Typography variant="h6" gutterBottom>
+              No traces found
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Try adjusting your filters or check back after running tests or
+              invoking endpoints.
+            </Typography>
+          </Box>
+        )}
+      </Paper>
 
       <TraceDrawer
         open={drawerOpen}

--- a/apps/frontend/src/app/(protected)/traces/components/TracesClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClientWrapper.tsx
@@ -3,14 +3,13 @@
 import React, { useCallback, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
-import { Alert, Box, Paper } from '@mui/material';
+import { Alert, Box } from '@mui/material';
 import RefreshOutlinedIcon from '@mui/icons-material/RefreshOutlined';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import TimelineOutlinedIcon from '@mui/icons-material/TimelineOutlined';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import TracesClient from './TracesClient';
 import type { TraceSummary } from '@/utils/api-client/interfaces/telemetry';
 import AccessDenied from '@/components/common/AccessDenied';
@@ -118,27 +117,19 @@ export default function TracesClientWrapper({
               : {}
           }
         >
-          <Paper
-            sx={{
-              width: '100%',
-              borderRadius: BORDER_RADIUS.md,
-              boxShadow: ELEVATION.xs,
-              border: theme => `1px solid ${theme.palette.greyscale.border}`,
-              overflow: 'hidden',
-            }}
-          >
-            <TracesClient
-              currentUserId={currentUserId}
-              currentUserName={currentUserName}
-              currentUserPicture={currentUserPicture}
-              initialTraceId={initialTraceId}
-              initialProjectId={initialProjectId}
-              onUnfilteredEmpty={handleUnfilteredEmpty}
-              refreshTrigger={refreshTrigger}
-              initialData={initialData}
-              initialTotalCount={initialTotalCount}
-            />
-          </Paper>
+          {/* The grid card lives inside TracesClient, so the rollup tiles can sit
+              above it rather than inside it. */}
+          <TracesClient
+            currentUserId={currentUserId}
+            currentUserName={currentUserName}
+            currentUserPicture={currentUserPicture}
+            initialTraceId={initialTraceId}
+            initialProjectId={initialProjectId}
+            onUnfilteredEmpty={handleUnfilteredEmpty}
+            refreshTrigger={refreshTrigger}
+            initialData={initialData}
+            initialTotalCount={initialTotalCount}
+          />
         </Box>
         {showEmptyHint && (
           <EntityEmptyState

--- a/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
@@ -21,6 +21,7 @@ import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
 import { isPassedStatusName } from '@/utils/test-result-status';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { formatDuration } from '@/utils/format-duration';
+import { formatCost, formatTokenCount } from '@/utils/trace-utils';
 import { formatDate } from '@/utils/date';
 import { TEST_TYPE_PILL_TABS } from '@/constants/test-types';
 import TraceFilterDrawer, {
@@ -291,6 +292,35 @@ export default function TracesTable({
         flex: 0.8,
         minWidth: 60,
         align: 'center',
+      },
+      // Not sortable: this grid paginates server-side but sorts client-side, and
+      // list.ts drops sort_by/sort_order before calling the API -- so a sortable
+      // Tokens or Cost header would silently reorder the current page only.
+      {
+        field: 'total_tokens',
+        headerName: 'Tokens',
+        flex: 1,
+        minWidth: 70,
+        align: 'right',
+        sortable: false,
+        renderCell: params => (
+          <Typography variant="body2">
+            {params.value ? formatTokenCount(params.value as number) : '\u2014'}
+          </Typography>
+        ),
+      },
+      {
+        field: 'total_cost_usd',
+        headerName: 'Cost',
+        flex: 1,
+        minWidth: 70,
+        align: 'right',
+        sortable: false,
+        renderCell: params => (
+          <Typography variant="body2">
+            {params.value ? formatCost(params.value as number) : '\u2014'}
+          </Typography>
+        ),
       },
       {
         field: 'trace_metrics_status',

--- a/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
@@ -3,6 +3,7 @@
 import React, { useContext, useMemo } from 'react';
 import {
   GridColDef,
+  GridSortModel,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
   GridToolbarExport,
@@ -21,7 +22,11 @@ import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
 import { isPassedStatusName } from '@/utils/test-result-status';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { formatDuration } from '@/utils/format-duration';
-import { formatCost, formatTokenCount } from '@/utils/trace-utils';
+import {
+  formatCost,
+  formatTokenCount,
+  tokenSplitLabel,
+} from '@/utils/trace-utils';
 import { formatDate } from '@/utils/date';
 import { TEST_TYPE_PILL_TABS } from '@/constants/test-types';
 import TraceFilterDrawer, {
@@ -116,6 +121,8 @@ interface TracesTableProps {
   onFilterDrawerOpen: () => void;
   onFilterDrawerClose: () => void;
   fixedTestRunId?: string;
+  sortModel?: GridSortModel;
+  onSortModelChange?: (model: GridSortModel) => void;
 }
 
 export default function TracesTable({
@@ -137,6 +144,8 @@ export default function TracesTable({
   onFilterDrawerOpen,
   onFilterDrawerClose,
   fixedTestRunId,
+  sortModel,
+  onSortModelChange,
 }: TracesTableProps) {
   const hasActiveDrawerFilters = hasActiveTraceDrawerFilters(drawerFilters, {
     testRunScope: Boolean(fixedTestRunId),
@@ -200,6 +209,8 @@ export default function TracesTable({
       },
       {
         field: 'conversation_input',
+        // a JSONB span attribute, so the backend cannot order by it.
+        sortable: false,
         headerName: 'Input',
         flex: 3.2,
         minWidth: 160,
@@ -234,6 +245,8 @@ export default function TracesTable({
       },
       {
         field: 'endpoint_name',
+        // three joins away, so the backend cannot order by it.
+        sortable: false,
         headerName: 'Endpoint',
         flex: 1.8,
         minWidth: 100,
@@ -293,18 +306,22 @@ export default function TracesTable({
         minWidth: 60,
         align: 'center',
       },
-      // Not sortable: this grid paginates server-side but sorts client-side, and
-      // list.ts drops sort_by/sort_order before calling the API -- so a sortable
-      // Tokens or Cost header would silently reorder the current page only.
       {
         field: 'total_tokens',
         headerName: 'Tokens',
         flex: 1,
         minWidth: 70,
         align: 'right',
-        sortable: false,
         renderCell: params => (
-          <Typography variant="body2">
+          <Typography
+            variant="body2"
+            // Native title: the split is already on the row, and the drawer shows
+            // the same breakdown on its token chip.
+            title={tokenSplitLabel(
+              params.row.total_input_tokens,
+              params.row.total_output_tokens
+            )}
+          >
             {params.value ? formatTokenCount(params.value as number) : '\u2014'}
           </Typography>
         ),
@@ -315,7 +332,6 @@ export default function TracesTable({
         flex: 1,
         minWidth: 70,
         align: 'right',
-        sortable: false,
         renderCell: params => (
           <Typography variant="body2">
             {params.value ? formatCost(params.value as number) : '\u2014'}
@@ -324,6 +340,8 @@ export default function TracesTable({
       },
       {
         field: 'trace_metrics_status',
+        // a relationship, not a column, so the backend cannot order by it.
+        sortable: false,
         headerName: 'Evaluation',
         flex: 1.4,
         minWidth: 100,
@@ -440,11 +458,14 @@ export default function TracesTable({
         }}
         pageSizeOptions={[25, 50, 100]}
         disablePaperWrapper
+        sortingMode="server"
+        sortModel={sortModel}
+        onSortModelChange={onSortModelChange}
         toolbarSlot={() => (
           <TracesUnifiedToolbar hideTypeFilter={Boolean(fixedTestRunId)} />
         )}
         persistState
-        storageKey="traces-grid"
+        storageKey="traces-grid-v2"
         sx={{
           '& .MuiDataGrid-row': {
             cursor: 'pointer',

--- a/apps/frontend/src/app/(protected)/traces/components/list.ts
+++ b/apps/frontend/src/app/(protected)/traces/components/list.ts
@@ -46,6 +46,8 @@ export function tracesList(
     resource: 'traces',
     capability: Capability.Telemetry.READ,
     defaultPageSize: 50,
+    // The shared default is created_at, which this endpoint does not sort by.
+    defaultSort: { by: 'start_time', order: 'desc' },
     filters: TRACES_FILTERS,
     extraParams: f => {
       const { search, typeFilter, ...drawer } = f;
@@ -60,18 +62,18 @@ export function tracesList(
       return params;
     },
     list: async (_factory, params) => {
-      const {
-        skip,
-        limit,
-        sort_by: _sortBy,
-        sort_order: _sortOrder,
-        ...rest
-      } = params;
+      const { skip, limit, sort_by, sort_order, ...rest } = params;
       const response = await (
         factory ?? new ApiClientFactory(undefined, scopedProjectId ?? undefined)
       )
         .getTelemetryClient()
-        .listTraces({ ...rest, limit, offset: skip });
+        .listTraces({
+          ...rest,
+          limit,
+          offset: skip,
+          sort_by,
+          sort_order: sort_order as 'asc' | 'desc' | undefined,
+        });
       return {
         data: response.traces,
         pagination: {

--- a/apps/frontend/src/utils/__tests__/trace-utils.test.ts
+++ b/apps/frontend/src/utils/__tests__/trace-utils.test.ts
@@ -14,7 +14,10 @@ import {
   getTreeDepth,
   formatTraceDate,
   getStatusChipProps,
+  spanUsage,
+  tokenSplitLabel,
 } from '../trace-utils';
+import type { SpanNode } from '../api-client/interfaces/telemetry';
 
 describe('trace-utils', () => {
   describe('formatDurationShort', () => {
@@ -121,6 +124,102 @@ describe('trace-utils', () => {
     it('formats numbers with thousands separator', () => {
       expect(formatTokenCount(1000)).toContain('1');
       expect(formatTokenCount(10000)).toContain('10');
+    });
+  });
+
+  describe('spanUsage', () => {
+    const span = (
+      attributes: Record<string, string | number | boolean>,
+      costUsd?: number | null
+    ) =>
+      ({
+        span_id: 'a',
+        span_name: 'ai.llm.invoke',
+        span_kind: 'CLIENT',
+        start_time: '2026-01-01T00:00:00Z',
+        end_time: '2026-01-01T00:00:01Z',
+        duration_ms: 1000,
+        status_code: 'OK',
+        attributes,
+        cost_usd: costUsd,
+        events: [],
+        children: [],
+        execution: 'completed',
+        verdict: null,
+      }) as unknown as SpanNode;
+
+    it('returns null for a span with neither tokens nor cost', () => {
+      expect(spanUsage(span({ 'ai.tool.name': 'search' }))).toBeNull();
+    });
+
+    it('reads the token counts off the attributes', () => {
+      expect(
+        spanUsage(
+          span({
+            'ai.llm.tokens.input': 100,
+            'ai.llm.tokens.output': 50,
+            'ai.llm.tokens.total': 150,
+          })
+        )
+      ).toEqual({ input: 100, output: 50, total: 150, costUsd: null });
+    });
+
+    it('trusts the reported total over input + output', () => {
+      // Google ADK folds cache-read tokens into the total it reports.
+      const usage = spanUsage(
+        span({
+          'ai.llm.tokens.input': 100,
+          'ai.llm.tokens.output': 50,
+          'ai.llm.tokens.total': 950,
+        })
+      );
+
+      expect(usage?.total).toBe(950);
+    });
+
+    it('derives the total when none is reported', () => {
+      const usage = spanUsage(
+        span({ 'ai.llm.tokens.input': 100, 'ai.llm.tokens.output': 50 })
+      );
+
+      expect(usage?.total).toBe(150);
+    });
+
+    it('reports a cost-only span, for an unpriced-token edge case', () => {
+      expect(spanUsage(span({}, 0.0042))).toEqual({
+        input: 0,
+        output: 0,
+        total: 0,
+        costUsd: 0.0042,
+      });
+    });
+
+    it('treats a zero or absent cost as no cost', () => {
+      expect(
+        spanUsage(span({ 'ai.llm.tokens.total': 10 }, 0))?.costUsd
+      ).toBeNull();
+      expect(
+        spanUsage(span({ 'ai.llm.tokens.total': 10 }, null))?.costUsd
+      ).toBeNull();
+    });
+
+    it('ignores non-numeric attribute values', () => {
+      expect(spanUsage(span({ 'ai.llm.tokens.total': 'lots' }))).toBeNull();
+    });
+  });
+
+  describe('tokenSplitLabel', () => {
+    it('labels the two figures without implying they sum to the total', () => {
+      expect(tokenSplitLabel(1204, 318)).toBe('1,204 input \u00b7 318 output');
+    });
+
+    it('returns undefined when neither figure is known', () => {
+      expect(tokenSplitLabel(0, 0)).toBeUndefined();
+      expect(tokenSplitLabel(null, undefined)).toBeUndefined();
+    });
+
+    it('still labels when only one figure is known', () => {
+      expect(tokenSplitLabel(100, 0)).toBe('100 input \u00b7 0 output');
     });
   });
 

--- a/apps/frontend/src/utils/__tests__/trace-utils.test.ts
+++ b/apps/frontend/src/utils/__tests__/trace-utils.test.ts
@@ -15,6 +15,7 @@ import {
   formatTraceDate,
   getStatusChipProps,
   spanUsage,
+  subtreeUsage,
   tokenSplitLabel,
 } from '../trace-utils';
 import type { SpanNode } from '../api-client/interfaces/telemetry';
@@ -205,6 +206,113 @@ describe('trace-utils', () => {
 
     it('ignores non-numeric attribute values', () => {
       expect(spanUsage(span({ 'ai.llm.tokens.total': 'lots' }))).toBeNull();
+    });
+  });
+
+  describe('subtreeUsage', () => {
+    const llmSpan = (
+      id: string,
+      input: number,
+      output: number,
+      total: number,
+      costUsd?: number
+    ) =>
+      ({
+        span_id: id,
+        span_name: 'ai.llm.invoke',
+        span_kind: 'CLIENT',
+        start_time: '2026-01-01T00:00:00Z',
+        end_time: '2026-01-01T00:00:01Z',
+        duration_ms: 1000,
+        status_code: 'OK',
+        attributes: {
+          'ai.operation.type': 'llm.invoke',
+          'ai.llm.tokens.input': input,
+          'ai.llm.tokens.output': output,
+          'ai.llm.tokens.total': total,
+        },
+        cost_usd: costUsd,
+        events: [],
+        children: [],
+        execution: 'completed',
+        verdict: null,
+      }) as unknown as SpanNode;
+
+    const container = (id: string, children: SpanNode[]) =>
+      ({
+        span_id: id,
+        span_name: 'function.haystack.pipeline.run',
+        span_kind: 'INTERNAL',
+        start_time: '2026-01-01T00:00:00Z',
+        end_time: '2026-01-01T00:00:01Z',
+        duration_ms: 1000,
+        status_code: 'OK',
+        attributes: {},
+        events: [],
+        children,
+        execution: 'completed',
+        verdict: null,
+      }) as unknown as SpanNode;
+
+    it('reports a leaf span own usage, with no rollup count', () => {
+      const usage = subtreeUsage(llmSpan('a', 100, 50, 150, 0.002));
+
+      expect(usage).toEqual({
+        input: 100,
+        output: 50,
+        total: 150,
+        costUsd: 0.002,
+        llmSpanCount: 0,
+      });
+    });
+
+    it('sums descendants for a container span that has none of its own', () => {
+      // The Haystack shape: only the ai.llm.invoke leaves carry tokens.
+      const tree = container('root', [
+        container('step-1', [llmSpan('a', 100, 50, 150, 0.002)]),
+        container('step-2', [llmSpan('b', 200, 70, 270, 0.004)]),
+      ]);
+
+      expect(subtreeUsage(tree)).toEqual({
+        input: 300,
+        output: 120,
+        total: 420,
+        costUsd: 0.006,
+        llmSpanCount: 2,
+      });
+    });
+
+    it('returns null for a subtree with no LLM spans anywhere', () => {
+      const tree = container('root', [container('tool', [])]);
+
+      expect(subtreeUsage(tree)).toBeNull();
+    });
+
+    it('keeps a reported total larger than input plus output', () => {
+      // ADK folds cache-read tokens into the total, so the rollup must sum each
+      // node's reported total rather than recomputing it from the split.
+      const tree = container('root', [llmSpan('adk', 100, 50, 950)]);
+
+      const usage = subtreeUsage(tree);
+
+      expect(usage?.total).toBe(950);
+      expect(usage?.input).toBe(100);
+      expect(usage?.output).toBe(50);
+    });
+
+    it('leaves cost null when nothing in the subtree is priced', () => {
+      const tree = container('root', [llmSpan('a', 100, 50, 150)]);
+
+      expect(subtreeUsage(tree)?.costUsd).toBeNull();
+    });
+
+    it('counts only the spans that actually contributed', () => {
+      const tree = container('root', [
+        llmSpan('a', 100, 50, 150),
+        container('tool', []),
+      ]);
+
+      expect(subtreeUsage(tree)?.llmSpanCount).toBe(1);
     });
   });
 

--- a/apps/frontend/src/utils/api-client/interfaces/telemetry.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/telemetry.ts
@@ -79,6 +79,9 @@ export interface SpanNode {
   status_code: string;
   status_message?: string;
   attributes: Record<string, string | number | boolean>;
+  /** Priced by enrichment; absent until a trace has been enriched. */
+  cost_usd?: number | null;
+  model_name?: string | null;
   events: SpanEvent[];
   children: SpanNode[];
   trace_metrics?: Record<string, unknown>;
@@ -101,6 +104,13 @@ export interface TraceSummary {
   duration_ms: number;
   span_count: number;
   root_operation: string;
+
+  // Token usage and cost. Summed over the trace's llm.invoke spans, so a trace with
+  // no LLM spans omits them rather than reporting zero.
+  total_tokens?: number | null;
+  total_input_tokens?: number | null;
+  total_output_tokens?: number | null;
+  total_cost_usd?: number | null;
 
   // Endpoint information (optional)
   endpoint_id?: string;
@@ -128,6 +138,14 @@ export interface TraceDetailResponse {
   duration_ms: number;
   span_count: number;
   error_count: number;
+
+  // Token usage and cost across the trace's llm.invoke spans. The detail endpoint
+  // has the whole span set, so unlike TraceSummary it always resolves the split.
+  total_tokens: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cost_usd: number;
+
   root_spans: SpanNode[];
 
   // Trace metrics evaluation. execution/verdict are the source of truth

--- a/apps/frontend/src/utils/api-client/interfaces/telemetry.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/telemetry.ts
@@ -226,6 +226,8 @@ export interface TraceQueryParams {
   trace_metrics_status?: TraceMetricsStatus;
   limit?: number;
   offset?: number;
+  sort_by?: string;
+  sort_order?: 'asc' | 'desc';
 }
 
 /**

--- a/apps/frontend/src/utils/trace-utils.ts
+++ b/apps/frontend/src/utils/trace-utils.ts
@@ -94,6 +94,66 @@ export function formatTokenCount(tokens: number): string {
   return tokens.toLocaleString();
 }
 
+export interface SpanUsage {
+  input: number;
+  output: number;
+  total: number;
+  costUsd: number | null;
+}
+
+/**
+ * Token counts and cost for one span, or null when it has neither.
+ *
+ * Tokens come off the raw span attributes; cost comes from `cost_usd`, which the
+ * backend fills in from the enrichment breakdown -- the attributes never carry a
+ * price. Most spans (tool calls, function spans) have neither, and an empty
+ * "Usage" block on every span is noise, hence the null.
+ */
+export function spanUsage(span: SpanNode): SpanUsage | null {
+  const attrs = span.attributes ?? {};
+  const asCount = (value: unknown): number => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  };
+
+  const input = asCount(attrs['ai.llm.tokens.input']);
+  const output = asCount(attrs['ai.llm.tokens.output']);
+  // Reported rather than derived: Google ADK folds cache-read tokens into its
+  // total, so input + output can fall short of it.
+  const reportedTotal = asCount(attrs['ai.llm.tokens.total']);
+  const total = reportedTotal > 0 ? reportedTotal : input + output;
+  const costUsd =
+    typeof span.cost_usd === 'number' && span.cost_usd > 0
+      ? span.cost_usd
+      : null;
+
+  if (total === 0 && costUsd === null) {
+    return null;
+  }
+
+  return { input, output, total, costUsd };
+}
+
+/**
+ * Input/output tokens as two separate figures, deliberately not presented as a
+ * breakdown of the total: Google ADK folds cache-read tokens into the total it
+ * reports, so input + output legitimately falls short of it.
+ *
+ * Returns undefined when neither figure is known, so the caller renders no
+ * tooltip rather than an empty one.
+ */
+export function tokenSplitLabel(
+  inputTokens: number | null | undefined,
+  outputTokens: number | null | undefined
+): string | undefined {
+  const input = inputTokens ?? 0;
+  const output = outputTokens ?? 0;
+  if (input === 0 && output === 0) {
+    return undefined;
+  }
+  return `${formatTokenCount(input)} input \u00b7 ${formatTokenCount(output)} output`;
+}
+
 /**
  * Get span type from span name
  * Returns human-readable type label

--- a/apps/frontend/src/utils/trace-utils.ts
+++ b/apps/frontend/src/utils/trace-utils.ts
@@ -135,6 +135,51 @@ export function spanUsage(span: SpanNode): SpanUsage | null {
 }
 
 /**
+ * Usage for a span and everything beneath it.
+ *
+ * Only `ai.llm.invoke` leaves carry token attributes, so a container span on its own
+ * reports nothing. Rolling the subtree up is what makes the panel useful: clicking an
+ * agent span answers "what did this agent cost", which is the question people are
+ * actually asking when they click it.
+ *
+ * `llmSpanCount` is how many spans in the subtree contributed, so the caller can say
+ * where the number came from. It is 0 on a leaf, which is how callers tell a rollup
+ * from a span's own usage.
+ */
+export function subtreeUsage(
+  span: SpanNode
+): (SpanUsage & { llmSpanCount: number }) | null {
+  const own = spanUsage(span);
+  let input = own?.input ?? 0;
+  let output = own?.output ?? 0;
+  let total = own?.total ?? 0;
+  let costUsd = own?.costUsd ?? null;
+  let llmSpanCount = 0;
+
+  for (const child of span.children ?? []) {
+    const below = subtreeUsage(child);
+    if (!below) {
+      continue;
+    }
+    input += below.input;
+    output += below.output;
+    // Summed from each node's own reported total rather than recomputed, so ADK's
+    // cache-read tokens survive the rollup.
+    total += below.total;
+    if (below.costUsd !== null) {
+      costUsd = (costUsd ?? 0) + below.costUsd;
+    }
+    llmSpanCount += below.llmSpanCount + (spanUsage(child) ? 1 : 0);
+  }
+
+  if (total === 0 && costUsd === null) {
+    return null;
+  }
+
+  return { input, output, total, costUsd, llmSpanCount };
+}
+
+/**
  * Input/output tokens as two separate figures, deliberately not presented as a
  * breakdown of the total: Google ADK folds cache-read tokens into the total it
  * reports, so input + output legitimately falls short of it.

--- a/tests/backend/crud/test_trace_metrics_aggregated.py
+++ b/tests/backend/crud/test_trace_metrics_aggregated.py
@@ -1,0 +1,187 @@
+"""Tests for get_trace_metrics_aggregated.
+
+The project-level rollup behind ``GET /telemetry/metrics``. Tokens and costs here
+must aggregate per *trace*: enrichment writes its trace-level blob onto every span
+row, so summing across rows multiplies the real figure by the span count.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from rhesis.telemetry.attributes import AIAttributes
+from rhesis.telemetry.schemas import SpanKind, StatusCode
+
+from rhesis.backend.app.crud.telemetry import (
+    create_trace_spans,
+    get_trace_metrics_aggregated,
+    mark_trace_processed,
+)
+from rhesis.backend.app.schemas.telemetry import OTELSpanCreate
+
+TRACE_COST_USD = 0.05
+TRACE_TOKENS = 420
+
+
+def span(trace_id, span_id, project_id, *, parent=None, operation, tokens=None, error=False):
+    now = datetime.now(timezone.utc)
+    attributes = {AIAttributes.OPERATION_TYPE: operation}
+    if tokens is not None:
+        attributes[AIAttributes.MODEL_NAME] = "gpt-4"
+        attributes[AIAttributes.LLM_TOKENS_INPUT] = tokens[0]
+        attributes[AIAttributes.LLM_TOKENS_OUTPUT] = tokens[1]
+        attributes[AIAttributes.LLM_TOKENS_TOTAL] = tokens[2]
+    return OTELSpanCreate(
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent,
+        project_id=project_id,
+        environment="development",
+        span_name="ai.llm.invoke" if operation == "llm.invoke" else "ai.agent.invoke",
+        span_kind=SpanKind.CLIENT,
+        start_time=now,
+        end_time=now + timedelta(seconds=1),
+        status_code=StatusCode.ERROR if error else StatusCode.OK,
+        attributes=attributes,
+    )
+
+
+def enrichment_blob(total_tokens=TRACE_TOKENS, cost_usd=TRACE_COST_USD):
+    return {
+        "costs": {
+            "total_cost_usd": cost_usd,
+            "total_cost_eur": cost_usd * 0.9,
+            "total_input_tokens": 300,
+            "total_output_tokens": 120,
+            "total_tokens": total_tokens,
+            "breakdown": [],
+        }
+    }
+
+
+@pytest.fixture
+def six_span_trace(test_db, db_project, test_org_id):
+    """One enriched trace of six spans: an agent run plus five model calls.
+
+    The shape that used to report six times the real cost.
+    """
+    trace_id = uuid.uuid4().hex
+    project_id = str(db_project.id)
+    spans = [
+        span(trace_id, uuid.uuid4().hex[:16], project_id, operation="agent.invoke"),
+    ]
+    for _ in range(5):
+        spans.append(
+            span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                parent=spans[0].span_id,
+                operation="llm.invoke",
+                tokens=(60, 24, 84),
+            )
+        )
+    create_trace_spans(test_db, spans, organization_id=test_org_id)
+    mark_trace_processed(test_db, trace_id, enrichment_blob())
+    return trace_id, project_id
+
+
+@pytest.mark.integration
+class TestTokenAndCostAggregation:
+    """Tokens and cost aggregate once per trace, not once per span row."""
+
+    def test_cost_is_not_multiplied_by_span_count(
+        self, test_db, six_span_trace, test_org_id
+    ):
+        """Regression: this used to report 6x the trace's real cost."""
+        _, project_id = six_span_trace
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id
+        )
+
+        assert metrics["total_spans"] == 6
+        assert metrics["total_traces"] == 1
+        assert metrics["total_cost_usd"] == pytest.approx(TRACE_COST_USD, rel=1e-6)
+
+    def test_tokens_come_from_enrichment_not_a_raw_span_sum(
+        self, test_db, six_span_trace, test_org_id
+    ):
+        """The enriched total wins, so aggregate-reporting frameworks aren't doubled."""
+        _, project_id = six_span_trace
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id
+        )
+
+        assert metrics["total_tokens"] == TRACE_TOKENS
+
+    def test_span_counts_and_error_rate_still_span_level(
+        self, test_db, db_project, test_org_id
+    ):
+        """Collapsing tokens per trace must not collapse the span-level metrics."""
+        trace_id = uuid.uuid4().hex
+        project_id = str(db_project.id)
+        spans = [
+            span(trace_id, uuid.uuid4().hex[:16], project_id, operation="agent.invoke"),
+            span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                operation="llm.invoke",
+                tokens=(10, 5, 15),
+                error=True,
+            ),
+        ]
+        create_trace_spans(test_db, spans, organization_id=test_org_id)
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id
+        )
+
+        assert metrics["total_spans"] == 2
+        assert metrics["error_rate"] == pytest.approx(0.5)
+        assert metrics["operation_breakdown"]["llm.invoke"] == 1
+        assert metrics["operation_breakdown"]["agent.invoke"] == 1
+
+    def test_unenriched_trace_falls_back_to_llm_invoke_spans(
+        self, test_db, db_project, test_org_id
+    ):
+        """A freshly ingested trace still reports tokens before enrichment runs.
+
+        The agent-run span repeats its children's aggregate, so a raw sum over all
+        spans would report 60 instead of 30.
+        """
+        trace_id = uuid.uuid4().hex
+        project_id = str(db_project.id)
+        spans = [
+            span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                operation="agent.invoke",
+                tokens=(20, 10, 30),
+            ),
+            span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                operation="llm.invoke",
+                tokens=(10, 5, 15),
+            ),
+            span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                operation="llm.invoke",
+                tokens=(10, 5, 15),
+            ),
+        ]
+        create_trace_spans(test_db, spans, organization_id=test_org_id)
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id
+        )
+
+        assert metrics["total_tokens"] == 30
+        assert metrics["total_cost_usd"] == 0.0

--- a/tests/backend/routes/test_telemetry_query.py
+++ b/tests/backend/routes/test_telemetry_query.py
@@ -9,6 +9,7 @@ This module tests the telemetry query endpoints including:
 - Error handling and edge cases
 """
 
+import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -1206,6 +1207,7 @@ class TestCrossOrganizationSecurity:
         import uuid
 
         from rhesis.telemetry.schemas import OTELSpan
+
         from tests.backend.fixtures.test_setup import create_test_organization_and_user
 
         org, user, _ = create_test_organization_and_user(
@@ -1349,3 +1351,253 @@ class TestCrossOrganizationSecurity:
         response = client_b.get(f"/telemetry/metrics?project_id={project_b.id}")
         assert response.status_code == 200, response.text
         assert response.json()["total_traces"] == 2
+
+
+@pytest.mark.integration
+class TestTraceTokenAndCostVisibility:
+    """Tokens and cost as the trace UI reads them, over the real endpoints.
+
+    The list column, the drawer chips and the project rollup must all report the
+    same figure for the same trace -- they used to report three different ones.
+    """
+
+    @staticmethod
+    def _span(trace_id, span_id, project_id, *, parent=None, operation, tokens=None):
+        now = datetime.now(timezone.utc)
+        attributes = {"ai.operation.type": operation}
+        if tokens is not None:
+            attributes["ai.model.name"] = "gpt-4"
+            attributes["ai.llm.tokens.input"] = tokens[0]
+            attributes["ai.llm.tokens.output"] = tokens[1]
+            attributes["ai.llm.tokens.total"] = tokens[2]
+        return {
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "parent_span_id": parent,
+            "project_id": project_id,
+            "environment": "development",
+            "span_name": "ai.llm.invoke" if operation == "llm.invoke" else "ai.agent.invoke",
+            "span_kind": "CLIENT",
+            "start_time": now.isoformat(),
+            "end_time": (now + timedelta(milliseconds=250)).isoformat(),
+            "status_code": "OK",
+            "attributes": attributes,
+            "events": [],
+            "links": [],
+            "resource": {},
+        }
+
+    @staticmethod
+    def _summary(client, project_id, trace_id):
+        response = client.get(f"/telemetry/traces?project_id={project_id}&limit=100")
+        assert response.status_code == status.HTTP_200_OK
+        for trace in response.json()["traces"]:
+            if trace["trace_id"] == trace_id:
+                return trace
+        raise AssertionError(f"trace {trace_id} missing from the list response")
+
+    def _ingest(self, client, spans):
+        response = client.post("/telemetry/traces", json={"spans": spans})
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_pydantic_ai_run_is_not_double_counted(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """The agent-run span repeats its children's aggregate under the same keys.
+
+        Summing every span would report 840; only the llm.invoke spans count.
+        """
+        project_id = str(db_project.id)
+        trace_id = uuid.uuid4().hex
+        agent_span = uuid.uuid4().hex[:16]
+        spans = [
+            self._span(
+                trace_id, agent_span, project_id, operation="agent.invoke", tokens=(300, 120, 420)
+            ),
+            self._span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                parent=agent_span,
+                operation="llm.invoke",
+                tokens=(100, 50, 150),
+            ),
+            self._span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                parent=agent_span,
+                operation="llm.invoke",
+                tokens=(200, 70, 270),
+            ),
+        ]
+        self._ingest(authenticated_client, spans)
+
+        response = authenticated_client.get(f"/telemetry/traces/{trace_id}?project_id={project_id}")
+        assert response.status_code == status.HTTP_200_OK
+        detail = response.json()
+
+        assert detail["total_tokens"] == 420
+        assert detail["total_input_tokens"] == 300
+        assert detail["total_output_tokens"] == 120
+
+    def test_list_and_detail_report_the_same_tokens(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """The core bug: the list read the root span alone and so showed 0."""
+        project_id = str(db_project.id)
+        trace_id = uuid.uuid4().hex
+        agent_span = uuid.uuid4().hex[:16]
+        spans = [
+            # A root span with no token attributes at all -- the usual shape, and
+            # what the list used to read its figure from.
+            self._span(trace_id, agent_span, project_id, operation="agent.invoke"),
+            self._span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                parent=agent_span,
+                operation="llm.invoke",
+                tokens=(100, 50, 150),
+            ),
+            self._span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                parent=agent_span,
+                operation="llm.invoke",
+                tokens=(200, 70, 270),
+            ),
+        ]
+        self._ingest(authenticated_client, spans)
+
+        detail = authenticated_client.get(
+            f"/telemetry/traces/{trace_id}?project_id={project_id}"
+        ).json()
+        summary = self._summary(authenticated_client, project_id, trace_id)
+
+        assert detail["total_tokens"] == 420
+        assert summary["total_tokens"] == detail["total_tokens"]
+
+    def test_reported_total_survives_the_round_trip(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """Google ADK folds cache-read tokens into its total, so it exceeds in + out."""
+        project_id = str(db_project.id)
+        trace_id = uuid.uuid4().hex
+        self._ingest(
+            authenticated_client,
+            [
+                self._span(
+                    trace_id,
+                    uuid.uuid4().hex[:16],
+                    project_id,
+                    operation="llm.invoke",
+                    tokens=(100, 50, 950),
+                )
+            ],
+        )
+
+        detail = authenticated_client.get(
+            f"/telemetry/traces/{trace_id}?project_id={project_id}"
+        ).json()
+
+        assert detail["total_tokens"] == 950
+        assert self._summary(authenticated_client, project_id, trace_id)["total_tokens"] == 950
+
+    def test_trace_with_no_llm_spans_omits_tokens(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """The list sends null so the column shows an em dash rather than a 0."""
+        project_id = str(db_project.id)
+        trace_id = uuid.uuid4().hex
+        self._ingest(
+            authenticated_client,
+            [self._span(trace_id, uuid.uuid4().hex[:16], project_id, operation="tool.invoke")],
+        )
+
+        detail = authenticated_client.get(
+            f"/telemetry/traces/{trace_id}?project_id={project_id}"
+        ).json()
+
+        assert detail["total_tokens"] == 0
+        assert self._summary(authenticated_client, project_id, trace_id)["total_tokens"] is None
+
+    def test_span_nodes_expose_cost_once_enriched(
+        self, authenticated_client: TestClient, db_project, test_db, test_org_id
+    ):
+        """Per-span cost reaches the Span Details panel, and only for priced spans."""
+        from rhesis.backend.app.crud.telemetry import mark_trace_processed
+
+        project_id = str(db_project.id)
+        trace_id = uuid.uuid4().hex
+        agent_span = uuid.uuid4().hex[:16]
+        llm_span = uuid.uuid4().hex[:16]
+        self._ingest(
+            authenticated_client,
+            [
+                self._span(
+                    trace_id,
+                    agent_span,
+                    project_id,
+                    operation="agent.invoke",
+                    tokens=(100, 50, 150),
+                ),
+                self._span(
+                    trace_id,
+                    llm_span,
+                    project_id,
+                    parent=agent_span,
+                    operation="llm.invoke",
+                    tokens=(100, 50, 150),
+                ),
+            ],
+        )
+
+        # Stand in for the async enrichment job, which does not run in tests.
+        mark_trace_processed(
+            test_db,
+            trace_id,
+            {
+                "costs": {
+                    "total_cost_usd": 0.006,
+                    "total_cost_eur": 0.0054,
+                    "total_input_tokens": 100,
+                    "total_output_tokens": 50,
+                    "total_tokens": 150,
+                    "breakdown": [
+                        {
+                            "span_id": llm_span,
+                            "model_name": "gpt-4",
+                            "input_tokens": 100,
+                            "output_tokens": 50,
+                            "total_tokens": 150,
+                            "input_cost_usd": 0.003,
+                            "output_cost_usd": 0.003,
+                            "total_cost_usd": 0.006,
+                            "input_cost_eur": 0.0027,
+                            "output_cost_eur": 0.0027,
+                            "total_cost_eur": 0.0054,
+                        }
+                    ],
+                }
+            },
+        )
+
+        detail = authenticated_client.get(
+            f"/telemetry/traces/{trace_id}?project_id={project_id}"
+        ).json()
+
+        def walk(nodes):
+            for node in nodes:
+                yield node
+                yield from walk(node["children"])
+
+        by_span = {node["span_id"]: node for node in walk(detail["root_spans"])}
+
+        assert detail["total_cost_usd"] == pytest.approx(0.006)
+        assert by_span[llm_span]["cost_usd"] == pytest.approx(0.006)
+        assert by_span[llm_span]["model_name"] == "gpt-4"
+        # The agent-run span is never priced, so it shows no Usage cost.
+        assert by_span[agent_span]["cost_usd"] is None
+        assert by_span[agent_span]["model_name"] is None

--- a/tests/backend/routes/test_telemetry_query.py
+++ b/tests/backend/routes/test_telemetry_query.py
@@ -1604,6 +1604,138 @@ class TestTraceTokenAndCostVisibility:
 
 
 @pytest.mark.integration
+class TestTraceListSorting:
+    """Server-side sorting on the traces list.
+
+    Sorting has to happen in SQL: sorting in the browser only reorders the rows on
+    the current page, so "most expensive first" would really mean "most expensive of
+    the newest 50".
+    """
+
+    @staticmethod
+    def _span(trace_id, span_id, project_id, *, tokens, started):
+        return {
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "project_id": project_id,
+            "environment": "development",
+            "span_name": "ai.llm.invoke",
+            "span_kind": "CLIENT",
+            "start_time": started.isoformat(),
+            "end_time": (started + timedelta(milliseconds=250)).isoformat(),
+            "status_code": "OK",
+            "attributes": {
+                "ai.operation.type": "llm.invoke",
+                "ai.model.name": "gpt-4",
+                "ai.llm.tokens.input": tokens[0],
+                "ai.llm.tokens.output": tokens[1],
+                "ai.llm.tokens.total": tokens[2],
+            },
+            "events": [],
+            "links": [],
+            "resource": {},
+        }
+
+    @pytest.fixture
+    def three_traces(self, authenticated_client: TestClient, db_project):
+        """Three single-span traces with deliberately different token counts."""
+        project_id = str(db_project.id)
+        now = datetime.now(timezone.utc)
+        made = []
+        for index, tokens in enumerate([(10, 5, 15), (400, 100, 500), (60, 20, 80)]):
+            trace_id = uuid.uuid4().hex
+            span = self._span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                tokens=tokens,
+                started=now - timedelta(minutes=index),
+            )
+            response = authenticated_client.post("/telemetry/traces", json={"spans": [span]})
+            assert response.status_code == status.HTTP_200_OK
+            made.append((trace_id, tokens[2]))
+        return project_id, made
+
+    def _tokens_in_order(self, client, project_id, order):
+        response = client.get(
+            f"/telemetry/traces?project_id={project_id}"
+            f"&sort_by=total_tokens&sort_order={order}&limit=100"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        return [t["total_tokens"] for t in response.json()["traces"] if t["total_tokens"]]
+
+    def test_sorts_by_tokens_descending(self, authenticated_client: TestClient, three_traces):
+        project_id, _ = three_traces
+
+        tokens = self._tokens_in_order(authenticated_client, project_id, "desc")
+
+        assert tokens == sorted(tokens, reverse=True)
+        assert tokens[0] == 500
+
+    def test_sorts_by_tokens_ascending(self, authenticated_client: TestClient, three_traces):
+        project_id, _ = three_traces
+
+        tokens = self._tokens_in_order(authenticated_client, project_id, "asc")
+
+        assert tokens == sorted(tokens)
+
+    def test_unpriced_traces_sort_last_on_cost(
+        self, authenticated_client: TestClient, three_traces
+    ):
+        """Cost has no pre-enrichment fallback, so every one of these is unpriced.
+
+        Postgres puts NULLs first on DESC, so without NULLS LAST a "most expensive"
+        sort would lead with traces whose cost is simply unknown.
+        """
+        project_id, _ = three_traces
+
+        response = authenticated_client.get(
+            f"/telemetry/traces?project_id={project_id}"
+            f"&sort_by=total_cost_usd&sort_order=desc&limit=100"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        costs = [t["total_cost_usd"] for t in response.json()["traces"]]
+        priced = [c for c in costs if c is not None]
+        assert costs[: len(priced)] == priced
+
+    def test_sorting_is_stable_across_pages(self, authenticated_client: TestClient, three_traces):
+        """Rows tied on the sort key need a tiebreaker or paging repeats them."""
+        project_id, _ = three_traces
+
+        first = authenticated_client.get(
+            f"/telemetry/traces?project_id={project_id}"
+            f"&sort_by=total_cost_usd&sort_order=desc&limit=2&offset=0"
+        ).json()["traces"]
+        second = authenticated_client.get(
+            f"/telemetry/traces?project_id={project_id}"
+            f"&sort_by=total_cost_usd&sort_order=desc&limit=2&offset=2"
+        ).json()["traces"]
+
+        ids = [t["trace_id"] for t in first] + [t["trace_id"] for t in second]
+        assert len(ids) == len(set(ids))
+
+    def test_unknown_sort_field_is_rejected(self, authenticated_client: TestClient, db_project):
+        """The three columns with no SQL sort key must not silently do nothing."""
+        response = authenticated_client.get(
+            f"/telemetry/traces?project_id={db_project.id}&sort_by=endpoint_name"
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "endpoint_name" in response.json()["detail"]
+
+    def test_default_ordering_is_unchanged(self, authenticated_client: TestClient, three_traces):
+        """No sort_by keeps the newest-first order the list has always had."""
+        project_id, _ = three_traces
+
+        response = authenticated_client.get(f"/telemetry/traces?project_id={project_id}&limit=100")
+
+        assert response.status_code == status.HTTP_200_OK
+        starts = [t["start_time"] for t in response.json()["traces"]]
+        assert starts == sorted(starts, reverse=True)
+
+
+@pytest.mark.integration
 class TestTokenTotalFallbackShapes:
     """Span shapes where the reported total is missing or contradicts input/output."""
 

--- a/tests/backend/routes/test_telemetry_query.py
+++ b/tests/backend/routes/test_telemetry_query.py
@@ -1601,3 +1601,100 @@ class TestTraceTokenAndCostVisibility:
         # The agent-run span is never priced, so it shows no Usage cost.
         assert by_span[agent_span]["cost_usd"] is None
         assert by_span[agent_span]["model_name"] is None
+
+
+@pytest.mark.integration
+class TestTokenTotalFallbackShapes:
+    """Span shapes where the reported total is missing or contradicts input/output."""
+
+    @staticmethod
+    def _span(trace_id, project_id, attributes):
+        now = datetime.now(timezone.utc)
+        return {
+            "trace_id": trace_id,
+            "span_id": uuid.uuid4().hex[:16],
+            "project_id": project_id,
+            "environment": "development",
+            "span_name": "ai.llm.invoke",
+            "span_kind": "CLIENT",
+            "start_time": now.isoformat(),
+            "end_time": (now + timedelta(milliseconds=100)).isoformat(),
+            "status_code": "OK",
+            "attributes": {
+                "ai.operation.type": "llm.invoke",
+                "ai.model.name": "gpt-4",
+                **attributes,
+            },
+            "events": [],
+            "links": [],
+            "resource": {},
+        }
+
+    def _ingest_and_read(self, client, project_id, attributes):
+        trace_id = uuid.uuid4().hex
+        response = client.post(
+            "/telemetry/traces",
+            json={"spans": [self._span(trace_id, project_id, attributes)]},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        detail = client.get(f"/telemetry/traces/{trace_id}?project_id={project_id}").json()
+        listed = client.get(f"/telemetry/traces?project_id={project_id}&limit=100").json()
+        summary = next(t for t in listed["traces"] if t["trace_id"] == trace_id)
+        return detail, summary
+
+    def test_missing_total_falls_back_to_input_plus_output(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """The SQL fallback used to sum only the total, so this listed as 0."""
+        detail, summary = self._ingest_and_read(
+            authenticated_client,
+            str(db_project.id),
+            {"ai.llm.tokens.input": 100, "ai.llm.tokens.output": 50},
+        )
+
+        assert detail["total_tokens"] == 150
+        assert summary["total_tokens"] == 150
+
+    def test_only_one_side_reported(self, authenticated_client: TestClient, db_project):
+        """NULL + 100 is NULL in SQL, so each side has to be coalesced separately."""
+        detail, summary = self._ingest_and_read(
+            authenticated_client, str(db_project.id), {"ai.llm.tokens.input": 100}
+        )
+
+        assert detail["total_tokens"] == 100
+        assert summary["total_tokens"] == 100
+
+    def test_zero_total_beside_real_usage_is_treated_as_missing(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """A zero total next to non-zero input/output contradicts itself."""
+        detail, summary = self._ingest_and_read(
+            authenticated_client,
+            str(db_project.id),
+            {
+                "ai.llm.tokens.input": 100,
+                "ai.llm.tokens.output": 50,
+                "ai.llm.tokens.total": 0,
+            },
+        )
+
+        assert detail["total_tokens"] == 150
+        assert summary["total_tokens"] == 150
+
+    def test_reported_total_still_wins_when_larger(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """ADK folds cache-read tokens in, so the total legitimately exceeds the sum."""
+        detail, summary = self._ingest_and_read(
+            authenticated_client,
+            str(db_project.id),
+            {
+                "ai.llm.tokens.input": 100,
+                "ai.llm.tokens.output": 50,
+                "ai.llm.tokens.total": 950,
+            },
+        )
+
+        assert detail["total_tokens"] == 950
+        assert summary["total_tokens"] == 950

--- a/tests/backend/services/telemetry/test_enrichment.py
+++ b/tests/backend/services/telemetry/test_enrichment.py
@@ -16,6 +16,7 @@ from rhesis.backend.app.services.telemetry.enrichment import (
     detect_anomalies,
     extract_metadata,
 )
+from rhesis.backend.app.services.telemetry.enrichment.core import UNKNOWN_MODEL_NAME
 from rhesis.backend.app.services.telemetry.enrichment.processor import TraceEnricher
 
 
@@ -135,8 +136,12 @@ class TestCalculateTokenCosts:
 
         assert costs is None
 
-    def test_calculate_costs_unknown_model(self):
-        """Test cost calculation gracefully handles unknown models (skips them)."""
+    def test_calculate_costs_unknown_model_keeps_tokens(self):
+        """An unpriceable model still contributes its tokens, at zero cost.
+
+        Tokens are known even when the price is not, so dropping the span would make
+        a self-hosted or unrecognised model report zero usage.
+        """
         spans = [
             Mock(
                 spec=Trace,
@@ -146,14 +151,185 @@ class TestCalculateTokenCosts:
                     AIAttributes.MODEL_NAME: "unknown-model-xyz-123",
                     AIAttributes.LLM_TOKENS_INPUT: 100,
                     AIAttributes.LLM_TOKENS_OUTPUT: 50,
+                    AIAttributes.LLM_TOKENS_TOTAL: 150,
                 },
             )
         ]
 
         costs = calculate_token_costs(spans)
 
-        # Should return None since LiteLLM will fail to price unknown model
-        assert costs is None
+        assert costs is not None
+        assert costs.total_cost_usd == 0.0
+        assert costs.total_cost_eur == 0.0
+        assert costs.total_input_tokens == 100
+        assert costs.total_output_tokens == 50
+        assert costs.total_tokens == 150
+
+    def test_calculate_costs_mixed_priced_and_unpriced(self):
+        """A trace mixing a priced and an unpriced model counts both models' tokens."""
+        spans = [
+            Mock(
+                spec=Trace,
+                span_id="priced",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.MODEL_NAME: "gpt-4",
+                    AIAttributes.LLM_TOKENS_INPUT: 100,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 50,
+                    AIAttributes.LLM_TOKENS_TOTAL: 150,
+                },
+            ),
+            Mock(
+                spec=Trace,
+                span_id="unpriced",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.MODEL_NAME: "unknown-model-xyz-123",
+                    AIAttributes.LLM_TOKENS_INPUT: 200,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 70,
+                    AIAttributes.LLM_TOKENS_TOTAL: 270,
+                },
+            ),
+        ]
+
+        costs = calculate_token_costs(spans)
+
+        assert costs is not None
+        assert len(costs.breakdown) == 2
+        assert costs.total_tokens == 420
+        assert costs.total_input_tokens == 300
+        assert costs.total_output_tokens == 120
+
+        # Only the priced span carries cost; the unpriced one is recorded at zero.
+        expected_usd = sum(
+            litellm.cost_per_token(model="gpt-4", prompt_tokens=100, completion_tokens=50)
+        )
+        assert costs.total_cost_usd == pytest.approx(expected_usd, rel=0.01)
+        unpriced = next(b for b in costs.breakdown if b.span_id == "unpriced")
+        assert unpriced.total_cost_usd == 0.0
+        assert unpriced.total_tokens == 270
+
+    def test_calculate_costs_missing_model_name_keeps_tokens(self):
+        """A span with no model name is recorded at zero cost rather than dropped."""
+        spans = [
+            Mock(
+                spec=Trace,
+                span_id="span1",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.LLM_TOKENS_INPUT: 30,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 20,
+                    AIAttributes.LLM_TOKENS_TOTAL: 50,
+                },
+            )
+        ]
+
+        costs = calculate_token_costs(spans)
+
+        assert costs is not None
+        assert costs.total_tokens == 50
+        assert costs.total_cost_usd == 0.0
+        assert costs.breakdown[0].model_name == UNKNOWN_MODEL_NAME
+
+    def test_reported_total_is_trusted_not_derived(self):
+        """Google ADK folds cache-read tokens into the reported total.
+
+        Its ``ai.llm.tokens.total`` therefore exceeds ``input + output`` on purpose,
+        and deriving the total would silently discard the cached tokens.
+        """
+        spans = [
+            Mock(
+                spec=Trace,
+                span_id="adk-span",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.MODEL_NAME: "gpt-4",
+                    AIAttributes.LLM_TOKENS_INPUT: 100,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 50,
+                    # 800 cache-read tokens folded in by google_adk/mapping.py
+                    AIAttributes.LLM_TOKENS_TOTAL: 950,
+                },
+            )
+        ]
+
+        costs = calculate_token_costs(spans)
+
+        assert costs is not None
+        assert costs.total_tokens == 950
+        assert costs.total_input_tokens == 100
+        assert costs.total_output_tokens == 50
+
+    def test_total_falls_back_to_sum_when_not_reported(self):
+        """A span with no reported total derives one from input + output."""
+        spans = [
+            Mock(
+                spec=Trace,
+                span_id="span1",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.MODEL_NAME: "gpt-4",
+                    AIAttributes.LLM_TOKENS_INPUT: 100,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 50,
+                },
+            )
+        ]
+
+        costs = calculate_token_costs(spans)
+
+        assert costs is not None
+        assert costs.total_tokens == 150
+
+    def test_aggregated_agent_span_is_not_double_counted(self):
+        """pydantic-ai reports usage twice; only the llm.invoke spans are counted.
+
+        Its agent-run span carries the aggregate of its children's usage under the
+        same ``ai.llm.tokens.*`` keys, so counting every span would roughly double
+        the trace's real figure.
+        """
+        spans = [
+            # Agent-run span carrying the aggregate of both model calls.
+            Mock(
+                spec=Trace,
+                span_id="agent-run",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_AGENT_INVOKE,
+                    AIAttributes.MODEL_NAME: "gpt-4",
+                    AIAttributes.LLM_TOKENS_INPUT: 300,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 120,
+                    AIAttributes.LLM_TOKENS_TOTAL: 420,
+                },
+            ),
+            Mock(
+                spec=Trace,
+                span_id="model-call-1",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.MODEL_NAME: "gpt-4",
+                    AIAttributes.LLM_TOKENS_INPUT: 100,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 50,
+                    AIAttributes.LLM_TOKENS_TOTAL: 150,
+                },
+            ),
+            Mock(
+                spec=Trace,
+                span_id="model-call-2",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.MODEL_NAME: "gpt-4",
+                    AIAttributes.LLM_TOKENS_INPUT: 200,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 70,
+                    AIAttributes.LLM_TOKENS_TOTAL: 270,
+                },
+            ),
+        ]
+
+        costs = calculate_token_costs(spans)
+
+        assert costs is not None
+        # The children sum to 420 -- the same figure the agent span reports. Counting
+        # all three spans would give 840.
+        assert costs.total_tokens == 420
+        assert len(costs.breakdown) == 2
 
     def test_calculate_costs_model_variants(self):
         """Test that LiteLLM handles model variants (e.g., gpt-4-0613)."""

--- a/tests/backend/services/telemetry/test_token_totals.py
+++ b/tests/backend/services/telemetry/test_token_totals.py
@@ -1,0 +1,187 @@
+"""Tests for trace-level token totals.
+
+These cover the one definition of "how many tokens did this trace use" that the
+traces list, the trace detail drawer, the test-run trace list and the project
+metrics endpoint all share.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from rhesis.telemetry.attributes import AIAttributes
+
+from rhesis.backend.app.models.trace import Trace
+from rhesis.backend.app.services.telemetry.token_totals import (
+    token_totals_from_enriched,
+    token_totals_from_spans,
+    trace_cost_usd,
+    trace_summary_totals,
+    trace_token_totals,
+)
+
+
+def llm_span(span_id, input_tokens, output_tokens, total=None, enriched=None):
+    """An ``llm.invoke`` span -- the kind that carries countable usage."""
+    attributes = {
+        AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+        AIAttributes.MODEL_NAME: "gpt-4",
+        AIAttributes.LLM_TOKENS_INPUT: input_tokens,
+        AIAttributes.LLM_TOKENS_OUTPUT: output_tokens,
+    }
+    if total is not None:
+        attributes[AIAttributes.LLM_TOKENS_TOTAL] = total
+    return Mock(spec=Trace, span_id=span_id, attributes=attributes, enriched_data=enriched)
+
+
+def enrichment(total_input, total_output, total, cost_usd=0.0, cost_eur=0.0):
+    """An enriched_data blob shaped the way the enrichment service writes it."""
+    return {
+        "costs": {
+            "total_cost_usd": cost_usd,
+            "total_cost_eur": cost_eur,
+            "total_input_tokens": total_input,
+            "total_output_tokens": total_output,
+            "total_tokens": total,
+            "breakdown": [],
+        }
+    }
+
+
+@pytest.mark.unit
+class TestTokenTotalsFromSpans:
+    """The pre-enrichment fallback, summed over llm.invoke spans."""
+
+    def test_sums_llm_invoke_spans(self):
+        spans = [llm_span("a", 100, 50, 150), llm_span("b", 200, 70, 270)]
+
+        assert token_totals_from_spans(spans) == (300, 120, 420)
+
+    def test_ignores_aggregated_agent_span(self):
+        """The pydantic-ai double-count case.
+
+        Its agent-run span repeats the aggregate of its children's usage under the
+        same attribute keys, so a naive sum over every span would report 840.
+        """
+        agent_run = Mock(
+            spec=Trace,
+            span_id="agent-run",
+            attributes={
+                AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_AGENT_INVOKE,
+                AIAttributes.LLM_TOKENS_INPUT: 300,
+                AIAttributes.LLM_TOKENS_OUTPUT: 120,
+                AIAttributes.LLM_TOKENS_TOTAL: 420,
+            },
+            enriched_data=None,
+        )
+        spans = [agent_run, llm_span("call-1", 100, 50, 150), llm_span("call-2", 200, 70, 270)]
+
+        assert token_totals_from_spans(spans) == (300, 120, 420)
+
+    def test_trusts_reported_total_over_derived(self):
+        """Google ADK folds cache-read tokens into the reported total on purpose."""
+        spans = [llm_span("adk", 100, 50, total=950)]
+
+        assert token_totals_from_spans(spans) == (100, 50, 950)
+
+    def test_derives_total_when_not_reported(self):
+        spans = [llm_span("a", 100, 50)]
+
+        assert token_totals_from_spans(spans) == (100, 50, 150)
+
+    def test_no_llm_spans_is_zero_not_an_error(self):
+        tool_span = Mock(
+            spec=Trace,
+            span_id="tool",
+            attributes={AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_TOOL_INVOKE},
+            enriched_data=None,
+        )
+
+        assert token_totals_from_spans([tool_span]) == (0, 0, 0)
+
+    def test_span_with_no_attributes(self):
+        bare = Mock(spec=Trace, span_id="bare", attributes=None, enriched_data=None)
+
+        assert token_totals_from_spans([bare]) == (0, 0, 0)
+
+
+@pytest.mark.unit
+class TestTokenTotalsFromEnriched:
+    """Reading the totals back out of the enrichment blob."""
+
+    def test_reads_the_totals(self):
+        assert token_totals_from_enriched(enrichment(300, 120, 420)) == (300, 120, 420)
+
+    def test_unenriched_trace_is_unknown_not_zero(self):
+        """None means "fall back", which is not the same as a confident zero."""
+        assert token_totals_from_enriched(None) is None
+        assert token_totals_from_enriched({}) is None
+        assert token_totals_from_enriched({"costs": {}}) is None
+
+    def test_blob_predating_the_token_fields_is_unknown(self):
+        """An enrichment blob written before this change has costs but no tokens."""
+        legacy = {"costs": {"total_cost_usd": 0.02, "total_cost_eur": 0.018, "breakdown": []}}
+
+        assert token_totals_from_enriched(legacy) is None
+
+
+@pytest.mark.unit
+class TestTraceTokenTotals:
+    """The detail endpoint's accessor: enrichment first, spans as fallback."""
+
+    def test_prefers_enrichment(self):
+        spans = [llm_span("a", 1, 1, 2, enriched=enrichment(300, 120, 420))]
+
+        assert trace_token_totals(spans) == (300, 120, 420)
+
+    def test_falls_back_to_spans_before_enrichment_runs(self):
+        spans = [llm_span("a", 100, 50, 150), llm_span("b", 200, 70, 270)]
+
+        assert trace_token_totals(spans) == (300, 120, 420)
+
+    def test_both_paths_agree_for_the_same_spans(self):
+        """The property that keeps the list and the drawer showing one number."""
+        spans = [llm_span("a", 100, 50, 150), llm_span("b", 200, 70, 270)]
+        from_spans = token_totals_from_spans(spans)
+
+        enriched_spans = [
+            llm_span("a", 100, 50, 150, enriched=enrichment(*from_spans)),
+            llm_span("b", 200, 70, 270, enriched=enrichment(*from_spans)),
+        ]
+
+        assert trace_token_totals(enriched_spans) == from_spans
+
+    def test_empty_span_set(self):
+        assert trace_token_totals([]) == (0, 0, 0)
+
+
+@pytest.mark.unit
+class TestTraceSummaryTotals:
+    """The list endpoints' accessor, which has one row rather than a span set."""
+
+    def test_uses_enrichment_when_present(self):
+        totals = trace_summary_totals(
+            enrichment(300, 120, 420, cost_usd=0.02, cost_eur=0.018), llm_tokens_fallback=999
+        )
+
+        assert totals == (300, 120, 420, 0.02, 0.018)
+
+    def test_uses_the_sql_fallback_before_enrichment_runs(self):
+        """A freshly ingested trace still lists its tokens, and no cost yet."""
+        totals = trace_summary_totals(None, llm_tokens_fallback=420)
+
+        assert totals == (0, 0, 420, 0.0, 0.0)
+
+    def test_no_llm_spans_reports_zero(self):
+        assert trace_summary_totals(None, llm_tokens_fallback=0) == (0, 0, 0, 0.0, 0.0)
+
+
+@pytest.mark.unit
+class TestTraceCostUsd:
+    """Cost has no fallback: it cannot be derived from span attributes."""
+
+    def test_reads_the_enriched_cost(self):
+        assert trace_cost_usd(enrichment(1, 1, 2, cost_usd=0.0123)) == 0.0123
+
+    def test_unenriched_trace_is_zero(self):
+        assert trace_cost_usd(None) == 0.0
+        assert trace_cost_usd({}) == 0.0


### PR DESCRIPTION
## Purpose

Rhesis already ingested LLM token counts and already priced them with LiteLLM, but almost none of it reached the user. Enrichment wrote a full per-span cost breakdown into `Trace.enriched_data["costs"]`, the backend already sent `total_tokens` and `total_cost_usd` on `TraceSummary` and `TraceDetailResponse` — and no frontend component read any of it. `formatCost()` and `formatTokenCount()` had existed in `trace-utils.ts` with no caller outside their own unit test. You opened a trace, saw `6 spans · 1.32s · development`, and had no idea what the run cost or how many tokens it burned.

Surfacing it first meant fixing what was underneath, because there were **four** different definitions of "this trace's token total" in the codebase, and three of them were wrong:

| Site | What it did |
|---|---|
| traces list | read `ai.llm.tokens.total` off the root span alone — usually an agent-run span with no token attribute, so it showed `0` |
| test-run trace list | the same root-span-only pattern, a near-verbatim copy |
| trace detail | summed **every** span, double-counting frameworks that report aggregated usage on the agent-run span *and* per-call usage on its children |
| project metrics | SQL `SUM` over all span rows in the project, with the same double-count |

Cost enrichment already avoided the double-count, because it prices only spans where `ai.operation.type == "llm.invoke"`, which excludes the aggregate-carrying agent-run span. That filtered set is the correct basis for tokens too, so making tokens and cost derive from one source is the core of this change.

Two further bugs surfaced while doing it, both fixed here:

- **Project-metrics cost was inflated by span count.** `mark_trace_processed` writes the identical trace-level `enriched_data` blob onto *every* span row of the trace, and the metrics query summed it across rows — so a six-span trace reported six times its real cost. That number goes on screen with the new rollup tiles, so it could not stay.
- **Unpriceable models lost their tokens entirely.** On a LiteLLM pricing failure the loop hit `continue` *before* appending the breakdown, so the span's token counts never reached `enriched_data`. A self-hosted or unrecognised model reported zero usage, and a trace mixing priced and unpriced spans silently undercounted.

## What Changed

**Backend — one source of truth**

- `services/telemetry/enrichment/core.py` rolls input/output/total tokens into `TokenCosts`, and records unpriceable spans at zero cost with their real tokens instead of dropping them. The per-span body moves into `_price_span` to stay under the `ruff.toml` complexity ceiling.
- New `services/telemetry/token_totals.py` is the single accessor all read paths now use. It prefers the enrichment breakdown and falls back to summing `ai.llm.tokens.total` over `llm.invoke` spans.
- The fallback matters because enrichment is dispatched asynchronously after ingest, so a trace opened immediately has `enriched_data = {}`. `query_traces` gets a matching correlated subquery so the list and the drawer agree in that window too, instead of the list showing `0` while the drawer shows the real figure.
- The two list endpoints now share `trace_summary_totals` rather than each carrying its own copy of the same arithmetic.
- `get_trace_metrics_aggregated` collapses to one row per trace before aggregating tokens and cost. `total_spans`, `error_count` and the duration percentiles stay span-level, which is why `base` is not deduplicated wholesale.
- `SpanNode` gains `cost_usd` and `model_name`, indexed out of the breakdown by `span_id`. The raw span attributes carry tokens but never a price, so the Span Details panel had no other way to get it.

**Frontend — four surfaces**

- Token and cost chips in the trace drawer header, hidden rather than showing `0` when a trace has no LLM spans.
- A Usage block in Span Details, shown only when a span actually has tokens or cost. `ai.llm.tokens.*` is dropped from the raw attributes table so it does not appear twice.
- Tokens and Cost columns in the traces list, falling back to an em dash.
- A four-tile project rollup, which finally gives `GET /telemetry/metrics` a consumer — it had been implemented and unused, its docstring still saying "for future dashboard use".

## Additional Context

**`total_tokens` is read as reported, never derived as `input + output`.** Google ADK deliberately folds cache-read tokens into `ai.llm.tokens.total` (`google_adk/mapping.py` uses `=` where every other integration uses `setdefault`), so for ADK spans the total legitimately exceeds `input + output`. Deriving it would silently discard cached tokens, and asserting the identity in a test would fail against real ADK data. The drawer tooltip therefore presents input and output as two independent figures rather than a breakdown of the total.

**Both new columns are `sortable: false`.** The grid paginates server-side but sorts client-side, and `list.ts` drops `sort_by`/`sort_order` before calling the API. A sortable Cost header would silently reorder the current page only — worse than no sorting, since sorting by cost is exactly what someone would try. Backend sort support for these fields is a separate change.

**The rollup tiles say when they are broader than the table.** `GET /telemetry/metrics` only narrows by project, environment and time, so an active endpoint, trace-source or search filter would make the tiles cover more traces than the rows below. They carry a caption saying so rather than silently disagreeing. Widening the endpoint to accept the remaining filters is its own change.

Deliberately out of scope:

- **Embedding tokens are no longer counted.** Embedder spans carry `ai.llm.tokens.*` but map to `ai.operation.type = embedding.create`, so the `llm.invoke` filter excludes them and the detail endpoint, which used to sum every span, no longer picks them up. This is deliberate: enrichment never priced embeddings either, so counting their tokens would put tokens and cost back out of step. Anyone who has looked at an embedding-heavy trace before will notice the number drop.

- **The SDK's own agent emits no token attributes.** `sdk/src/rhesis/sdk/agents/base.py` sets `ai.operation.type = llm.invoke` but never the token attributes, even though `packages/rhesis/src/rhesis/telemetry/attributes.py` has a builder that produces exactly the right set. Traces from Rhesis's own agent will show no tokens. It is an SDK change on the SDK's release cycle.
- **Normalizing non-Rhesis token conventions at ingest.** Spans arriving with only `gen_ai.usage.*`, OpenInference or OpenLLMetry keys are stored verbatim and read by nothing, because translation happens client-side per framework. A server-side normalizer in `create_trace_spans` would fix that for every producer at once, but it carries its own backfill question.
- Cost in EUR (the backend computes it; it stays out of the response schema), per-org currency preference, and cost budgets or alerting.
- The usage page and the `usage` table are untouched. `MODEL_TOKENS` there meters tokens *Rhesis* spends on an org's behalf — test generation, LLM judges. Traced tokens are the customer's own agent's tokens arriving over OTLP. Two separate ledgers, deliberately.

This PR is ~1650 lines (roughly 850 production, 810 tests), above the 400-line guidance in `.claude/skills/pull-request/SKILL.md`. Kept as one PR deliberately, since splitting the token unification from the surfaces would land a correctness fix nobody can see and then a UI change that has to be trusted. The four commits are scoped so each reads on its own.

## Testing

**Automated** — 204 backend tests and 847 frontend tests pass; `ruff`, `eslint`, `prettier` and `tsc` are clean.

New backend coverage:

- `tests/backend/services/telemetry/test_token_totals.py` — the pydantic-ai double-count case built explicitly from that span shape, the enriched and fallback paths agreeing for the same spans, and a trace with no LLM spans returning zeros rather than raising.
- `tests/backend/crud/test_trace_metrics_aggregated.py` — a multi-span trace reports its cost **once**, the regression test for the inflation, plus assertions that `total_spans`, `error_count` and the percentiles are unchanged by the restructuring.
- `tests/backend/routes/test_telemetry_query.py::TestTraceTokenAndCostVisibility` — the same properties over the real endpoints: no double count, list and detail agreeing, the ADK total surviving, `null` for a trace with no LLM spans, and per-span cost reaching `SpanNode`.
- `test_enrichment.py::test_calculate_costs_unknown_model` previously asserted that unpriceable spans were dropped. That contract is what this PR fixes, so the test now asserts the tokens are kept at zero cost, alongside a new mixed priced/unpriced case.

**Against the running stack** — verified end to end on a local backend, Postgres and Celery worker by posting pydantic-ai-shaped and ADK-shaped traces over HTTP:

- a pydantic-ai run reports **420 tokens, not 840**
- list and detail agree both before and after enrichment
- **the token total does not change when enrichment lands** for a trace that has stopped growing: the SQL fallback and the enriched path produce the same number. A multi-turn conversation still adding spans under one `trace_id` reports its pre-growth total for one enrichment cycle, and every surface reports the same stale value meanwhile rather than each showing a different one
- per-span costs sum exactly to the trace cost (`$0.0162`), and the agent-run span is correctly unpriced
- an ADK-shaped total of `950` survives instead of collapsing to `150`
- a trace with no LLM spans sends `null`, so the column renders an em dash

Also sanity-checked against a real 190-span, 14-turn `reg-advisor` conversation: 47 `llm.invoke` spans summing to exactly the reported 44,721 input + 1,014 output, and `$0.0127` matching LiteLLM's `gemini-3.1-flash-lite` rates to per-span rounding.

**To reproduce locally**: run an agent that has a Rhesis integration (`cd agents/reg-advisor && uv run python chat_terminal/chat.py`), then open Traces at `localhost:3000` scoped to that agent's project. Open the trace *immediately* to see tokens present while cost is still blank — that is the pre-enrichment fallback — then refresh and confirm cost appears while the token number stays put.

**Not verified**: the rendered chips in a browser. Every layer beneath the rendering has a real check, but nobody has yet looked at the UI itself.

---

## Review round two

Thanks @harry-rhesis and peqy. Everything raised is addressed, plus three UI changes Arman asked for.

**From the review**

- The rollup tiles no longer render on a test run's Traces tab, where they were counting the whole project across all time next to a dozen listed rows.
- Both SQL fallbacks now share one `span_total_tokens_expr`: `COALESCE(NULLIF(total, 0), COALESCE(input, 0) + COALESCE(output, 0), 0)`. Each side needs its own `COALESCE` because `NULL + 100` is `NULL` in SQL, which would otherwise drop a span reporting only one side. The `NULLIF` answers peqy's question about a zero total beside real usage, and the same rule now applies in both Python paths.
- `Trace.total_tokens` is deleted. Nothing read it, and it returned the per-span shape that caused the original bug.
- `TraceSummary.total_input_tokens` / `total_output_tokens` now feed a tooltip on the Tokens cell.
- Embedding exclusion and the staleness window are both documented above.

**New in this round**

- **The four tiles moved above the grid card** instead of sitting inside it.
- **The traces grid sorts on the server.** It paginated server-side but sorted client-side, so a sort only reordered the rows already on screen. Tokens sort on the same expression the response reports, cost sorts `NULLS LAST` so unpriced traces do not lead a "most expensive" list, and every sort ends with `start_time` then `id` so paging does not repeat rows. `conversation_input`, `endpoint_name` and `trace_metrics_status` are marked unsortable, since none of them has a SQL sort key and MUI applies `sortingMode` grid-wide.
- **Per-span usage rolls up the subtree.** Only `ai.llm.invoke` leaves carry token attributes, so clicking a pipeline, coordinator or agent span showed nothing at all. It now sums the span and everything under it, says how many LLM spans fed the number, and renders as text lines matching the Timing block.

**Verification:** 214 backend and 853 frontend tests pass; ruff, eslint, prettier and tsc are clean. Checked against a live backend: sorting by cost puts the most expensive trace first, sorting by tokens puts the largest first, and `sort_by=endpoint_name` returns 400. New coverage in `TestTraceListSorting`, `TestTokenTotalFallbackShapes` and the `subtreeUsage` unit tests.

The `trivy (backend)` failure was an install-step TLS error inside the action, not a finding. Both Trivy steps set `exit-code: 0`, so a vulnerability cannot fail that job. Re-run triggered.
