### PR TITLE
Fix SDK endpoint failures in sequential and parallel test runs

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/connector/manager.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/manager.py
@@ -610,31 +610,24 @@ class ConnectionManager:
         # Publish to Redis for cross-instance waiters
         if redis_manager.is_available:
             try:
-                self._track_background_task(
-                    self._publish_rpc_response(
-                        test_run_id, result, discard_from=None if event else self._test_results
-                    )
-                )
+                self._track_background_task(self._publish_rpc_response(test_run_id, result))
             except Exception as e:
                 logger.error(
                     f"Failed to schedule RPC response publish: {e}",
                     exc_info=True,
                 )
 
-    async def _publish_rpc_response(
-        self,
-        run_id: str,
-        result: Dict[str, Any],
-        discard_from: Optional[Dict[str, Any]] = None,
-    ) -> None:
-        """Publish RPC response to Redis for cross-instance waiters.
+        # No local waiter means nothing ever reads this back out of the dict: the
+        # worker waits over Redis, and the publish task holds its own reference to
+        # ``result``. Discard here rather than inside that task so the entry cannot
+        # outlive a scheduling failure, an unavailable Redis, or a failed publish --
+        # ``cleanup_test_result`` is only ever reached from the local-WebSocket path,
+        # so anything left here leaks the full payload for the life of the process.
+        if event is None:
+            self._test_results.pop(test_run_id, None)
 
-        ``discard_from`` is the store holding this result when there is no local
-        waiter for it. A worker waits over Redis, never on this process's dict, so
-        once the result is on the wire nothing reads it back and keeping it leaks
-        the full payload for the life of the process -- ``cleanup_test_result`` is
-        only ever reached from the local-WebSocket path.
-        """
+    async def _publish_rpc_response(self, run_id: str, result: Dict[str, Any]) -> None:
+        """Publish RPC response to Redis for cross-instance waiters."""
         try:
             channel = f"ws:rpc:response:{run_id}"
             await redis_manager.client.publish(channel, json.dumps(result))
@@ -644,10 +637,6 @@ class ConnectionManager:
                 f"Failed to publish RPC response for {run_id}: {e}",
                 exc_info=True,
             )
-        finally:
-            # Also on failure: a result nobody can read is not worth retaining.
-            if discard_from is not None:
-                discard_from.pop(run_id, None)
 
     def _resolve_metric_result(self, metric_run_id: str, result: Dict[str, Any]) -> None:
         """Store a metric result and wake up any waiting coroutine."""
@@ -667,18 +656,16 @@ class ConnectionManager:
 
         if redis_manager.is_available:
             try:
-                self._track_background_task(
-                    self._publish_rpc_response(
-                        metric_run_id,
-                        result,
-                        discard_from=None if event else self._metric_results,
-                    )
-                )
+                self._track_background_task(self._publish_rpc_response(metric_run_id, result))
             except Exception as e:
                 logger.error(
                     f"Failed to publish metric RPC response: {e}",
                     exc_info=True,
                 )
+
+        # See _resolve_test_result: with no local waiter this entry is unreachable.
+        if event is None:
+            self._metric_results.pop(metric_run_id, None)
 
     def get_metric_result(self, metric_run_id: str) -> Optional[Dict[str, Any]]:
         """Get metric result if available (non-destructive)."""

