### PR TITLE
Show what a test run cost, and give reviews their own tab

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/crud/telemetry.py
@@ -32,6 +32,20 @@ from rhesis.backend.app.utils.query_utils import QueryBuilder, include, resolve_
 logger = logging.getLogger(__name__)
 
 
+def validate_uuid_param(value: Optional[str], param_name: str) -> Optional[UUID]:
+    """Validate and convert a UUID string, raising a 400 rather than a 500 on garbage."""
+    from fastapi import HTTPException
+
+    if not value:
+        return None
+    try:
+        return UUID(value)
+    except (ValueError, TypeError):
+        raise HTTPException(
+            status_code=400, detail=f"Invalid UUID format for {param_name}: {value}"
+        )
+
+
 def span_total_tokens_expr(attributes):
     """Per-span token total in SQL, matching ``_span_token_counts`` in enrichment/core.py.
 
@@ -409,19 +423,7 @@ def query_traces(
     """
     from uuid import UUID
 
-    from fastapi import HTTPException
     from sqlalchemy.orm import aliased, joinedload
-
-    def validate_uuid_param(value: Optional[str], param_name: str) -> Optional[UUID]:
-        """Validate and convert UUID string, raising HTTPException if invalid."""
-        if not value:
-            return None
-        try:
-            return UUID(value)
-        except (ValueError, TypeError):
-            raise HTTPException(
-                status_code=400, detail=f"Invalid UUID format for {param_name}: {value}"
-            )
 
     # Convert organization_id to UUID
     org_uuid = UUID(organization_id)
@@ -985,11 +987,18 @@ def get_trace_metrics_aggregated(
     environment: Optional[str] = None,
     start_time_after: Optional[datetime] = None,
     start_time_before: Optional[datetime] = None,
+    test_run_id: Optional[str] = None,
 ) -> dict:
     """Compute trace metrics using SQL-level aggregation.
 
     Uses PostgreSQL aggregate functions (COUNT, SUM, AVG, percentile_cont)
     to avoid loading large result sets into Python memory.
+
+    ``test_run_id`` narrows every metric to one run. It is a column on every span
+    row, stamped at ingest, so the scoping is exact. Note that ``total_spans``
+    counts span rows while the traces list shows one deduped root span per trace;
+    ``total_traces`` is a distinct count of trace_id, so that one still lines up
+    with the rows on screen.
     """
     from uuid import UUID
 
