### PR TITLE
Join Haystack turns through the shared conversation anchor

### DIFF
--- a/docs/content/docs/tracing/haystack.mdx
+++ b/docs/content/docs/tracing/haystack.mdx
@@ -146,7 +146,7 @@ tracing.flush()`}
 
 Assign `turn.output` yourself. Only your application knows which part of a pipeline result is the reply the user saw — it may be a tool result or a value held in agent state rather than the last assistant message.
 
-Every turn after the first joins the first turn's trace, so the conversation reads as one trace. Calling `start_conversation` again begins a new one. `RhesisTracing` never raises: if Rhesis is not configured it logs a warning and every method becomes a no-op, so tracing cannot take your application down. Check `tracing.enabled` to report it.
+Every turn after the first joins the first turn's trace, so the conversation reads as one trace. Calling `start_conversation` with a new id begins a new one; passing an id this process already recorded a turn for rejoins that conversation, whether the earlier turn came from here or from [`conversation_turn`](/docs/tracing/conversation-tracing#standalone-apps-owning-the-turn). `RhesisTracing` never raises: if Rhesis is not configured it logs a warning and every method becomes a no-op, so tracing cannot take your application down. Check `tracing.enabled` to report it.
 
 ## Trace Links
 

--- a/sdk/src/rhesis/sdk/telemetry/integrations/haystack/conversation.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/haystack/conversation.py
@@ -17,11 +17,15 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Optional
 
-from opentelemetry import trace
-from opentelemetry.trace import NonRecordingSpan, Span, SpanContext, TraceFlags
+from opentelemetry.trace import Span
 
 from rhesis.telemetry.constants import ConversationContext
 from rhesis.telemetry.context import get_root_trace_id, set_root_trace_id
+from rhesis.telemetry.conversation import (
+    anchor_conversation,
+    build_conversation_parent_context,
+    get_conversation_anchor,
+)
 
 if TYPE_CHECKING:
     from rhesis.sdk.telemetry.integrations.haystack.tracer import RhesisTracer
@@ -36,32 +40,6 @@ _MAX_IO = ConversationContext.MAX_IO_LENGTH
 # Forwarded to RhesisClient when this class has to create one. Anything else a caller passes is a
 # tracer setting, handled by HaystackIntegration.configure().
 _CLIENT_KWARGS = ("api_key", "base_url", "project_id", "environment")
-
-
-def _conversation_parent_context(trace_id: str) -> Any:
-    """
-    Build a synthetic parent so a turn inherits the conversation's trace id.
-
-    OpenTelemetry mints a fresh trace id for every parentless span, which would scatter one
-    conversation across a trace per turn. Attaching a non-recording parent carrying the
-    conversation's trace id makes the new span join it instead. The parent's span id is the agreed
-    placeholder that the Rhesis exporter strips, so the turn is still stored as a root span -- the
-    same approach the Rhesis SDK uses for turns it serves itself.
-
-    :param trace_id: 32-character hex trace id of the conversation's first turn.
-    :returns: An OTel context carrying the synthetic parent, or ``None`` if the id is unusable.
-    """
-    try:
-        span_context = SpanContext(
-            trace_id=int(trace_id, 16),
-            span_id=ConversationContext.SYNTHETIC_PARENT_SPAN_ID,
-            is_remote=True,
-            trace_flags=TraceFlags(TraceFlags.SAMPLED),
-        )
-    except (TypeError, ValueError):
-        logger.warning("Invalid conversation trace id %r; starting a new trace", trace_id)
-        return None
-    return trace.set_span_in_context(NonRecordingSpan(span_context))
 
 
 class ConversationTurn:
@@ -147,7 +125,7 @@ class RhesisTracing:
         """
         self.name = name
         self.turn_span_name = turn_span_name
-        self._conversation_trace_id: Optional[str] = None
+        self._unnamed_anchor: Optional[str] = None
         self._tracer: Optional[RhesisTracer] = None
 
         if not enabled:
@@ -231,8 +209,9 @@ class RhesisTracing:
         """
         Group the turns that follow into one conversation, sharing one trace.
 
-        Calling this again starts a new conversation: the next turn opens a new trace and later
-        turns join it.
+        Calling this with a new id starts a new conversation: the next turn opens a new trace and
+        later turns join it. Passing an id this process has already recorded a turn for rejoins that
+        conversation's trace, whether the earlier turn came from here or from ``conversation_turn``.
 
         :param conversation_id: Identifier grouping the turns, shown as the conversation in Rhesis.
         :param invocation_context: Extra metadata for the root span (test run identifiers, tags, …).
@@ -242,7 +221,19 @@ class RhesisTracing:
         from rhesis.sdk.telemetry.integrations.haystack.tracer import tracing_context_var
 
         tracing_context_var.set({"session_id": conversation_id, **invocation_context})
-        self._conversation_trace_id = None
+        self._unnamed_anchor = None
+
+    def _parent_context(self, conversation_id: Optional[str]) -> Any:
+        """Pull this turn onto the trace its conversation started on.
+
+        A named conversation resolves through the shared anchor store, so a turn opened here lands
+        on the same trace as one ``conversation_turn`` or ``@endpoint`` opened for the same id.
+        Without a name there is no key to share, so the turns of this instance chain through it.
+        """
+        anchor = (
+            get_conversation_anchor(conversation_id) if conversation_id else self._unnamed_anchor
+        )
+        return build_conversation_parent_context(anchor) if anchor else None
 
     @contextmanager
     def turn(self, user_input: str) -> Iterator[ConversationTurn]:
@@ -265,11 +256,7 @@ class RhesisTracing:
         from rhesis.sdk.telemetry.integrations.haystack.tracer import tracing_context_var
 
         conversation_id = (tracing_context_var.get({}) or {}).get("session_id")
-        parent_context = (
-            _conversation_parent_context(self._conversation_trace_id)
-            if self._conversation_trace_id
-            else None
-        )
+        parent_context = self._parent_context(conversation_id)
         # Opened through the tracer's own provider rather than ``trace.get_tracer()`` so a turn is
         # flushed by the same provider as its children.
         otel_tracer = tracer.telemetry.otel_tracer
@@ -283,7 +270,10 @@ class RhesisTracing:
                 span.set_attribute(_SPAN_ATTRS.CONVERSATION_INPUT, user_input[:_MAX_IO])
 
             trace_id = format(span.get_span_context().trace_id, "032x")
-            self._conversation_trace_id = trace_id
+            if conversation_id:
+                anchor_conversation(conversation_id, trace_id)
+            elif self._unnamed_anchor is None:
+                self._unnamed_anchor = trace_id
             # Marks the turn as owned here, so the Haystack root span nests inside it instead of
             # claiming the turn and restating its input and output.
             set_root_trace_id(trace_id)

--- a/tests/sdk/telemetry/integrations/haystack_integration/conftest.py
+++ b/tests/sdk/telemetry/integrations/haystack_integration/conftest.py
@@ -1,8 +1,8 @@
 """Fixtures for the Haystack integration tests.
 
-Every fixture here is scoped to this package. Three of the four are autouse because the state they
-manage is process-wide: Haystack's content-tracing flag, the integration's ContextVars, and the
-tracer Haystack keeps in a module-level global.
+Every fixture here is scoped to this package. Most are autouse because the state they manage is
+process-wide: Haystack's content-tracing flag, the integration's ContextVars, the tracer Haystack
+keeps in a module-level global, and the conversation anchor store shared with the rest of Rhesis.
 """
 
 import pytest
@@ -16,6 +16,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
+from rhesis.telemetry import conversation as rhesis_conversation
 
 from rhesis.sdk.telemetry.integrations.haystack.integration import get_integration
 from rhesis.sdk.telemetry.integrations.haystack.tracer import (
@@ -66,6 +67,19 @@ def reset_context_vars():
     tracing_context_var.reset(context_token)
     span_stack_var.reset(stack_token)
     trace_id_var.reset(trace_token)
+
+
+@pytest.fixture(autouse=True)
+def reset_conversation_anchors():
+    """Forget which trace each conversation started on.
+
+    ``RhesisTracing`` joins the turns of a conversation through the anchor store in
+    ``rhesis.telemetry.conversation``, which is process-wide and shared with ``conversation_turn``.
+    Without this, two tests using the same conversation id would land on one trace.
+    """
+    rhesis_conversation._anchors.clear()
+    yield
+    rhesis_conversation._anchors.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/sdk/telemetry/integrations/haystack_integration/test_conversation.py
+++ b/tests/sdk/telemetry/integrations/haystack_integration/test_conversation.py
@@ -7,12 +7,12 @@ pytest.importorskip("haystack")
 from haystack import Pipeline, component
 from rhesis.telemetry.constants import ConversationContext
 from rhesis.telemetry.context import get_root_trace_id
+from rhesis.telemetry.conversation import conversation_turn
 
 from rhesis.sdk.telemetry.integrations.haystack.conversation import (
     DEFAULT_TURN_SPAN_NAME,
     ConversationTurn,
     RhesisTracing,
-    _conversation_parent_context,
 )
 from rhesis.sdk.telemetry.integrations.haystack.integration import (
     HaystackIntegration,
@@ -305,12 +305,59 @@ class TestConversationContinuity:
         trace_ids = {s.context.trace_id for s in exporter.get_finished_spans()}
         assert len(trace_ids) == 1
 
+    def test_turns_without_a_conversation_id_still_share_a_trace(self, sdk_provider):
+        """Nothing to key an anchor on, so the instance chains its own turns."""
+        exporter, _ = sdk_provider
+        tracing = RhesisTracing("app")
+        with tracing.turn("first"):
+            pass
+        with tracing.turn("second"):
+            pass
 
-class TestConversationParentContext:
-    def test_bad_trace_id_is_rejected_without_raising(self, caplog):
-        with caplog.at_level("WARNING"):
-            assert _conversation_parent_context("not-hex") is None
-        assert "Invalid conversation trace id" in caplog.text
+        assert len({s.context.trace_id for s in turn_spans(exporter)}) == 1
 
-    def test_valid_trace_id_builds_a_context(self):
-        assert _conversation_parent_context("a" * 32) is not None
+
+class TestSharedAnchorStore:
+    """``RhesisTracing`` joins turns through the same store as ``conversation_turn``.
+
+    A Haystack app that also wraps work in ``conversation_turn`` -- for a turn Haystack does not
+    serve, say -- used to get one trace per mechanism for the same conversation, because this
+    module kept the first turn's trace id to itself.
+    """
+
+    def test_a_haystack_turn_joins_a_conversation_turn_trace(self, sdk_provider):
+        exporter, _ = sdk_provider
+        with conversation_turn("conv-1", input="first") as turn:
+            turn.output = "reply"
+
+        tracing = RhesisTracing("app")
+        tracing.start_conversation("conv-1")
+        with tracing.turn("second") as turn:
+            turn.output = "reply"
+
+        assert len({s.context.trace_id for s in exporter.get_finished_spans()}) == 1
+
+    def test_a_conversation_turn_joins_a_haystack_trace(self, sdk_provider):
+        """The mirror case: whichever mechanism ran first owns the anchor."""
+        exporter, _ = sdk_provider
+        tracing = RhesisTracing("app")
+        tracing.start_conversation("conv-1")
+        with tracing.turn("first") as turn:
+            turn.output = "reply"
+
+        with conversation_turn("conv-1", input="second") as turn:
+            turn.output = "reply"
+
+        assert len({s.context.trace_id for s in exporter.get_finished_spans()}) == 1
+
+    def test_a_different_conversation_is_not_joined(self, sdk_provider):
+        exporter, _ = sdk_provider
+        with conversation_turn("conv-1", input="first") as turn:
+            turn.output = "reply"
+
+        tracing = RhesisTracing("app")
+        tracing.start_conversation("conv-2")
+        with tracing.turn("first") as turn:
+            turn.output = "reply"
+
+        assert len({s.context.trace_id for s in exporter.get_finished_spans()}) == 2


### PR DESCRIPTION
## Purpose

`haystack/conversation.py` kept its own copy of the synthetic-parent trick and remembered a conversation's first-turn trace id in a private instance field. So a Haystack app that also opened a `conversation_turn` for the same conversation id, for a turn Haystack does not serve, got **two traces for one conversation**: each mechanism consulted only its own record and neither knew the other had already anchored that id.

PR #2711 exposed `get_conversation_anchor` and `anchor_conversation` for exactly this, and the LangGraph integration already uses them. This makes Haystack the last integration with a private copy.

## What Changed

- `_conversation_parent_context` is gone, replaced by the shared `build_conversation_parent_context`. Alongside deleting the duplicate, this picks up a check the private copy lacked: a rejection of trace id zero, which OTEL will not accept.
- A named conversation now resolves its anchor through the shared store, so a turn opened here lands on the same trace as one `conversation_turn` or `@endpoint` opened for the same id, in either order.
- The instance field stays for turns opened *without* a conversation id, where there is no key to share. That path is unchanged and now has a test.

**One deliberate behaviour change.** Calling `start_conversation("c-1")` twice used to start a fresh trace. It now rejoins `c-1`'s trace, because the shared store is first-writer-wins: whichever turn ran first keeps the id anything else in the process already observed and published. That is the rule `conversation_turn` follows, so I took matching it as the point rather than something to work around. The docstring and `haystack.mdx` both said the old thing and are corrected.

## Additional Context

- Uses the two accessors #2711 added to `packages/rhesis/src/rhesis/telemetry/conversation.py`. That PR has since merged, so this branch is rebased onto `main` and stands on its own.
- Companion PR #2713 fixes the equivalent conversation-joining gap in the MAF integration. It is independent of both this and #2711.

## Testing

`204 passed` in the Haystack suite, `813 passed` across `tests/sdk/telemetry`. Ruff check and format clean.

The two new cross-mechanism tests were mutation-tested: making `_parent_context` ignore the shared store and consult only the instance field makes both fail, while the negative control (`test_a_different_conversation_is_not_joined`) still passes. So they are testing the join, not just exercising it.

Also added a `reset_conversation_anchors` fixture. The anchor store is process-wide, so without it two tests reusing a conversation id would land on one trace and `test_later_turns_hang_off_the_synthetic_parent` would fail depending on collection order.

To reproduce the bug this fixes, before this change: open a `conversation_turn("c-1")`, then run a `RhesisTracing` turn under `start_conversation("c-1")`, and count distinct trace ids. Two before, one after.
