### PR TITLE
Stop opening a DB session for every SDK WebSocket message

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/connector.py
+++ b/apps/backend/src/rhesis/backend/app/routers/connector.py
@@ -69,7 +69,12 @@ def _assert_project_membership(db: Session, project_id_str: str, user: User) -> 
 # --- Security limits (configurable via env) ---
 MAX_MESSAGE_SIZE = int(os.getenv("WS_MAX_MESSAGE_SIZE", str(1024 * 1024)))
 IDLE_TIMEOUT = int(os.getenv("WS_IDLE_TIMEOUT", "300"))
-RATE_LIMIT_PER_SECOND = int(os.getenv("WS_RATE_LIMIT", "50"))
+# Useful concurrency on one connection is roughly limit x call latency, so the
+# old default of 50 capped a single endpoint at ~100 in-flight 2s calls, well
+# below what one pod can absorb. Over the limit the frame is dropped and the
+# caller sees only a 120s timeout, so setting this too low is paid for in
+# mystery stalls rather than in backpressure.
+RATE_LIMIT_PER_SECOND = int(os.getenv("WS_RATE_LIMIT", "500"))
 
 
 async def require_websocket_user(websocket: WebSocket) -> tuple[User, str | None]:

--- a/apps/backend/src/rhesis/backend/app/routers/connector.py
+++ b/apps/backend/src/rhesis/backend/app/routers/connector.py
@@ -7,6 +7,7 @@ import os
 import time
 import uuid
 from datetime import datetime, timezone
+from functools import partial
 from typing import Any, Dict
 
 from fastapi import Depends, HTTPException, WebSocket, WebSocketDisconnect
@@ -157,6 +158,10 @@ async def _message_loop(
     """
     msg_timestamps: list[float] = []
 
+    def _open_db(project_id: str):
+        """Open a tenant-scoped session, for the handlers that need one."""
+        return get_db_with_tenant_variables(context.organization_id, context.user_id, project_id)
+
     while True:
         try:
             data = await asyncio.wait_for(
@@ -205,10 +210,10 @@ async def _message_loop(
             )
             continue
 
-        # Resolve the project_id for this message so the DB session scope
-        # matches the actual project.  Without this, auto_filter appends
-        # "WHERE project_id IS NULL" to every query on the session, which
-        # conflicts with the explicit "WHERE project_id = ?" filters in
+        # Resolve the project_id for this message so that a session opened
+        # downstream is scoped to the actual project.  Without this, auto_filter
+        # appends "WHERE project_id IS NULL" to every query on the session,
+        # which conflicts with the explicit "WHERE project_id = ?" filters in
         # sync_sdk_endpoints/test_result handlers and returns zero rows.
         #
         # - register:    project_id is in the message payload itself.
@@ -222,16 +227,13 @@ async def _message_loop(
                 context.connection_id
             )
 
-        with get_db_with_tenant_variables(
-            context.organization_id, context.user_id, scope_project_id
-        ) as db:
-            response = await connection_manager.handle_message(
-                connection_id=context.connection_id,
-                message=message,
-                db=db,
-                organization_id=context.organization_id,
-                user_id=context.user_id,
-            )
+        response = await connection_manager.handle_message(
+            connection_id=context.connection_id,
+            message=message,
+            db_factory=partial(_open_db, scope_project_id),
+            organization_id=context.organization_id,
+            user_id=context.user_id,
+        )
 
         if response:
             await websocket.send_json(response)

--- a/apps/backend/src/rhesis/backend/app/services/connector/handler.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/handler.py
@@ -10,6 +10,7 @@ from rhesis.backend.app.services.connector.handlers import (
     registration_handler,
     test_result_handler,
 )
+from rhesis.backend.app.services.connector.session import DbSessionFactory
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,7 @@ class SDKMessageHandler:
         environment: str,
         message: Dict[str, Any],
         db: Optional[Session] = None,
+        db_factory: Optional[DbSessionFactory] = None,
     ) -> None:
         """
         Handle test result message from SDK.
@@ -57,6 +59,7 @@ class SDKMessageHandler:
             environment=environment,
             message=message,
             db=db,
+            db_factory=db_factory,
         )
 
     async def handle_pong_message(self, project_id: str, environment: str) -> None:

--- a/apps/backend/src/rhesis/backend/app/services/connector/handlers/test_result.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/handlers/test_result.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app.services.connector.schemas import TestResultMessage
+from rhesis.backend.app.services.connector.session import DbSessionFactory, resolve_session
 
 logger = logging.getLogger(__name__)
 
@@ -20,60 +21,76 @@ class TestResultHandler:
         environment: str,
         message: Dict[str, Any],
         db: Optional[Session] = None,
+        db_factory: Optional[DbSessionFactory] = None,
     ) -> None:
         """
         Handle test result message from SDK.
 
-        Args:
-            project_id: Project identifier
-            environment: Environment name
-            message: Test result message
-            db: Database session for updating endpoint status
-        """
-        self._log_test_result(project_id, environment, message)
-
-        # Handle late-arriving validation results if database session provided
-        if db:
-            await self._handle_late_validation_result(project_id, environment, message, db)
-
-    def _log_test_result(self, project_id: str, environment: str, message: Dict[str, Any]) -> None:
-        """
-        Log test result details.
+        Only ``validation_`` run ids touch the database, so that check runs
+        before any session is acquired — every other result is the hot path and
+        must not pay for a session it never uses.
 
         Args:
             project_id: Project identifier
             environment: Environment name
             message: Test result message
+            db: Open session, when the caller already owns one
+            db_factory: Opens a session on demand, for the late-validation path
         """
         try:
             result = TestResultMessage(**message)
