### PR TITLE
Stop one Google ADK exporter starving the others

### DIFF
--- a/sdk/src/rhesis/sdk/telemetry/integrations/google_adk/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/google_adk/translator.py
@@ -55,6 +55,7 @@ from rhesis.sdk.telemetry.integrations.genai import (
     TRUTHY_ENV_VALUES,
     AncestryRegistry,
     ConversationTraceRegistry,
+    DeferredReleaseQueue,
     RetracedSpan,
     TranslatedSpan,
     content_capture_enabled,
@@ -324,10 +325,16 @@ class _ConversationContentRegistry:
         self._adk_session_by_trace: dict[int, tuple[int, str]] = {}
         self._rhesis_conversation_by_trace: dict[int, str] = {}
         self._max_entries = max_entries
-        # Traces whose content has been handed to an exporter, oldest first.
-        self._served: dict[int, None] = {}
-        self._max_served = max_served
         self._lock = threading.Lock()
+        # All four stores go in: one left out never gets freed. Guarded by the
+        # lock above, which the queue expects the caller to hold.
+        self._release = DeferredReleaseQueue(
+            self._rhesis_conversation_by_trace,
+            self._adk_session_by_trace,
+            self._input_by_trace,
+            self._output_by_trace,
+            max_served=max_served,
+        )
 
     def _evict_if_needed(self, store: dict) -> None:
         if len(store) < self._max_entries:
@@ -418,51 +425,12 @@ class _ConversationContentRegistry:
             adk_session = self._adk_session_by_trace.get(trace_id)
             conv_input = self._input_by_trace.get(trace_id)
             conv_output = self._output_by_trace.get(trace_id)
-            self._queue_release(trace_id)
+            self._release.queue_release(trace_id)
         conversation_id = rhesis_id or (adk_session[1] if adk_session else None)
         return (
             conversation_id,
             conv_input[1] if conv_input else None,
             conv_output[1] if conv_output else None,
-        )
-
-    def _queue_release(self, trace_id: int) -> None:
-        """Drop the entries of whatever has fallen far enough behind.
-
-        Deferred rather than immediate so every exporter reading the same batch
-        sees the same content, and bounded so a long-running process does not
-        hold 10 KB of conversation text per trace until the entry cap evicts it.
-        The queue is deliberately larger than an OTEL export batch, since a busy
-        service can flush hundreds of run roots at once and the exporters do not
-        drain their queues in lockstep.
-
-        Caller holds the lock.
-        """
-        if not self._has_entries(trace_id):
-            # Nothing to release, so it must not take a slot: a run of traces
-            # with no conversation content on them would otherwise push out the
-            # entries of the ones that have it.
-            return
-        self._served.pop(trace_id, None)
-        self._served[trace_id] = None
-        while len(self._served) > self._max_served:
-            stale = next(iter(self._served))
-            del self._served[stale]
-            self._rhesis_conversation_by_trace.pop(stale, None)
-            self._adk_session_by_trace.pop(stale, None)
-            self._input_by_trace.pop(stale, None)
-            self._output_by_trace.pop(stale, None)
-
-    def _has_entries(self, trace_id: int) -> bool:
-        """Whether any of the four stores holds something for this trace."""
-        return any(
-            trace_id in store
-            for store in (
-                self._rhesis_conversation_by_trace,
-                self._adk_session_by_trace,
-                self._input_by_trace,
-                self._output_by_trace,
-            )
         )
 
 

--- a/sdk/src/rhesis/sdk/telemetry/integrations/google_adk/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/google_adk/translator.py
@@ -308,17 +308,25 @@ class _ConversationContentRegistry:
     A Rhesis conversation id (set by the app via
     ``rhesis.telemetry.context.set_conversation_id``) is recorded at span start
     while that contextvar is still live, and takes precedence over the ADK
-    session id. All stores are bounded and strings are truncated to
+    session id.
+
+    Entries are released a bounded number of reads after the first exporter
+    reads them, rather than on that read, so that several wrapped exporters all
+    stamp the same content; see :meth:`read_for_root`. Every store is bounded
+    independently of that, and strings are truncated to
     :data:`~rhesis.telemetry.constants.ConversationContext.MAX_IO_LENGTH` at
     record time.
     """
 
-    def __init__(self, max_entries: int = 4096) -> None:
+    def __init__(self, max_entries: int = 4096, max_served: int = 512) -> None:
         self._input_by_trace: dict[int, tuple[int, str]] = {}
         self._output_by_trace: dict[int, tuple[int, str]] = {}
         self._adk_session_by_trace: dict[int, tuple[int, str]] = {}
         self._rhesis_conversation_by_trace: dict[int, str] = {}
         self._max_entries = max_entries
+        # Traces whose content has been handed to an exporter, oldest first.
+        self._served: dict[int, None] = {}
+        self._max_served = max_served
         self._lock = threading.Lock()
 
     def _evict_if_needed(self, store: dict) -> None:
@@ -394,25 +402,67 @@ class _ConversationContentRegistry:
         except Exception:  # noqa: BLE001 - recording must never break tracing
             logger.debug("Failed to record ADK conversation id", exc_info=True)
 
-    def consume(self, trace_id: int | None) -> tuple[str | None, str | None, str | None]:
-        """Pop and return ``(conversation_id, input, output)`` for ``trace_id``.
+    def read_for_root(self, trace_id: int | None) -> tuple[str | None, str | None, str | None]:
+        """Return ``(conversation_id, input, output)`` for ``trace_id`` and queue its release.
 
-        Called exactly once per trace, when its root span is exported, so entries
-        do not linger for the process lifetime even when the run was nested under
-        a Rhesis ``@endpoint`` span and nothing gets stamped.
+        Read rather than popped. ``enable()`` wraps *every* exporter on the
+        provider, so a process running its own OTLP collector beside Rhesis has
+        two translating exporters, each exporting the same spans. Popping here
+        gave the content to whichever reached the trace root first and left the
+        other stamping a root span with no conversation on it.
         """
         if trace_id is None:
             return None, None, None
         with self._lock:
-            rhesis_id = self._rhesis_conversation_by_trace.pop(trace_id, None)
-            adk_session = self._adk_session_by_trace.pop(trace_id, None)
-            conv_input = self._input_by_trace.pop(trace_id, None)
-            conv_output = self._output_by_trace.pop(trace_id, None)
+            rhesis_id = self._rhesis_conversation_by_trace.get(trace_id)
+            adk_session = self._adk_session_by_trace.get(trace_id)
+            conv_input = self._input_by_trace.get(trace_id)
+            conv_output = self._output_by_trace.get(trace_id)
+            self._queue_release(trace_id)
         conversation_id = rhesis_id or (adk_session[1] if adk_session else None)
         return (
             conversation_id,
             conv_input[1] if conv_input else None,
             conv_output[1] if conv_output else None,
+        )
+
+    def _queue_release(self, trace_id: int) -> None:
+        """Drop the entries of whatever has fallen far enough behind.
+
+        Deferred rather than immediate so every exporter reading the same batch
+        sees the same content, and bounded so a long-running process does not
+        hold 10 KB of conversation text per trace until the entry cap evicts it.
+        The queue is deliberately larger than an OTEL export batch, since a busy
+        service can flush hundreds of run roots at once and the exporters do not
+        drain their queues in lockstep.
+
+        Caller holds the lock.
+        """
+        if not self._has_entries(trace_id):
+            # Nothing to release, so it must not take a slot: a run of traces
+            # with no conversation content on them would otherwise push out the
+            # entries of the ones that have it.
+            return
+        self._served.pop(trace_id, None)
+        self._served[trace_id] = None
+        while len(self._served) > self._max_served:
+            stale = next(iter(self._served))
+            del self._served[stale]
+            self._rhesis_conversation_by_trace.pop(stale, None)
+            self._adk_session_by_trace.pop(stale, None)
+            self._input_by_trace.pop(stale, None)
+            self._output_by_trace.pop(stale, None)
+
+    def _has_entries(self, trace_id: int) -> bool:
+        """Whether any of the four stores holds something for this trace."""
+        return any(
+            trace_id in store
+            for store in (
+                self._rhesis_conversation_by_trace,
+                self._adk_session_by_trace,
+                self._input_by_trace,
+                self._output_by_trace,
+            )
         )
 
 
@@ -427,9 +477,10 @@ _conversation_traces = ConversationTraceRegistry()
 def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
     """Build Rhesis conversation attributes for an ADK trace-root span.
 
-    Always consumes the per-trace entry so it does not linger when the ADK run is
-    nested under a Rhesis ``@endpoint`` / ``@observe`` parent (the long-running
-    service path). Stamping is limited to trace roots (``parent is None``):
+    Always queues the per-trace entry for release so it does not linger when the
+    ADK run is nested under a Rhesis ``@endpoint`` / ``@observe`` parent (the
+    long-running service path). Stamping is limited to trace roots (``parent is
+    None``):
     inside an enclosing Rhesis span, that span owns turn-root semantics and the
     ADK root must not claim them again.
 
@@ -447,10 +498,10 @@ def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
 
     ctx = getattr(span, "context", None)
     trace_id = getattr(ctx, "trace_id", None)
-    conversation_id, conv_input, conv_output = _conversation_content.consume(trace_id)
+    conversation_id, conv_input, conv_output = _conversation_content.read_for_root(trace_id)
 
-    # Released above but not stamped: an enclosing Rhesis span owns turn-root
-    # semantics for this trace.
+    # Queued for release above but not stamped: an enclosing Rhesis span owns
+    # turn-root semantics for this trace.
     if getattr(span, "parent", None) is not None:
         return None
 

--- a/tests/sdk/telemetry/integrations/test_google_adk.py
+++ b/tests/sdk/telemetry/integrations/test_google_adk.py
@@ -1079,6 +1079,102 @@ class TestConversationTurnRoot:
         assert stamped[0].parent is None
 
 
+class TestConversationContentRegistry:
+    """The per-trace store the root span's conversation attributes come from.
+
+    ADK's trace root carries almost nothing, so the query and the answer are
+    collected from the nested model spans and stamped onto the root when it is
+    exported. Reading that store must not be a one-shot.
+    """
+
+    def test_read_is_repeatable(self):
+        """Reading does not pop: every wrapped exporter has to see the same content."""
+        registry = translator._ConversationContentRegistry()
+        registry.record_model_span(
+            7, start_time=1, end_time=2, input_text="the query", output_text="the answer"
+        )
+        registry.record_rhesis_conversation_id(7, "conv-a")
+
+        assert registry.read_for_root(7) == ("conv-a", "the query", "the answer")
+        assert registry.read_for_root(7) == ("conv-a", "the query", "the answer")
+        # Unknown trace ids yield an all-None triple.
+        assert registry.read_for_root(999) == (None, None, None)
+
+    def test_a_read_queues_the_release(self):
+        """Holding 10 KB of conversation text per trace until the entry cap
+        evicts it would cost a long-running service far more than it needs to."""
+        registry = translator._ConversationContentRegistry(max_served=2)
+        registry.record_model_span(
+            1, start_time=1, end_time=2, input_text="query", output_text="answer"
+        )
+        registry.record_rhesis_conversation_id(1, "conv-1")
+
+        assert registry.read_for_root(1)[0] == "conv-1"
+        for later in (2, 3):
+            registry.record_rhesis_conversation_id(later, f"conv-{later}")
+            registry.read_for_root(later)
+
+        assert registry.read_for_root(1) == (None, None, None), "should have fallen off the queue"
+
+    def test_the_adk_session_id_is_released_too(self):
+        """It is a fourth store, and a missed one would keep growing on its own."""
+        registry = translator._ConversationContentRegistry(max_served=1)
+        registry.record_model_span(1, start_time=1, end_time=2, adk_session_id="adk-1")
+        registry.record_model_span(2, start_time=1, end_time=2, adk_session_id="adk-2")
+
+        registry.read_for_root(1)
+        registry.read_for_root(2)
+
+        assert registry._adk_session_by_trace.get(1) is None, "the older one is released"
+        assert registry._adk_session_by_trace.get(2) is not None, "the newer one is still live"
+
+    def test_a_trace_with_nothing_recorded_does_not_take_a_slot(self):
+        """Otherwise a run of content-free traces evicts the ones with content."""
+        registry = translator._ConversationContentRegistry(max_served=1)
+        registry.record_rhesis_conversation_id(1, "conv-1")
+        registry.read_for_root(1)
+
+        for empty in range(2, 10):
+            assert registry.read_for_root(empty) == (None, None, None)
+
+        assert registry.read_for_root(1) == ("conv-1", None, None)
+
+    @pytest.mark.asyncio
+    async def test_every_wrapped_exporter_stamps_the_conversation(
+        self, captured_spans, integration
+    ):
+        """``enable()`` wraps every exporter on the provider, so a process running
+        its own OTLP collector beside Rhesis has several translating exporters
+        over the same spans. Each has to stamp the conversation, not just the one
+        that reaches the trace root first.
+
+        The raw processor is attached *after* ``enable()`` so it stays unwrapped
+        and hands back ADK's own spans to replay. OTEL cannot remove a span
+        processor, so it stays for the session; nothing else reads its exporter.
+        """
+        raw = InMemorySpanExporter()
+        otel_trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(raw))
+
+        set_conversation_id("conv-every-exporter")
+        script(text("It is 20C in Berlin."))
+        await run_agent(Agent(name="greeter", model=CannedLlm(), instruction="Greet."))
+
+        adk_spans = raw.get_finished_spans()
+        assert adk_spans, "expected the raw processor to capture ADK's own spans"
+
+        sa = ConversationContext.SpanAttributes
+        for _ in range(2):
+            inner = InMemorySpanExporter()
+            GoogleADKTranslatingExporter(inner).export(adk_spans)
+            stamped = [
+                s for s in inner.get_finished_spans() if (s.attributes or {}).get(sa.IS_TURN_ROOT)
+            ]
+            assert len(stamped) == 1, "the run root should still carry the turn"
+            assert stamped[0].attributes[sa.CONVERSATION_ID] == "conv-every-exporter"
+            assert stamped[0].attributes[sa.CONVERSATION_INPUT] == "What is the weather in Berlin?"
+            assert stamped[0].attributes[sa.CONVERSATION_OUTPUT] == "It is 20C in Berlin."
+
+
 class TestConversationTraceJoin:
     """Every turn of a conversation has to land in one Rhesis trace.
 

--- a/tests/sdk/telemetry/integrations/test_google_adk.py
+++ b/tests/sdk/telemetry/integrations/test_google_adk.py
@@ -1196,8 +1196,7 @@ class TestConversationContentRegistry:
         that reaches the trace root first.
 
         The raw processor is attached *after* ``enable()`` so it stays unwrapped
-        and hands back ADK's own spans to replay. OTEL cannot remove a span
-        processor, so it stays for the session; nothing else reads its exporter.
+        and hands back ADK's own spans to replay.
         """
         raw = InMemorySpanExporter()
         otel_trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(raw))
@@ -1207,6 +1206,12 @@ class TestConversationContentRegistry:
         await run_agent(Agent(name="greeter", model=CannedLlm(), instruction="Greet."))
 
         adk_spans = raw.get_finished_spans()
+        # OTEL cannot remove a span processor, so this one keeps receiving every
+        # span for the rest of the session. Shutting the exporter down makes its
+        # export a no-op, so it stops accumulating spans nothing will read. The
+        # processor itself stays, and later ``enable()`` calls still wrap it --
+        # which is exactly the multiple-exporter setup this test is about.
+        raw.shutdown()
         assert adk_spans, "expected the raw processor to capture ADK's own spans"
 
         sa = ConversationContext.SpanAttributes

--- a/tests/sdk/telemetry/integrations/test_google_adk.py
+++ b/tests/sdk/telemetry/integrations/test_google_adk.py
@@ -1129,7 +1129,12 @@ class TestConversationContentRegistry:
         assert registry._adk_session_by_trace.get(2) is not None, "the newer one is still live"
 
     def test_a_trace_with_nothing_recorded_does_not_take_a_slot(self):
-        """Otherwise a run of content-free traces evicts the ones with content."""
+        """Otherwise a run of content-free traces evicts the ones with content.
+
+        A single-turn run sets no conversation id, and content capture can be off
+        entirely, so reads that find nothing are the common case in some
+        processes.
+        """
         registry = translator._ConversationContentRegistry(max_served=1)
         registry.record_rhesis_conversation_id(1, "conv-1")
         registry.read_for_root(1)
@@ -1138,6 +1143,48 @@ class TestConversationContentRegistry:
             assert registry.read_for_root(empty) == (None, None, None)
 
         assert registry.read_for_root(1) == ("conv-1", None, None)
+
+    @pytest.mark.parametrize(
+        "record",
+        [
+            pytest.param(
+                lambda reg, tid: reg.record_rhesis_conversation_id(tid, f"conv-{tid}"),
+                id="rhesis-conversation-id-only",
+            ),
+            pytest.param(
+                lambda reg, tid: reg.record_model_span(
+                    tid, start_time=1, end_time=2, adk_session_id=f"adk-{tid}"
+                ),
+                id="adk-session-id-only",
+            ),
+            pytest.param(
+                lambda reg, tid: reg.record_model_span(
+                    tid, start_time=1, end_time=2, input_text="query"
+                ),
+                id="input-only",
+            ),
+            pytest.param(
+                lambda reg, tid: reg.record_model_span(
+                    tid, start_time=1, end_time=2, output_text="answer"
+                ),
+                id="output-only",
+            ),
+        ],
+    )
+    def test_content_in_any_one_store_counts_as_content(self, record):
+        """A store left out of the "is there anything here" check makes its
+        entries invisible to the release queue, so they are never freed and the
+        store grows until the entry cap evicts it -- which is the leak the queue
+        exists to stop."""
+        registry = translator._ConversationContentRegistry(max_served=1)
+        record(registry, 1)
+        registry.read_for_root(1)
+        assert registry.read_for_root(1) != (None, None, None), "precondition: trace 1 has content"
+
+        record(registry, 2)
+        registry.read_for_root(2)
+
+        assert registry.read_for_root(1) == (None, None, None), "trace 1 should be released"
 
     @pytest.mark.asyncio
     async def test_every_wrapped_exporter_stamps_the_conversation(


### PR DESCRIPTION
## Purpose

The same flaw #2713 fixes in the MAF integration, in Google ADK. I flagged it there as "probably present, deserves its own change"; it is present.

`conversation_root_attributes` popped the per-trace conversation content as it stamped an ADK run root. `enable()` wraps *every* exporter on the provider, so a process running its own OTLP collector beside Rhesis has two translating exporters exporting the same spans: whichever reached the trace root first took the content, and the other stamped a root span carrying no conversation at all. Which one won was arbitrary.

It costs more here than in MAF. ADK's run root is the *only* place that content can go, because the v1 `invocation` span has no attributes of its own and the user's query and the final answer live on nested `call_llm` spans. An exporter that loses the race loses the conversation for that trace entirely, rather than just some of its fields.

## What Changed

The content is read rather than popped, and released a bounded number of reads later, matching the MAF registry. Deferring keeps entries alive long enough for the other exporters to see the same trace; the bound keeps a long-running process from holding 10 KB of conversation text per trace until the 4096-entry cap evicts it. The queue is larger than an OTEL export batch, since a busy service can flush hundreds of run roots at once and the exporters do not drain their queues in lockstep.

**A read of a trace with nothing recorded takes no slot in the release queue.** I found this by writing a test that was wrong, and reading why it failed rather than adjusting the assertion. #2713 now carries the same guard, so the two registries behave identically apart from the stores each one owns. Without the guard, a run of content-free traces (single-turn runs, or content capture switched off) pushes the entries of traces that *do* have content out of the queue early. ADK has four stores rather than MAF's three, and all four are checked, the ADK session id included, so the eviction path cannot quietly miss one and grow on its own.

## Additional Context

- Independent of #2713 and #2714. It branches off `main` and touches no file either of them touches. Merge order does not matter.
- Uses the shared `DeferredReleaseQueue` from #2718, which has merged, so this branch sits on `main` directly and stands alone.
- The last commit swaps this registry's private copy of the queue for the shared class, so ADK and MAF no longer carry two implementations that can drift.
- This is the last of the three integrations that kept conversation state this way. Haystack (#2714) now shares the anchor store; MAF (#2713) and ADK read without popping.

## Testing

`3019 passed` in `tests/sdk` (excluding `tests/sdk/integration`, which needs Docker). Ruff check and format clean. The ADK suite grew from 128 to 137 tests.

Every behavioural change is mutation-tested, and each mutation is caught by the test written for it:

| Mutation | Caught by |
|---|---|
| Make the read pop again | `test_every_wrapped_exporter_stamps_the_conversation`, plus 3 registry tests |
| Never release a served entry | `test_a_read_queues_the_release`, `test_the_adk_session_id_is_released_too` |
| Let an empty read take a slot | `test_a_trace_with_nothing_recorded_does_not_take_a_slot` |
| Stop releasing the ADK session store | `test_the_adk_session_id_is_released_too` |
| Drop any one store from the guard | `test_content_in_any_one_store_counts_as_content`, one case per store |
| Omit any one store when constructing the shared queue | same test, re-run after the refactor |

`test_every_wrapped_exporter_stamps_the_conversation` runs a real ADK agent, captures ADK's own spans through a processor attached *after* `enable()` so it stays unwrapped, then replays that batch through two freshly built translating exporters. With the wrapped exporter from the fixture that makes three readers of the same trace, all of which must stamp. Note that OTEL cannot remove a span processor, so the raw one stays attached for the session; nothing else reads its exporter.

The existing ADK suite did not catch this because its `session_provider` attaches a single processor, so the race never occurred. The MAF suite happens to run with two and that is where the bug first showed itself.


## Review feedback applied

peqy's one comment was valid and is fixed in `test(sdk): stop the adk replay exporter accumulating spans`. The raw span processor the two-exporter test attaches cannot be removed (OTEL has no API for it), so its exporter kept collecting every span in the session into an unbounded list nothing reads. `raw.shutdown()` makes its export a no-op, which stops the growth quietly since `SimpleSpanProcessor` ignores the returned `FAILURE`.

One nuance worth recording, since the comment did not mention it: this isolates the memory, not the test. The leftover processor is still found and wrapped by every later `enable()`, so subsequent tests keep running with two translating exporters over the same spans. That is harmless, and is exactly the configuration this PR makes safe.