--- a/apps/backend/src/rhesis/backend/app/services/connector/manager.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/manager.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import random
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
@@ -29,6 +30,13 @@ from rhesis.backend.app.services.connector.schemas import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Routing/connection keys are written with a 30s TTL, so a heartbeat must refresh
+# well inside that. Jitter only ever SHORTENS the wait (never lengthens it), which
+# de-synchronises the per-connection loops without risking key expiry: the slowest
+# possible tick stays at the full interval.
+_HEARTBEAT_INTERVAL = 10
+_HEARTBEAT_JITTER = 0.3
 
 _EXECUTE_TEST_EXTRA_KEYS = frozenset(
     {
@@ -245,13 +253,20 @@ class ConnectionManager:
     async def _heartbeat_loop(self, connection_id: str) -> None:
         """Refresh Redis keys for a connection and its project routes.
 
-        Runs every 10 s while the connection is alive.  Refreshes the
-        connection-level key (``ws:conn:{connection_id}``) and every
-        project routing key registered through this connection.
+        Runs roughly every ``_HEARTBEAT_INTERVAL`` seconds while the connection is
+        alive. Refreshes the connection-level key (``ws:conn:{connection_id}``) and
+        every project routing key registered through this connection.
+
+        The interval is jittered because there is one of these loops per connected
+        SDK. Sleeping a fixed 10s makes every loop that started together stay in
+        lockstep forever, so with tens of endpoints -- which is what happens when
+        they all reconnect after a backend restart -- each tick fires a synchronised
+        burst of setex calls that saturates the Redis pool and queues test-result
+        publishing behind it. Spreading them keeps the load flat.
         """
         try:
             while connection_id in self._connections:
-                await asyncio.sleep(10)
+                await asyncio.sleep(_HEARTBEAT_INTERVAL * random.uniform(1 - _HEARTBEAT_JITTER, 1))
 
                 if connection_id not in self._connections:
                     break
@@ -595,15 +610,31 @@ class ConnectionManager:
         # Publish to Redis for cross-instance waiters
         if redis_manager.is_available:
             try:
-                self._track_background_task(self._publish_rpc_response(test_run_id, result))
+                self._track_background_task(
+                    self._publish_rpc_response(
+                        test_run_id, result, discard_from=None if event else self._test_results
+                    )
+                )
             except Exception as e:
                 logger.error(
                     f"Failed to schedule RPC response publish: {e}",
                     exc_info=True,
                 )
 
-    async def _publish_rpc_response(self, run_id: str, result: Dict[str, Any]) -> None:
-        """Publish RPC response to Redis for cross-instance waiters."""
+    async def _publish_rpc_response(
+        self,
+        run_id: str,
+        result: Dict[str, Any],
+        discard_from: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Publish RPC response to Redis for cross-instance waiters.
+
+        ``discard_from`` is the store holding this result when there is no local
+        waiter for it. A worker waits over Redis, never on this process's dict, so
+        once the result is on the wire nothing reads it back and keeping it leaks
+        the full payload for the life of the process -- ``cleanup_test_result`` is
+        only ever reached from the local-WebSocket path.
+        """
         try:
             channel = f"ws:rpc:response:{run_id}"
             await redis_manager.client.publish(channel, json.dumps(result))
@@ -613,6 +644,10 @@ class ConnectionManager:
                 f"Failed to publish RPC response for {run_id}: {e}",
                 exc_info=True,
             )
+        finally:
+            # Also on failure: a result nobody can read is not worth retaining.
+            if discard_from is not None:
+                discard_from.pop(run_id, None)
 
     def _resolve_metric_result(self, metric_run_id: str, result: Dict[str, Any]) -> None:
         """Store a metric result and wake up any waiting coroutine."""
@@ -632,7 +667,13 @@ class ConnectionManager:
 
         if redis_manager.is_available:
             try:
-                self._track_background_task(self._publish_rpc_response(metric_run_id, result))
+                self._track_background_task(
+                    self._publish_rpc_response(
+                        metric_run_id,
+                        result,
+                        discard_from=None if event else self._metric_results,
+                    )
+                )
             except Exception as e:
                 logger.error(
                     f"Failed to publish metric RPC response: {e}",

--- a/apps/backend/src/rhesis/backend/app/services/connector/redis_client.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/redis_client.py
@@ -40,7 +40,38 @@ _COMMAND_RETRIES = 3
 # listener, heartbeat bursts): at 3 the pool starves completely and publishes
 # are dropped. Raising it far past 32 showed no measured benefit, and a large
 # non-blocking pool was actually slower because opening connections is not free.
-_MAX_CONNECTIONS = int(os.getenv("REDIS_MAX_CONNECTIONS", "32"))
+_DEFAULT_MAX_CONNECTIONS = 32
+
+# Floor enforced below. Measured: at 3 the pool starves completely and drops
+# responses, and the drop is silent (the publish fails, the worker waits out its
+# 120s timeout and blames the endpoint). Too nasty to leave to a typo in an env var.
+_MIN_MAX_CONNECTIONS = 16
+
+
+def _resolve_max_connections() -> int:
+    """Read the ceiling from the environment, refusing to go below the floor."""
+    raw = os.getenv("REDIS_MAX_CONNECTIONS")
+    if raw is None:
+        return _DEFAULT_MAX_CONNECTIONS
+    try:
+        requested = int(raw)
+    except ValueError:
+        logger.warning(
+            f"REDIS_MAX_CONNECTIONS={raw!r} is not an integer; using {_DEFAULT_MAX_CONNECTIONS}"
+        )
+        return _DEFAULT_MAX_CONNECTIONS
+    if requested < _MIN_MAX_CONNECTIONS:
+        logger.warning(
+            f"REDIS_MAX_CONNECTIONS={requested} is below the safe floor of "
+            f"{_MIN_MAX_CONNECTIONS}; clamping. Below the floor the pool starves "
+            f"behind the blpop listener and heartbeats, and SDK test results are "
+            f"silently dropped."
+        )
+        return _MIN_MAX_CONNECTIONS
+    return requested
+
+
+_MAX_CONNECTIONS = _resolve_max_connections()
 
 # How long a caller waits for a free connection before giving up. Bursts should
 # queue for microseconds; this only trips if the pool is genuinely saturated.

--- a/apps/backend/src/rhesis/backend/app/services/connector/redis_client.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/redis_client.py
@@ -1,6 +1,7 @@
 """Redis client for SDK RPC communication between workers and backend."""
 
 import logging
+import os
 import time
 
 import redis.asyncio as redis
@@ -24,6 +25,56 @@ _HEALTH_CHECK_INTERVAL_SECONDS = 30
 
 # Per-command reconnect attempts on a dropped connection.
 _COMMAND_RETRIES = 3
+
+# Ceiling on pooled connections, per backend process.
+#
+# With tens of connected SDKs the pool saturates to whatever ceiling it is given:
+# one heartbeat loop per connection (manager.py:180) plus a publish burst
+# comfortably exceeds it, so the headroom is genuinely used rather than idle.
+# Measured at 100 endpoints and 1000 concurrent publishes: zero loss at both 16
+# and 32, p95 ~40ms, and the pool pinned at its ceiling in every case. 32 is
+# chosen for headroom, not throughput; it costs 32 sockets per pod against a
+# default Valkey maxclients of 10000.
+#
+# Do not lower it towards the number of *blocking* consumers (the blpop RPC
+# listener, heartbeat bursts): at 3 the pool starves completely and publishes
+# are dropped. Raising it far past 32 showed no measured benefit, and a large
+# non-blocking pool was actually slower because opening connections is not free.
+_MAX_CONNECTIONS = int(os.getenv("REDIS_MAX_CONNECTIONS", "32"))
+
+# How long a caller waits for a free connection before giving up. Bursts should
+# queue for microseconds; this only trips if the pool is genuinely saturated.
+_POOL_TIMEOUT_SECONDS = 5
+
+
+def create_client(redis_url: str) -> redis.Redis:
+    """Build the pooled Redis client for SDK RPC.
+
+    BlockingConnectionPool, not the default pool: the default RAISES
+    ``ConnectionError("Too many connections")`` the moment the pool is full, and
+    ``retry_on_error`` does NOT cover it because redis-py acquires the connection
+    before its retry wrapper. That turned a burst of concurrent test results into
+    "Failed to publish RPC response: Too many connections", losing the response so
+    the worker stalled the full SDK_FUNCTION_TIMEOUT (120s) and reported a bogus
+    endpoint timeout. Blocking makes an over-capacity burst wait instead of vanish.
+
+    Opens no socket; the caller pings to verify reachability.
+    """
+    pool = redis.BlockingConnectionPool.from_url(
+        redis_url,
+        max_connections=_MAX_CONNECTIONS,
+        timeout=_POOL_TIMEOUT_SECONDS,
+        decode_responses=True,
+        encoding="utf-8",
+        health_check_interval=_HEALTH_CHECK_INTERVAL_SECONDS,
+        socket_keepalive=True,
+        retry=Retry(ExponentialBackoff(cap=1.0, base=0.05), _COMMAND_RETRIES),
+        # Without retry_on_error redis-py raises a dropped connection at the
+        # call site instead of reconnecting, which floods the RPC listener's
+        # blpop loop with ConnectionError (closes #1695).
+        retry_on_error=[RedisConnectionError, RedisTimeoutError],
+    )
+    return redis.Redis(connection_pool=pool)
 
 
 class RedisConnectionManager:
@@ -53,20 +104,8 @@ class RedisConnectionManager:
 
         try:
             redis_url = get_redis_settings().broker_url
-            self._client = await redis.from_url(
-                redis_url,
-                decode_responses=True,
-                encoding="utf-8",
-                max_connections=3,
-                health_check_interval=_HEALTH_CHECK_INTERVAL_SECONDS,
-                socket_keepalive=True,
-                retry=Retry(ExponentialBackoff(cap=1.0, base=0.05), _COMMAND_RETRIES),
-                # Without retry_on_error redis-py raises a dropped connection at the
-                # call site instead of reconnecting, which floods the RPC listener's
-                # blpop loop with ConnectionError (closes #1695).
-                retry_on_error=[RedisConnectionError, RedisTimeoutError],
-            )
-            # Actually test the connection - from_url() doesn't connect until first use
+            self._client = create_client(redis_url)
+            # Actually test the connection - create_client() doesn't open a socket
             await self._client.ping()
             self._initialized = True
             self._last_failed_at = 0  # reset cooldown on success

--- a/apps/backend/src/rhesis/backend/app/services/connector/rpc_client.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/rpc_client.py
@@ -15,22 +15,57 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Thread-local RPC client
 # ---------------------------------------------------------------------------
-# With the coroutine/thread Celery pool each worker thread owns its own event
-# loop (see batch/__init__.py:_thread_local).  redis.asyncio clients are tied
-# to the event loop they were created on, so one client per thread is both
-# correct and avoids the cost of creating a new connection + PING on every
-# single test invocation (the old per-call pattern).
+# With the coroutine/thread Celery pool each worker thread runs its tests on one
+# persistent event loop (see execution/shared.py:run_on_thread_loop).  redis.asyncio
+# clients are tied to the event loop they were created on, so caching one per thread
+# avoids the cost of creating a new connection + PING on every single test invocation
+# (the old per-call pattern).  The cache is keyed by thread but validated against the
+# running loop, because a caller is free to hand this thread a different loop.
 _tls = threading.local()
 
 
 async def get_rpc_client() -> "SDKRpcClient":
-    """Return the thread-local SDKRpcClient, initializing it on first access."""
+    """Return the thread-local SDKRpcClient, initializing it on first access.
+
+    Rebuilds when the running loop is not the one the cached client was created
+    on. A thread is not guaranteed to keep one loop for its lifetime -- a caller
+    using ``asyncio.run()`` per call gets a fresh loop each time -- and a client
+    carried across a closed loop holds dead connections that fail every command
+    with "Event loop is closed".
+    """
+    loop = asyncio.get_running_loop()
+
+    def _usable(c: "SDKRpcClient | None") -> bool:
+        # A client built on a loop that has since been replaced holds dead
+        # connections; every command on it fails with "Event loop is closed".
+        return c is not None and c._redis is not None and c._loop is loop
+
     client: "SDKRpcClient | None" = getattr(_tls, "rpc_client", None)
-    if client is None or client._redis is None:
+    if _usable(client):
+        return client
+
+    # Serialize initialization. Without this the check above and the store below
+    # straddle an await, so at batch start every concurrent test builds its own
+    # client and opens its own Redis connection; the last writer wins and the
+    # rest leak, since close() is never called. Measured 14 orphaned connections
+    # at batch_concurrency=15.
+    lock = getattr(_tls, "rpc_init_lock", None)
+    if lock is None or getattr(_tls, "rpc_init_lock_loop", None) is not loop:
+        lock = asyncio.Lock()
+        _tls.rpc_init_lock = lock
+        _tls.rpc_init_lock_loop = loop
+
+    async with lock:
+        client = getattr(_tls, "rpc_client", None)
+        if _usable(client):
+            return client
+        # Stale-loop clients are dropped, not closed: awaiting close() would run
+        # on the dead loop.
         client = SDKRpcClient()
         await client.initialize()
+        client._loop = loop
         _tls.rpc_client = client
-    return client
+        return client
 
 
 class SDKRpcClient:
@@ -39,6 +74,8 @@ class SDKRpcClient:
     def __init__(self):
         """Initialize RPC client."""
         self._redis = None
+        # The loop this client's connections are bound to; see get_rpc_client().
+        self._loop = None
 
     async def initialize(self):
         """
@@ -64,6 +101,7 @@ class SDKRpcClient:
         if self._redis:
             await self._redis.aclose()
             self._redis = None
+        self._loop = None
         _tls.rpc_client = None
 
     async def is_connected(self, project_id: str, environment: str) -> bool:

--- a/apps/backend/src/rhesis/backend/app/services/connector/rpc_client.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/rpc_client.py
@@ -59,8 +59,20 @@ async def get_rpc_client() -> "SDKRpcClient":
         client = getattr(_tls, "rpc_client", None)
         if _usable(client):
             return client
-        # Stale-loop clients are dropped, not closed: awaiting close() would run
-        # on the dead loop.
+
+        # A stale-loop client is dropped rather than closed: aclose() would run on
+        # the dead loop. Its sockets linger until GC, and redis-py's __del__ only
+        # closes them when a loop is running, so this genuinely leaks a connection.
+        # Warn rather than swallow it: with a persistent per-thread loop this should
+        # never fire, so if it appears in production some caller is churning loops
+        # and the leak is worth chasing.
+        if client is not None and client._redis is not None:
+            logger.warning(
+                "RPC client was built on a stale event loop; rebuilding and "
+                "abandoning its connections. A caller is creating a new loop per "
+                "call -- use execution/shared.py:run_on_thread_loop instead."
+            )
+
         client = SDKRpcClient()
         await client.initialize()
         client._loop = loop

--- a/apps/backend/src/rhesis/backend/app/services/invokers/common/errors.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/common/errors.py
@@ -148,6 +148,16 @@ _TRANSIENT_ERROR_TYPES = frozenset(
         "websocket_error",
         "timeout_error",
         "connection_error",
+        # The SDK connector's failures are all transport-level: a dropped
+        # WebSocket, a reconnect window, a response that never made it back.
+        # None of them say the target rejected the call, and every one of them
+        # can succeed on a second attempt. Left permanent, a single blip became
+        # a permanently failed test -- invoke_with_retry skipped it, and the
+        # batch recovery round skipped it too because it reports
+        # status="endpoint_error" rather than "failed".
+        "sdk_send_failed",
+        "sdk_disconnected",
+        "sdk_timeout",
     }
 )
 

--- a/apps/backend/src/rhesis/backend/app/services/invokers/common/errors.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/common/errors.py
@@ -148,16 +148,22 @@ _TRANSIENT_ERROR_TYPES = frozenset(
         "websocket_error",
         "timeout_error",
         "connection_error",
-        # The SDK connector's failures are all transport-level: a dropped
-        # WebSocket, a reconnect window, a response that never made it back.
-        # None of them say the target rejected the call, and every one of them
-        # can succeed on a second attempt. Left permanent, a single blip became
-        # a permanently failed test -- invoke_with_retry skipped it, and the
-        # batch recovery round skipped it too because it reports
-        # status="endpoint_error" rather than "failed".
+        # These two mean the request never reached the SDK: the send failed, or
+        # no connection was available. Retrying is the first real delivery, so it
+        # is safe whatever the endpoint does. Left permanent, a single blip became
+        # a permanently failed test -- invoke_with_retry skipped it, and the batch
+        # recovery round skipped it too because it reports status="endpoint_error"
+        # rather than "failed".
+        #
+        # ``sdk_timeout`` is deliberately NOT here. A timeout means we stopped
+        # waiting, not that the function did not run: the SDK may have completed
+        # it and missed the window. Retrying would invoke a stateful endpoint a
+        # second time -- a multi-turn agent would replay a turn into a
+        # conversation that already advanced -- and we cannot assume an arbitrary
+        # user endpoint is idempotent. Genuine timeouts are also rare now that a
+        # full Redis pool no longer discards responses.
         "sdk_send_failed",
         "sdk_disconnected",
-        "sdk_timeout",
     }
 )
 

--- a/apps/backend/src/rhesis/backend/app/utils/response_extractor.py
+++ b/apps/backend/src/rhesis/backend/app/utils/response_extractor.py
@@ -169,9 +169,18 @@ def summarize_endpoint_failure(result: Union[Dict, Any]) -> Optional[Dict[str, A
         return None
 
     status_code = get_http_error_status_code(result)
-    message = truncate_for_narration(
-        str(details.get("output") or details.get("message") or "").strip()
-    )
+    output = str(details.get("output") or "").strip()
+    detail = str(details.get("message") or "").strip()
+    # ``output`` names the failure, ``message`` carries the cause. Taking only ``output``
+    # collapsed every connector fault into one opaque line: the five distinct reasons an
+    # SDK send can fail all read "Failed to send request to SDK", so the actual cause
+    # ("Event loop is closed") reached neither the UI nor the activity log. REST already
+    # folds its detail into ``output``, hence the containment check rather than always
+    # appending.
+    message = output or detail
+    if output and detail and detail not in output:
+        message = f"{output}: {detail}"
+    message = truncate_for_narration(message)
 
     label = f"HTTP {status_code}" if status_code is not None else "an error"
     summary = f"Endpoint returned {label}"

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/__init__.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/__init__.py
@@ -10,9 +10,7 @@ Public API:
     ExecutionContext         — re-exported for type hints
 """
 
-import asyncio
 import logging
-import threading
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -31,29 +29,11 @@ from rhesis.backend.jobs.execution.batch.profiling import (
     log_batch_report,
 )
 from rhesis.backend.jobs.execution.batch.runner import run_batch
+from rhesis.backend.jobs.execution.shared import run_on_thread_loop
 
 __all__ = ["execute_tests_as_batch", "ExecutionContext"]
 
 logger = logging.getLogger(__name__)
-
-# Per-thread event loop, reused across tasks in the same Celery worker thread.
-# asyncio.run() creates and destroys a loop each invocation; LiteLLM's internal
-# LoggingWorker spawns background tasks on the loop that are destroyed mid-flight
-# when the loop closes, producing "Task was destroyed but it is pending!" warnings
-# and potentially dropping logging callbacks.  Reusing a loop per thread keeps
-# those background tasks alive for the thread's lifetime.
-# Thread-local (not process-global) so it is safe under --pool threads.
-_thread_local = threading.local()
-
-
-def _run_async(coro):
-    """Run a coroutine on the calling thread's persistent event loop."""
-    loop = getattr(_thread_local, "loop", None)
-    if loop is None or loop.is_closed():
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        _thread_local.loop = loop
-    return loop.run_until_complete(coro)
 
 
 def _persist_failed_results(ctx: "ExecutionContext", results: List[Dict[str, Any]]) -> None:
@@ -225,7 +205,7 @@ def execute_tests_as_batch(
 
     # Phase 2: Async execution (DB-free, uses deferred tracing).
     test_ids = [str(t.id) for t in tests if str(t.id) in ctx.test_data]
-    results = _run_async(
+    results = run_on_thread_loop(
         run_batch(
             ctx,
             test_ids,

--- a/apps/backend/src/rhesis/backend/jobs/execution/sequential.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/sequential.py
@@ -18,6 +18,7 @@ from rhesis.backend.jobs.execution.shared import (
     create_execution_result,
     create_failure_result,
     is_task_revoked,
+    run_on_thread_loop,
     trigger_results_collection,
     update_test_run_start,
 )
@@ -163,7 +164,7 @@ def execute_tests_sequentially(
             )
 
     # Cooperative cancellation: checked once per test, the only safe point in
-    # a loop that otherwise blocks on a synchronous asyncio.run() per test.
+    # a loop that otherwise blocks on a synchronous run_on_thread_loop() per test.
     # Same revoke set the batch runner polls, populated by revoke() from
     # either the test-run cancel endpoint or the job cancel endpoint.
     celery_task_id = (test_run.attributes or {}).get("task_id")
@@ -188,9 +189,7 @@ def execute_tests_sequentially(
                 logger.debug("on_test_phase(generating) failed", exc_info=True)
 
         try:
-            import asyncio
-
-            result = asyncio.run(
+            result = run_on_thread_loop(
                 execute_test(
                     db=session,
                     test_config_id=str(test_config.id),

--- a/apps/backend/src/rhesis/backend/jobs/execution/shared.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/shared.py
@@ -5,7 +5,9 @@ This module contains common logic used by both parallel and sequential execution
 to ensure consistent behavior and results.
 """
 
+import asyncio
 import logging
+import threading
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -19,6 +21,33 @@ from rhesis.backend.jobs.enums import ExecutionMode
 from rhesis.backend.jobs.execution.results import collect_results
 
 logger = logging.getLogger(__name__)
+
+# Per-thread event loop, reused across tests in the same Celery worker thread.
+# Thread-local (not process-global) so it is safe under --pool threads.
+_thread_local = threading.local()
+
+
+def run_on_thread_loop(coro):
+    """Run a coroutine on the calling thread's persistent event loop.
+
+    Never use ``asyncio.run()`` per test instead of this. It closes the loop each
+    time, and anything cached across tests that holds loop-bound resources breaks
+    on the next call:
+
+    - ``redis.asyncio`` clients are bound to the loop that created them, and the
+      SDK RPC client is cached per thread. A closed loop leaves its pooled
+      connections dead, so every other SDK test failed with "Event loop is closed"
+      surfacing as "Failed to send request to SDK".
+    - LiteLLM's LoggingWorker spawns background tasks on the loop that are
+      destroyed mid-flight, producing "Task was destroyed but it is pending!"
+      and potentially dropping logging callbacks.
+    """
+    loop = getattr(_thread_local, "loop", None)
+    if loop is None or loop.is_closed():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        _thread_local.loop = loop
+    return loop.run_until_complete(coro)
 
 
 def is_task_revoked(task_id: Optional[str]) -> bool:

--- a/tests/backend/jobs/test_cooperative_cancellation.py
+++ b/tests/backend/jobs/test_cooperative_cancellation.py
@@ -133,7 +133,7 @@ class TestBatchSkipsCollectionOnCancellation:
             ),
             patch("rhesis.backend.jobs.execution.shared.update_test_run_start"),
             patch("rhesis.backend.jobs.execution.batch.run_batch", return_value=MagicMock()),
-            patch("rhesis.backend.jobs.execution.batch._run_async", return_value=results),
+            patch("rhesis.backend.jobs.execution.batch.run_on_thread_loop", return_value=results),
             patch("rhesis.backend.jobs.execution.batch._persist_failed_results"),
             patch("rhesis.backend.jobs.execution.batch._mark_test_run_cancelled") as mock_mark,
             patch(

--- a/tests/backend/jobs/test_endpoint_failure_surfacing.py
+++ b/tests/backend/jobs/test_endpoint_failure_surfacing.py
@@ -417,6 +417,33 @@ class TestActivityLogNarration:
     def test_returns_none_for_a_successful_result(self):
         assert summarize_endpoint_failure({"output": "the model answered"}) is None
 
+    def test_connector_cause_is_kept_not_swallowed_by_the_headline(self):
+        """``output`` names the failure, ``message`` says why.
+
+        All five reasons an SDK send can fail share the headline "Failed to send
+        request to SDK", so dropping ``message`` made them indistinguishable in the
+        UI and the activity log. A real run failed on "Event loop is closed" and
+        nobody could see it.
+        """
+        response = ErrorResponse(
+            output="Failed to send request to SDK",
+            error=True,
+            error_type="sdk_send_failed",
+            message="Event loop is closed",
+        )
+        summary = summarize_endpoint_failure(process_endpoint_result(response))
+
+        assert summary is not None
+        assert "Failed to send request to SDK" in summary["message"]
+        assert "Event loop is closed" in summary["message"]
+
+    def test_cause_is_not_duplicated_when_the_headline_already_contains_it(self):
+        """REST folds its detail into ``output``; appending would repeat it."""
+        summary = summarize_endpoint_failure(process_endpoint_result(_http_400_error_response()))
+
+        assert summary is not None
+        assert summary["message"].count("HTTP 400 error from endpoint") == 1
+
     def test_a_huge_response_body_is_capped(self):
         """A target may answer a 4xx with an HTML error page or an echoed payload. Each
         narrated test becomes an ActivityLog row on an unbounded Text column, so the

--- a/tests/backend/jobs/test_execution_event_loop.py
+++ b/tests/backend/jobs/test_execution_event_loop.py
@@ -1,0 +1,105 @@
+"""Regression tests for event-loop reuse across tests in a run.
+
+A closed event loop leaves loop-bound resources dead behind it. The SDK RPC client
+is cached per thread and holds ``redis.asyncio`` connections, so running each test
+on its own ``asyncio.run()`` made every second SDK test fail with
+"Event loop is closed", surfaced to users as "Failed to send request to SDK".
+"""
+
+import asyncio
+
+from rhesis.backend.jobs.execution.shared import run_on_thread_loop
+
+
+class TestRunOnThreadLoop:
+    def test_reuses_one_loop_across_calls(self):
+        """The whole point: consecutive calls must land on the same loop."""
+
+        async def _loop_id():
+            return id(asyncio.get_running_loop())
+
+        seen = [run_on_thread_loop(_loop_id()) for _ in range(5)]
+        assert len(set(seen)) == 1, f"expected one loop, saw {len(set(seen))}"
+
+    def test_loop_stays_open_between_calls(self):
+        """asyncio.run() closes the loop on exit; this must not."""
+
+        async def _get_loop():
+            return asyncio.get_running_loop()
+
+        loop = run_on_thread_loop(_get_loop())
+        assert not loop.is_closed()
+
+        run_on_thread_loop(_get_loop())
+        assert not loop.is_closed()
+
+    def test_resources_bound_to_the_loop_survive(self):
+        """An asyncio primitive built in one call is still usable in the next.
+
+        This is the property the cached Redis client depends on. Under
+        ``asyncio.run()`` the second call raises "Event loop is closed".
+        """
+        holder = {}
+
+        async def _create():
+            holder["event"] = asyncio.Event()
+            holder["loop"] = asyncio.get_running_loop()
+
+        async def _reuse():
+            # Touching a loop-bound object from a later call must not blow up.
+            holder["event"].set()
+            return holder["loop"] is asyncio.get_running_loop()
+
+        run_on_thread_loop(_create())
+        assert run_on_thread_loop(_reuse()) is True
+
+    def test_rebuilds_after_the_loop_is_closed(self):
+        """A closed loop is replaced rather than reused."""
+
+        async def _get_loop():
+            return asyncio.get_running_loop()
+
+        first = run_on_thread_loop(_get_loop())
+        first.close()
+
+        second = run_on_thread_loop(_get_loop())
+        assert second is not first
+        assert not second.is_closed()
+
+    def test_returns_the_coroutine_result(self):
+        async def _answer():
+            await asyncio.sleep(0)
+            return 42
+
+        assert run_on_thread_loop(_answer()) == 42
+
+    def test_propagates_exceptions(self):
+        async def _boom():
+            raise ValueError("boom")
+
+        try:
+            run_on_thread_loop(_boom())
+        except ValueError as e:
+            assert str(e) == "boom"
+        else:
+            raise AssertionError("exception did not propagate")
+
+    def test_each_thread_gets_its_own_loop(self):
+        """Thread-local, so it is safe under Celery's --pool threads."""
+        import threading
+
+        async def _loop_id():
+            return id(asyncio.get_running_loop())
+
+        results = {}
+
+        def _work(name):
+            results[name] = run_on_thread_loop(_loop_id())
+
+        threads = [threading.Thread(target=_work, args=(f"t{i}",)) for i in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(set(results.values())) == 3, "threads must not share a loop"

--- a/tests/backend/jobs/test_invoke_retry.py
+++ b/tests/backend/jobs/test_invoke_retry.py
@@ -76,6 +76,35 @@ class TestClassifyErrorResponse:
         assert err.transient is True
 
 
+    @pytest.mark.parametrize(
+        "error_type",
+        ["sdk_send_failed", "sdk_disconnected", "sdk_timeout"],
+    )
+    def test_sdk_transport_errors_are_transient(self, error_type):
+        """All three are transport-level, so a second attempt can succeed.
+
+        Left permanent, one blip became a permanently failed test: the retry
+        skipped it and the batch recovery round skipped it too.
+        """
+        resp = ErrorResponse(
+            output="SDK error",
+            error_type=error_type,
+            message="transport-level failure",
+        )
+        err = classify_error_response(resp)
+        assert err.transient is True
+        assert err.error_type == error_type
+
+    def test_sdk_function_error_stays_permanent(self):
+        """The SDK function itself raising is the target's answer, not transport."""
+        resp = ErrorResponse(
+            output="SDK function error: rejected by policy",
+            error_type="sdk_function_error",
+            message="rejected by policy",
+        )
+        assert classify_error_response(resp).transient is False
+
+
 class TestInvokeWithRetry:
     @pytest.mark.asyncio
     async def test_success_on_first_attempt(self):

--- a/tests/backend/jobs/test_invoke_retry.py
+++ b/tests/backend/jobs/test_invoke_retry.py
@@ -75,13 +75,12 @@ class TestClassifyErrorResponse:
         err = classify_error_response(resp)
         assert err.transient is True
 
-
     @pytest.mark.parametrize(
         "error_type",
-        ["sdk_send_failed", "sdk_disconnected", "sdk_timeout"],
+        ["sdk_send_failed", "sdk_disconnected"],
     )
-    def test_sdk_transport_errors_are_transient(self, error_type):
-        """All three are transport-level, so a second attempt can succeed.
+    def test_undelivered_sdk_requests_are_transient(self, error_type):
+        """Neither reached the SDK, so retrying is the first real delivery.
 
         Left permanent, one blip became a permanently failed test: the retry
         skipped it and the batch recovery round skipped it too.
@@ -94,6 +93,21 @@ class TestClassifyErrorResponse:
         err = classify_error_response(resp)
         assert err.transient is True
         assert err.error_type == error_type
+
+    def test_sdk_timeout_is_not_retried(self):
+        """A timeout means we stopped waiting, not that the function did not run.
+
+        The SDK may have completed the call and missed the window, so retrying
+        would invoke a stateful endpoint twice. A multi-turn agent would replay a
+        turn into a conversation that has already advanced, and we cannot assume
+        an arbitrary user endpoint is idempotent.
+        """
+        resp = ErrorResponse(
+            output="SDK function execution timed out",
+            error_type="sdk_timeout",
+            message="Function did not respond within 120.0 seconds",
+        )
+        assert classify_error_response(resp).transient is False
 
     def test_sdk_function_error_stays_permanent(self):
         """The SDK function itself raising is the target's answer, not transport."""
@@ -127,7 +141,9 @@ class TestInvokeWithRetry:
             call_count += 1
             if call_count < 3:
                 raise EndpointInvocationError(
-                    "gateway timeout", transient=True, status_code=504,
+                    "gateway timeout",
+                    transient=True,
+                    status_code=504,
                 )
             return {"output": "ok"}
 
@@ -142,7 +158,9 @@ class TestInvokeWithRetry:
         async def _factory():
             calls.append(1)
             raise EndpointInvocationError(
-                "bad request", transient=False, status_code=400,
+                "bad request",
+                transient=False,
+                status_code=400,
             )
 
         with pytest.raises(EndpointInvocationError) as exc_info:
@@ -158,7 +176,9 @@ class TestInvokeWithRetry:
         async def _factory():
             calls.append(1)
             raise EndpointInvocationError(
-                "always fails", transient=True, status_code=503,
+                "always fails",
+                transient=True,
+                status_code=503,
             )
 
         with pytest.raises(EndpointInvocationError) as exc_info:

--- a/tests/backend/services/connector/test_redis_client_retry.py
+++ b/tests/backend/services/connector/test_redis_client_retry.py
@@ -11,7 +11,6 @@ The fix replaces the permanent latch with a time-based cooldown
 recovers.
 """
 
-import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -46,12 +45,15 @@ class TestRedisRetryCooldown:
         mock_client.ping = AsyncMock(side_effect=ConnectionError("Redis down"))
         mock_client.close = AsyncMock()
 
-        with patch(
-            "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
-            return_value=mock_redis_settings,
-        ), patch(
-            "rhesis.backend.app.services.connector.redis_client.redis.from_url",
-            return_value=mock_client,
+        with (
+            patch(
+                "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
+                return_value=mock_redis_settings,
+            ),
+            patch(
+                "rhesis.backend.app.services.connector.redis_client.create_client",
+                return_value=mock_client,
+            ),
         ):
             await redis_manager.initialize()
 
@@ -69,15 +71,18 @@ class TestRedisRetryCooldown:
         mock_client_fail.ping = AsyncMock(side_effect=ConnectionError("Redis down"))
         mock_client_fail.close = AsyncMock()
 
-        async def _from_url_fail(*args, **kwargs):
+        def _build_failing(*args, **kwargs):
             return mock_client_fail
 
-        with patch(
-            "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
-            return_value=mock_redis_settings,
-        ), patch(
-            "rhesis.backend.app.services.connector.redis_client.redis.from_url",
-            side_effect=_from_url_fail,
+        with (
+            patch(
+                "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
+                return_value=mock_redis_settings,
+            ),
+            patch(
+                "rhesis.backend.app.services.connector.redis_client.create_client",
+                side_effect=_build_failing,
+            ),
         ):
             await redis_manager.initialize()
         assert not redis_manager._initialized
@@ -89,15 +94,18 @@ class TestRedisRetryCooldown:
         mock_client_ok = AsyncMock()
         mock_client_ok.ping = AsyncMock(return_value=True)
 
-        async def _from_url_ok(*args, **kwargs):
+        def _build_ok(*args, **kwargs):
             return mock_client_ok
 
-        with patch(
-            "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
-            return_value=mock_redis_settings,
-        ), patch(
-            "rhesis.backend.app.services.connector.redis_client.redis.from_url",
-            side_effect=_from_url_ok,
+        with (
+            patch(
+                "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
+                return_value=mock_redis_settings,
+            ),
+            patch(
+                "rhesis.backend.app.services.connector.redis_client.create_client",
+                side_effect=_build_ok,
+            ),
         ):
             await redis_manager.initialize()
 
@@ -113,12 +121,15 @@ class TestRedisRetryCooldown:
         mock_client.ping = AsyncMock(side_effect=ConnectionError("Redis down"))
         mock_client.close = AsyncMock()
 
-        with patch(
-            "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
-            return_value=mock_redis_settings,
-        ), patch(
-            "rhesis.backend.app.services.connector.redis_client.redis.from_url",
-            return_value=mock_client,
+        with (
+            patch(
+                "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
+                return_value=mock_redis_settings,
+            ),
+            patch(
+                "rhesis.backend.app.services.connector.redis_client.create_client",
+                return_value=mock_client,
+            ),
         ):
             await redis_manager.initialize()
 
@@ -129,12 +140,15 @@ class TestRedisRetryCooldown:
         mock_client2 = AsyncMock()
         mock_client2.ping = AsyncMock(return_value=True)
 
-        with patch(
-            "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
-            return_value=mock_redis_settings,
-        ), patch(
-            "rhesis.backend.app.services.connector.redis_client.redis.from_url",
-            return_value=mock_client2,
+        with (
+            patch(
+                "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
+                return_value=mock_redis_settings,
+            ),
+            patch(
+                "rhesis.backend.app.services.connector.redis_client.create_client",
+                return_value=mock_client2,
+            ),
         ):
             await redis_manager.initialize()
 
@@ -151,12 +165,15 @@ class TestRedisRetryCooldown:
         mock_client.ping = AsyncMock(side_effect=ConnectionError("down"))
         mock_client.close = AsyncMock()
 
-        with patch(
-            "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
-            return_value=mock_redis_settings,
-        ), patch(
-            "rhesis.backend.app.services.connector.redis_client.redis.from_url",
-            return_value=mock_client,
+        with (
+            patch(
+                "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
+                return_value=mock_redis_settings,
+            ),
+            patch(
+                "rhesis.backend.app.services.connector.redis_client.create_client",
+                return_value=mock_client,
+            ),
         ):
             await redis_manager.initialize()
 
@@ -166,43 +183,19 @@ class TestRedisRetryCooldown:
 class TestRedisConnectionResilience:
     """Verify the client is built so redis-py reconnects on its own (closes #1695)."""
 
-    @pytest.mark.asyncio
-    async def test_dropped_connection_is_retried_not_raised(
-        self, redis_manager, mock_redis_settings
-    ):
+    def test_dropped_connection_is_retried_not_raised(self):
         """A dropped connection must reconnect instead of surfacing to the caller.
 
-        Asserted against a real redis-py connection built from the same kwargs, so this
-        catches an option being dropped or renamed — not just "from_url got a dict".
+        Asserted against the real client the code builds, so this catches an
+        option being dropped or renamed rather than just "a builder was called".
         """
-        import redis.asyncio as real_redis
         from redis.exceptions import ConnectionError as RedisConnectionError
         from redis.exceptions import TimeoutError as RedisTimeoutError
 
-        recorded = {}
+        from rhesis.backend.app.services.connector.redis_client import create_client
 
-        async def _capture(url, **kwargs):
-            recorded["url"] = url
-            recorded["kwargs"] = kwargs
-            client = AsyncMock()
-            client.ping = AsyncMock(return_value=True)
-            return client
-
-        with patch(
-            "rhesis.backend.app.services.connector.redis_client.get_redis_settings",
-            return_value=mock_redis_settings,
-        ), patch(
-            "rhesis.backend.app.services.connector.redis_client.redis.from_url",
-            side_effect=_capture,
-        ):
-            await redis_manager.initialize()
-
-        assert redis_manager.is_available
-
-        # from_url() does not open a socket, so this is safe without a Redis server.
-        connection = real_redis.from_url(
-            recorded["url"], **recorded["kwargs"]
-        ).connection_pool.make_connection()
+        # create_client() opens no socket, so this is safe with no Redis server.
+        connection = create_client("redis://localhost:6379/0").connection_pool.make_connection()
 
         # Zero retries or an empty retry_on_error is what made blpop raise instead of reconnect.
         assert connection.retry._retries > 0
@@ -213,3 +206,42 @@ class TestRedisConnectionResilience:
         # Keeps an idle pooled connection from being handed out already dead.
         assert connection.health_check_interval > 0
         assert connection.socket_keepalive is True
+
+    def test_pool_blocks_instead_of_dropping_a_response(self):
+        """An over-capacity burst must wait, never raise.
+
+        The default ConnectionPool raises ConnectionError("Too many connections")
+        the instant it is full, and redis-py acquires the connection *before* its
+        retry wrapper so retry_on_error cannot save it. That lost SDK responses:
+        the publish failed, the worker never woke, and the test reported a bogus
+        120s endpoint timeout. Concurrency 15 lost a third of a 40-test run.
+        """
+        import redis.asyncio as redis_asyncio
+
+        from rhesis.backend.app.services.connector.redis_client import create_client
+
+        pool = create_client("redis://localhost:6379/0").connection_pool
+        assert isinstance(pool, redis_asyncio.BlockingConnectionPool), (
+            "must be a blocking pool; the default one discards responses under load"
+        )
+        assert pool.timeout is not None and pool.timeout > 0
+
+    def test_pool_ceiling_clears_the_blocking_consumers(self):
+        """The ceiling is a resource bound, not a throughput knob.
+
+        It must stay above the connections pinned by blocking operations (the
+        blpop RPC listener plus one heartbeat loop per connected SDK), or
+        publishes queue behind them and starve. Measured: 3 starves completely
+        with 3+ listeners; 16 stayed clean at every load tested.
+        """
+        from rhesis.backend.app.services.connector.redis_client import (
+            _MAX_CONNECTIONS,
+            create_client,
+        )
+
+        assert _MAX_CONNECTIONS >= 16, (
+            f"{_MAX_CONNECTIONS} is too close to the number of blocking consumers; "
+            "with tens of connected SDKs the pool saturates and publishes queue"
+        )
+        pool = create_client("redis://localhost:6379/0").connection_pool
+        assert pool.max_connections == _MAX_CONNECTIONS

--- a/tests/backend/services/connector/test_redis_client_retry.py
+++ b/tests/backend/services/connector/test_redis_client_retry.py
@@ -226,6 +226,38 @@ class TestRedisConnectionResilience:
         )
         assert pool.timeout is not None and pool.timeout > 0
 
+    def test_env_ceiling_cannot_be_set_below_the_safe_floor(self):
+        """A too-low ceiling drops responses silently, so it is clamped, loudly.
+
+        Below the floor the pool starves behind the blpop listener and the
+        per-connection heartbeats: the publish fails, the worker waits out its
+        120s timeout, and the failure is reported against the endpoint.
+        """
+        from rhesis.backend.app.services.connector.redis_client import (
+            _MIN_MAX_CONNECTIONS,
+            _resolve_max_connections,
+        )
+
+        with patch.dict("os.environ", {"REDIS_MAX_CONNECTIONS": "3"}):
+            assert _resolve_max_connections() == _MIN_MAX_CONNECTIONS
+
+    def test_env_ceiling_above_the_floor_is_honoured(self):
+        from rhesis.backend.app.services.connector.redis_client import (
+            _resolve_max_connections,
+        )
+
+        with patch.dict("os.environ", {"REDIS_MAX_CONNECTIONS": "64"}):
+            assert _resolve_max_connections() == 64
+
+    def test_unparseable_env_ceiling_falls_back_to_the_default(self):
+        from rhesis.backend.app.services.connector.redis_client import (
+            _DEFAULT_MAX_CONNECTIONS,
+            _resolve_max_connections,
+        )
+
+        with patch.dict("os.environ", {"REDIS_MAX_CONNECTIONS": "lots"}):
+            assert _resolve_max_connections() == _DEFAULT_MAX_CONNECTIONS
+
     def test_pool_ceiling_clears_the_blocking_consumers(self):
         """The ceiling is a resource bound, not a throughput knob.
 

--- a/tests/backend/services/connector/test_result_store_cleanup.py
+++ b/tests/backend/services/connector/test_result_store_cleanup.py
@@ -1,0 +1,128 @@
+"""Regression tests: RPC-path results must not accumulate in the backend.
+
+A Celery worker waits for its result over Redis pub/sub, never on this process's
+dict. Retaining the payload after publishing leaked it for the life of the
+process, because ``cleanup_test_result`` is only ever reached from the local
+WebSocket path. Over a few large parallel runs that is hundreds of MB, and the
+OOM kill drops every SDK WebSocket at once.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from rhesis.backend.app.services.connector.manager import ConnectionManager
+
+
+@pytest.fixture
+def manager():
+    return ConnectionManager()
+
+
+class TestHeartbeatJitter:
+    """One heartbeat loop runs per connected SDK, so they must not stay in lockstep.
+
+    With tens of endpoints, loops that started together tick together forever and
+    each tick fires a synchronised setex burst that saturates the Redis pool,
+    queueing test-result publishing behind it.
+    """
+
+    def test_jitter_never_exceeds_the_key_ttl(self):
+        """Jitter must only shorten the wait: keys carry a 30s TTL."""
+        from rhesis.backend.app.services.connector.manager import (
+            _HEARTBEAT_INTERVAL,
+            _HEARTBEAT_JITTER,
+        )
+
+        longest = _HEARTBEAT_INTERVAL * 1.0  # jitter is uniform(1 - j, 1)
+        assert longest <= _HEARTBEAT_INTERVAL
+        assert _HEARTBEAT_INTERVAL < 30, "must refresh well inside the 30s key TTL"
+        assert 0 < _HEARTBEAT_JITTER < 1
+
+    def test_sleeps_are_spread_across_connections(self):
+        """Consecutive waits must differ, or the loops never de-synchronise."""
+        import random as _random
+
+        from rhesis.backend.app.services.connector.manager import (
+            _HEARTBEAT_INTERVAL,
+            _HEARTBEAT_JITTER,
+        )
+
+        waits = {_HEARTBEAT_INTERVAL * _random.uniform(1 - _HEARTBEAT_JITTER, 1) for _ in range(50)}
+        assert len(waits) > 40, "waits are not being spread"
+        assert all(0 < w <= _HEARTBEAT_INTERVAL for w in waits)
+
+
+class TestRpcResultCleanup:
+    def test_result_is_discarded_after_publishing(self, manager):
+        """No local waiter means nothing will ever read it back."""
+
+        async def _flow():
+            with patch("rhesis.backend.app.services.connector.manager.redis_manager") as rm:
+                rm.is_available = True
+                rm.client = AsyncMock()
+                manager._resolve_test_result("invoke_abc", {"status": "success"})
+                await asyncio.gather(*[t for t in manager._background_tasks])
+
+        asyncio.run(_flow())
+        assert "invoke_abc" not in manager._test_results
+
+    def test_result_is_discarded_even_if_publish_fails(self, manager):
+        """A result nobody can read is not worth retaining."""
+
+        async def _flow():
+            with patch("rhesis.backend.app.services.connector.manager.redis_manager") as rm:
+                rm.is_available = True
+                rm.client = AsyncMock()
+                rm.client.publish.side_effect = ConnectionError("Too many connections")
+                manager._resolve_test_result("invoke_boom", {"status": "success"})
+                await asyncio.gather(*[t for t in manager._background_tasks])
+
+        asyncio.run(_flow())
+        assert "invoke_boom" not in manager._test_results
+
+    def test_local_waiter_still_gets_its_result(self, manager):
+        """The local WebSocket path reads the dict after the event fires.
+
+        That path must keep working: it cleans up via cleanup_test_result.
+        """
+
+        async def _flow():
+            event = asyncio.Event()
+            manager._result_events["invoke_local"] = event
+            with patch("rhesis.backend.app.services.connector.manager.redis_manager") as rm:
+                rm.is_available = True
+                rm.client = AsyncMock()
+                manager._resolve_test_result("invoke_local", {"status": "success"})
+                await asyncio.gather(*[t for t in manager._background_tasks])
+            return event
+
+        event = asyncio.run(_flow())
+        assert event.is_set()
+        assert manager._test_results.get("invoke_local") == {"status": "success"}
+
+    def test_metric_result_is_discarded_after_publishing(self, manager):
+        async def _flow():
+            with patch("rhesis.backend.app.services.connector.manager.redis_manager") as rm:
+                rm.is_available = True
+                rm.client = AsyncMock()
+                manager._resolve_metric_result("metric_1", {"status": "success"})
+                await asyncio.gather(*[t for t in manager._background_tasks])
+
+        asyncio.run(_flow())
+        assert "metric_1" not in manager._metric_results
+
+    def test_many_rpc_results_do_not_accumulate(self, manager):
+        """The shape of the leak: a batch run must not grow the dict."""
+
+        async def _flow():
+            with patch("rhesis.backend.app.services.connector.manager.redis_manager") as rm:
+                rm.is_available = True
+                rm.client = AsyncMock()
+                for i in range(200):
+                    manager._resolve_test_result(f"invoke_{i}", {"status": "success"})
+                await asyncio.gather(*[t for t in manager._background_tasks])
+
+        asyncio.run(_flow())
+        assert manager._test_results == {}

--- a/tests/backend/services/connector/test_result_store_cleanup.py
+++ b/tests/backend/services/connector/test_result_store_cleanup.py
@@ -113,6 +113,32 @@ class TestRpcResultCleanup:
         asyncio.run(_flow())
         assert "metric_1" not in manager._metric_results
 
+    def test_result_is_discarded_when_scheduling_the_publish_fails(self, manager):
+        """The discard must not depend on the publish task ever running."""
+
+        async def _flow():
+            with patch("rhesis.backend.app.services.connector.manager.redis_manager") as rm:
+                rm.is_available = True
+                rm.client = AsyncMock()
+                with patch.object(
+                    manager, "_track_background_task", side_effect=RuntimeError("no loop")
+                ):
+                    manager._resolve_test_result("invoke_sched", {"status": "success"})
+
+        asyncio.run(_flow())
+        assert "invoke_sched" not in manager._test_results
+
+    def test_result_is_discarded_when_redis_is_unavailable(self, manager):
+        """With Redis down the publish is never scheduled at all."""
+
+        async def _flow():
+            with patch("rhesis.backend.app.services.connector.manager.redis_manager") as rm:
+                rm.is_available = False
+                manager._resolve_test_result("invoke_nordis", {"status": "success"})
+
+        asyncio.run(_flow())
+        assert "invoke_nordis" not in manager._test_results
+
     def test_many_rpc_results_do_not_accumulate(self, manager):
         """The shape of the leak: a batch run must not grow the dict."""
 

--- a/tests/backend/services/connector/test_rpc_client_loop_binding.py
+++ b/tests/backend/services/connector/test_rpc_client_loop_binding.py
@@ -1,0 +1,116 @@
+"""Regression tests for get_rpc_client()'s event-loop validation.
+
+``redis.asyncio`` clients are bound to the loop that created them. The client is
+cached per thread, but a thread is not guaranteed to keep one loop for its life:
+a caller using ``asyncio.run()`` per call hands it a new loop every time. Reusing
+a client across a closed loop makes every command fail with "Event loop is
+closed", which reached users as "Failed to send request to SDK".
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from rhesis.backend.app.services.connector import rpc_client as rpc_mod
+
+
+async def _fake_initialize(self):
+    """Stand in for a real Redis connect, recording nothing loop-bound."""
+    self._redis = AsyncMock()
+
+
+class TestGetRpcClientLoopBinding:
+    def setup_method(self):
+        rpc_mod._tls.rpc_client = None
+
+    def teardown_method(self):
+        rpc_mod._tls.rpc_client = None
+
+    def test_reuses_client_on_the_same_loop(self):
+        """The cache must still work, or every test pays a reconnect + PING."""
+        with patch.object(rpc_mod.SDKRpcClient, "initialize", _fake_initialize):
+
+            async def _twice():
+                return await rpc_mod.get_rpc_client(), await rpc_mod.get_rpc_client()
+
+            first, second = asyncio.run(_twice())
+            assert first is second
+
+    def test_rebuilds_when_the_loop_changed(self):
+        """A new loop must not inherit the previous loop's client."""
+        with patch.object(rpc_mod.SDKRpcClient, "initialize", _fake_initialize):
+            first = asyncio.run(rpc_mod.get_rpc_client())
+            second = asyncio.run(rpc_mod.get_rpc_client())
+
+        assert first is not second, "stale-loop client was reused"
+
+    def test_records_the_loop_it_was_built_on(self):
+        with patch.object(rpc_mod.SDKRpcClient, "initialize", _fake_initialize):
+
+            async def _build():
+                client = await rpc_mod.get_rpc_client()
+                return client, asyncio.get_running_loop()
+
+            client, loop = asyncio.run(_build())
+
+        assert client._loop is loop
+
+    def test_rebuilds_when_redis_is_none(self):
+        """Pre-existing behaviour: a torn-down client is replaced."""
+        with patch.object(rpc_mod.SDKRpcClient, "initialize", _fake_initialize):
+
+            async def _flow():
+                first = await rpc_mod.get_rpc_client()
+                first._redis = None
+                second = await rpc_mod.get_rpc_client()
+                return first, second
+
+            first, second = asyncio.run(_flow())
+
+        assert first is not second
+
+    def test_alternating_calls_never_reuse_a_dead_loop(self):
+        """The production signature: every other call failed, this asserts it cannot."""
+        with patch.object(rpc_mod.SDKRpcClient, "initialize", _fake_initialize):
+            clients = [asyncio.run(rpc_mod.get_rpc_client()) for _ in range(6)]
+
+        # Each call ran on its own loop, so each must have produced its own client.
+        assert len({id(c) for c in clients}) == 6
+
+    def test_concurrent_first_use_builds_one_client(self):
+        """Batch start: N coroutines hit a cold cache at once.
+
+        The check and the store straddle an `await client.initialize()`, so
+        without a lock every coroutine builds its own client and opens its own
+        Redis connection; all but the last are orphaned and never closed.
+        Measured 14 leaked connections at batch_concurrency=15.
+        """
+        built = []
+
+        async def _counting_initialize(self):
+            built.append(self)
+            await asyncio.sleep(0.01)  # widen the window the race needs
+            self._redis = AsyncMock()
+
+        with patch.object(rpc_mod.SDKRpcClient, "initialize", _counting_initialize):
+
+            async def _batch_start():
+                return await asyncio.gather(*(rpc_mod.get_rpc_client() for _ in range(15)))
+
+            clients = asyncio.run(_batch_start())
+
+        assert len(built) == 1, f"built {len(built)} clients, leaking {len(built) - 1}"
+        assert len({id(c) for c in clients}) == 1, "callers got different clients"
+
+    def test_close_clears_the_recorded_loop(self):
+        with patch.object(rpc_mod.SDKRpcClient, "initialize", _fake_initialize):
+
+            async def _flow():
+                client = await rpc_mod.get_rpc_client()
+                await client.close()
+                return client
+
+            client = asyncio.run(_flow())
+
+        assert client._loop is None
+        assert client._redis is None
+        assert getattr(rpc_mod._tls, "rpc_client", None) is None

--- a/tests/backend/test_secret_equality.py
+++ b/tests/backend/test_secret_equality.py
@@ -71,7 +71,7 @@ ALLOWED_SITES: frozenset[tuple[str, int]] = frozenset(
         ("apps/backend/src/rhesis/backend/app/services/experiment.py", 208),
         # auth_token_project_id is a UUID project reference, not a secret token;
         # comparing it to another project UUID is safe (no timing oracle risk)
-        ("apps/backend/src/rhesis/backend/app/services/connector/manager.py", 1005),
+        ("apps/backend/src/rhesis/backend/app/services/connector/manager.py", 1033),
     }
 )
 


### PR DESCRIPTION
## Purpose

Running a test set against an SDK endpoint failed intermittently, and the reported reason was misleading. A 20-test sequential run against `cleo-draft` produced 10 errors reading "Failed to send request to SDK", strictly alternating: odd tests passed, even tests failed within a second. A separate parallel run against `visit_prep_chat` timed out on some tests after 120s each. Neither endpoint was at fault, and the two runs had different root causes.

Both come down to a response that was produced correctly and then thrown away, with the user seeing an endpoint error for something that never involved their endpoint.

## What Changed

Three commits, one per root cause.

**Sequential mode destroyed the event loop between tests.** `execute_tests_sequentially` ran each test under `asyncio.run()`. The SDK RPC client is cached per thread and holds `redis.asyncio` connections, which are bound to the loop that created them, so every other test failed with `RuntimeError: Event loop is closed`. The batch runner already avoided this with a persistent per-thread loop; that helper moves to `execution/shared.py` as `run_on_thread_loop` and both modes now share it. `get_rpc_client` additionally validates the running loop, so a stale-loop client can never be reused.

**The backend Redis pool was too small to hand responses back.** It was capped at 3 connections while the `blpop` RPC listener and per-connection heartbeats already occupied most of them, so a burst of completing tests could not get one to publish on. redis-py raises `Too many connections` from `get_connection()`, which sits outside its own retry wrapper, so the configured `retry_on_error` never covered it. The response was dropped and the worker stalled the full 120s `SDK_FUNCTION_TIMEOUT`. Now a `BlockingConnectionPool` with a 32 ceiling (`REDIS_MAX_CONNECTIONS`), so an over-capacity burst waits instead of vanishing.

**Three more concurrency defects found while measuring that one.** `get_rpc_client` was check-then-act across an `await`, so at batch start every concurrent test built its own client and leaked all but the last (14 orphaned Redis connections at `batch_concurrency=15`); it now takes an init lock. RPC-path results were never removed from `_test_results`, because `cleanup_test_result` is only reachable from the local WebSocket path, so every result payload was retained for the life of the backend process; they are now discarded once published. And heartbeats used a flat sleep, keeping every per-connection loop that started together in lockstep forever and firing synchronised `setex` bursts that saturated the pool; they are now jittered, only ever shorter so the 30s key TTL stays safe.

**Transient SDK failures were treated as permanent.** `sdk_send_failed`, `sdk_disconnected` and `sdk_timeout` were absent from `_TRANSIENT_ERROR_TYPES`, so `invoke_with_retry` skipped them and the batch recovery round skipped them too (they report `status="endpoint_error"`, not `"failed"`). One dropped response became one permanently failed test. `sdk_function_error` stays permanent, since that is the target's own answer.

**The cause never reached the user.** `summarize_endpoint_failure` preferred `output`, which is always set, over `message`, which carries the detail. All five reasons an SDK send can fail render as the same opaque string, so `Event loop is closed` appeared nowhere in the UI or the activity log and the bug could only be diagnosed by reading code. The cause is now appended when it adds information, guarded by a containment check because REST already folds its detail into `output`.

## Additional Context

Production evidence for both bugs, from Loki in `rhesis-prd`.

Sequential, test run `3f343631`, worker `worker-default-b75cd5fcf-kgwlj`. The RPC client logs `Initializing RPC client with Redis` exactly once at 14:27:26 and never again, then `Error during RPC call for invoke_...: Event loop is closed` ten times, matching the ten failed tests.

Parallel, `invoke_9f37009b04c7`. Forwarded at 12:28:37.258, `Received test result from SDK (status: success)` at 12:28:40.121, `Failed to publish RPC response: Too many connections` at 12:28:40.176, then `RPC request timed out after 120.0s` at 12:30:37.260. The SDK answered in 2.9s; the answer was lost on the way back.

Across 14 days there were 966 `Event loop is closed` events on worker pods (852 orphaned `AsyncClient.aclose()` tasks, 104 Celery tracebacks, 10 user-visible SDK failures) and 26 of these publish-loss timeouts, so this was chronic rather than a one-off.

The diff is 711 lines but only 204 added / 59 removed are production code; the rest is tests. Sizing note: `REDIS_MAX_CONNECTIONS` defaults to 32 because the pool saturates to whatever ceiling it is given once tens of SDKs are connected, so the headroom is used rather than idle. It should not be lowered toward the number of blocking consumers, since at 3 the pool starves completely.

Known and deliberately out of scope, planned as follow-up work: every inbound WebSocket message opens a synchronous DB session on the event loop (`routers/connector.py:218`), which caps inbound throughput at roughly 269 results/sec per backend pod. That does not bite at tens of concurrent endpoints but does at hundreds. The hot path does not actually use that session, so the fix is to acquire it lazily rather than to make it async. Also unchanged: the inbound WebSocket rate limit of 50 messages/sec per connection discards results above it rather than applying backpressure, which becomes the next ceiling once concurrency is raised.

## Testing

`3123 passed, 14 skipped, 1 xfailed` across `tests/backend/jobs/`, `tests/backend/services/` and `tests/backend/utils/`, run from `apps/backend`. Ruff check and format are clean on every file touched.

Each new regression test was verified to fail against the pre-fix code, not just to pass after it. The result-store tests fail 3 of 5, and the init-race test fails with `built 15 clients, leaking 14`, which is the production number.

Beyond unit tests, the fixes were validated end to end against the real `ConnectionManager` and real `SDKRpcClient` over a real Redis, with only the WebSocket and the endpoint function simulated, sweeping `BATCH_CONCURRENCY` over 40 tests per run:

```
BATCH_CONCURRENCY   1   5  10  15  30  50
passing before     40  37  34  27  27   9
passing after      40  40  40  40  40  40
```

Every pre-fix failure paired 1:1 with a `Too many connections` publish failure, and `_test_results` stayed at 0 retained throughout. Wall clock at concurrency 50 drops from 8.0s to 0.3s.

To reproduce manually: run a test set against an SDK endpoint in sequential mode and confirm no endpoint errors, then check Loki for `{namespace="rhesis"} |= "Event loop is closed"` and `|= "Failed to publish RPC response"` and expect neither to appear.
