### PR TITLE
Join MAF conversation turns into one trace

### DIFF
--- a/docs/content/docs/tracing/agent-framework.mdx
+++ b/docs/content/docs/tracing/agent-framework.mdx
@@ -153,6 +153,23 @@ async def chat(input: str, conversation_id: str = None) -> dict:
   Do not call `agent_framework.observability.configure_otel_providers()` (or `setup_observability()`) after creating the `RhesisClient`. Doing so replaces the Rhesis tracer provider and spans will no longer reach Rhesis. `auto_instrument("agent_framework")` already enables MAF instrumentation against the Rhesis provider for you.
 </Callout>
 
+## Multi-Turn Conversations
+
+MAF opens its own root span per turn, so OpenTelemetry mints a fresh trace id every time you run an agent or a workflow. Bind a conversation id and the integration puts all of that conversation's turns on one trace, with the run root of each turn carrying the turn's message and reply:
+
+<CodeBlock filename="session.py" language="python">
+{`from rhesis.telemetry.context import set_conversation_id
+
+set_conversation_id("user-42")
+
+for message in ["Hello", "Tell me more"]:
+    result = await agent.run(message)`}
+</CodeBlock>
+
+The first turn keeps the trace id it was born with and later turns join it, so a link to the first turn still resolves. Bind the id before the run starts: the target trace has to be known when the run root is created, and MAF assigns no span attributes before then.
+
+Two cases stand this down, because there the trace id is already owned and published elsewhere: a run inside an `@endpoint` or `@observe` span, and a platform-driven turn. Both join the turns themselves, so the integration leaves their spans where they are.
+
 ## Worked Example: Travel Agent
 
 The repository ships a runnable multi-agent MAF demo - a `HandoffBuilder` workflow with a coordinator and three specialists - built specifically to produce agent, LLM, tool, and handoff traces in Rhesis. See [`agents/travel-agent`](https://github.com/rhesis-ai/rhesis/tree/main/agents/travel-agent) and its [architecture notes](https://github.com/rhesis-ai/rhesis/blob/main/agents/travel-agent/docs/architecture.md).

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/mapping.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/mapping.py
@@ -87,6 +87,10 @@ WORKFLOW_RUN_SPAN_NAME = "workflow.run"
 # Graph View knows how to connect.
 HANDOFF_TOOL_PREFIX = "handoff_to_"
 
+# MAF names an agent span after the operation that opened it, so the agent's own
+# name follows the prefix (``invoke_agent researcher``).
+_AGENT_SPAN_PREFIXES: tuple[str, ...] = (f"{OP_INVOKE_AGENT} ", f"{OP_CREATE_AGENT} ")
+
 # Operation -> Rhesis span name. The validator in
 # :mod:`rhesis.telemetry.attributes` accepts ``ai.<domain>(.<action>)?`` and
 # anything starting with ``function.``, so we are careful to land here.
@@ -339,3 +343,12 @@ def translate_handoff_attributes(
 def is_workflow_run_span(original_name: str | None) -> bool:
     """Return True for MAF's top-level ``workflow.run`` span (the run root)."""
     return original_name == WORKFLOW_RUN_SPAN_NAME
+
+
+def is_agent_invocation_span(original_name: str | None) -> bool:
+    """Return True for MAF's per-run agent span (``invoke_agent <name>``).
+
+    A plain ``agent.run()`` emits no ``workflow.run`` span, so this is the trace
+    root there and the only span that can carry the turn's conversation.
+    """
+    return bool(original_name) and original_name.startswith(_AGENT_SPAN_PREFIXES)

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
@@ -35,6 +35,7 @@ from rhesis.sdk.telemetry.integrations.agent_framework import mapping
 from rhesis.sdk.telemetry.integrations.genai import (
     AncestryRegistry,
     ConversationTraceRegistry,
+    DeferredReleaseQueue,
     RetracedSpan,
 )
 from rhesis.sdk.telemetry.integrations.genai import (
@@ -380,10 +381,15 @@ class _ConversationContentRegistry:
         self._output_by_trace: dict[int, str] = {}
         self._session_by_trace: dict[int, str] = {}
         self._max_entries = max_entries
-        # Traces whose content has been handed to an exporter, oldest first.
-        self._served: dict[int, None] = {}
-        self._max_served = max_served
         self._lock = threading.Lock()
+        # Every store goes in: one left out never gets freed. Guarded by the
+        # lock above, which the queue expects the caller to hold.
+        self._release = DeferredReleaseQueue(
+            self._session_by_trace,
+            self._input_by_trace,
+            self._output_by_trace,
+            max_served=max_served,
+        )
 
     def _evict_if_needed(self, store: dict[int, str]) -> None:
         if len(store) < self._max_entries:
@@ -462,7 +468,7 @@ class _ConversationContentRegistry:
             session = self._session_by_trace.get(trace_id)
             conv_input = self._input_by_trace.get(trace_id)
             conv_output = self._output_by_trace.get(trace_id)
-            self._queue_release(trace_id)
+            self._release.queue_release(trace_id)
         return session, conv_input, conv_output
 
     def release(self, trace_id: int | None) -> None:
@@ -474,44 +480,7 @@ class _ConversationContentRegistry:
         if trace_id is None:
             return
         with self._lock:
-            self._queue_release(trace_id)
-
-    def _queue_release(self, trace_id: int) -> None:
-        """Drop the entries of whatever has fallen far enough behind.
-
-        Deferred rather than immediate so every exporter reading the same batch
-        sees the same content, and bounded so a long-running process does not
-        hold 10 KB of conversation text per trace until the entry cap evicts it.
-        The queue is deliberately larger than an OTEL export batch, since a busy
-        service can flush hundreds of run roots at once and the exporters do not
-        drain their queues in lockstep.
-
-        Caller holds the lock.
-        """
-        if not self._has_entries(trace_id):
-            # Nothing to release, so it must not take a slot: a run of traces
-            # with no conversation content on them would otherwise push out the
-            # entries of the ones that have it.
-            return
-        self._served.pop(trace_id, None)
-        self._served[trace_id] = None
-        while len(self._served) > self._max_served:
-            stale = next(iter(self._served))
-            del self._served[stale]
-            self._session_by_trace.pop(stale, None)
-            self._input_by_trace.pop(stale, None)
-            self._output_by_trace.pop(stale, None)
-
-    def _has_entries(self, trace_id: int) -> bool:
-        """Whether any of the three stores holds something for this trace."""
-        return any(
-            trace_id in store
-            for store in (
-                self._session_by_trace,
-                self._input_by_trace,
-                self._output_by_trace,
-            )
-        )
+            self._release.queue_release(trace_id)
 
 
 # Shared singleton: the dedup processor records chat I/O at span end, the

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
@@ -358,17 +358,25 @@ class _ConversationContentRegistry:
     It is the gate for turn-root stamping: only when the agent has set a real
     conversation id for the run does the root ``workflow.run`` span become a
     Rhesis conversation turn root. Pure single-turn runs (e.g. the ``run_traces``
-    smoke test) set no id and stay plain traces. All stores are bounded; the
-    oldest entries are evicted once the cap is hit. Input/output strings are
+    smoke test) set no id and stay plain traces.
+
+    Entries are released a bounded number of reads after the first exporter
+    reads them, rather than on that read, so that several wrapped exporters all
+    stamp the same content; see :meth:`read_for_root`. Every store is bounded
+    independently of that, the oldest entries being evicted once the cap is hit.
+    Input/output strings are
     truncated to :data:`~rhesis.telemetry.constants.ConversationContext.MAX_IO_LENGTH`
     at record time.
     """
 
-    def __init__(self, max_entries: int = 4096) -> None:
+    def __init__(self, max_entries: int = 4096, max_served: int = 512) -> None:
         self._input_by_trace: dict[int, str] = {}
         self._output_by_trace: dict[int, str] = {}
         self._session_by_trace: dict[int, str] = {}
         self._max_entries = max_entries
+        # Traces whose content has been handed to an exporter, oldest first.
+        self._served: dict[int, None] = {}
+        self._max_served = max_served
         self._lock = threading.Lock()
 
     def _evict_if_needed(self, store: dict[int, str]) -> None:
@@ -431,22 +439,57 @@ class _ConversationContentRegistry:
         with self._lock:
             return self._session_by_trace.get(trace_id)
 
-    def consume(self, trace_id: int | None) -> tuple[str | None, str | None, str | None]:
-        """Pop and return ``(session_id, input, output)`` for ``trace_id``.
+    def read_for_root(self, trace_id: int | None) -> tuple[str | None, str | None, str | None]:
+        """Return ``(session_id, input, output)`` for ``trace_id`` and queue its release.
 
-        Called exactly once per trace when its root ``workflow.run`` span is
-        exported, so per-trace entries do not linger for the process lifetime
-        (bounding memory beyond the eviction cap and removing any risk of stale
-        content resurfacing if a trace id were ever reused). Returns all-``None``
-        when nothing was recorded for the trace.
+        Read rather than popped. ``enable()`` wraps *every* exporter on the
+        provider, so a process running its own OTLP collector beside Rhesis has
+        two translating exporters, each exporting the same spans. Popping here
+        gave the content to whichever reached the trace root first and left the
+        other stamping a root span with no conversation on it.
+
+        Returns all-``None`` when nothing was recorded for the trace.
         """
         if trace_id is None:
             return None, None, None
         with self._lock:
-            session = self._session_by_trace.pop(trace_id, None)
-            conv_input = self._input_by_trace.pop(trace_id, None)
-            conv_output = self._output_by_trace.pop(trace_id, None)
+            session = self._session_by_trace.get(trace_id)
+            conv_input = self._input_by_trace.get(trace_id)
+            conv_output = self._output_by_trace.get(trace_id)
+            self._queue_release(trace_id)
         return session, conv_input, conv_output
+
+    def release(self, trace_id: int | None) -> None:
+        """Queue ``trace_id``'s entries for release without reading them.
+
+        For a run whose content nothing will stamp: a ``workflow.run`` nested
+        under an ``@endpoint``/``@observe`` span, where that span owns the turn.
+        """
+        if trace_id is None:
+            return
+        with self._lock:
+            self._queue_release(trace_id)
+
+    def _queue_release(self, trace_id: int) -> None:
+        """Drop the entries of whatever has fallen far enough behind.
+
+        Deferred rather than immediate so every exporter reading the same batch
+        sees the same content, and bounded so a long-running process does not
+        hold 10 KB of conversation text per trace until the entry cap evicts it.
+        The queue is deliberately larger than an OTEL export batch, since a busy
+        service can flush hundreds of run roots at once and the exporters do not
+        drain their queues in lockstep.
+
+        Caller holds the lock.
+        """
+        self._served.pop(trace_id, None)
+        self._served[trace_id] = None
+        while len(self._served) > self._max_served:
+            stale = next(iter(self._served))
+            del self._served[stale]
+            self._session_by_trace.pop(stale, None)
+            self._input_by_trace.pop(stale, None)
+            self._output_by_trace.pop(stale, None)
 
 
 # Shared singleton: the dedup processor records chat I/O at span end, the
@@ -491,9 +534,9 @@ def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
     if trace_id is None:
         return None
 
-    # Release per-trace entries on every workflow.run export, even when nested
-    # under @endpoint/@observe (no stamping in that case).
-    session_id, conv_input, conv_output = _conversation_content.consume(trace_id)
+    # Queue the per-trace entries for release on every workflow.run export, even
+    # when nested under @endpoint/@observe (no stamping in that case).
+    session_id, conv_input, conv_output = _conversation_content.read_for_root(trace_id)
 
     if getattr(span, "parent", None) is not None:
         return None

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
@@ -32,7 +32,11 @@ from rhesis.sdk.telemetry.integrations.agent_framework import mapping
 
 # Shared with other native-GenAI integrations (see genai.py); imported under
 # the historical private names so existing references keep working.
-from rhesis.sdk.telemetry.integrations.genai import AncestryRegistry
+from rhesis.sdk.telemetry.integrations.genai import (
+    AncestryRegistry,
+    ConversationTraceRegistry,
+    RetracedSpan,
+)
 from rhesis.sdk.telemetry.integrations.genai import (
     TranslatedSpan as _TranslatedSpan,
 )
@@ -43,6 +47,8 @@ from rhesis.telemetry.attributes import AIAttributes
 from rhesis.telemetry.constants import ConversationContext
 from rhesis.telemetry.context import (
     get_conversation_id,
+    get_conversation_trace_id,
+    get_root_trace_id,
     is_llm_observation_active,
     set_llm_observation_active,
 )
@@ -356,8 +362,8 @@ class _ConversationContentRegistry:
     A per-trace conversation/session id is also recorded here at chat-span
     *start* (while the caller's ``set_conversation_id`` contextvar is active).
     It is the gate for turn-root stamping: only when the agent has set a real
-    conversation id for the run does the root ``workflow.run`` span become a
-    Rhesis conversation turn root. Pure single-turn runs (e.g. the ``run_traces``
+    conversation id for the run does the run's root span become a Rhesis
+    conversation turn root. Pure single-turn runs (e.g. the ``run_traces``
     smoke test) set no id and stay plain traces.
 
     Entries are released a bounded number of reads after the first exporter
@@ -496,17 +502,28 @@ class _ConversationContentRegistry:
 # translating exporter reads it when stamping a root ``workflow.run`` span.
 _conversation_content = _ConversationContentRegistry()
 
+# MAF opens its own root span per turn, so OTEL mints a fresh trace id each time
+# and a conversation arrives as one unrelated trace per turn -- every turn
+# correctly labelled with the same conversation id, and none of them together.
+# The dedup processor claims each turn's trace at span start, where the
+# conversation ContextVars are still readable; the exporter rewrites the later
+# turns onto the first turn's id. Same registry the Google ADK integration uses.
+_conversation_traces = ConversationTraceRegistry()
+
 
 def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
-    """Build conversation attributes for a ``workflow.run`` span.
+    """Build conversation attributes for the span that roots a MAF run.
+
+    That is ``workflow.run`` for a workflow, and ``invoke_agent <name>`` for a
+    plain ``agent.run()``, which emits no workflow span at all.
 
     Always :meth:`consumes <_ConversationContentRegistry.consume>` the per-trace
     chat I/O recorded for this span's trace id so entries do not linger when the
     ``workflow.run`` span is nested under a Rhesis ``@endpoint``/``@observe``
     parent (the common long-running-service path). Stamping is limited to trace
-    roots only (``parent is None``): when the workflow runs inside an enclosing
-    Rhesis span, that span owns turn-root semantics and ``workflow.run`` must
-    not be stamped again.
+    roots only (``parent is None``): when the run happens inside an enclosing
+    Rhesis span, that span owns turn-root semantics and the MAF root must not be
+    stamped again.
 
     When stamped, the span always gets the conversation ``input``/``output``
     (from the nested chat spans via :data:`_conversation_content`) so the
@@ -523,23 +540,29 @@ def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
       test): stamp only input/output. The run stays a plain single-turn trace
       (``conversation.id`` remains null) but its conversation is still visible.
 
-    Returns ``None`` when this is not a ``workflow.run`` span, or when it is a
-    trace root with neither a session id nor any captured input/output (e.g.
-    content capture disabled), leaving the span untouched.
+    Returns ``None`` when this is not a run root, or when it is a trace root
+    with neither a session id nor any captured input/output (e.g. content
+    capture disabled), leaving the span untouched.
     """
-    if not mapping.is_workflow_run_span(getattr(span, "name", None)):
+    name = getattr(span, "name", None)
+    is_workflow_run = mapping.is_workflow_run_span(name)
+    if not (is_workflow_run or mapping.is_agent_invocation_span(name)):
         return None
     ctx = getattr(span, "context", None)
     trace_id = getattr(ctx, "trace_id", None)
     if trace_id is None:
         return None
 
-    # Queue the per-trace entries for release on every workflow.run export, even
-    # when nested under @endpoint/@observe (no stamping in that case).
-    session_id, conv_input, conv_output = _conversation_content.read_for_root(trace_id)
-
     if getattr(span, "parent", None) is not None:
+        # Release per-trace entries on a nested workflow.run, which is the
+        # @endpoint/@observe path: nothing else in the trace will read them.
+        # Not for a nested agent span - inside a workflow that is every agent in
+        # the run, and the first one would release the content the root needs.
+        if is_workflow_run:
+            _conversation_content.release(trace_id)
         return None
+
+    session_id, conv_input, conv_output = _conversation_content.read_for_root(trace_id)
 
     attrs: dict[str, Any] = {}
     if session_id:
@@ -668,7 +691,24 @@ class MAFTranslatingExporter(SpanExporter):
                     translated.append(_safe_fallback_span(span))
             else:
                 translated.append(span)
-        return self._wrapped.export(translated)
+        return self._wrapped.export(self._join_conversation_traces(translated))
+
+    @staticmethod
+    def _join_conversation_traces(spans: list[ReadableSpan]) -> list[ReadableSpan]:
+        """Rewrite every span of a claimed trace onto its conversation's trace id.
+
+        Applies to non-MAF spans as well. They share the trace with the MAF run --
+        an enclosing ``@endpoint`` span, an HTTP client span from an unrelated
+        instrumentation -- and leaving them behind on the original trace id would
+        tear the turn in half.
+        """
+        joined: list[ReadableSpan] = []
+        for span in spans:
+            target = _conversation_traces.target(
+                getattr(getattr(span, "context", None), "trace_id", None)
+            )
+            joined.append(RetracedSpan(span, target) if target is not None else span)
+        return joined
 
     def shutdown(self) -> None:
         try:
@@ -760,6 +800,11 @@ class MAFLLMDedupSpanProcessor(SpanProcessor):
                 return None
         return getattr(ctx, "span_id", None)
 
+    @staticmethod
+    def _trace_id(span) -> int | None:
+        """Return ``span_context.trace_id`` if present, else ``None``."""
+        return getattr(getattr(span, "context", None), "trace_id", None)
+
     def _store_prev_flag(self, span, prev: bool) -> None:
         """Stash the outer flag value where ``on_end`` can find it.
 
@@ -795,6 +840,21 @@ class MAFLLMDedupSpanProcessor(SpanProcessor):
             # parent chain tool -> chat -> invoke_agent is fully indexed before
             # any of them export.
             _handoff_ancestry.record(span)
+            # Claim this turn's trace for the conversation on every MAF span, not
+            # just the chat spans below: the claim has to be recorded before any
+            # span of the trace is exported, and the workflow/agent root starts
+            # first. Claiming only from a chat span would let a sibling that ends
+            # earlier ship on the original trace id in an earlier batch.
+            #
+            # Both ContextVars mean something outside this process already owns
+            # the trace identity -- ``root_trace_id`` is what an enclosing
+            # ``@endpoint``/``@observe`` publishes as its result and as the next
+            # turn's conversation trace, ``conversation_trace_id`` is a trace the
+            # platform minted and is writing its own turn records to. Either way
+            # it joins the turns itself, and moving spans off that id would
+            # strand the link and the reply on a trace with no spans.
+            if get_root_trace_id() is None and get_conversation_trace_id() is None:
+                _conversation_traces.claim(self._trace_id(span), get_conversation_id())
             # NOTE: at ``on_start`` time MAF has not yet called
             # ``span.set_attributes(...)``. ``ChatTelemetryLayer`` constructs
             # the span via ``start_span(f"{operation} {span_name}")`` and only
@@ -813,9 +873,7 @@ class MAFLLMDedupSpanProcessor(SpanProcessor):
             # contextvar set by the caller (e.g. ``run_chat_turn``) is still
             # active. Recording here avoids relying on ``on_end`` context, which
             # could differ if a future processor ever deferred span completion.
-            ctx = getattr(span, "context", None)
-            trace_id = getattr(ctx, "trace_id", None)
-            _conversation_content.record_session(trace_id, get_conversation_id())
+            _conversation_content.record_session(self._trace_id(span), get_conversation_id())
             prev = is_llm_observation_active()
             self._store_prev_flag(span, prev)
             if not prev:

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
@@ -533,13 +533,19 @@ def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
     That is ``workflow.run`` for a workflow, and ``invoke_agent <name>`` for a
     plain ``agent.run()``, which emits no workflow span at all.
 
-    Always :meth:`consumes <_ConversationContentRegistry.consume>` the per-trace
-    chat I/O recorded for this span's trace id so entries do not linger when the
-    ``workflow.run`` span is nested under a Rhesis ``@endpoint``/``@observe``
-    parent (the common long-running-service path). Stamping is limited to trace
-    roots only (``parent is None``): when the run happens inside an enclosing
-    Rhesis span, that span owns turn-root semantics and the MAF root must not be
-    stamped again.
+    Stamping is limited to trace roots only (``parent is None``): when the run
+    happens inside an enclosing Rhesis span, that span owns turn-root semantics
+    and the MAF root must not be stamped again.
+
+    Reads the per-trace chat I/O through
+    :meth:`~_ConversationContentRegistry.read_for_root`, which queues it for
+    release rather than taking it, so the other wrapped exporters still see it.
+    A ``workflow.run`` that is *not* the trace root queues the release without
+    reading, since an enclosing ``@endpoint``/``@observe`` span owns the turn and
+    nothing else in the trace will read that content. A nested ``invoke_agent``
+    does not, because inside a workflow that is every agent in the run and the
+    first would release what the root needs. So a plain ``agent.run()`` under an
+    enclosing Rhesis span leaves its entries to the store's own eviction cap.
 
     When stamped, the span always gets the conversation ``input``/``output``
     (from the nested chat spans via :data:`_conversation_content`) so the

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
@@ -488,6 +488,11 @@ class _ConversationContentRegistry:
 
         Caller holds the lock.
         """
+        if not self._has_entries(trace_id):
+            # Nothing to release, so it must not take a slot: a run of traces
+            # with no conversation content on them would otherwise push out the
+            # entries of the ones that have it.
+            return
         self._served.pop(trace_id, None)
         self._served[trace_id] = None
         while len(self._served) > self._max_served:
@@ -496,6 +501,17 @@ class _ConversationContentRegistry:
             self._session_by_trace.pop(stale, None)
             self._input_by_trace.pop(stale, None)
             self._output_by_trace.pop(stale, None)
+
+    def _has_entries(self, trace_id: int) -> bool:
+        """Whether any of the three stores holds something for this trace."""
+        return any(
+            trace_id in store
+            for store in (
+                self._session_by_trace,
+                self._input_by_trace,
+                self._output_by_trace,
+            )
+        )
 
 
 # Shared singleton: the dedup processor records chat I/O at span end, the

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
@@ -487,6 +487,56 @@ class _ConversationContentRegistry:
 # translating exporter reads it when stamping a root ``workflow.run`` span.
 _conversation_content = _ConversationContentRegistry()
 
+
+class _MafRootedTraces:
+    """Trace ids whose trace root is a MAF span.
+
+    Answers the one question a *nested* run root needs: will anything in this
+    trace read the conversation content? Only a MAF span at the trace root ever
+    stamps a turn, so when one exists it is the reader and a nested span must
+    leave the content alone. When none exists - the run sits under a Rhesis
+    ``@endpoint``/``@observe`` span, which owns the turn itself - nobody reads,
+    so the nested span can release instead of leaving the entries to the store's
+    eviction cap.
+
+    Marked at span *start*, where a trace root always precedes the nested spans
+    that ask about it, and read at export. One entry per trace rather than per
+    span, and bounded, so a long-running process cannot grow it without limit.
+    """
+
+    def __init__(self, max_entries: int = 4096) -> None:
+        self._traces: dict[int, None] = {}
+        self._max_entries = max_entries
+        self._lock = threading.Lock()
+
+    def mark(self, trace_id: int | None) -> None:
+        """Record that this trace is rooted by a MAF span. Never raises."""
+        if trace_id is None:
+            return
+        try:
+            with self._lock:
+                while len(self._traces) >= self._max_entries:
+                    try:
+                        del self._traces[next(iter(self._traces))]
+                    except StopIteration:  # pragma: no cover - racy but harmless
+                        break
+                self._traces[trace_id] = None
+        except Exception:  # noqa: BLE001 - marking must never break tracing
+            logger.debug("Failed to mark a MAF-rooted trace", exc_info=True)
+
+    def contains(self, trace_id: int | None) -> bool:
+        if trace_id is None:
+            return False
+        with self._lock:
+            return trace_id in self._traces
+
+    def clear(self) -> None:
+        with self._lock:
+            self._traces.clear()
+
+
+_maf_rooted_traces = _MafRootedTraces()
+
 # MAF opens its own root span per turn, so OTEL mints a fresh trace id each time
 # and a conversation arrives as one unrelated trace per turn -- every turn
 # correctly labelled with the same conversation id, and none of them together.
@@ -509,12 +559,13 @@ def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
     Reads the per-trace chat I/O through
     :meth:`~_ConversationContentRegistry.read_for_root`, which queues it for
     release rather than taking it, so the other wrapped exporters still see it.
-    A ``workflow.run`` that is *not* the trace root queues the release without
-    reading, since an enclosing ``@endpoint``/``@observe`` span owns the turn and
-    nothing else in the trace will read that content. A nested ``invoke_agent``
-    does not, because inside a workflow that is every agent in the run and the
-    first would release what the root needs. So a plain ``agent.run()`` under an
-    enclosing Rhesis span leaves its entries to the store's own eviction cap.
+
+    A run root that is *not* the trace root stamps nothing, and whether it may
+    release turns on what roots the trace. A MAF span there is the reader and
+    exports after its children, so releasing would take what it needs; anything
+    else - a Rhesis ``@endpoint``/``@observe`` span owning the turn - means
+    nothing reads, so the entries are released instead of being left to the
+    store's eviction cap. See :class:`_MafRootedTraces`.
 
     When stamped, the span always gets the conversation ``input``/``output``
     (from the nested chat spans via :data:`_conversation_content`) so the
@@ -545,11 +596,12 @@ def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
         return None
 
     if getattr(span, "parent", None) is not None:
-        # Release per-trace entries on a nested workflow.run, which is the
-        # @endpoint/@observe path: nothing else in the trace will read them.
-        # Not for a nested agent span - inside a workflow that is every agent in
-        # the run, and the first one would release the content the root needs.
-        if is_workflow_run:
+        # A MAF span at the trace root is the one that reads this content, and
+        # it exports after its children, so releasing here would take what it
+        # needs. With no MAF root the turn belongs to an enclosing
+        # @endpoint/@observe span, nothing reads, and leaving the entries to the
+        # store's eviction cap is the leak the release queue exists to prevent.
+        if not _maf_rooted_traces.contains(trace_id):
             _conversation_content.release(trace_id)
         return None
 
@@ -831,6 +883,10 @@ class MAFLLMDedupSpanProcessor(SpanProcessor):
             # parent chain tool -> chat -> invoke_agent is fully indexed before
             # any of them export.
             _handoff_ancestry.record(span)
+            # A MAF span with no parent roots the trace, which tells the nested
+            # run roots that something here will read the conversation content.
+            if getattr(span, "parent", None) is None:
+                _maf_rooted_traces.mark(self._trace_id(span))
             # Claim this turn's trace for the conversation on every MAF span, not
             # just the chat spans below: the claim has to be recorded before any
             # span of the trace is exported, and the workflow/agent root starts

--- a/tests/sdk/telemetry/integrations/test_agent_framework.py
+++ b/tests/sdk/telemetry/integrations/test_agent_framework.py
@@ -1481,6 +1481,52 @@ def test_conversation_content_registry_release_without_reading():
     assert reg.get_session(2) == "sess-2"
 
 
+def test_conversation_content_registry_ignores_a_trace_with_nothing_recorded():
+    """Otherwise a run of content-free traces evicts the ones with content.
+
+    A single-turn run sets no conversation id, and content capture can be off
+    entirely, so reads that find nothing are the common case in some processes.
+    """
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    reg = tr_mod._ConversationContentRegistry(max_served=1)
+    reg.record_session(1, "sess-1")
+    reg.read_for_root(1)
+
+    for empty in range(2, 10):
+        assert reg.read_for_root(empty) == (None, None, None)
+
+    assert reg.read_for_root(1) == ("sess-1", None, None)
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        pytest.param(lambda reg, tid: reg.record_session(tid, f"sess-{tid}"), id="session-only"),
+        pytest.param(lambda reg, tid: reg.record_chat(tid, input_text="query"), id="input-only"),
+        pytest.param(lambda reg, tid: reg.record_chat(tid, output_text="answer"), id="output-only"),
+    ],
+)
+def test_conversation_content_registry_releases_whichever_store_holds_the_content(record):
+    """Content in any one store has to count as content.
+
+    A store left out of the "is there anything here" check makes its entries
+    invisible to the release queue, so they are never freed and the store grows
+    until the entry cap evicts it -- which is the leak the queue exists to stop.
+    """
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    reg = tr_mod._ConversationContentRegistry(max_served=1)
+    record(reg, 1)
+    reg.read_for_root(1)
+    assert reg.read_for_root(1) != (None, None, None), "precondition: trace 1 has content"
+
+    record(reg, 2)
+    reg.read_for_root(2)
+
+    assert reg.read_for_root(1) == (None, None, None), "trace 1 should have been released"
+
+
 def test_two_wrapped_exporters_both_stamp_the_conversation():
     """``enable()`` wraps every exporter on the provider, so a process with its
     own OTLP collector beside Rhesis has two translating exporters exporting the

--- a/tests/sdk/telemetry/integrations/test_agent_framework.py
+++ b/tests/sdk/telemetry/integrations/test_agent_framework.py
@@ -1664,6 +1664,173 @@ def test_exporter_skips_turn_root_on_nested_workflow_run():
     assert sa.CONVERSATION_OUTPUT not in attrs
 
 
+class TestNestedRunRootRelease:
+    """Who frees the per-trace content when no MAF span will stamp it.
+
+    A run under a Rhesis ``@endpoint``/``@observe`` span has its turn owned by
+    that span, so no MAF span reads the content and nothing used to free it
+    either: the entries sat until the store's 4096-entry cap evicted them, which
+    is the leak the release queue exists to prevent. Releasing from any nested
+    span instead would be wrong the other way round, because inside a MAF-rooted
+    trace the root is the reader and exports last.
+    """
+
+    @pytest.fixture(autouse=True)
+    def forget_marked_traces(self):
+        from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+        tr_mod._maf_rooted_traces.clear()
+        yield
+        tr_mod._maf_rooted_traces.clear()
+
+    @staticmethod
+    def _queued_for_release(trace_id: int) -> bool:
+        """Whether the trace has reached the release queue.
+
+        The entries are still readable at this point, deliberately: the queue
+        frees them once enough other traces have been read past them, so that
+        every wrapped exporter sees the same content. Reaching the queue is what
+        distinguishes "will be freed" from "left to the entry cap".
+        """
+        from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+        return trace_id in tr_mod._conversation_content._release._served
+
+    @staticmethod
+    def _record(trace_id: int) -> None:
+        from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+        tr_mod._conversation_content.record_session(trace_id, f"sess-{trace_id}")
+        tr_mod._conversation_content.record_chat(trace_id, input_text="q", output_text="a")
+
+    @pytest.mark.parametrize(
+        "nested_name",
+        [
+            pytest.param("invoke_agent researcher", id="plain-agent-run"),
+            pytest.param("workflow.run", id="workflow-run"),
+        ],
+    )
+    def test_a_nested_run_root_releases_when_no_maf_span_roots_the_trace(self, nested_name):
+        """The ``@endpoint`` path: the endpoint span owns the turn, so nobody reads."""
+        from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+        trace_id = 0xE0DE01
+        self._record(trace_id)
+        # No mark: the trace root is the enclosing Rhesis span, not a MAF span.
+        nested = _FakeChatSpan(span_id=900, trace_id=trace_id, parent_id=1, name=nested_name)
+
+        tr_mod.MAFTranslatingExporter(InMemorySpanExporter()).export([nested])
+
+        assert self._queued_for_release(trace_id), "nothing will read this, so free it"
+
+    @pytest.mark.parametrize(
+        "nested_name",
+        [
+            pytest.param("invoke_agent researcher", id="agent-inside-a-workflow"),
+            pytest.param("workflow.run", id="sub-workflow-inside-a-workflow"),
+        ],
+    )
+    def test_a_nested_run_root_leaves_the_content_when_a_maf_span_roots_the_trace(
+        self, nested_name
+    ):
+        """The root exports after its children, so an early release loses its content.
+
+        The sub-workflow case is the one the previous rule got wrong: it released
+        on every nested ``workflow.run``, including one under a ``workflow.run``
+        trace root that still had to read.
+        """
+        from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+        trace_id = 0xE0DE02
+        self._record(trace_id)
+        tr_mod._maf_rooted_traces.mark(trace_id)
+        nested = _FakeChatSpan(span_id=901, trace_id=trace_id, parent_id=1, name=nested_name)
+
+        tr_mod.MAFTranslatingExporter(InMemorySpanExporter()).export([nested])
+
+        assert not self._queued_for_release(trace_id), "the trace root still has to read this"
+
+    def test_the_root_still_reads_after_a_nested_span_exported(self):
+        """Children export first, so the ordering has to survive end to end."""
+        from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+        trace_id = 0xE0DE03
+        self._record(trace_id)
+        tr_mod._maf_rooted_traces.mark(trace_id)
+        nested = _FakeChatSpan(span_id=902, trace_id=trace_id, parent_id=903, name="invoke_agent a")
+        root = _FakeChatSpan(span_id=903, trace_id=trace_id, parent_id=None, name="workflow.run")
+
+        captured = InMemorySpanExporter()
+        tr_mod.MAFTranslatingExporter(captured).export([nested, root])
+
+        stamped = next(
+            s for s in captured.get_finished_spans() if s.name == "function.workflow.run"
+        )
+        sa = ConversationContext.SpanAttributes
+        assert stamped.attributes.get(sa.CONVERSATION_ID) == f"sess-{trace_id}"
+        assert stamped.attributes.get(sa.CONVERSATION_INPUT) == "q"
+
+
+class TestMarkingTheTraceRoot:
+    """``on_start`` is where the mark has to happen.
+
+    A trace root always starts before the nested spans that ask about it, and it
+    exports after them, so start is the only moment the answer is available in
+    time. Without the mark every nested run root would queue a release the root
+    still needs.
+    """
+
+    @pytest.fixture(autouse=True)
+    def forget_marked_traces(self):
+        from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+        tr_mod._maf_rooted_traces.clear()
+        yield
+        tr_mod._maf_rooted_traces.clear()
+
+    @staticmethod
+    def _started(span) -> None:
+        processor = MAFLLMDedupSpanProcessor()
+        processor.activate()
+        try:
+            processor.on_start(span)
+        finally:
+            processor.deactivate()
+
+    def test_a_parentless_maf_span_marks_its_trace(self):
+        from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+        trace_id = 0xB0A501
+        self._started(
+            _FakeChatSpan(span_id=910, trace_id=trace_id, parent_id=None, name="workflow.run")
+        )
+
+        assert tr_mod._maf_rooted_traces.contains(trace_id)
+
+    def test_a_nested_maf_span_does_not(self):
+        """Otherwise every trace looks MAF-rooted and nothing is ever released."""
+        from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+        trace_id = 0xB0A502
+        self._started(
+            _FakeChatSpan(span_id=911, trace_id=trace_id, parent_id=1, name="invoke_agent a")
+        )
+
+        assert not tr_mod._maf_rooted_traces.contains(trace_id)
+
+
+def test_maf_rooted_traces_is_bounded():
+    """A long-running process must not grow the marker set without limit."""
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    marks = tr_mod._MafRootedTraces(max_entries=2)
+    for trace_id in (1, 2, 3):
+        marks.mark(trace_id)
+
+    assert marks.contains(1) is False, "the oldest mark is evicted"
+    assert marks.contains(2) and marks.contains(3)
+
+
 def test_conversation_content_registry_truncates_io_at_record_time():
     from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
 

--- a/tests/sdk/telemetry/integrations/test_agent_framework.py
+++ b/tests/sdk/telemetry/integrations/test_agent_framework.py
@@ -51,8 +51,12 @@ from rhesis.telemetry.attributes import AIAttributes, validate_span_name  # noqa
 from rhesis.telemetry.constants import ConversationContext  # noqa: E402
 from rhesis.telemetry.context import (  # noqa: E402
     is_llm_observation_active,
+    set_conversation_id,
+    set_conversation_trace_id,
     set_llm_observation_active,
+    set_root_trace_id,
 )
+from rhesis.telemetry.conversation import conversation_turn  # noqa: E402
 
 from rhesis.sdk.telemetry.integrations.agent_framework import (  # noqa: E402
     MAFIntegration,
@@ -287,6 +291,15 @@ def reset_llm_observation_flag():
     """Always exit a test with the LLM-observation flag cleared."""
     yield
     set_llm_observation_active(False)
+
+
+@pytest.fixture(autouse=True)
+def reset_conversation_context():
+    """Keep the conversation contextvars from leaking between tests."""
+    yield
+    set_conversation_id(None)
+    set_conversation_trace_id(None)
+    set_root_trace_id(None)
 
 
 def _drain_spans(provider: TracerProvider, exporter: InMemorySpanExporter):
@@ -1614,6 +1627,297 @@ def test_conversation_content_registry_truncates_io_at_record_time():
     conv_input, conv_output = reg.get(42)
     assert conv_input is not None and len(conv_input) == ConversationContext.MAX_IO_LENGTH
     assert conv_output is not None and len(conv_output) == ConversationContext.MAX_IO_LENGTH
+
+
+# ---------------------------------------------------------------------------
+# Conversation trace join: every turn of a conversation in one trace
+# ---------------------------------------------------------------------------
+
+
+async def _run_turns(count: int, *, conversation_id: str | None) -> None:
+    """Run ``count`` independent agent turns, optionally under one conversation."""
+    if conversation_id is not None:
+        set_conversation_id(conversation_id)
+    for index in range(count):
+        client = DeterministicChatClient([_text_response(f"Answer {index}.")])
+        agent = Agent(client=client, instructions="Answer.", name="joiner")
+        await agent.run(f"Question {index}?")
+
+
+def _trace_ids(spans) -> set[int]:
+    return {s.context.trace_id for s in spans}
+
+
+@pytest.fixture
+def drained_exporter(session_provider, captured_spans) -> InMemorySpanExporter:
+    """The in-memory exporter, guaranteed empty before the test runs.
+
+    ``captured_spans`` clears on teardown, but a test that never drains leaves
+    its spans buffered in the ``BatchSpanProcessor``, and they arrive in the next
+    test's flush. These tests count trace ids, so a stray turn from an earlier
+    test reads as a turn that failed to join.
+    """
+    provider, _captured, _bsp = session_provider
+    provider.force_flush()
+    captured_spans.clear()
+    return captured_spans
+
+
+@pytest.mark.asyncio
+async def test_turns_of_one_conversation_share_one_trace(
+    drained_exporter, integration, reset_observability_settings, session_provider
+):
+    """MAF opens its own root span per turn, so OTEL mints a fresh trace id each
+    time. Left alone, a ten-turn chat arrives as ten unrelated traces even though
+    every turn carries the same conversation id."""
+    enable_instrumentation()
+    provider, _captured, _bsp = session_provider
+
+    await _run_turns(3, conversation_id="conv-join")
+
+    spans = _drain_spans(provider, drained_exporter)
+    assert len(_trace_ids(spans)) == 1
+    # One turn root per turn, all on that single trace, each carrying the id the
+    # exporter propagates to every other span sharing the trace.
+    sa = ConversationContext.SpanAttributes
+    stamped = [s for s in spans if (s.attributes or {}).get(sa.IS_TURN_ROOT)]
+    assert len(stamped) == 3
+    assert all(s.parent is None for s in stamped)
+    assert {s.attributes[sa.CONVERSATION_ID] for s in stamped} == {"conv-join"}
+
+
+@pytest.mark.asyncio
+async def test_the_first_turn_keeps_its_own_trace_id(
+    drained_exporter, integration, reset_observability_settings, session_provider
+):
+    """The anchor is turn 1's real id, so turn 1 is never moved.
+
+    Anything that observed a trace id for the first turn -- an endpoint result, a
+    backend turn record, a link in the viewer -- still resolves.
+    """
+    enable_instrumentation()
+    provider, _captured, _bsp = session_provider
+
+    await _run_turns(1, conversation_id="conv-anchor")
+    first = _trace_ids(_drain_spans(provider, drained_exporter))
+    assert len(first) == 1
+    drained_exporter.clear()
+
+    await _run_turns(2, conversation_id="conv-anchor")
+    assert _trace_ids(_drain_spans(provider, drained_exporter)) == first
+
+
+@pytest.mark.asyncio
+async def test_two_conversations_do_not_collide(
+    drained_exporter, integration, reset_observability_settings, session_provider
+):
+    enable_instrumentation()
+    provider, _captured, _bsp = session_provider
+
+    await _run_turns(1, conversation_id="conv-a")
+    first = _trace_ids(_drain_spans(provider, drained_exporter))
+    drained_exporter.clear()
+    await _run_turns(1, conversation_id="conv-b")
+    second = _trace_ids(_drain_spans(provider, drained_exporter))
+
+    assert len(first) == len(second) == 1
+    assert first != second
+
+
+@pytest.mark.asyncio
+async def test_without_a_conversation_id_each_turn_keeps_its_own_trace(
+    drained_exporter, integration, reset_observability_settings, session_provider
+):
+    """The documented limit of the join: the target trace has to be known when
+    the run root is created, and only the Rhesis contextvar is readable then."""
+    enable_instrumentation()
+    provider, _captured, _bsp = session_provider
+
+    await _run_turns(2, conversation_id=None)
+
+    assert len(_trace_ids(_drain_spans(provider, drained_exporter))) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_platform_owned_conversation_is_left_alone(
+    drained_exporter, integration, reset_observability_settings, session_provider
+):
+    """``conversation_trace_id`` means the platform minted the trace itself.
+
+    It is writing its own turn records -- the mapped input and the reply -- to
+    that trace and joining the turns by its id. Moving spans anywhere would
+    separate the agent's spans from the reply.
+    """
+    enable_instrumentation()
+    provider, _captured, _bsp = session_provider
+
+    set_conversation_trace_id("ab" * 16)
+    await _run_turns(2, conversation_id="conv-platform")
+
+    spans = _drain_spans(provider, drained_exporter)
+    # Untouched: whatever OTEL assigned each turn, not an id of our choosing.
+    assert int("ab" * 16, 16) not in _trace_ids(spans)
+    assert len(_trace_ids(spans)) == 2
+
+
+@pytest.mark.asyncio
+async def test_an_enclosing_rhesis_span_keeps_ownership_of_the_trace_id(
+    drained_exporter, integration, reset_observability_settings, session_provider
+):
+    """The served path: never move spans off the trace id the platform published.
+
+    With an ``@endpoint``/``@observe`` span above the run, ``root_trace_id`` is
+    the id the platform hands onwards -- the endpoint result, the next turn's
+    conversation trace, the link the viewer opens. Rewriting under it strands all
+    of those on a trace id with no spans.
+    """
+    enable_instrumentation()
+    provider, _captured, _bsp = session_provider
+
+    set_conversation_id("conv-served")
+    tracer = provider.get_tracer("rhesis.sdk")
+    with tracer.start_as_current_span("function.chat_endpoint") as endpoint_span:
+        published = endpoint_span.get_span_context().trace_id
+        set_root_trace_id(format(published, "032x"))
+        await _run_turns(2, conversation_id=None)
+
+    assert _trace_ids(_drain_spans(provider, drained_exporter)) == {published}
+
+
+@pytest.mark.asyncio
+async def test_a_conversation_turn_above_the_run_owns_the_turn(
+    drained_exporter, integration, reset_observability_settings, session_provider
+):
+    """An app that owns its turn boundary must own it alone.
+
+    ``conversation_turn`` exists for apps whose reply is not the model's last
+    message. When one is open the MAF root must not claim turn-root too, and the
+    rewrite must move nothing: that span already published the trace id.
+    """
+    enable_instrumentation()
+    provider, _captured, _bsp = session_provider
+
+    with conversation_turn("conv-owned", input="Question?") as turn:
+        await _run_turns(1, conversation_id=None)
+        published = turn.trace_id
+        turn.output = "a reply the model never produced"
+
+    spans = _drain_spans(provider, drained_exporter)
+    stamped = [
+        s
+        for s in spans
+        if (s.attributes or {}).get(ConversationContext.SpanAttributes.IS_TURN_ROOT)
+    ]
+    assert [s.name for s in stamped] == ["function.conversation_turn"]
+    assert {format(t, "032x") for t in _trace_ids(spans)} == {published}
+
+
+@pytest.mark.asyncio
+async def test_child_parents_are_rebound_to_the_new_trace(
+    drained_exporter, integration, reset_observability_settings, session_provider
+):
+    """A parent link still pointing at the abandoned trace is an inconsistency
+    the next reader has to work out."""
+    enable_instrumentation()
+    provider, _captured, _bsp = session_provider
+
+    await _run_turns(2, conversation_id="conv-parents")
+
+    for span in _drain_spans(provider, drained_exporter):
+        if span.parent is not None:
+            assert span.parent.trace_id == span.context.trace_id
+
+
+@pytest.mark.asyncio
+async def test_translation_survives_the_join(
+    drained_exporter, integration, reset_observability_settings, session_provider
+):
+    """Regression guard: the retrace wrapper must not shadow the translation.
+
+    ``ReadableSpan`` serves ``name`` / ``attributes`` from private slots, so a
+    wrapper forwarding by ``__getattr__`` alone resolves them on the innermost
+    span and silently ships the raw MAF values.
+    """
+    enable_instrumentation()
+    provider, _captured, _bsp = session_provider
+
+    await _run_turns(2, conversation_id="conv-intact")
+
+    spans = _drain_spans(provider, drained_exporter)
+    names = [s.name for s in spans]
+    assert "ai.llm.invoke" in names
+    # ``AIOperationType`` subclasses ``str``, so this reads the value, not the repr.
+    assert not any(name.startswith(("chat ", "invoke_agent ")) for name in names)
+    llm = next(s for s in spans if s.name == "ai.llm.invoke")
+    assert llm.attributes[AIAttributes.LLM_TOKENS_TOTAL] == 18
+
+
+def test_exporter_stamps_turn_root_on_root_agent_span():
+    """A plain ``agent.run()`` emits no ``workflow.run``, so its ``invoke_agent``
+    span is the trace root and the only span that can carry the turn."""
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    trace_id = 0xA6E27
+    tr_mod._conversation_content.record_chat(
+        trace_id, input_text="Question?", output_text="Answer."
+    )
+    tr_mod._conversation_content.record_session(trace_id, "sess-agent")
+    root = _FakeChatSpan(
+        span_id=810, trace_id=trace_id, parent_id=None, name="invoke_agent researcher"
+    )
+
+    captured_inner = InMemorySpanExporter()
+    tr_mod.MAFTranslatingExporter(captured_inner).export([root])
+
+    out = captured_inner.get_finished_spans()
+    attrs = dict(out[0].attributes or {})
+    sa = ConversationContext.SpanAttributes
+    assert out[0].name == "ai.agent.invoke"
+    assert attrs.get(sa.IS_TURN_ROOT) is True
+    assert attrs.get(sa.CONVERSATION_ID) == "sess-agent"
+    assert attrs.get(sa.CONVERSATION_INPUT) == "Question?"
+    assert attrs.get(sa.CONVERSATION_OUTPUT) == "Answer."
+
+
+def test_exporter_skips_turn_root_on_nested_agent_span():
+    """Inside a workflow, or under an ``@endpoint`` span, an agent span is not
+    the trace root and that enclosing span owns turn-root semantics."""
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    trace_id = 0xA6E28
+    tr_mod._conversation_content.record_session(trace_id, "sess-nested-agent")
+    nested = _FakeChatSpan(
+        span_id=811, trace_id=trace_id, parent_id=800, name="invoke_agent researcher"
+    )
+
+    captured_inner = InMemorySpanExporter()
+    tr_mod.MAFTranslatingExporter(captured_inner).export([nested])
+
+    attrs = dict(captured_inner.get_finished_spans()[0].attributes or {})
+    assert ConversationContext.SpanAttributes.IS_TURN_ROOT not in attrs
+
+
+def test_a_nested_agent_span_leaves_the_content_for_the_root():
+    """Every agent in a workflow is a nested agent span. If one consumed the
+    per-trace content, the ``workflow.run`` root would export with none of it."""
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    trace_id = 0xA6E29
+    tr_mod._conversation_content.record_session(trace_id, "sess-order")
+    nested = _FakeChatSpan(
+        span_id=812, trace_id=trace_id, parent_id=801, name="invoke_agent researcher"
+    )
+    root = _FakeChatSpan(span_id=801, trace_id=trace_id, parent_id=None, name="workflow.run")
+
+    captured_inner = InMemorySpanExporter()
+    # Nested first, which is the order they end in.
+    tr_mod.MAFTranslatingExporter(captured_inner).export([nested, root])
+
+    workflow = next(
+        s for s in captured_inner.get_finished_spans() if s.name == "function.workflow.run"
+    )
+    sa = ConversationContext.SpanAttributes
+    assert workflow.attributes.get(sa.CONVERSATION_ID) == "sess-order"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sdk/telemetry/integrations/test_agent_framework.py
+++ b/tests/sdk/telemetry/integrations/test_agent_framework.py
@@ -1417,39 +1417,78 @@ def test_conversation_content_registry_records_session_first_wins():
     assert reg.get_session(999) is None
 
 
-def test_conversation_content_registry_consume_pops_entries():
-    """``consume`` returns the recorded triple once and clears it afterwards."""
+def test_conversation_content_registry_read_is_repeatable():
+    """Reading does not pop: every wrapped exporter has to see the same content."""
     from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
 
     reg = tr_mod._ConversationContentRegistry()
     reg.record_chat(7, input_text="first query", output_text="final plan")
     reg.record_session(7, "session-a")
 
-    assert reg.consume(7) == ("session-a", "first query", "final plan")
-    # Entries are gone after the first consume: the root span is exported once.
-    assert reg.consume(7) == (None, None, None)
-    assert reg.get(7) == (None, None)
-    assert reg.get_session(7) is None
+    assert reg.read_for_root(7) == ("session-a", "first query", "final plan")
+    assert reg.read_for_root(7) == ("session-a", "first query", "final plan")
     # Unknown trace ids yield an all-None triple.
-    assert reg.consume(999) == (None, None, None)
+    assert reg.read_for_root(999) == (None, None, None)
 
 
-def test_exporter_consumes_conversation_content_after_stamping():
-    """After the root span is exported, its per-trace content is released."""
+def test_conversation_content_registry_releases_what_falls_behind():
+    """A read schedules the release; it happens once enough others have been read.
+
+    Holding 10 KB of conversation text per trace until the entry cap evicts it
+    would cost a long-running service far more memory than it needs to.
+    """
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    reg = tr_mod._ConversationContentRegistry(max_served=2)
+    reg.record_chat(1, input_text="first", output_text="reply")
+    reg.record_session(1, "sess-1")
+
+    assert reg.read_for_root(1)[0] == "sess-1"
+    for later in (2, 3):
+        reg.record_session(later, f"sess-{later}")
+        reg.read_for_root(later)
+
+    assert reg.read_for_root(1) == (None, None, None), "should have fallen off the queue"
+    assert reg.get(1) == (None, None)
+    assert reg.get_session(1) is None
+
+
+def test_conversation_content_registry_release_without_reading():
+    """``release`` is for a run whose content nothing will stamp."""
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    reg = tr_mod._ConversationContentRegistry(max_served=1)
+    reg.record_session(1, "sess-1")
+    reg.record_session(2, "sess-2")
+
+    reg.release(1)
+    reg.release(2)
+
+    assert reg.get_session(1) is None
+    assert reg.get_session(2) == "sess-2"
+
+
+def test_two_wrapped_exporters_both_stamp_the_conversation():
+    """``enable()`` wraps every exporter on the provider, so a process with its
+    own OTLP collector beside Rhesis has two translating exporters exporting the
+    same spans. Both have to stamp the conversation, not just the faster one."""
     from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
 
     trace_id = 0xBEEF01
     tr_mod._conversation_content.record_chat(
         trace_id, input_text="Plan a day trip", output_text="Here is your plan"
     )
-    tr_mod._conversation_content.record_session(trace_id, "sess-consume")
+    tr_mod._conversation_content.record_session(trace_id, "sess-two-exporters")
     run = _FakeChatSpan(span_id=760, trace_id=trace_id, parent_id=None, name="workflow.run")
 
-    exporter = tr_mod.MAFTranslatingExporter(InMemorySpanExporter())
-    exporter.export([run])
-
-    # The registry no longer retains anything for this trace.
-    assert tr_mod._conversation_content.consume(trace_id) == (None, None, None)
+    sa = ConversationContext.SpanAttributes
+    for _ in range(2):
+        inner = InMemorySpanExporter()
+        tr_mod.MAFTranslatingExporter(inner).export([run])
+        attrs = dict(inner.get_finished_spans()[0].attributes or {})
+        assert attrs.get(sa.CONVERSATION_ID) == "sess-two-exporters"
+        assert attrs.get(sa.CONVERSATION_INPUT) == "Plan a day trip"
+        assert attrs.get(sa.CONVERSATION_OUTPUT) == "Here is your plan"
 
 
 def test_exporter_stamps_turn_root_on_root_workflow_run():
@@ -1540,7 +1579,9 @@ def test_exporter_skips_root_without_session_or_content():
 def test_exporter_skips_turn_root_on_nested_workflow_run():
     """A ``workflow.run`` nested under a parent (e.g. a Rhesis @endpoint span)
     must NOT be stamped as a turn root -- the enclosing span owns that role.
-    Per-trace registry entries must still be released on export.
+
+    The release of its per-trace entries is covered by the registry's own tests;
+    here the point is that nothing is stamped.
     """
     from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
 
@@ -1562,7 +1603,6 @@ def test_exporter_skips_turn_root_on_nested_workflow_run():
     assert sa.CONVERSATION_ID not in attrs
     assert sa.CONVERSATION_INPUT not in attrs
     assert sa.CONVERSATION_OUTPUT not in attrs
-    assert tr_mod._conversation_content.consume(trace_id) == (None, None, None)
 
 
 def test_conversation_content_registry_truncates_io_at_record_time():


### PR DESCRIPTION
## Purpose

A multi-turn Microsoft Agent Framework conversation arrived in Rhesis as one unrelated trace per turn. Every turn was correctly labelled with the same conversation id, but nothing put them together, so the Conversation tab showed a one-turn conversation per trace instead of the session.

MAF opens its own root span per turn, so OpenTelemetry mints a fresh trace id each time. The Google ADK integration already solves this, and the machinery it uses (`ConversationTraceRegistry`, `RetracedSpan`) lives in the shared `genai.py`. MAF simply never adopted it.

Fixing that surfaced two more problems that had to be fixed for the join to be an improvement rather than a regression. Both are described below.

## What Changed

**`fix(sdk): stop one maf exporter starving the others`**

`conversation_root_attributes` popped the per-trace conversation content as it stamped a root span. `enable()` wraps *every* exporter on the provider, so a process running its own OTLP collector beside Rhesis has two translating exporters exporting the same spans: whichever reached the trace root first took the content, and the other stamped a root span carrying no conversation at all. Which one won was arbitrary.

The content is now read rather than popped, and released a bounded number of reads later. Deferring keeps entries alive long enough for the other exporters to see the same trace; the bound keeps a long-running process from holding 10 KB of conversation text per trace until the 4096-entry cap evicts it. The queue is larger than an OTEL export batch, since a busy service can flush hundreds of run roots at once and the exporters do not drain their queues in lockstep.

This is a pre-existing bug, not one introduced here. It is first in the branch because the join cannot be verified end to end while it stands.

**`docs(sdk): correct what the maf conversation reader does`** and **`refactor(sdk): use the shared release queue in the maf registry`**

The docstring still pointed at `_ConversationContentRegistry.consume`, renamed in this branch, so the cross-reference resolved to nothing, and "always consumes" was wrong twice over. It now says which span releases and which does not, including the one path the release queue does not reach: a plain `agent.run()` under an enclosing Rhesis span leaves its entries to the store's eviction cap. That path is pre-existing, unchanged here, and bounded; see the note below.

The refactor then drops the private queue for `DeferredReleaseQueue` (added in #2718, now merged), so MAF and ADK share one implementation.

**`fix(sdk): release maf conversation content nothing will read`**

A run under a Rhesis `@endpoint`/`@observe` span has its turn owned by that span, so no MAF span stamps it, and nothing freed the per-trace content either. A plain `agent.run()` emits no `workflow.run`, so the one guard that released anything never fired and the entries sat until the store's 4096-entry cap evicted them, which is the leak the release queue exists to prevent.

Releasing from any nested run root would be wrong the other way round: inside a MAF-rooted trace the root is the reader and exports after its children. So the fix tracks, at span start, whether a trace's root is a MAF span, and releases from a nested run root only when it is not. One entry per trace, bounded.

That rule also corrects the previous one, which released on every nested `workflow.run`, including a sub-workflow under a `workflow.run` trace root that still had to read its content. Span start is the only moment the answer is available: a trace root starts before the nested spans that ask about it, and exports after them.

**Still not covered**, and called out in the commit: a trace whose only MAF span is a bare `chat` span, from calling a chat client with no agent around it. There is no run root to release from, so those entries still wait for the entry cap.

**`fix(sdk): let an empty maf read keep its release slot`**

A read of a trace with nothing recorded took a slot in the release queue, so a run of content-free traces (single-turn runs, or content capture switched off) pushed the entries of traces that *do* have content out of the queue before the other exporters had read them. The check covers every store: leaving one out makes its entries invisible to the queue, so they are never freed and the store grows until the entry cap evicts it, which is the leak the queue exists to prevent.

**`fix(sdk): join maf conversation turns into one trace`**

Claim each turn's trace at span start, where the conversation ContextVars are still readable, and rewrite later turns onto the first turn's id at export. The first turn keeps the id it was born with, so anything that already observed or published it still resolves.

Two cases stand the rewrite down, because the trace id is already owned and published elsewhere: an enclosing `@endpoint`/`@observe` span, and a platform-driven turn. Both join the turns themselves, and moving spans off that id would strand the link and the reply on a trace with no spans.

The same commit also stamps the turn root on a root `invoke_agent` span. Only `workflow.run` carried it, and a plain `agent.run()` emits no workflow span at all. Without this the join would have put a plain-agent chat's turns on one trace with **no** conversation attributes anywhere on it, which is worse than leaving them apart. A nested agent span is deliberately left alone: inside a workflow that is every agent in the run, and the first one would release the content the root needs.

Docs: a "Multi-Turn Conversations" section on the MAF page, covering the binding, the ordering requirement, and the two stand-down cases.

## Additional Context

- Independent of #2711. It touches no file that PR touches, so it applies to `main` on its own.
- Uses the shared `DeferredReleaseQueue` from #2718, which has merged, so this branch sits on `main` directly and stands alone.
- #2715 fixes the same pop-on-read flaw in the Google ADK integration. Both now consume the shared queue rather than keeping a copy each.
- peqy's third point, that a nested `invoke_agent` under an `@endpoint`/`@observe` span never releases, is fixed in the last commit rather than deferred. Worth noting `AncestryRegistry` could not have closed it: `record()` only indexes spans that have a parent, so a root `workflow.run` is absent from it and "is my parent a MAF span" would wrongly answer no and release early. Keying on "does a MAF span root this trace" avoids that and costs one entry per trace instead of one per span.
- peqy also asked whether `release()` should free entries immediately. It should not: a nested `workflow.run` inside a root one would destroy the content before the root reads it, since children export first. That is the bug the first commit fixes.
- The join's limit is documented in a test: without a bound conversation id, each turn keeps its own trace. The target trace has to be known when the run root is created, and MAF assigns no span attributes before then, so only the Rhesis ContextVar is readable at that point.

## Testing

`3036 passed` in `tests/sdk` (excluding `tests/sdk/integration`, which needs Docker). Ruff check and format clean. Each commit was verified to pass standing alone, so there is no broken intermediate to bisect through.

The MAF suite grew from 74 to 118 tests: 9 end-to-end tests driving real MAF agents through the join, plus exporter-level tests for the agent-root stamping and the registry's read/release contract.

Every behavioural change was mutation-tested, and each mutation is caught by the test written for it:

| Mutation | Caught by |
|---|---|
| Remove the claim | `test_turns_of_one_conversation_share_one_trace` |
| Remove the retrace at export | `test_turns_of_one_conversation_share_one_trace` |
| Drop the ContextVar guard | `test_a_platform_owned_conversation_is_left_alone` |
| Revert the agent-root stamp | `test_exporter_stamps_turn_root_on_root_agent_span` |
| Let a nested agent span consume | `test_a_nested_agent_span_leaves_the_content_for_the_root` |
| Make the registry read pop again | `test_two_wrapped_exporters_both_stamp_the_conversation`, and the end-to-end join test |
| Never release a served entry | `test_conversation_content_registry_releases_what_falls_behind` |
| Let an empty read take a slot | `test_conversation_content_registry_ignores_a_trace_with_nothing_recorded` |
| Never release from a nested run root (the old leak) | `test_a_nested_run_root_releases_when_no_maf_span_roots_the_trace` |
| Always release from a nested run root | `test_a_nested_run_root_leaves_the_content_when_a_maf_span_roots_the_trace` |
| Restore the old "release on any nested workflow.run" rule | both of the above |
| Never mark the trace root at span start | `test_a_parentless_maf_span_marks_its_trace` |
| Leave the marker set unbounded | `test_maf_rooted_traces_is_bounded` |
| Drop any one store from the guard | `test_conversation_content_registry_releases_whichever_store_holds_the_content`, one case per store |

One note on the test harness, since it cost me time and may cost a reviewer some. The MAF `session_provider` fixture rides whatever provider is already global, which already carries a `BatchSpanProcessor`, so the suite genuinely runs with two wrapped exporters. That is what made the popping bug observable. Separately, a test that never drains leaves its spans buffered and they arrive in the next test's flush, which reads as a turn that failed to join. The `drained_exporter` fixture handles that and says why.

I could not build the docs site to check the new page renders (`docs/src/node_modules` is absent). I verified `CodeBlock` is imported on the page and the block matches the existing pattern; a reviewer running the site locally is the real check.


One note on how that last batch was verified. "Never mark the trace root" initially survived every test, because the release tests marked traces by hand and so never exercised `on_start`. Driving the processor's `on_start` directly closed it. Worth knowing as a reviewer that an early release is not immediate data loss either way: `release()` queues, so the root keeps its content unless several hundred traces pass in between.