@@ -1009,6 +1018,9 @@ def get_trace_metrics_aggregated(
         filters.append(T.start_time >= start_time_after)
     if start_time_before:
         filters.append(T.start_time <= start_time_before)
+    test_run_uuid = validate_uuid_param(test_run_id, "test_run_id")
+    if test_run_uuid:
+        filters.append(T.test_run_id == test_run_uuid)
 
     base = db.query(T).filter(*filters).subquery()
 

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -773,6 +773,7 @@ def get_metrics(
     environment: Optional[str] = Query(None, description="Environment filter"),
     start_time_after: Optional[datetime] = Query(None, description="Start time >= (ISO 8601)"),
     start_time_before: Optional[datetime] = Query(None, description="Start time <= (ISO 8601)"),
+    test_run_id: Optional[str] = Query(None, description="Scope metrics to a single test run"),
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
 ) -> TraceMetricsResponse:
@@ -795,6 +796,7 @@ def get_metrics(
         environment: Environment filter (optional)
         start_time_after: Start of time range
         start_time_before: End of time range
+        test_run_id: Narrow every metric to one test run (optional)
 
     Returns:
         Aggregated metrics
@@ -809,11 +811,15 @@ def get_metrics(
             environment=environment,
             start_time_after=start_time_after,
             start_time_before=start_time_before,
+            test_run_id=test_run_id,
         )
 
         logger.info(f"Calculated metrics for project {project_id}")
         return TraceMetricsResponse(**result)
 
+    except HTTPException:
+        # A deliberate 4xx, such as a malformed test_run_id, must not become a 500.
+        raise
     except Exception as e:
         # Check if it's a database permission error
         error_msg = str(e).lower()

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -44,12 +44,15 @@ import {
   getEffectiveTestResultStatus,
 } from '@/utils/test-result-status';
 import { TAB_KEYS, TabKey, tabIndexFromKey } from '../utils/tab-key';
+import TestRunReviewsTab from './TestRunReviewsTab';
+import TestResultDrawer, { TEST_RESULT_DRAWER_TAB } from './TestResultDrawer';
 
 const TAB_LABELS: Record<TabKey, string> = {
   summary: 'Summary',
   configuration: 'Configuration',
   linked_entities: 'Tests',
   traces: 'Traces',
+  reviews: 'Reviews',
 };
 
 interface TabPanelProps {
@@ -140,11 +143,14 @@ export default function TestRunMainView({
     )
   );
 
-  // Fetch test results for the Tests tab.
-  const needsTestResults = React.useRef(
-    activeTab === TAB_KEYS.indexOf('linked_entities')
-  );
-  if (activeTab === TAB_KEYS.indexOf('linked_entities')) {
+  // Fetch test results for the Tests tab, and for Reviews, which builds its list
+  // out of the reviews hanging off those same results.
+  const tabsNeedingResults = [
+    TAB_KEYS.indexOf('linked_entities'),
+    TAB_KEYS.indexOf('reviews'),
+  ];
+  const needsTestResults = React.useRef(tabsNeedingResults.includes(activeTab));
+  if (tabsNeedingResults.includes(activeTab)) {
     needsTestResults.current = true;
   }
 
@@ -338,6 +344,16 @@ export default function TestRunMainView({
     }));
     handleTabChange(TAB_KEYS.indexOf('linked_entities'));
   }, [handleTabChange]);
+
+  /** The Reviews tab opens a result in place rather than sending you to the Tests
+   *  tab, the same way the playground opens a trace from a conversation. */
+  const [reviewedResultId, setReviewedResultId] = useState<string | null>(null);
+  const reviewedResult = useMemo(
+    () =>
+      testResults.find(result => String(result.id) === reviewedResultId) ??
+      null,
+    [testResults, reviewedResultId]
+  );
 
   const handleTestResultUpdate = useCallback(
     (updatedTest: TestResultDetail) => {
@@ -624,6 +640,33 @@ export default function TestRunMainView({
           currentUserPicture={currentUserPicture}
           initialTraces={initialTraces}
           initialTracesTotalCount={initialTracesTotalCount}
+        />
+      </TabPanel>
+
+      <TabPanel value={activeTab} index={4}>
+        <TestRunReviewsTab
+          testResults={testResults}
+          loading={loading}
+          onViewTestResult={setReviewedResultId}
+        />
+        <TestResultDrawer
+          open={reviewedResult !== null}
+          onClose={() => setReviewedResultId(null)}
+          test={reviewedResult}
+          prompts={prompts}
+          requirements={requirements}
+          testRunId={testRunId}
+          onTestResultUpdate={handleTestResultUpdate}
+          currentUserId={currentUserId}
+          currentUserName={currentUserName}
+          currentUserPicture={currentUserPicture}
+          initialTab={TEST_RESULT_DRAWER_TAB.reviews}
+          testSetType={
+            testRun.test_configuration?.test_set?.test_set_type?.type_value
+          }
+          project={testRun.test_configuration?.endpoint?.project}
+          projectName={testRun.test_configuration?.endpoint?.project?.name}
+          metricsSource={testRun.test_configuration?.attributes?.metrics_source}
         />
       </TabPanel>
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunReviewsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunReviewsTab.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import {
+  Avatar,
+  Box,
+  Chip,
+  CircularProgress,
+  Paper,
+  Typography,
+} from '@mui/material';
+import RateReviewOutlinedIcon from '@mui/icons-material/RateReviewOutlined';
+import { formatDistanceToNow } from 'date-fns';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { isPassedStatusName } from '@/utils/test-result-status';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
+import type {
+  Review,
+  TestResultDetail,
+} from '@/utils/api-client/interfaces/test-results';
+
+interface TestRunReviewsTabProps {
+  testResults: TestResultDetail[];
+  loading?: boolean;
+  /** Opens the result drawer on its Reviews tab, where reviews are written. */
+  onViewTestResult?: (testResultId: string) => void;
+}
+
+interface RunReview {
+  review: Review;
+  testResultId: string;
+  testLabel: string;
+}
+
+function relativeTime(dateString: string): string {
+  try {
+    return formatDistanceToNow(new Date(dateString), {
+      addSuffix: true,
+    }).toUpperCase();
+  } catch {
+    return 'N/A';
+  }
+}
+
+/** Mirrors the labelling in TestDetailReviewsTab so a review reads the same in both places. */
+function statusLabel(statusName: string): { passed: boolean; label: string } {
+  const name = statusName.toLowerCase();
+  if (name === 'fail') return { passed: false, label: 'Failed' };
+  if (name === 'pass') return { passed: true, label: 'Passed' };
+  return { passed: isPassedStatusName(statusName), label: statusName };
+}
+
+/**
+ * Every human review recorded across a test run.
+ *
+ * Built from the test results the page already loads rather than a new endpoint:
+ * each result carries its own `test_reviews.reviews`, so the run-level view is a
+ * flatten and a sort. Writing and editing reviews stays in the result drawer,
+ * which this links into.
+ */
+export default function TestRunReviewsTab({
+  testResults,
+  loading = false,
+  onViewTestResult,
+}: TestRunReviewsTabProps) {
+  const reviews = useMemo<RunReview[]>(() => {
+    const flattened = testResults.flatMap(result =>
+      (result.test_reviews?.reviews ?? []).map(review => ({
+        review,
+        testResultId: String(result.id),
+        testLabel:
+          result.test?.prompt?.content?.slice(0, 80) ??
+          `Test ${String(result.id).slice(0, 8)}`,
+      }))
+    );
+    return flattened.sort(
+      (a, b) =>
+        new Date(b.review.updated_at).getTime() -
+        new Date(a.review.updated_at).getTime()
+    );
+  }, [testResults]);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (reviews.length === 0) {
+    return (
+      <EntityEmptyState
+        icon={RateReviewOutlinedIcon}
+        title="No reviews yet"
+        description="Reviews are recorded against individual tests from the Tests tab. Any you add will be listed here."
+      />
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {reviews.map(({ review, testResultId, testLabel }) => {
+        const display = statusLabel(review.status.name);
+        return (
+          <Paper
+            key={review.review_id}
+            onClick={
+              onViewTestResult
+                ? () => onViewTestResult(testResultId)
+                : undefined
+            }
+            sx={{
+              p: 2.5,
+              borderRadius: BORDER_RADIUS.md,
+              border: theme => `1px solid ${theme.palette.greyscale.border}`,
+              boxShadow: 'none',
+              cursor: onViewTestResult ? 'pointer' : 'default',
+              '&:hover': onViewTestResult
+                ? { borderColor: 'primary.main' }
+                : undefined,
+            }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                mb: 1.5,
+                gap: 1,
+              }}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                <Avatar
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    fontSize: 12,
+                    bgcolor: 'primary.main',
+                  }}
+                >
+                  {review.user.name.charAt(0).toUpperCase()}
+                </Avatar>
+                <Typography variant="body2" fontWeight={700}>
+                  {review.user.name}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ letterSpacing: 0.5 }}
+                >
+                  {relativeTime(review.updated_at)}
+                </Typography>
+              </Box>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                {review.resolved && (
+                  <Chip size="small" label="Resolved" variant="outlined" />
+                )}
+                <Chip
+                  size="small"
+                  label={display.label}
+                  color={display.passed ? 'success' : 'error'}
+                  variant="outlined"
+                />
+              </Box>
+            </Box>
+
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: 'block', mb: 0.5 }}
+            >
+              {testLabel}
+            </Typography>
+
+            {review.comments && (
+              <Typography variant="body2">{review.comments}</Typography>
+            )}
+          </Paper>
+        );
+      })}
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTracesTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTracesTab.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import React, { useCallback, useState } from 'react';
-import { Box, Paper } from '@mui/material';
+import { Box } from '@mui/material';
 import TimelineOutlinedIcon from '@mui/icons-material/TimelineOutlined';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import TracesClient from '@/app/(protected)/traces/components/TracesClient';
 import type { TraceSummary } from '@/utils/api-client/interfaces/telemetry';
 
@@ -60,25 +59,17 @@ export default function TestRunTracesTab({
             : {}
         }
       >
-        <Paper
-          sx={{
-            width: '100%',
-            borderRadius: BORDER_RADIUS.md,
-            boxShadow: ELEVATION.xs,
-            border: theme => `1px solid ${theme.palette.greyscale.border}`,
-            overflow: 'hidden',
-          }}
-        >
-          <TracesClient
-            currentUserId={currentUserId}
-            currentUserName={currentUserName}
-            currentUserPicture={currentUserPicture}
-            fixedTestRunId={testRunId}
-            onUnfilteredEmpty={handleUnfilteredEmpty}
-            initialData={initialTraces}
-            initialTotalCount={initialTracesTotalCount}
-          />
-        </Paper>
+        {/* No card here: TracesClient wraps the grid in its own, so the rollup
+            tiles sit above it exactly as they do on the Traces page. */}
+        <TracesClient
+          currentUserId={currentUserId}
+          currentUserName={currentUserName}
+          currentUserPicture={currentUserPicture}
+          fixedTestRunId={testRunId}
+          onUnfilteredEmpty={handleUnfilteredEmpty}
+          initialData={initialTraces}
+          initialTotalCount={initialTracesTotalCount}
+        />
       </Box>
 
       {showEmptyHint && (

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/__tests__/TestRunReviewsTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/__tests__/TestRunReviewsTab.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@/test-utils';
+import '@testing-library/jest-dom';
+import TestRunReviewsTab from '../TestRunReviewsTab';
+import type { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+
+function review(
+  id: string,
+  name: string,
+  updatedAt: string,
+  status = 'Pass',
+  comments = ''
+) {
+  return {
+    review_id: id,
+    status: { name: status },
+    user: { user_id: `user-${name}`, name },
+    comments,
+    created_at: updatedAt,
+    updated_at: updatedAt,
+    target: { type: 'test_result', reference: null },
+  };
+}
+
+function result(
+  id: string,
+  reviews: ReturnType<typeof review>[]
+): TestResultDetail {
+  return {
+    id,
+    test_reviews: { reviews },
+    test: { prompt: { content: `Prompt for ${id}` } },
+  } as unknown as TestResultDetail;
+}
+
+describe('TestRunReviewsTab', () => {
+  it('shows the empty state when no test in the run has been reviewed', () => {
+    render(<TestRunReviewsTab testResults={[result('a', [])]} />);
+
+    expect(screen.getByText('No reviews yet')).toBeInTheDocument();
+  });
+
+  it('flattens reviews from every test result into one list', () => {
+    render(
+      <TestRunReviewsTab
+        testResults={[
+          result('a', [review('r1', 'Alice', '2026-09-01T10:00:00Z')]),
+          result('b', [review('r2', 'Bob', '2026-09-02T10:00:00Z')]),
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('puts the most recently updated review first', () => {
+    render(
+      <TestRunReviewsTab
+        testResults={[
+          result('a', [review('r1', 'Older', '2026-09-01T10:00:00Z')]),
+          result('b', [review('r2', 'Newer', '2026-09-05T10:00:00Z')]),
+        ]}
+      />
+    );
+
+    const names = screen
+      .getAllByText(/Older|Newer/)
+      .map(node => node.textContent);
+    expect(names[0]).toBe('Newer');
+  });
+
+  it('hands back the result id so the caller can open it in place', () => {
+    // The caller opens a drawer without leaving the Reviews tab, the way the
+    // playground opens a trace from a conversation.
+    const onViewTestResult = jest.fn();
+    render(
+      <TestRunReviewsTab
+        testResults={[
+          result('abc', [review('r1', 'Alice', '2026-09-01T10:00:00Z')]),
+        ]}
+        onViewTestResult={onViewTestResult}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Alice'));
+
+    expect(onViewTestResult).toHaveBeenCalledWith('abc');
+  });
+
+  it('does not blow up when no handler is given', () => {
+    render(
+      <TestRunReviewsTab
+        testResults={[
+          result('abc', [review('r1', 'Alice', '2026-09-01T10:00:00Z')]),
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Alice'));
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('shows the review comment and its verdict', () => {
+    render(
+      <TestRunReviewsTab
+        testResults={[
+          result('a', [
+            review(
+              'r1',
+              'Alice',
+              '2026-09-01T10:00:00Z',
+              'Fail',
+              'Wrong refusal'
+            ),
+          ]),
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Wrong refusal')).toBeInTheDocument();
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/KpiCard.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/KpiCard.tsx
@@ -27,6 +27,12 @@ interface KpiCardProps {
   visual?: React.ReactNode;
   /** Explains the metric in a hover tooltip via a small info icon next to the title. */
   infoTooltip?: string;
+  /** A second metric of equal standing, shown beside `value`. Both drop a size so
+   *  the pair still fits the card width. Used by the Usage card, where tokens and
+   *  cost answer the same question and neither is the subtitle of the other. */
+  secondary?: { value: string | number; label: string };
+  /** Labels the primary value when `secondary` is set, so the two read as a pair. */
+  valueLabel?: string;
   /** Makes the whole card a button, e.g. to drill into a filtered view. */
   onClick?: () => void;
 }
@@ -39,6 +45,8 @@ export default function KpiCard({
   subtitle,
   visual,
   infoTooltip,
+  secondary,
+  valueLabel,
   onClick,
 }: KpiCardProps) {
   const content = (
@@ -56,27 +64,58 @@ export default function KpiCard({
         )}
       </Box>
 
-      <Typography
-        variant="h4"
-        fontWeight={600}
-        sx={{
-          mb: 1,
-          fontVariantNumeric: 'tabular-nums',
-          color: valueColor,
-        }}
-      >
-        {value}
-        {valueSuffix && (
-          <Typography
-            component="span"
-            variant="body1"
-            color="text.secondary"
-            sx={{ ml: 0.5, fontVariantNumeric: 'tabular-nums' }}
-          >
-            {valueSuffix}
-          </Typography>
-        )}
-      </Typography>
+      {secondary ? (
+        <Box sx={{ display: 'flex', gap: 3, mb: 1 }}>
+          <Box>
+            <Typography
+              variant="h5"
+              fontWeight={600}
+              sx={{ fontVariantNumeric: 'tabular-nums', color: valueColor }}
+            >
+              {value}
+            </Typography>
+            {valueLabel && (
+              <Typography variant="caption" color="text.secondary">
+                {valueLabel}
+              </Typography>
+            )}
+          </Box>
+          <Box>
+            <Typography
+              variant="h5"
+              fontWeight={600}
+              sx={{ fontVariantNumeric: 'tabular-nums' }}
+            >
+              {secondary.value}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {secondary.label}
+            </Typography>
+          </Box>
+        </Box>
+      ) : (
+        <Typography
+          variant="h4"
+          fontWeight={600}
+          sx={{
+            mb: 1,
+            fontVariantNumeric: 'tabular-nums',
+            color: valueColor,
+          }}
+        >
+          {value}
+          {valueSuffix && (
+            <Typography
+              component="span"
+              variant="body1"
+              color="text.secondary"
+              sx={{ ml: 0.5, fontVariantNumeric: 'tabular-nums' }}
+            >
+              {valueSuffix}
+            </Typography>
+          )}
+        </Typography>
+      )}
 
       {visual}
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/KpiRow.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/KpiRow.tsx
@@ -14,6 +14,8 @@ import {
 } from './verdict-timeline';
 import { describeStrip } from './verdict-strip-render';
 import { STRIP_HEIGHTS } from './summary-tokens';
+import { formatCost, formatTokenCount } from '@/utils/trace-utils';
+import { useTestRunUsage } from '../../hooks/useTestRunUsage';
 import type {
   VerdictMatrix,
   TestRunDetail,
@@ -37,6 +39,7 @@ export default function KpiRow({
   onViewFailures,
 }: KpiRowProps) {
   const { kpis } = matrix;
+  const usage = useTestRunUsage(testRun.id);
 
   const durationDisplay = useMemo(() => {
     if (isRunning) return undefined;
@@ -163,18 +166,25 @@ export default function KpiRow({
           />
         </Grid>
 
-        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-          <KpiCard
-            title="Reviews"
-            value={kpis.reviews_count}
-            subtitle={
-              kpis.reviews_count > 0
-                ? `of ${kpis.tests_executed} tests`
-                : 'No reviews yet'
-            }
-            infoTooltip="Tests with at least one human review recorded."
-          />
-        </Grid>
+        {/* Held back until the numbers arrive rather than shown as zeros, the
+            same way the rollup tiles on the Traces page behave. */}
+        {usage && (
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <KpiCard
+              title="Usage"
+              value={formatTokenCount(usage.total_tokens)}
+              valueLabel="tokens"
+              secondary={{
+                value: formatCost(usage.total_cost_usd),
+                label: 'cost',
+              }}
+              subtitle={`across ${usage.total_traces} ${
+                usage.total_traces === 1 ? 'trace' : 'traces'
+              }`}
+              infoTooltip="Tokens and cost across this run's traced LLM calls. Cost appears once enrichment has priced the run."
+            />
+          </Grid>
+        )}
       </Grid>
     </Box>
   );

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/KpiRow.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/KpiRow.test.tsx
@@ -11,6 +11,22 @@ import type {
   TestRunDetail,
 } from '@/utils/api-client/interfaces/test-run';
 
+// The Usage card fetches its own totals; drive them rather than the network.
+jest.mock('../../../hooks/useTestRunUsage', () => ({
+  useTestRunUsage: jest.fn(() => null),
+}));
+
+import { useTestRunUsage } from '../../../hooks/useTestRunUsage';
+import type { TraceMetricsResponse } from '@/utils/api-client/interfaces/telemetry';
+
+function mockUsage(usage: Partial<TraceMetricsResponse> | null) {
+  (useTestRunUsage as jest.Mock).mockReturnValue(usage);
+}
+
+beforeEach(() => {
+  mockUsage(null);
+});
+
 beforeAll(() => {
   HTMLCanvasElement.prototype.getContext = jest.fn().mockReturnValue({
     clearRect: jest.fn(),
@@ -389,31 +405,63 @@ describe('KpiRow', () => {
     expect(onViewFailures).not.toHaveBeenCalled();
   });
 
-  it('shows "No reviews yet" on the Reviews card when nothing has been reviewed', () => {
+  it('omits the Usage card until the token and cost numbers arrive', () => {
+    // Showing zeros would read as "this run cost nothing", which is a different
+    // claim from "we do not know yet".
+    mockUsage(null);
     renderWithClock(
       <KpiRow
-        matrix={makeMatrix({ reviews_count: 0 })}
+        matrix={makeMatrix({})}
         testRun={makeTestRun()}
         isRunning={false}
         testIds={[]}
         timings={EMPTY_TIMINGS}
       />
     );
-    expect(screen.getByText('Reviews')).toBeInTheDocument();
-    expect(screen.getByText('No reviews yet')).toBeInTheDocument();
+    expect(screen.queryByText('Usage')).not.toBeInTheDocument();
   });
 
-  it('shows the review count and a "of N tests" subtitle when reviews exist', () => {
+  it('shows tokens and cost side by side on the Usage card', () => {
+    mockUsage({
+      total_traces: 12,
+      total_spans: 190,
+      total_tokens: 45735,
+      total_cost_usd: 0.012695,
+    });
     renderWithClock(
       <KpiRow
-        matrix={makeMatrix({ reviews_count: 3, tests_executed: 5 })}
+        matrix={makeMatrix({})}
         testRun={makeTestRun()}
         isRunning={false}
         testIds={[]}
         timings={EMPTY_TIMINGS}
       />
     );
-    expect(screen.getByText('3')).toBeInTheDocument();
-    expect(screen.getByText('of 5 tests')).toBeInTheDocument();
+    expect(screen.getByText('Usage')).toBeInTheDocument();
+    expect(screen.getByText('45,735')).toBeInTheDocument();
+    expect(screen.getByText('tokens')).toBeInTheDocument();
+    // formatCost drops to two decimals above a cent, same as the Traces page.
+    expect(screen.getByText('$0.01')).toBeInTheDocument();
+    expect(screen.getByText('cost')).toBeInTheDocument();
+    expect(screen.getByText('across 12 traces')).toBeInTheDocument();
+  });
+
+  it('says trace rather than traces when the run produced one', () => {
+    mockUsage({
+      total_traces: 1,
+      total_spans: 3,
+      total_tokens: 150,
+      total_cost_usd: 0.001,
+    });
+    renderWithClock(
+      <KpiRow
+        matrix={makeMatrix({})}
+        testRun={makeTestRun()}
+        isRunning={false}
+        testIds={[]}
+        timings={EMPTY_TIMINGS}
+      />
+    );
+    expect(screen.getByText('across 1 trace')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunUsage.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunUsage.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { readActiveProjectId } from '@/utils/active-project';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import type { TraceMetricsResponse } from '@/utils/api-client/interfaces/telemetry';
+
+/**
+ * Token and cost totals for one test run's traces.
+ *
+ * Reads GET /telemetry/metrics rather than riding along on the verdict matrix,
+ * even though the other KPI numbers live there. The matrix is cached once a run
+ * goes terminal, while trace enrichment runs asynchronously after ingest, so a
+ * run cached the moment it finished would report a cost of zero for the whole
+ * cache lifetime. Going to the metrics endpoint also means this card and the
+ * rollup tiles on the Traces tab cannot disagree.
+ *
+ * Returns null until the numbers arrive, so callers render nothing rather than
+ * zeros they do not yet have.
+ */
+export function useTestRunUsage(
+  testRunId: string
+): TraceMetricsResponse | null {
+  const { activeProject } = useActiveProject();
+  const projectId = activeProject?.id
+    ? String(activeProject.id)
+    : readActiveProjectId();
+  const [usage, setUsage] = useState<TraceMetricsResponse | null>(null);
+
+  useEffect(() => {
+    if (!projectId || !testRunId) {
+      setUsage(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const metrics = await new ApiClientFactory(undefined, projectId)
+          .getTelemetryClient()
+          .getMetrics({ project_id: projectId, test_run_id: testRunId });
+        if (!cancelled) {
+          setUsage(metrics);
+        }
+      } catch {
+        // The card is supplementary; a failure here must not take the summary
+        // down with it.
+        if (!cancelled) {
+          setUsage(null);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, testRunId]);
+
+  return usage;
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
@@ -65,8 +65,11 @@ export default async function TestRunPage({
     tabParam,
     hasSelectedResult && !tabParam
   );
+  // Reviews is built from the same test results the Tests tab uses, so a deep
+  // link to ?tab=reviews needs the same prefetch or it lands on an empty list.
   const wantsLinkedEntities =
-    initialTabIndex === TAB_KEYS.indexOf('linked_entities');
+    initialTabIndex === TAB_KEYS.indexOf('linked_entities') ||
+    initialTabIndex === TAB_KEYS.indexOf('reviews');
   const wantsTraces = initialTabIndex === TAB_KEYS.indexOf('traces');
 
   const scopedProjectId = (await getServerActiveProjectId()) ?? null;

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/utils/tab-key.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/utils/tab-key.ts
@@ -7,11 +7,14 @@
  * tab's data while the client opens a different one.
  */
 
+// Order defines the tab indices, so append rather than insert: anything else
+// shifts every TabPanel index and the legacy key aliases below.
 export const TAB_KEYS = [
   'summary',
   'linked_entities',
   'configuration',
   'traces',
+  'reviews',
 ] as const;
 
 export type TabKey = (typeof TAB_KEYS)[number];

--- a/apps/frontend/src/app/(protected)/traces/components/TraceMetricsSummary.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceMetricsSummary.tsx
@@ -13,6 +13,8 @@ import { formatCost, formatTokenCount } from '@/utils/trace-utils';
 
 interface TraceMetricsSummaryProps {
   projectId: string | null;
+  /** Narrows the totals to one test run, for the Traces tab inside a run. */
+  testRunId?: string;
   environment?: string;
   startTimeAfter?: string;
   startTimeBefore?: string;
@@ -35,6 +37,7 @@ interface TraceMetricsSummaryProps {
  */
 export default function TraceMetricsSummary({
   projectId,
+  testRunId,
   environment,
   startTimeAfter,
   startTimeBefore,
@@ -59,6 +62,7 @@ export default function TraceMetricsSummary({
         ).getTelemetryClient();
         const result = await client.getMetrics({
           project_id: projectId,
+          ...(testRunId ? { test_run_id: testRunId } : {}),
           ...(environment ? { environment } : {}),
           ...(startTimeAfter ? { start_time_after: startTimeAfter } : {}),
           ...(startTimeBefore ? { start_time_before: startTimeBefore } : {}),
@@ -80,7 +84,14 @@ export default function TraceMetricsSummary({
     return () => {
       cancelled = true;
     };
-  }, [projectId, environment, startTimeAfter, startTimeBefore, refreshTrigger]);
+  }, [
+    projectId,
+    testRunId,
+    environment,
+    startTimeAfter,
+    startTimeBefore,
+    refreshTrigger,
+  ]);
 
   if (!metrics) {
     return null;

--- a/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
@@ -197,17 +197,18 @@ export default function TracesClient({
   const showFilteredEmpty =
     !listLoading && traces.length === 0 && totalCount === 0;
 
-  // GET /telemetry/metrics only narrows by project, environment and time, so any
-  // other active filter makes the rollup broader than the listed rows. Tell it,
-  // rather than letting the two silently disagree.
+  // GET /telemetry/metrics narrows by project, environment, time and test run, so
+  // any other active filter makes the rollup broader than the listed rows. Tell
+  // it, rather than letting the two silently disagree.
   const rollupProjectId = drawerFilters.projectId || scopedProjectId;
+  const rollupTestRunId =
+    fixedTestRunId ?? drawerFilters.testRunId ?? undefined;
   const hasUnsupportedRollupFilters = Boolean(
     searchQuery.trim() ||
     (typeFilter && typeFilter !== 'all') ||
     drawerFilters.endpointId ||
     drawerFilters.traceSource ||
     drawerFilters.traceMetricsStatus ||
-    drawerFilters.testRunId ||
     drawerFilters.testResultId ||
     drawerFilters.testId
   );
@@ -218,19 +219,17 @@ export default function TracesClient({
 
   return (
     <>
-      {/* Project totals sit above the grid card, not inside it. Skipped on a test
-          run's Traces tab: the metrics endpoint cannot filter by test run, so the
-          tiles there would count the whole project next to a dozen listed rows. */}
-      {!fixedTestRunId && (
-        <TraceMetricsSummary
-          projectId={rollupProjectId}
-          environment={drawerFilters.environment ?? undefined}
-          startTimeAfter={rollupTimeParams.start_time_after}
-          startTimeBefore={rollupTimeParams.start_time_before}
-          hasUnsupportedFilters={hasUnsupportedRollupFilters}
-          refreshTrigger={refreshTrigger}
-        />
-      )}
+      {/* Totals sit above the grid card, not inside it. The metrics endpoint scopes
+          by test run, so on a run's Traces tab these describe that run. */}
+      <TraceMetricsSummary
+        projectId={rollupProjectId}
+        testRunId={rollupTestRunId}
+        environment={drawerFilters.environment ?? undefined}
+        startTimeAfter={rollupTimeParams.start_time_after}
+        startTimeBefore={rollupTimeParams.start_time_before}
+        hasUnsupportedFilters={hasUnsupportedRollupFilters}
+        refreshTrigger={refreshTrigger}
+      />
 
       <Paper sx={GRID_PAPER_SX}>
         {error && (

--- a/apps/frontend/src/utils/api-client/telemetry-client.ts
+++ b/apps/frontend/src/utils/api-client/telemetry-client.ts
@@ -61,6 +61,8 @@ export class TelemetryClient extends BaseApiClient {
     environment?: string;
     start_time_after?: string;
     start_time_before?: string;
+    /** Narrows every metric to one test run. */
+    test_run_id?: string;
   }): Promise<TraceMetricsResponse> {
     const queryParams = new URLSearchParams();
 

--- a/tests/backend/crud/test_trace_metrics_aggregated.py
+++ b/tests/backend/crud/test_trace_metrics_aggregated.py
@@ -12,6 +12,7 @@ import pytest
 from rhesis.telemetry.attributes import AIAttributes
 from rhesis.telemetry.schemas import SpanKind, StatusCode
 
+from rhesis.backend.app.constants import TestExecutionContext
 from rhesis.backend.app.crud.telemetry import (
     create_trace_spans,
     get_trace_metrics_aggregated,
@@ -90,9 +91,7 @@ def six_span_trace(test_db, db_project, test_org_id):
 class TestTokenAndCostAggregation:
     """Tokens and cost aggregate once per trace, not once per span row."""
 
-    def test_cost_is_not_multiplied_by_span_count(
-        self, test_db, six_span_trace, test_org_id
-    ):
+    def test_cost_is_not_multiplied_by_span_count(self, test_db, six_span_trace, test_org_id):
         """Regression: this used to report 6x the trace's real cost."""
         _, project_id = six_span_trace
 
@@ -116,9 +115,7 @@ class TestTokenAndCostAggregation:
 
         assert metrics["total_tokens"] == TRACE_TOKENS
 
-    def test_span_counts_and_error_rate_still_span_level(
-        self, test_db, db_project, test_org_id
-    ):
+    def test_span_counts_and_error_rate_still_span_level(self, test_db, db_project, test_org_id):
         """Collapsing tokens per trace must not collapse the span-level metrics."""
         trace_id = uuid.uuid4().hex
         project_id = str(db_project.id)
@@ -185,3 +182,109 @@ class TestTokenAndCostAggregation:
 
         assert metrics["total_tokens"] == 30
         assert metrics["total_cost_usd"] == 0.0
+
+
+def run_span(trace_id, project_id, test_run_id, *, operation, tokens=None):
+    """A span stamped with a test run, the way test execution ingests them."""
+    created = span(trace_id, uuid.uuid4().hex[:16], project_id, operation=operation, tokens=tokens)
+    created.attributes[TestExecutionContext.SpanAttributes.TEST_RUN_ID] = str(test_run_id)
+    return created
+
+
+@pytest.mark.integration
+class TestTestRunScoping:
+    """Metrics narrowed to a single test run.
+
+    Without this the test run Traces tab has to hide its rollup tiles, because the
+    only numbers available cover the whole project.
+    """
+
+    @pytest.fixture
+    def two_runs(self, test_db, db_project, test_org_id, db_test_run, db_test_run_running):
+        """Two runs in one project: 2 llm spans totalling 150 tokens, and 1 of 500."""
+        project_id = str(db_project.id)
+        run_a, run_b = db_test_run.id, db_test_run_running.id
+
+        trace_a = uuid.uuid4().hex
+        create_trace_spans(
+            test_db,
+            [
+                run_span(trace_a, project_id, run_a, operation="agent.invoke"),
+                run_span(trace_a, project_id, run_a, operation="llm.invoke", tokens=(50, 25, 75)),
+                run_span(trace_a, project_id, run_a, operation="llm.invoke", tokens=(50, 25, 75)),
+            ],
+            organization_id=test_org_id,
+        )
+
+        trace_b = uuid.uuid4().hex
+        create_trace_spans(
+            test_db,
+            [
+                run_span(
+                    trace_b, project_id, run_b, operation="llm.invoke", tokens=(400, 100, 500)
+                ),
+            ],
+            organization_id=test_org_id,
+        )
+        return project_id, str(run_a), str(run_b), trace_a
+
+    def test_counts_only_the_requested_run(self, test_db, two_runs, test_org_id):
+        project_id, run_a, _, _ = two_runs
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id, test_run_id=run_a
+        )
+
+        assert metrics["total_traces"] == 1
+        assert metrics["total_spans"] == 3
+        assert metrics["total_tokens"] == 150
+
+    def test_the_other_run_does_not_leak_in(self, test_db, two_runs, test_org_id):
+        project_id, _, run_b, _ = two_runs
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id, test_run_id=run_b
+        )
+
+        assert metrics["total_traces"] == 1
+        assert metrics["total_spans"] == 1
+        assert metrics["total_tokens"] == 500
+
+    def test_without_a_run_the_whole_project_is_counted(self, test_db, two_runs, test_org_id):
+        """The Traces page passes no test_run_id and must be unaffected."""
+        project_id, _, _, _ = two_runs
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id
+        )
+
+        assert metrics["total_traces"] >= 2
+        assert metrics["total_tokens"] >= 650
+
+    def test_cost_is_scoped_too(self, test_db, two_runs, test_org_id):
+        """Enrichment writes its blob per trace, so cost has to follow the same filter."""
+        project_id, run_a, run_b, trace_a = two_runs
+        mark_trace_processed(test_db, trace_a, enrichment_blob())
+
+        priced = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id, test_run_id=run_a
+        )
+        unpriced = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id, test_run_id=run_b
+        )
+
+        assert priced["total_cost_usd"] == pytest.approx(TRACE_COST_USD)
+        assert unpriced["total_cost_usd"] == 0.0
+
+    def test_malformed_run_id_is_a_400(self, test_db, db_project, test_org_id):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as caught:
+            get_trace_metrics_aggregated(
+                test_db,
+                organization_id=test_org_id,
+                project_id=str(db_project.id),
+                test_run_id="not-a-uuid",
+            )
+
+        assert caught.value.status_code == 400


### PR DESCRIPTION
## Purpose

A test run could not tell you what it cost. #2707 put token counts and cost on the Traces page, but inside a run neither number appeared anywhere: the Summary tab showed Pass rate, Tests executed, Failures and Reviews, and the Traces tab showed a bare table. Cost is the number customers react to, so a run that cannot report it is a real gap.

One thing was blocking both halves of the fix. `GET /telemetry/metrics` could only narrow by project, environment and time, so it could not describe a single run. That is exactly why #2707 suppressed the rollup tiles on a run's Traces tab, after review caught a run listing twelve traces showing four tiles that counted the whole project. The guard even said so:

```tsx
{/* Skipped on a test run's Traces tab: the metrics endpoint cannot filter by test run ... */}
{!fixedTestRunId && (
```

This removes that limitation rather than working around it, which unblocks the tiles and gives the Summary tab a number to show, from the same source.

Reviews moves out of the KPI row in the process. It was spending a quarter of the summary row to say "0", and there was no way to see the reviews in a run without opening tests one at a time.

## What Changed

**Backend, one filter**

`get_trace_metrics_aggregated` takes `test_run_id`. It builds a single `filters` list feeding one `base` subquery and every metric derives from that, so the new filter narrows traces, spans, tokens, cost, error rate and the duration percentiles together. `test_run_id` is a column on every span row, stamped at ingest, so the scoping is exact rather than approximate.

Two smaller things came with it: `validate_uuid_param` moved out of `query_traces` to module scope so both queries share one copy, and the metrics endpoint now re-raises `HTTPException` instead of converting it to a 500, which a malformed `test_run_id` would otherwise have done.

**Summary tab: a Usage card**

`KpiCard` gained an optional `secondary` metric, and the Reviews slot became a Usage card holding tokens and cost side by side as peers rather than one as the other's subtitle. Nothing else about the card changed, so the other three render exactly as before.

**Reviews tab**

A fifth tab listing every review in the run: who left it, when, which test, the verdict and the comment. No new endpoint. Each test result already carries its own `test_reviews.reviews`, so the run-level view is a flatten and a sort over results the page loads anyway. The Tests tab and Reviews share that fetch, and a deep link to `?tab=reviews` prefetches it server-side so the tab does not open empty.

Clicking a review opens that result in a drawer on its own Reviews tab and stays put, the way the playground opens a trace from a conversation. The drawer looks its result up from the same list the tab renders, so resolving or editing a review updates the list behind it without a refetch.

**Traces tab: the tiles are back, and the card nesting is fixed**

With the endpoint scoping by run, the tiles return and describe the run. `TestRunTracesTab` also had its own copy of the hand-rolled grid card, which wrapped both the tiles and the card `TracesClient` already renders around the grid. That nested one card inside another and put the tiles inside the box, unlike the Traces page. Removing it leaves a single card around the grid, so both pages now look the same.

## Additional Context

**The Usage card reads the metrics endpoint, not the verdict matrix.** The matrix is the obvious-looking home since every other KPI lives there, but it is cached once a run goes terminal while trace enrichment runs asynchronously after ingest. A run cached the moment it finished would report a cost of zero for the whole cache lifetime, and unlike tokens, cost has no pre-enrichment fallback. Reading the metrics endpoint also means this card and the Traces tab tiles cannot disagree, since they are the same query.

**The card is held back until the numbers arrive** rather than rendered as zeros. "We do not know yet" and "this run cost nothing" are different claims, and the rollup tiles on the Traces page already behave this way.

**`reviews` is appended to `TAB_KEYS`, not inserted.** The order defines the tab indices, so anything else shifts every `TabPanel` and the legacy `results`/`stats`/`logs` aliases.

**One semantic difference worth knowing:** the endpoint counts every span row while the traces list shows one deduped root span per trace, so `total_spans` is deliberately larger than the row count. `total_traces` is a distinct count of `trace_id`, so that one matches what is listed.

Deliberately out of scope:

- **The rest of the trace filters on the metrics endpoint.** `endpoint_id` needs a three-hop join before `.subquery()` and `search` needs its own subquery. Neither is needed here, and the tiles already say when they are broader than the listed rows.
- **A run-level reviews endpoint.** Reviews are built from results the page already loads. If reviews later need pagination or filtering independent of the Tests tab, that would need one.
- **Cost precision.** `formatCost` rounds to two decimals above a cent, so a run costing `$0.032621` shows `$0.03`. That is the shared formatter used on the Traces page, and changing it would affect both.

## Testing

**Automated** — 213 backend tests and 2544 frontend tests pass; ruff, eslint, prettier and tsc are clean.

New coverage:

- `tests/backend/crud/test_trace_metrics_aggregated.py::TestTestRunScoping` — metrics scoped to a run count only that run, a second run in the same project does not leak in, cost follows the same filter, omitting `test_run_id` still returns whole-project numbers so the Traces page is unaffected, and a malformed id is a 400 rather than a 500.
- `KpiRow.test.tsx` — the Usage card shows tokens and cost side by side, is omitted until the numbers arrive, and says "trace" rather than "traces" for a run with one. The two tests that asserted on the Reviews card are replaced, since that card is gone.
- `TestRunReviewsTab.test.tsx` — flattens reviews across results, sorts newest first, shows the empty state, hands the result id back for the drawer, and survives having no handler.

**Against the running stack**, on test run `c74e414d`:

```
whole project   traces=105  spans=1603  tokens=344,317  cost=$0.1238
scoped to run   traces=60   spans=60    tokens=112,557  cost=$0.0326
malformed id    HTTP 400
```

**In the browser** — the Traces tab tiles sit above the grid card and match the rows beneath them rather than the project, the Usage card matches those tiles exactly, the Reviews tab lists reviews and opens the result drawer in place, and the Traces page itself is unchanged since `test_run_id` is optional.