-            logger.info("=" * 80)
-            logger.info("📥 TEST RESULT RECEIVED")
-            logger.info(f"Project: {project_id}:{environment}")
-            logger.info(f"Test Run ID: {result.test_run_id}")
-            logger.info(f"Status: {result.status}")
-            logger.info(f"Duration: {result.duration_ms}ms")
-
-            if result.status == "success":
-                # Log output (truncate if too long)
-                output_str = str(result.output)
-                if len(output_str) > 500:
-                    logger.info(f"Output (first 500 chars): {output_str[:500]}...")
-                    logger.info(f"Output (last 100 chars): ...{output_str[-100:]}")
-                else:
-                    logger.info(f"Output: {output_str}")
-            else:
-                logger.error(f"Error: {result.error}")
-
-            logger.info("=" * 80)
         except Exception as e:
-            logger.error(f"Error logging test result: {e}")
+            logger.error(f"Error parsing test result: {e}")
+            return
+
+        self._log_test_result(project_id, environment, result)
+
+        if not result.test_run_id.startswith("validation_"):
+            return
+
+        with resolve_session(db, db_factory) as session:
+            if session is not None:
+                await self._handle_late_validation_result(project_id, environment, result, session)
+
+    def _log_test_result(
+        self, project_id: str, environment: str, result: TestResultMessage
+    ) -> None:
+        """Log one record per result, with the payload only at DEBUG.
+
+        This runs once per inbound result on the WebSocket loop, and every record
+        is JSON-formatted and regex-redacted before it reaches stdout, so the
+        number of records matters more than what is in them.
+        """
+        if result.status != "success":
+            logger.error(
+                "Test result %s:%s run=%s failed after %sms: %s",
+                project_id,
+                environment,
+                result.test_run_id,
+                result.duration_ms,
+                result.error,
+            )
+            return
+
+        logger.info(
+            "Test result %s:%s run=%s status=%s duration=%sms",
+            project_id,
+            environment,
+            result.test_run_id,
+            result.status,
+            result.duration_ms,
+        )
+        if logger.isEnabledFor(logging.DEBUG):
+            output_str = str(result.output)
+            if len(output_str) > 500:
+                output_str = f"{output_str[:500]}...{output_str[-100:]}"
+            logger.debug("Test result %s output: %s", result.test_run_id, output_str)
 
     async def _handle_late_validation_result(
         self,
         project_id: str,
         environment: str,
-        message: Dict[str, Any],
+        result: TestResultMessage,
         db: Session,
     ) -> None:
         """
@@ -85,18 +102,10 @@ class TestResultHandler:
         Args:
             project_id: Project identifier
             environment: Environment name
-            message: Test result message
+            result: Parsed test result, already known to be a validation run
             db: Database session
         """
         try:
-            # Parse the test result
-            result = TestResultMessage(**message)
-
-            # Check if this is a validation test (test_run_id starts with "validation_")
-            if not result.test_run_id.startswith("validation_"):
-                logger.debug(f"Not a validation test result: {result.test_run_id}")
-                return
-
             logger.info(f"🔄 Processing late validation result for {result.test_run_id}")
 
             # Find the endpoint by project_id, environment, and function name

--- a/apps/backend/src/rhesis/backend/app/services/connector/manager.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/manager.py
@@ -28,6 +28,7 @@ from rhesis.backend.app.services.connector.schemas import (
     RegisterMessage,
     WebSocketConnectionContext,
 )
+from rhesis.backend.app.services.connector.session import DbSessionFactory, resolve_session
 
 logger = logging.getLogger(__name__)
 
@@ -595,9 +596,10 @@ class ConnectionManager:
             logger.warning(f"Ignoring late result for cancelled test run: {test_run_id}")
             return
 
