### PR TITLE
Add a shared deferred-release queue for the GenAI integrations

### DIFF
--- a/sdk/src/rhesis/sdk/telemetry/integrations/genai.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/genai.py
@@ -724,6 +724,74 @@ class ConversationTraceRegistry:
             self._targets.clear()
 
 
+class DeferredReleaseQueue:
+    """Frees per-trace entries a bounded number of reads after the first read.
+
+    A natively instrumented framework carries a turn's text on its nested model
+    spans, not on the run root that has to be stamped with it, so an integration
+    collects that text per trace id and reads it back when the root is exported.
+    Popping it on that read looks right and is not: ``enable()`` wraps *every*
+    exporter on the provider, so a process running its own OTLP collector beside
+    Rhesis exports the same spans through several translating exporters, and
+    whichever reached the root first took the content and left the others
+    stamping a root span with nothing on it.
+
+    Keeping every entry instead trades that for a leak: at
+    :data:`~rhesis.telemetry.constants.ConversationContext.MAX_IO_LENGTH` per
+    field, a long-running process would sit on megabytes of conversation text
+    waiting for the store's own entry cap. So entries are freed once enough
+    other traces have been read past them - long enough for the other exporters
+    to see the same trace, short enough to stay small. The queue is deliberately
+    larger than an OTEL export batch, since a busy service can flush hundreds of
+    run roots at once and the exporters do not drain their queues in lockstep.
+
+    Holds the stores by reference and mutates them in place, so an owner must
+    not rebind them after construction. Takes no lock of its own: every method
+    expects the owner's lock to be held, which is what keeps a read of the
+    stores and the release that follows it atomic together.
+    """
+
+    def __init__(self, *stores: dict, max_served: int = 512) -> None:
+        """Queue releases across ``stores``, all keyed by trace id."""
+        self._stores = stores
+        self._served: dict[int, None] = {}
+        self._max_served = max_served
+
+    def queue_release(self, trace_id: int) -> None:
+        """Mark ``trace_id`` read, freeing whatever has fallen far enough behind.
+
+        A trace with nothing recorded takes no slot: it has nothing to free, and
+        a run of content-free traces would otherwise push out the entries of the
+        traces that do have some. Caller holds the lock.
+        """
+        if not self.has_entries(trace_id):
+            return
+        # Re-reading moves a trace back to the newest, so the entries stay while
+        # anything is still asking for them.
+        self._served.pop(trace_id, None)
+        self._served[trace_id] = None
+        while len(self._served) > self._max_served:
+            stale = next(iter(self._served))
+            del self._served[stale]
+            for store in self._stores:
+                store.pop(stale, None)
+
+    def has_entries(self, trace_id: int) -> bool:
+        """Whether any store holds something for this trace. Caller holds the lock.
+
+        Every store an owner keeps has to be passed in. One left out is invisible
+        here, so its entries never reach the queue and never get freed - which is
+        the leak this class exists to prevent.
+        """
+        return any(trace_id in store for store in self._stores)
+
+    def clear(self) -> None:
+        """Forget the queue and empty every store. Caller holds the lock."""
+        self._served.clear()
+        for store in self._stores:
+            store.clear()
+
+
 def translate_events(
     original_events: Iterable[Event],
     span_attributes: Mapping[str, Any],

--- a/tests/sdk/telemetry/integrations/test_genai.py
+++ b/tests/sdk/telemetry/integrations/test_genai.py
@@ -1,0 +1,124 @@
+"""Tests for the framework-neutral GenAI helpers in ``genai.py``.
+
+These back the Microsoft Agent Framework and Google ADK integrations, which read
+a turn's text back from a per-trace store when the run root is exported. The
+store's release policy is the delicate part: too eager and one exporter starves
+the others, too lazy and a long-running process sits on megabytes of text.
+"""
+
+import pytest
+
+from rhesis.sdk.telemetry.integrations.genai import DeferredReleaseQueue
+
+
+@pytest.fixture
+def stores() -> tuple[dict, dict]:
+    """Two trace-keyed stores, the shape an integration registry keeps."""
+    return {}, {}
+
+
+class TestHasEntries:
+    def test_reports_content_in_any_store(self, stores):
+        first, second = stores
+        queue = DeferredReleaseQueue(first, second)
+
+        assert queue.has_entries(1) is False
+        second[1] = "only in the second store"
+        assert queue.has_entries(1) is True
+
+    def test_a_store_is_held_by_reference(self, stores):
+        """The owner records into its own dicts after building the queue."""
+        first, _second = stores
+        queue = DeferredReleaseQueue(*stores)
+
+        first[7] = "recorded later"
+
+        assert queue.has_entries(7) is True
+
+
+class TestQueueRelease:
+    def test_a_read_does_not_free_the_entry(self, stores):
+        """The other wrapped exporters still have to find it."""
+        first, _second = stores
+        first[1] = "content"
+        queue = DeferredReleaseQueue(*stores, max_served=4)
+
+        queue.queue_release(1)
+
+        assert first[1] == "content"
+
+    def test_entries_are_freed_once_enough_traces_follow(self, stores):
+        first, second = stores
+        queue = DeferredReleaseQueue(*stores, max_served=2)
+        for trace_id in (1, 2, 3):
+            first[trace_id] = f"in-{trace_id}"
+            second[trace_id] = f"out-{trace_id}"
+
+        for trace_id in (1, 2, 3):
+            queue.queue_release(trace_id)
+
+        assert 1 not in first and 1 not in second, "the oldest read is freed"
+        assert 2 in first and 3 in first, "the two most recent are kept"
+
+    def test_every_store_is_freed(self, stores):
+        """A store left out of the release loop grows on its own."""
+        first, second = stores
+        queue = DeferredReleaseQueue(*stores, max_served=1)
+        for trace_id in (1, 2):
+            first[trace_id] = "in"
+            second[trace_id] = "out"
+
+        queue.queue_release(1)
+        queue.queue_release(2)
+
+        assert 1 not in first
+        assert 1 not in second
+
+    def test_re_reading_moves_an_entry_back_to_the_newest(self, stores):
+        """A second exporter reading a trace should buy it more time, not none.
+
+        Re-inserting a key a dict already holds leaves its position alone, so
+        without the explicit removal first, the re-read counts for nothing and
+        the trace is freed on the same schedule as if it had been read once.
+        """
+        first, _second = stores
+        queue = DeferredReleaseQueue(*stores, max_served=2)
+        for trace_id in (1, 2, 3):
+            first[trace_id] = f"content-{trace_id}"
+
+        queue.queue_release(1)
+        queue.queue_release(2)
+        queue.queue_release(1)  # trace 1 read again, so it is the newest now
+        queue.queue_release(3)
+
+        assert first.get(1) == "content-1", "the re-read trace should have survived"
+        assert 2 not in first, "trace 2 was the oldest read, so it goes"
+
+    def test_a_trace_with_nothing_recorded_takes_no_slot(self, stores):
+        """Otherwise content-free traces evict the ones carrying content."""
+        first, _second = stores
+        queue = DeferredReleaseQueue(*stores, max_served=1)
+        first[1] = "content"
+        queue.queue_release(1)
+
+        for empty in range(2, 20):
+            queue.queue_release(empty)
+
+        assert first[1] == "content"
+
+
+class TestClear:
+    def test_empties_the_queue_and_the_stores(self, stores):
+        first, second = stores
+        queue = DeferredReleaseQueue(*stores, max_served=8)
+        first[1] = "in"
+        second[1] = "out"
+        queue.queue_release(1)
+
+        queue.clear()
+
+        assert first == {} and second == {}
+        # Nothing is still queued, so a later trace is not freed early.
+        first[2] = "in"
+        queue.queue_release(2)
+        assert first[2] == "in"


### PR DESCRIPTION
## Purpose

Base of a small stack. #2713 (MAF) and #2715 (Google ADK) each fix the same bug: the per-trace conversation content was popped as the run root was stamped, so with more than one wrapped exporter the first to reach the root took the content and the rest stamped a root span with nothing on it.

Both fixes need the same release policy, and as written each grew its own copy of it: the queue, the bound, the empty-read guard, and the docstrings, differing only in which stores they own. That duplication is not hypothetical harm. The two had already drifted apart once during review, with the empty-read guard landing in one and not the other, so this puts the policy in one place before either lands.

## What Changed

`DeferredReleaseQueue` in `sdk/src/rhesis/sdk/telemetry/integrations/genai.py`, alongside the rest of the framework-neutral GenAI bridge.

Two design points worth a reviewer's attention:

- **It holds the stores by reference and mutates them in place**, so an owner must not rebind them after construction. Both owners assign their dicts once in `__init__` and only ever mutate, so this holds today; it is stated in the class docstring.
- **It takes no lock of its own.** Every method expects the owner's lock to be held. That is what keeps a read of the stores and the release that follows it atomic together; a second lock inside the queue would let the two interleave. Each docstring says "Caller holds the lock."

`has_entries` takes every store the owner keeps. One left out is invisible to the queue, so its entries never get freed, which is the leak the class exists to prevent. That is called out in the docstring because it is the one way to use this wrongly and have every test still pass.

## Additional Context

- Stacked: #2713 and #2715 are both retargeted onto this branch and each swaps its private copy for this class. Neither depends on the other, so once this merges they can go in either order.
- Adds no behaviour on its own. It is the policy both consumers then adopt, so this PR alone is a new class plus its tests.

## Testing

8 unit tests, and `819 passed` across `tests/sdk/telemetry`. Ruff check and format clean.

Mutation-tested, each caught by the test written for it:

| Mutation | Caught by |
|---|---|
| Drop the empty-read guard | `test_a_trace_with_nothing_recorded_takes_no_slot` |
| Do not move a re-read entry back to newest | `test_re_reading_moves_an_entry_back_to_the_newest` |
| `has_entries` requires every store rather than any | `test_reports_content_in_any_store` |
| Free only the first store | `test_every_store_is_freed` |
| Never evict | `test_entries_are_freed_once_enough_traces_follow` |

Worth noting on the second row: my first version of that test passed under the mutation, because re-inserting a key a dict already holds leaves its position alone, so reading a trace three times in a row proves nothing. The test now reads trace 1, then 2, then 1 again, then 3, and asserts that 2 was freed and 1 survived.