-        logger.info(
-            f"Received test result from SDK: {test_run_id} "
-            f"(status: {result.get('status', 'unknown')})"
+        logger.debug(
+            "Received test result from SDK: %s (status: %s)",
+            test_run_id,
+            result.get("status", "unknown"),
         )
 
         self._test_results[test_run_id] = result
@@ -838,52 +840,31 @@ class ConnectionManager:
                 return pk.split(":", 1)
         return ("", "")
 
-    async def handle_message(
+    async def _handle_register_message(
         self,
-        connection_id: str = "",
-        message: Dict[str, Any] | None = None,
+        connection_id: str,
+        message: Dict[str, Any],
         db: Optional[Session] = None,
+        db_factory: Optional[DbSessionFactory] = None,
         organization_id: Optional[str] = None,
         user_id: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
-        """Handle incoming WebSocket message from SDK.
+    ) -> Dict[str, Any]:
+        """Authorize a register frame, add routing, and sync endpoints/metrics.
 
-        For ``register`` messages the project_id/environment are taken
-        from the message payload and authorized against the connection's
-        immutable context. For other messages they are resolved from
-        the routing table.
-
-        Returns:
-            Response message to send back, or None if no response needed.
+        Authorization and the sync share one session so they stay in a single
+        transaction, as they did when the router opened the session per message.
         """
-        if message is None:
-            message = {}
+        reg_project_id = message.get("project_id") or ""
+        reg_environment = message.get("environment") or ""
 
-        message_type = message.get("type")
-
-        msg_project_id = message.get("project_id", "")
-        msg_environment = message.get("environment", "")
-
-        if not msg_project_id and connection_id:
-            msg_project_id, msg_environment = self._resolve_project_for_connection(connection_id)
-
-        logger.info(
-            f"Processing message type: {message_type} "
-            f"from connection={connection_id or 'rpc'} "
-            f"({msg_project_id}:{msg_environment})"
-        )
-
-        if message_type == "register":
-            reg_project_id = message.get("project_id") or ""
-            reg_environment = message.get("environment") or ""
-
+        with resolve_session(db, db_factory) as session:
             # Project-scoped registration (endpoints + metrics)
             if connection_id and reg_project_id and reg_environment:
                 authorized = await self._authorize_and_register(
                     connection_id=connection_id,
                     project_id=reg_project_id,
                     environment=reg_environment,
-                    db=db,
+                    db=session,
                     organization_id=organization_id,
                     user_id=user_id,
                 )
@@ -910,7 +891,7 @@ class ConnectionManager:
                     project_id=reg_project_id,
                     environment=reg_environment,
                     message=message,
-                    db=db,
+                    db=session,
                     organization_id=organization_id,
                     user_id=user_id,
                 )
@@ -930,12 +911,64 @@ class ConnectionManager:
                 project_id="",
                 environment="",
                 message=message,
-                db=db,
+                db=session,
                 organization_id=organization_id,
                 user_id=user_id,
             )
             response["connection_id"] = connection_id
             return response
+
+    async def handle_message(
+        self,
+        connection_id: str = "",
+        message: Dict[str, Any] | None = None,
+        db: Optional[Session] = None,
+        db_factory: Optional[DbSessionFactory] = None,
+        organization_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Handle incoming WebSocket message from SDK.
+
+        For ``register`` messages the project_id/environment are taken
+        from the message payload and authorized against the connection's
+        immutable context. For other messages they are resolved from
+        the routing table.
+
+        Callers pass ``db_factory`` rather than an open ``db`` so that the
+        message types that need no database never pay for a session. Only
+        ``register`` and late validation results open one.
+
+        Returns:
+            Response message to send back, or None if no response needed.
+        """
+        if message is None:
+            message = {}
+
+        message_type = message.get("type")
+
+        msg_project_id = message.get("project_id", "")
+        msg_environment = message.get("environment", "")
+
+        if not msg_project_id and connection_id:
+            msg_project_id, msg_environment = self._resolve_project_for_connection(connection_id)
+
+        logger.debug(
+            "Processing message type: %s from connection=%s (%s:%s)",
+            message_type,
+            connection_id or "rpc",
+            msg_project_id,
+            msg_environment,
+        )
+
+        if message_type == "register":
+            return await self._handle_register_message(
+                connection_id=connection_id,
+                message=message,
+                db=db,
+                db_factory=db_factory,
+                organization_id=organization_id,
+                user_id=user_id,
+            )
 
         elif message_type == "test_result":
             test_run_id = message.get("test_run_id")
@@ -960,7 +993,11 @@ class ConnectionManager:
                 self._resolve_test_result(test_run_id, message)
 
             await message_handler.handle_test_result_message(
-                msg_project_id, msg_environment, message, db
+                msg_project_id,
+                msg_environment,
+                message,
+                db=db,
+                db_factory=db_factory,
             )
             return None
 

--- a/apps/backend/src/rhesis/backend/app/services/connector/manager.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/manager.py
@@ -1043,55 +1043,64 @@ class ConnectionManager:
         auth_org_id = context.organization_id
         auth_user_id = context.user_id
 
-        if db and auth_org_id and auth_user_id:
-            from uuid import UUID
-
-            from rhesis.backend.app.models.project import Project
-            from rhesis.backend.app.models.project_membership import ProjectMembership
-
-            try:
-                project_uuid = UUID(project_id)
-                auth_user_uuid = UUID(auth_user_id)
-                auth_org_uuid = UUID(auth_org_id)
-            except ValueError as exc:
-                logger.error(f"Invalid UUID format in register: {exc}")
-                return False
-
-            project = db.query(Project).filter_by(id=project_uuid).first()
-            if project is None:
-                logger.error(f"Project {project_id} not found (org {auth_org_id})")
-                return False
-
-            # Authorization: membership check (primary) OR token-scoped access
-            # (fallback for API tokens that were explicitly scoped to this project
-            # — e.g. tokens created before the membership backfill migration ran,
-            # or service-account tokens where the owner has no membership row).
-            auth_token_project_id = context.token_project_id
-            token_scoped = auth_token_project_id is not None and auth_token_project_id == project_id
-
-            if not token_scoped:
-                membership = (
-                    db.query(ProjectMembership)
-                    .filter_by(
-                        project_id=project_uuid,
-                        user_id=auth_user_uuid,
-                        organization_id=auth_org_uuid,
-                    )
-                    .first()
-                )
-                if not membership:
-                    logger.error(
-                        f"Project {project_id} access denied: user {auth_user_id} "
-                        f"is not a member and token is not scoped to this project "
-                        f"(org {auth_org_id})"
-                    )
-                    return False
-
-            logger.info(
-                f"Project authorized: {project.name} ({project_id}) for connection "
-                f"{connection_id} "
-                f"(via {'token scope' if token_scoped else 'membership'})"
+        # Fail closed. Without a session, or without an authenticated org and user,
+        # the membership check below cannot run, and skipping it would populate the
+        # routing table for a project this connection was never authorized for.
+        if db is None or not auth_org_id or not auth_user_id:
+            logger.error(
+                f"Refusing to register project {project_id}: cannot authorize "
+                f"(db={db is not None}, org={bool(auth_org_id)}, user={bool(auth_user_id)})"
             )
+            return False
+
+        from uuid import UUID
+
+        from rhesis.backend.app.models.project import Project
+        from rhesis.backend.app.models.project_membership import ProjectMembership
+
+        try:
+            project_uuid = UUID(project_id)
+            auth_user_uuid = UUID(auth_user_id)
+            auth_org_uuid = UUID(auth_org_id)
+        except ValueError as exc:
+            logger.error(f"Invalid UUID format in register: {exc}")
+            return False
+
+        project = db.query(Project).filter_by(id=project_uuid).first()
+        if project is None:
+            logger.error(f"Project {project_id} not found (org {auth_org_id})")
+            return False
+
+        # Authorization: membership check (primary) OR token-scoped access
+        # (fallback for API tokens that were explicitly scoped to this project
+        # — e.g. tokens created before the membership backfill migration ran,
+        # or service-account tokens where the owner has no membership row).
+        auth_token_project_id = context.token_project_id
+        token_scoped = auth_token_project_id is not None and auth_token_project_id == project_id
+
+        if not token_scoped:
+            membership = (
+                db.query(ProjectMembership)
+                .filter_by(
+                    project_id=project_uuid,
+                    user_id=auth_user_uuid,
+                    organization_id=auth_org_uuid,
+                )
+                .first()
+            )
+            if not membership:
+                logger.error(
+                    f"Project {project_id} access denied: user {auth_user_id} "
+                    f"is not a member and token is not scoped to this project "
+                    f"(org {auth_org_id})"
+                )
+                return False
+
+        logger.info(
+            f"Project authorized: {project.name} ({project_id}) for connection "
+            f"{connection_id} "
+            f"(via {'token scope' if token_scoped else 'membership'})"
+        )
 
         # Populate routing table
         key = self.get_connection_key(project_id, environment)

--- a/apps/backend/src/rhesis/backend/app/services/connector/session.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/session.py
@@ -1,0 +1,37 @@
+"""Session plumbing for the SDK connector's inbound message path.
+
+Inbound messages arrive faster than anything else on this loop, and
+``get_db_with_tenant_variables`` is synchronous: a pool checkout plus a GUC
+round trip, blocking the loop until it returns. Most message types never touch
+the database, so callers pass a factory and a session is opened only where a
+handler actually asks for one.
+"""
+
+from contextlib import AbstractContextManager, contextmanager
+from typing import Callable, Generator, Optional
+
+from sqlalchemy.orm import Session
+
+#: Opens a tenant-scoped session on demand. The router builds one per message
+#: from ``get_db_with_tenant_variables``; tests supply their own.
+DbSessionFactory = Callable[[], AbstractContextManager[Session]]
+
+
+@contextmanager
+def resolve_session(
+    db: Optional[Session] = None,
+    db_factory: Optional[DbSessionFactory] = None,
+) -> Generator[Optional[Session], None, None]:
+    """Yield whichever session the caller supplied, opening one only if asked.
+
+    An already-open ``db`` wins, so callers that own a session keep owning its
+    lifetime. With neither argument this yields ``None``, which every handler
+    already reads as "skip the database work".
+    """
+    if db is not None:
+        yield db
+    elif db_factory is not None:
+        with db_factory() as session:
+            yield session
+    else:
+        yield None

--- a/tests/backend/routes/test_connector.py
+++ b/tests/backend/routes/test_connector.py
@@ -8,14 +8,15 @@ This module tests the WebSocket connector endpoints including:
 - HTTP endpoints (trigger, status, trace)
 """
 
+import json
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from starlette.websockets import WebSocketDisconnect
 from fastapi import HTTPException, status
 from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from rhesis.backend.app.models.execution_trace import ExecutionTrace
 
@@ -630,3 +631,62 @@ class TestConnectorEdgeCases:
             assert response.status_code == status.HTTP_200_OK
             data = response.json()
             assert data["connected"] is False
+
+
+async def test_message_loop_opens_no_session_for_test_result():
+    """The message loop must not open a session per inbound frame.
+
+    A session is a pool checkout plus a GUC round trip on the event loop, and
+    the SDK sends one of these frames per finished test. Only the handlers that
+    actually query should pay for one.
+    """
+    from rhesis.backend.app.routers import connector as connector_router
+    from rhesis.backend.app.services.connector.schemas import WebSocketConnectionContext
+
+    frames = [
+        json.dumps(
+            {
+                "type": "test_result",
+                "test_run_id": "invoke_abc123",
+                "status": "success",
+                "output": {},
+                "duration_ms": 1.0,
+            }
+        )
+    ]
+
+    class _StubWebSocket:
+        def __init__(self):
+            self.sent = []
+
+        async def receive_text(self):
+            if frames:
+                return frames.pop(0)
+            raise WebSocketDisconnect()
+
+        async def send_json(self, payload):
+            self.sent.append(payload)
+
+        async def close(self, **kwargs):
+            pass
+
+    context = WebSocketConnectionContext(
+        user_id=str(uuid.uuid4()),
+        organization_id=str(uuid.uuid4()),
+        token_project_id=None,
+    )
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("the message loop must not open a database session")
+
+    handled = AsyncMock(return_value=None)
+    with (
+        patch.object(connector_router, "get_db_with_tenant_variables", _explode),
+        patch.object(connector_router.connection_manager, "handle_message", handled),
+    ):
+        with pytest.raises(WebSocketDisconnect):
+            await connector_router._message_loop(_StubWebSocket(), context)
+
+    handled.assert_awaited_once()
+    assert "db" not in handled.await_args.kwargs
+    assert callable(handled.await_args.kwargs["db_factory"])

--- a/tests/backend/services/connector/test_handler.py
+++ b/tests/backend/services/connector/test_handler.py
@@ -7,12 +7,16 @@ This module tests the SDKMessageHandler class including:
 - Error handling and logging
 """
 
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app.services.connector.handler import SDKMessageHandler
+from rhesis.backend.app.services.connector.schemas import TestResultMessage
+
+TEST_RESULT_LOGGER = "rhesis.backend.app.services.connector.handlers.test_result"
 
 
 class TestSDKMessageHandler:
@@ -198,11 +202,11 @@ class TestSDKMessageHandler:
                 message=sample_test_result_message,
             )
 
-            mock_log.assert_called_once_with(
-                project_context["project_id"],
-                project_context["environment"],
-                sample_test_result_message,
-            )
+            mock_log.assert_called_once()
+            logged_project, logged_env, logged_result = mock_log.call_args.args
+            assert logged_project == project_context["project_id"]
+            assert logged_env == project_context["environment"]
+            assert logged_result.test_run_id == sample_test_result_message["test_run_id"]
 
     @pytest.mark.asyncio
     async def test_handle_test_result_message_error(
@@ -229,60 +233,82 @@ class TestSDKMessageHandler:
         )
 
     def test_log_test_result_success(
-        self, handler: SDKMessageHandler, sample_test_result_message, project_context
+        self, handler: SDKMessageHandler, sample_test_result_message, project_context, caplog
     ):
-        """Test logging of successful test result"""
+        """A successful result costs exactly one INFO record."""
         from rhesis.backend.app.services.connector.handlers.test_result import test_result_handler
 
-        # Should not raise any exceptions
-        test_result_handler._log_test_result(
-            project_id=project_context["project_id"],
-            environment=project_context["environment"],
-            message=sample_test_result_message,
-        )
+        with caplog.at_level(logging.INFO, logger=TEST_RESULT_LOGGER):
+            test_result_handler._log_test_result(
+                project_id=project_context["project_id"],
+                environment=project_context["environment"],
+                result=TestResultMessage(**sample_test_result_message),
+            )
+
+        records = [r for r in caplog.records if r.name == TEST_RESULT_LOGGER]
+        assert len(records) == 1
+        assert records[0].levelno == logging.INFO
+        assert sample_test_result_message["test_run_id"] in records[0].getMessage()
 
     def test_log_test_result_error(
-        self, handler: SDKMessageHandler, sample_test_result_error_message, project_context
+        self, handler: SDKMessageHandler, sample_test_result_error_message, project_context, caplog
     ):
-        """Test logging of error test result"""
+        """A failed result costs one ERROR record carrying the error."""
         from rhesis.backend.app.services.connector.handlers.test_result import test_result_handler
 
-        # Should not raise any exceptions
-        test_result_handler._log_test_result(
-            project_id=project_context["project_id"],
-            environment=project_context["environment"],
-            message=sample_test_result_error_message,
+        with caplog.at_level(logging.INFO, logger=TEST_RESULT_LOGGER):
+            test_result_handler._log_test_result(
+                project_id=project_context["project_id"],
+                environment=project_context["environment"],
+                result=TestResultMessage(**sample_test_result_error_message),
+            )
+
+        records = [r for r in caplog.records if r.name == TEST_RESULT_LOGGER]
+        assert len(records) == 1
+        assert records[0].levelno == logging.ERROR
+        assert sample_test_result_error_message["error"] in records[0].getMessage()
+
+    def test_log_test_result_output_only_at_debug(
+        self, handler: SDKMessageHandler, project_context, caplog
+    ):
+        """The payload never reaches INFO, and is truncated when it does appear."""
+        from rhesis.backend.app.services.connector.handlers.test_result import test_result_handler
+
+        result = TestResultMessage(
+            test_run_id="test_abc123",
+            status="success",
+            output="x" * 1000,
+            duration_ms=100.0,
         )
 
-    def test_log_test_result_long_output(self, handler: SDKMessageHandler, project_context):
-        """Test logging of test result with long output"""
-        from rhesis.backend.app.services.connector.handlers.test_result import test_result_handler
+        with caplog.at_level(logging.INFO, logger=TEST_RESULT_LOGGER):
+            test_result_handler._log_test_result(
+                project_id=project_context["project_id"],
+                environment=project_context["environment"],
+                result=result,
+            )
+        assert not any("xxx" in r.getMessage() for r in caplog.records)
 
-        long_output_message = {
-            "type": "test_result",
-            "test_run_id": "test_abc123",
-            "status": "success",
-            "output": "x" * 1000,  # Long output to trigger truncation
-            "error": None,
-            "duration_ms": 100.0,
-        }
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger=TEST_RESULT_LOGGER):
+            test_result_handler._log_test_result(
+                project_id=project_context["project_id"],
+                environment=project_context["environment"],
+                result=result,
+            )
 
-        # Should not raise any exceptions
-        test_result_handler._log_test_result(
+        debug_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+        assert len(debug_messages) == 1
+        assert "..." in debug_messages[0]
+        assert len(debug_messages[0]) < 1000
+
+    @pytest.mark.asyncio
+    async def test_handle_test_result_message_invalid(
+        self, handler: SDKMessageHandler, project_context
+    ):
+        """A malformed frame is logged and dropped, never raised."""
+        await handler.handle_test_result_message(
             project_id=project_context["project_id"],
             environment=project_context["environment"],
-            message=long_output_message,
-        )
-
-    def test_log_test_result_invalid_message(self, handler: SDKMessageHandler, project_context):
-        """Test logging of invalid test result message"""
-        from rhesis.backend.app.services.connector.handlers.test_result import test_result_handler
-
-        invalid_message = {"type": "test_result", "invalid": "data"}
-
-        # Should handle gracefully and not raise exceptions
-        test_result_handler._log_test_result(
-            project_id=project_context["project_id"],
-            environment=project_context["environment"],
-            message=invalid_message,
+            message={"type": "test_result", "invalid": "data"},
         )

--- a/tests/backend/services/connector/test_manager.py
+++ b/tests/backend/services/connector/test_manager.py
@@ -9,6 +9,7 @@ This module tests the ConnectionManager class including:
 - Message routing and handling
 """
 
+import uuid
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -349,6 +350,42 @@ class TestConnectionManager:
         )
 
         assert response is None
+
+    @pytest.mark.asyncio
+    async def test_register_without_a_session_is_refused(
+        self, manager: ConnectionManager, sample_register_message, project_context, mock_websocket
+    ):
+        """Project-scoped register fails closed when no session can be opened.
+
+        Without one the membership check cannot run, and skipping it would add
+        routing for a project the connection was never authorized for.
+        """
+        conn_id = "conn-test-123"
+        context = WebSocketConnectionContext(
+            user_id=str(uuid.uuid4()),
+            organization_id=str(uuid.uuid4()),
+            token_project_id=None,
+        )
+        await manager.connect(conn_id, context, mock_websocket)
+
+        message = {
+            **sample_register_message,
+            "project_id": str(uuid.uuid4()),
+            "environment": project_context["environment"],
+        }
+
+        response = await manager.handle_message(
+            connection_id=conn_id,
+            message=message,
+            db=None,
+            db_factory=None,
+            organization_id=context.organization_id,
+            user_id=context.user_id,
+        )
+
+        assert response["status"] == "error"
+        assert manager._connection_projects.get(conn_id, set()) == set()
+        assert manager._project_routing == {}
 
     @pytest.mark.asyncio
     async def test_handle_message_hot_path_opens_no_session(

--- a/tests/backend/services/connector/test_manager.py
+++ b/tests/backend/services/connector/test_manager.py
@@ -9,6 +9,7 @@ This module tests the ConnectionManager class including:
 - Message routing and handling
 """
 
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -348,6 +349,84 @@ class TestConnectionManager:
         )
 
         assert response is None
+
+    @pytest.mark.asyncio
+    async def test_handle_message_hot_path_opens_no_session(
+        self,
+        manager: ConnectionManager,
+        sample_test_result_message,
+        sample_pong_message,
+        project_context,
+    ):
+        """Normal results, metric results and pongs must open no DB session.
+
+        A session costs a pool checkout and a GUC round trip on the WebSocket
+        loop, and none of these three message types issues a single query.
+        """
+        conn_id = "conn-test-123"
+        key = manager.get_connection_key(
+            project_context["project_id"], project_context["environment"]
+        )
+        manager._connection_projects[conn_id] = {key}
+
+        def exploding_factory():
+            raise AssertionError("the hot path must not open a database session")
+
+        hot_path_messages = [
+            sample_test_result_message,
+            {"type": "metric_result", "metric_run_id": "invoke_m1", "status": "success"},
+            sample_pong_message,
+        ]
+
+        for message in hot_path_messages:
+            response = await manager.handle_message(
+                connection_id=conn_id,
+                message=message,
+                db_factory=exploding_factory,
+                organization_id=None,
+            )
+            assert response is None
+
+    @pytest.mark.asyncio
+    async def test_handle_message_validation_result_opens_a_session(
+        self, manager: ConnectionManager, project_context
+    ):
+        """A late validation result is the one test_result that needs a session."""
+        conn_id = "conn-test-123"
+        key = manager.get_connection_key(
+            project_context["project_id"], project_context["environment"]
+        )
+        manager._connection_projects[conn_id] = {key}
+
+        session = Mock()
+        opened = []
+
+        @contextmanager
+        def factory():
+            opened.append(session)
+            yield session
+
+        target = (
+            "rhesis.backend.app.services.connector.handlers."
+            "test_result_handler._handle_late_validation_result"
+        )
+        with patch(target, new=AsyncMock()) as mock_late:
+            await manager.handle_message(
+                connection_id=conn_id,
+                message={
+                    "type": "test_result",
+                    "test_run_id": "validation_abc123",
+                    "status": "success",
+                    "output": {},
+                    "duration_ms": 1.0,
+                },
+                db_factory=factory,
+                organization_id=None,
+            )
+
+        assert opened == [session]
+        mock_late.assert_awaited_once()
+        assert mock_late.await_args.args[-1] is session
 
     @pytest.mark.asyncio
     async def test_multiple_connections_different_environments(self, manager: ConnectionManager):

--- a/tests/backend/services/connector/test_throughput.py
+++ b/tests/backend/services/connector/test_throughput.py
@@ -1,0 +1,160 @@
+"""Inbound WebSocket throughput benchmark for the SDK connector.
+
+Opt-in, because it is a timing measurement: ``RHESIS_RUN_BENCHMARKS=1``. It
+drives the real ``ConnectionManager.handle_message`` against the real database
+and reports inbound results/sec for three configurations, so the cost of the
+per-message session and the cost of the per-message logging can be told apart.
+
+    cd apps/backend
+    RHESIS_RUN_BENCHMARKS=1 uv run pytest \
+        ../../tests/backend/services/connector/test_throughput.py -s
+
+The eager arm is kept on purpose: it is what the router did before the session
+was made lazy, so the before/after comparison stays reproducible after merge.
+"""
+
+import logging
+import os
+import time
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from rhesis.backend.app.database import get_db_with_tenant_variables
+from rhesis.backend.app.services.connector.handlers import test_result_handler
+from rhesis.backend.app.services.connector.manager import ConnectionManager
+from rhesis.backend.logging.logging_config import JsonLogFormatter, RedactingFormatter
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("RHESIS_RUN_BENCHMARKS"),
+    reason="throughput benchmark; set RHESIS_RUN_BENCHMARKS=1 to run",
+)
+
+# Enough messages that per-message cost dominates fixture setup. Bursts, not
+# paced sends: asyncio.sleep cannot deliver high rates, so the loop drains as
+# fast as it can and we measure how long the drain took.
+MESSAGE_COUNT = int(os.getenv("RHESIS_BENCHMARK_MESSAGES", "2000"))
+
+CONNECTOR_LOGGERS = (
+    "rhesis.backend.app.services.connector.manager",
+    "rhesis.backend.app.services.connector.handlers.test_result",
+)
+
+
+@contextmanager
+def _production_logging(level: int):
+    """Format connector records the way the deployed backend does.
+
+    All three environments run INFO with ``jsonLoggerEnabled``, so every record
+    is JSON-formatted, run through every redaction regex and written to a real
+    fd. Under pytest these loggers reach a plain capturing handler instead,
+    which would hide most of what logging actually costs on the event loop.
+    """
+    sink = open(os.devnull, "w")
+    handler = logging.StreamHandler(stream=sink)
+    handler.setFormatter(RedactingFormatter(JsonLogFormatter()))
+
+    saved = []
+    for name in CONNECTOR_LOGGERS:
+        logger = logging.getLogger(name)
+        saved.append((logger, logger.handlers[:], logger.propagate, logger.level))
+        logger.handlers = [handler]
+        logger.propagate = False  # keep pytest's capture out of the measurement
+        logger.setLevel(level)
+    try:
+        yield
+    finally:
+        for logger, handlers, propagate, saved_level in saved:
+            logger.handlers = handlers
+            logger.propagate = propagate
+            logger.setLevel(saved_level)
+        sink.close()
+
+
+def _messages(count: int) -> list[dict]:
+    """Normal (non-validation) results — the frames that dominate a real run."""
+    return [
+        {
+            "type": "test_result",
+            "test_run_id": f"invoke_{index:08x}",
+            "status": "success",
+            "output": {"answer": "x" * 200},
+            "error": None,
+            "duration_ms": 12.5,
+        }
+        for index in range(count)
+    ]
+
+
+class _CountingLogger:
+    """Counts real calls to _log_test_result and delegates to it.
+
+    A harness whose stub silently swallows the work reports a beautiful number
+    and proves nothing, so every arm asserts on this total.
+    """
+
+    def __init__(self):
+        self.calls = 0
+        self._real = test_result_handler._log_test_result
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        return self._real(*args, **kwargs)
+
+
+async def test_inbound_throughput(test_org_id, authenticated_user_id, capsys):
+    """Measure inbound results/sec: eager session, lazy session, lazy without logs."""
+    manager = ConnectionManager()
+    conn_id = "bench-conn"
+    manager._connection_projects[conn_id] = {manager.get_connection_key("", "")}
+
+    def open_db():
+        return get_db_with_tenant_variables(test_org_id, authenticated_user_id, "")
+
+    async def drain(messages, **handle_kwargs) -> float:
+        start = time.perf_counter()
+        for message in messages:
+            await manager.handle_message(
+                connection_id=conn_id,
+                message=message,
+                organization_id=None,
+                **handle_kwargs,
+            )
+        return time.perf_counter() - start
+
+    async def eager_drain(messages) -> float:
+        """One session per message, wrapped around the call as the router did."""
+        start = time.perf_counter()
+        for message in messages:
+            with open_db() as db:
+                await manager.handle_message(
+                    connection_id=conn_id,
+                    message=message,
+                    db=db,
+                    organization_id=None,
+                )
+        return time.perf_counter() - start
+
+    arms = {
+        "eager session, logs at INFO": (logging.INFO, eager_drain, {}),
+        "lazy session, logs at INFO": (logging.INFO, drain, {"db_factory": open_db}),
+        "lazy session, logs off": (logging.WARNING, drain, {"db_factory": open_db}),
+    }
+
+    results: dict[str, float] = {}
+    for label, (level, run, kwargs) in arms.items():
+        counter = _CountingLogger()
+        with _production_logging(level):
+            with patch.object(test_result_handler, "_log_test_result", counter):
+                results[label] = await run(_messages(MESSAGE_COUNT), **kwargs)
+        assert counter.calls == MESSAGE_COUNT, f"{label} processed {counter.calls} messages"
+
+    with capsys.disabled():
+        print(f"\ninbound throughput over {MESSAGE_COUNT} test_result messages")
+        for label, elapsed in results.items():
+            print(f"  {label:<30} {MESSAGE_COUNT / elapsed:>10,.0f} results/sec")
+
+    eager = MESSAGE_COUNT / results["eager session, logs at INFO"]
+    lazy = MESSAGE_COUNT / results["lazy session, logs at INFO"]
+    assert lazy > eager * 2, f"expected a large win, got {lazy:,.0f} vs {eager:,.0f} results/sec"

--- a/tests/backend/test_secret_equality.py
+++ b/tests/backend/test_secret_equality.py
@@ -71,7 +71,7 @@ ALLOWED_SITES: frozenset[tuple[str, int]] = frozenset(
         ("apps/backend/src/rhesis/backend/app/services/experiment.py", 208),
         # auth_token_project_id is a UUID project reference, not a secret token;
         # comparing it to another project UUID is safe (no timing oracle risk)
-        ("apps/backend/src/rhesis/backend/app/services/connector/manager.py", 1033),
+        ("apps/backend/src/rhesis/backend/app/services/connector/manager.py", 1079),
     }
 )
 


### PR DESCRIPTION
## Purpose

Running many parallel calls against an SDK endpoint was capped at roughly 269 inbound results/sec per backend pod. The router wrapped every inbound WebSocket frame in `get_db_with_tenant_variables`, which is synchronous: a pool checkout, a GUC round trip, then a commit and reset, all on the event loop, with the message loop blocked until it returned. Measured here at about 2ms per message.

The hot path never used that session. Normal test results return from `handlers/test_result.py` without issuing a query, because only run ids starting `validation_` touch the database, and `metric_result` and `pong` never do. Only `register` needs one. So this removes the cost rather than relocating it, which is why it needs neither async SQLAlchemy nor a thread offload.

## What Changed

- New `services/connector/session.py` with `resolve_session()`, the one place that decides between a caller's open session, a factory, or neither. The router passes a factory and handlers open a session only when they ask for one.
- The `register` branch of `handle_message` moved into `_handle_register_message`, wrapped in a single `resolve_session` block so authorization and endpoint/metric sync still share one session and one transaction. `handle_message` still accepts an open `db`, so existing callers and tests are unaffected.
- Hot-path logging cut from 10-11 records per test result to 1. Every record is JSON-formatted and regex-redacted before reaching stdout at roughly 40µs apiece, so once the session was gone this became the dominant per-message cost. The output payload moved to DEBUG; a failed result keeps a single ERROR line.
- `WS_RATE_LIMIT` default raised from 50 to 500. Useful concurrency on one connection is roughly the limit times the call latency, so 50 capped a single endpoint at about 100 in-flight 2s calls. Over the limit the frame is dropped rather than backpressured, and the caller only ever sees the 120s timeout.
- `_authorize_and_register` now fails closed. It gated the project membership check on `if db and auth_org_id and auth_user_id`, so a caller supplying no session skipped authorization entirely and still populated the routing table, returning `True`. That predates this PR and is not reachable today, since the router is the only caller and always supplies a factory, but the plumbing went from one optional parameter to two so it is easier to miswire than it was. Raised by peqy in review.
- New opt-in throughput benchmark at `tests/backend/services/connector/test_throughput.py`.

## Additional Context

- **Tenant scope is unchanged.** The factory captures the same project scope the router already resolved per message, so nothing about RLS or the ORM auto-filter moves.
- The logging reduction is in the same commit as the session change on purpose. Parsing `TestResultMessage` once instead of twice is part of the session work, and that is what changes `_log_test_result`'s signature from a raw dict to a parsed model, so split apart neither half is independently buildable.
- Async SQLAlchemy was considered and is not the answer to this particular problem. The measured cost is network round trips (`pool_pre_ping`'s `SELECT 1`, the batched `set_config`, the commit, a second `set_config` to blank the GUCs, the close), and async removes none of them. It only stops them blocking the loop.
- `tests/backend/test_secret_equality.py` keys `ALLOWED_SITES` by `(file, line)`, and the refactor shifted the pre-approved `auth_token_project_id == project_id` comparison from line 1033 to 1079. The allowlist entry moves with it; the comparison itself is unchanged, and its original justification (a project UUID, not a secret token) still holds.
- Follow-on, not in this PR: three sites in `services/websocket` still call `get_db_with_tenant_variables` on the event loop. They are the same shape, but they fire per channel-subscribe and per chat turn, where the LLM call dominates, so they are not hot paths.

## Testing

Measured over 2000 `test_result` frames against a real Postgres, with the production JSON formatter and redaction filter installed on the connector loggers:

| arm | results/sec |
| --- | ---: |
| eager session per message, logs at INFO | 504 |
| lazy session, logs at INFO | 23,692 |
| lazy session, logs off | 545,597 |

```bash
cd apps/backend
RHESIS_RUN_BENCHMARKS=1 uv run pytest ../../tests/backend/services/connector/test_throughput.py -s
```

The eager arm is kept deliberately: it is what the router did before this change, so the comparison stays reproducible after merge. The benchmark installs the production log formatting itself, because under pytest these loggers otherwise reach a plain capturing handler, which hides most of what logging costs.

Three new tests, each of which fails against the code before this change:

- `tests/backend/routes/test_connector.py::test_message_loop_opens_no_session_for_test_result` patches `get_db_with_tenant_variables` to raise and drives the real `_message_loop`.
- `test_manager.py::test_handle_message_hot_path_opens_no_session` feeds `test_result`, `metric_result` and `pong` with a factory that raises if called.
- `test_manager.py::test_handle_message_validation_result_opens_a_session` confirms a `validation_*` run id still gets one.

Plus `test_manager.py::test_register_without_a_session_is_refused` for the fail-closed change, asserting both the error response and that `_project_routing` and `_connection_projects` stay empty. Verified it fails with the guard disabled and passes with it restored.

529 tests pass locally across `services/connector`, `services/websocket`, `routes/test_connector.py`, `services/invokers` and the endpoint service suites. CI runs the full backend suite and it is green: 8603 passed, 53 skipped, 1 xfailed.

```bash
cd apps/backend
uv run pytest ../../tests/backend/services/connector/ ../../tests/backend/services/websocket/ ../../tests/backend/routes/test_connector.py ../../tests/backend/services/invokers/ -q
```
