### PR TITLE
feat: configurable endpoint timeout_seconds

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/crud/endpoint.py
@@ -66,11 +66,29 @@ def get_endpoints(
     )
 
 
+def _merge_timeout_into_metadata(
+    db_endpoint: models.Endpoint,
+    timeout_seconds: Optional[int],
+) -> None:
+    """Merge timeout_seconds into endpoint_metadata without overwriting other keys."""
+    if timeout_seconds is None:
+        return
+    meta = dict(db_endpoint.endpoint_metadata or {})
+    meta["timeout_seconds"] = timeout_seconds
+    db_endpoint.endpoint_metadata = meta
+
+
 def create_endpoint(
     db: Session, endpoint: schemas.EndpointCreate, organization_id: str, user_id: str
 ) -> models.Endpoint:
     """Create endpoint."""
-    return create_item(db, models.Endpoint, endpoint, organization_id, user_id)
+    timeout_seconds = endpoint.timeout_seconds
+    db_endpoint = create_item(db, models.Endpoint, endpoint, organization_id, user_id)
+    if timeout_seconds is not None:
+        _merge_timeout_into_metadata(db_endpoint, timeout_seconds)
+        db.flush()
+        db.refresh(db_endpoint)
+    return db_endpoint
 
 
 def update_endpoint(
@@ -81,7 +99,13 @@ def update_endpoint(
     user_id: str,
 ) -> Optional[models.Endpoint]:
     """Update endpoint."""
-    return update_item(db, models.Endpoint, endpoint_id, endpoint, organization_id, user_id)
+    timeout_seconds = endpoint.timeout_seconds
+    db_endpoint = update_item(db, models.Endpoint, endpoint_id, endpoint, organization_id, user_id)
+    if db_endpoint is not None and timeout_seconds is not None:
+        _merge_timeout_into_metadata(db_endpoint, timeout_seconds)
+        db.flush()
+        db.refresh(db_endpoint)
+    return db_endpoint
 
 
 def delete_endpoint(

--- a/apps/backend/src/rhesis/backend/app/crud/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/crud/endpoint.py
@@ -66,15 +66,16 @@ def get_endpoints(
     )
 
 
-def _merge_timeout_into_metadata(
+def _set_metadata_timeout(
     db_endpoint: models.Endpoint,
     timeout_seconds: Optional[int],
 ) -> None:
-    """Merge timeout_seconds into endpoint_metadata without overwriting other keys."""
-    if timeout_seconds is None:
-        return
+    """Set or clear timeout_seconds in endpoint_metadata."""
     meta = dict(db_endpoint.endpoint_metadata or {})
-    meta["timeout_seconds"] = timeout_seconds
+    if timeout_seconds is not None:
+        meta["timeout_seconds"] = timeout_seconds
+    else:
+        meta.pop("timeout_seconds", None)
     db_endpoint.endpoint_metadata = meta
 
 
@@ -85,7 +86,7 @@ def create_endpoint(
     timeout_seconds = endpoint.timeout_seconds
     db_endpoint = create_item(db, models.Endpoint, endpoint, organization_id, user_id)
     if timeout_seconds is not None:
-        _merge_timeout_into_metadata(db_endpoint, timeout_seconds)
+        _set_metadata_timeout(db_endpoint, timeout_seconds)
         db.flush()
         db.refresh(db_endpoint)
     return db_endpoint
@@ -99,10 +100,10 @@ def update_endpoint(
     user_id: str,
 ) -> Optional[models.Endpoint]:
     """Update endpoint."""
-    timeout_seconds = endpoint.timeout_seconds
+    timeout_was_set = "timeout_seconds" in endpoint.model_fields_set
     db_endpoint = update_item(db, models.Endpoint, endpoint_id, endpoint, organization_id, user_id)
-    if db_endpoint is not None and timeout_seconds is not None:
-        _merge_timeout_into_metadata(db_endpoint, timeout_seconds)
+    if db_endpoint is not None and timeout_was_set:
+        _set_metadata_timeout(db_endpoint, endpoint.timeout_seconds)
         db.flush()
         db.refresh(db_endpoint)
     return db_endpoint

--- a/apps/backend/src/rhesis/backend/app/models/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/models/endpoint.py
@@ -81,3 +81,12 @@ class Endpoint(Base, ActivityTrackableMixin, TagsMixin):
     @property
     def has_auth_token(self) -> bool:
         return bool(self.auth_token)
+
+    @property
+    def timeout_seconds(self) -> int | None:
+        """Invocation timeout from endpoint_metadata, or None for system default."""
+        if self.endpoint_metadata and isinstance(self.endpoint_metadata, dict):
+            val = self.endpoint_metadata.get("timeout_seconds")
+            if val is not None:
+                return int(val)
+        return None

--- a/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
@@ -281,21 +281,21 @@ class Endpoint(Base, ServerIdentity):
     @model_validator(mode="before")
     @classmethod
     def _extract_timeout_from_metadata(cls, data):
-        """Pull timeout_seconds out of endpoint_metadata when the ORM model is serialised."""
-        if isinstance(data, dict):
-            meta = data.get("endpoint_metadata")
-        else:
-            meta = getattr(data, "endpoint_metadata", None)
+        """Pull timeout_seconds out of endpoint_metadata for dict inputs.
+
+        ORM objects expose timeout_seconds via a @property, so Pydantic's
+        from_attributes picks it up during field validation — no mutation needed.
+        """
+        if not isinstance(data, dict):
+            return data
+        meta = data.get("endpoint_metadata")
         timeout = None
         if isinstance(meta, dict) and "timeout_seconds" in meta:
             timeout = meta["timeout_seconds"]
         elif isinstance(meta, EndpointMetadata) and meta.timeout_seconds is not None:
             timeout = meta.timeout_seconds
         if timeout is not None:
-            if isinstance(data, dict):
-                data.setdefault("timeout_seconds", timeout)
-            elif not getattr(data, "timeout_seconds", None):
-                data.timeout_seconds = timeout
+            data.setdefault("timeout_seconds", timeout)
         return data
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
@@ -1,7 +1,14 @@
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import UUID4, BaseModel, field_validator, model_validator
+from pydantic import (
+    UUID4,
+    BaseModel,
+    ConfigDict,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 
 from rhesis.backend.app.models.enums import (
     EndpointAuthType,
@@ -14,8 +21,73 @@ from rhesis.backend.app.schemas.base import Base, ServerIdentity
 from rhesis.backend.app.schemas.references import ProjectReference, StatusReference
 from rhesis.backend.app.schemas.user import UserReference
 
+# --- Endpoint metadata sub-models ---
+# Each allows extra keys for forward-compatibility and strips None on serialization
+# so the JSON column stays clean.
 
-# Endpoint schemas
+
+class _MetadataBase(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    @model_serializer(mode="wrap")
+    def _exclude_none(self, handler):
+        return {k: v for k, v in handler(self).items() if v is not None}
+
+
+class SdkConnectionMetadata(_MetadataBase):
+    project_id: Optional[str] = None
+    environment: Optional[str] = None
+    function_name: Optional[str] = None
+
+
+class FunctionSchemaMetadata(_MetadataBase):
+    description: Optional[str] = None
+    parameters: Optional[Dict[str, Any]] = None
+    return_type: Optional[str] = None
+
+
+class MappingInfoMetadata(_MetadataBase):
+    source: Optional[str] = None
+    confidence: Optional[float] = None
+    reasoning: Optional[str] = None
+    generated_at: Optional[str] = None
+
+    @field_validator("confidence")
+    @classmethod
+    def _validate_confidence(cls, v: float | None) -> float | None:
+        if v is not None and (v < 0.0 or v > 1.0):
+            raise ValueError("confidence must be between 0.0 and 1.0")
+        return v
+
+
+class ValidationErrorMetadata(_MetadataBase):
+    error: Optional[str] = None
+    timestamp: Optional[str] = None
+    exception_type: Optional[str] = None
+    reason: Optional[str] = None
+
+
+class EndpointMetadata(_MetadataBase):
+    sdk_connection: Optional[SdkConnectionMetadata] = None
+    function_schema: Optional[FunctionSchemaMetadata] = None
+    mapping_info: Optional[MappingInfoMetadata] = None
+    validation_error: Optional[ValidationErrorMetadata] = None
+    last_error: Optional[str] = None
+    created_at: Optional[str] = None
+    last_registered: Optional[str] = None
+    timeout_seconds: Optional[int] = None
+
+    @field_validator("timeout_seconds")
+    @classmethod
+    def _validate_timeout_seconds(cls, v: int | None) -> int | None:
+        if v is not None and (v < 1 or v > 3600):
+            raise ValueError("timeout_seconds must be between 1 and 3600")
+        return v
+
+
+# --- Endpoint schemas ---
+
+
 class EndpointBase(Base):
     name: str
     description: Optional[str] = None
@@ -29,7 +101,7 @@ class EndpointBase(Base):
     openapi_spec_url: Optional[str] = None
     openapi_spec: Optional[Dict[str, Any]] = None
     llm_suggestions: Optional[Dict[str, Any]] = None
-    endpoint_metadata: Optional[Dict[str, Any]] = None
+    endpoint_metadata: Optional[EndpointMetadata] = None
 
     # Request Structure
     method: Optional[str] = None
@@ -52,8 +124,7 @@ class EndpointBase(Base):
     # Tracing control
     disable_tracing: bool = False
 
-    # Invocation timeout in seconds. Stored in endpoint_metadata; exposed here
-    # as a convenience field so callers don't have to manage the JSON blob.
+    # Convenience alias — also validated inside EndpointMetadata.
     timeout_seconds: Optional[int] = None
 
     @field_validator("timeout_seconds")
@@ -168,7 +239,7 @@ class Endpoint(Base, ServerIdentity):
     openapi_spec_url: Optional[str] = None
     openapi_spec: Optional[Dict[str, Any]] = None
     llm_suggestions: Optional[Dict[str, Any]] = None
-    endpoint_metadata: Optional[Dict[str, Any]] = None
+    endpoint_metadata: Optional[EndpointMetadata] = None
 
     # Request Structure
     method: Optional[str] = None
@@ -215,11 +286,16 @@ class Endpoint(Base, ServerIdentity):
             meta = data.get("endpoint_metadata")
         else:
             meta = getattr(data, "endpoint_metadata", None)
+        timeout = None
         if isinstance(meta, dict) and "timeout_seconds" in meta:
+            timeout = meta["timeout_seconds"]
+        elif isinstance(meta, EndpointMetadata) and meta.timeout_seconds is not None:
+            timeout = meta.timeout_seconds
+        if timeout is not None:
             if isinstance(data, dict):
-                data.setdefault("timeout_seconds", meta["timeout_seconds"])
+                data.setdefault("timeout_seconds", timeout)
             elif not getattr(data, "timeout_seconds", None):
-                data.timeout_seconds = meta["timeout_seconds"]
+                data.timeout_seconds = timeout
         return data
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import UUID4, BaseModel, field_validator
+from pydantic import UUID4, BaseModel, field_validator, model_validator
 
 from rhesis.backend.app.models.enums import (
     EndpointAuthType,
@@ -51,6 +51,17 @@ class EndpointBase(Base):
 
     # Tracing control
     disable_tracing: bool = False
+
+    # Invocation timeout in seconds. Stored in endpoint_metadata; exposed here
+    # as a convenience field so callers don't have to manage the JSON blob.
+    timeout_seconds: Optional[int] = None
+
+    @field_validator("timeout_seconds")
+    @classmethod
+    def _validate_timeout_seconds(cls, v: int | None) -> int | None:
+        if v is not None and (v < 1 or v > 3600):
+            raise ValueError("timeout_seconds must be between 1 and 3600")
+        return v
 
     auth_type: Optional[EndpointAuthType] = EndpointAuthType.BEARER_TOKEN
     auth_token: Optional[str] = None
@@ -183,6 +194,8 @@ class Endpoint(Base, ServerIdentity):
     # Tracing control
     disable_tracing: bool = False
 
+    timeout_seconds: Optional[int] = None
+
     auth_type: Optional[EndpointAuthType] = None
     has_auth_token: bool = False
     # Sensitive fields excluded from response:
@@ -193,6 +206,21 @@ class Endpoint(Base, ServerIdentity):
     scopes: Optional[List[str]] = None
     audience: Optional[str] = None
     extra_payload: Optional[Dict[str, Any]] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _extract_timeout_from_metadata(cls, data):
+        """Pull timeout_seconds out of endpoint_metadata when the ORM model is serialised."""
+        if isinstance(data, dict):
+            meta = data.get("endpoint_metadata")
+        else:
+            meta = getattr(data, "endpoint_metadata", None)
+        if isinstance(meta, dict) and "timeout_seconds" in meta:
+            if isinstance(data, dict):
+                data.setdefault("timeout_seconds", meta["timeout_seconds"])
+            elif not getattr(data, "timeout_seconds", None):
+                data.timeout_seconds = meta["timeout_seconds"]
+        return data
 
 
 # The detailed model with expanded relations

--- a/apps/backend/src/rhesis/backend/app/services/invokers/rest_invoker.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/rest_invoker.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 # worker thread (i.e. the same batch), avoiding the TCP handshake overhead of
 # creating a fresh client per invocation.
 _tls = threading.local()
-_HTTP_TIMEOUT = 30.0
+_DEFAULT_HTTP_TIMEOUT = 30.0
 
 # The event loop holds only a weak reference to a running task. The close below is
 # fire-and-forget, so without a reference here it can be collected before the socket
@@ -56,7 +56,7 @@ def _get_http_client() -> httpx.AsyncClient:
                 current_loop.create_task(client.aclose())
             except Exception:
                 pass
-        client = httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
+        client = httpx.AsyncClient(timeout=_DEFAULT_HTTP_TIMEOUT)
         _tls.http_client = client
         _tls.http_client_loop = current_loop
     return client
@@ -132,7 +132,10 @@ class RestEndpointInvoker(BaseEndpointInvoker):
             )
 
             # Make async request and handle response
-            response = await self._async_request(method, url, headers, request_body)
+            ep_timeout = float(endpoint.timeout_seconds) if endpoint.timeout_seconds else None
+            response = await self._async_request(
+                method, url, headers, request_body, timeout=ep_timeout
+            )
 
             # Log response summary
             logger.debug(f"Response received: {response.status_code}")
@@ -412,6 +415,8 @@ class RestEndpointInvoker(BaseEndpointInvoker):
         url: str,
         headers: Dict[str, str],
         body: Any,
+        *,
+        timeout: float | None = None,
     ) -> httpx.Response:
         """Make an async HTTP request. Retried on transient failures.
 
@@ -419,13 +424,16 @@ class RestEndpointInvoker(BaseEndpointInvoker):
         across all tests in the same worker-thread batch.
         """
         client = _get_http_client()
+        kw: Dict[str, Any] = {"headers": headers}
+        if timeout is not None:
+            kw["timeout"] = timeout
         if method == "GET":
-            return await client.get(url, headers=headers, params=body)
+            return await client.get(url, params=body, **kw)
         elif method == "POST":
-            return await client.post(url, headers=headers, json=body)
+            return await client.post(url, json=body, **kw)
         elif method == "PUT":
-            return await client.put(url, headers=headers, json=body)
+            return await client.put(url, json=body, **kw)
         elif method == "DELETE":
-            return await client.delete(url, headers=headers, json=body)
+            return await client.delete(url, json=body, **kw)
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")

--- a/apps/backend/src/rhesis/backend/app/services/invokers/sdk_invoker.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/sdk_invoker.py
@@ -179,6 +179,7 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
         function_name: str,
         function_kwargs: Dict[str, Any],
         execute_extras: Dict[str, Any] | None = None,
+        timeout: float = SDK_FUNCTION_TIMEOUT,
     ) -> Union[Dict[str, Any], ErrorResponse]:
         """
         Execute SDK function via RPC (Redis pub/sub).
@@ -189,6 +190,7 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
             test_run_id: Unique test run ID
             function_name: Function to invoke
             function_kwargs: Function arguments
+            timeout: Execution timeout in seconds
 
         Returns:
             Result dictionary from SDK, or ErrorResponse if RPC unavailable or not connected
@@ -227,7 +229,7 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
             test_run_id=test_run_id,
             function_name=function_name,
             inputs=function_kwargs,
-            timeout=SDK_FUNCTION_TIMEOUT,
+            timeout=timeout,
             execute_extras=execute_extras,
         )
 
@@ -239,6 +241,7 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
         function_name: str,
         function_kwargs: Dict[str, Any],
         execute_extras: Dict[str, Any] | None = None,
+        timeout: float = SDK_FUNCTION_TIMEOUT,
     ) -> Dict[str, Any]:
         """
         Execute SDK function via direct WebSocket connection.
@@ -249,6 +252,7 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
             test_run_id: Unique test run ID
             function_name: Function to invoke
             function_kwargs: Function arguments
+            timeout: Execution timeout in seconds
 
         Returns:
             Result dictionary from SDK
@@ -261,7 +265,7 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
             test_run_id=test_run_id,
             function_name=function_name,
             inputs=function_kwargs,
-            timeout=SDK_FUNCTION_TIMEOUT,
+            timeout=timeout,
             execute_extras=execute_extras,
         )
 
@@ -301,7 +305,7 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
             return self._create_error_response(
                 error_type="sdk_timeout",
                 output_message="SDK function execution timed out",
-                message=f"Function did not respond within {SDK_FUNCTION_TIMEOUT} seconds",
+                message="Function did not respond within the configured timeout",
                 request_details=self._safe_request_details(locals(), "SDK"),
             )
 
@@ -605,6 +609,8 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
             # Execute via RPC or direct WebSocket
             invocation_id = f"invoke_{uuid.uuid4().hex[:12]}"
             execute_extras = self._connector_parameter_extras()
+            ep_ts = endpoint.timeout_seconds
+            timeout = float(ep_ts) if ep_ts else SDK_FUNCTION_TIMEOUT
 
             if use_rpc:
                 result = await self._execute_via_rpc(
@@ -614,6 +620,7 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
                     function_name,
                     function_kwargs,
                     execute_extras=execute_extras,
+                    timeout=timeout,
                 )
             else:
                 result = await self._execute_via_websocket(
@@ -623,6 +630,7 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
                     function_name,
                     function_kwargs,
                     execute_extras=execute_extras,
+                    timeout=timeout,
                 )
 
             # Check for execution errors
@@ -662,11 +670,13 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
             # Re-raise HTTPExceptions (configuration errors)
             raise
         except asyncio.TimeoutError:
-            logger.error(f"Timeout waiting for SDK function after {SDK_FUNCTION_TIMEOUT}s")
+            ep_ts = endpoint.timeout_seconds
+            effective_timeout = float(ep_ts) if ep_ts else SDK_FUNCTION_TIMEOUT
+            logger.error(f"Timeout waiting for SDK function after {effective_timeout}s")
             return self._create_error_response(
                 error_type="sdk_timeout",
                 output_message="SDK function execution timed out",
-                message=f"Function did not respond within {SDK_FUNCTION_TIMEOUT} seconds",
+                message=f"Function did not respond within {effective_timeout} seconds",
                 request_details=self._safe_request_details(locals(), "SDK"),
             )
         except Exception as e:

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointConnectionTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointConnectionTab.tsx
@@ -6,10 +6,12 @@ import { Capability } from '@/constants/capabilities';
 import {
   Box,
   FormControl,
+  FormHelperText,
   Grid,
   InputLabel,
   MenuItem,
   Select,
+  TextField,
 } from '@mui/material';
 import { SECTION_GRID } from '@/styles/theme-constants';
 import EditableSection from '@/components/common/EditableSection';
@@ -225,6 +227,66 @@ export default function EndpointConnectionTab() {
             }
             editorWrapperStyle={editorWrapperStyle}
           />
+        )}
+      </EditableSection>
+
+      <EditableSection<{ timeout_seconds: string }>
+        editable={canEditEndpoint}
+        title="Timeout"
+        initialValue={{
+          timeout_seconds: endpoint.timeout_seconds
+            ? String(endpoint.timeout_seconds)
+            : '',
+        }}
+        onSave={async draft => {
+          const parsed = parseInt(draft.timeout_seconds, 10);
+          await saveFields({
+            timeout_seconds: !isNaN(parsed) && parsed > 0 ? parsed : null,
+          });
+        }}
+      >
+        {({ draft, setDraft, isEditing }) => (
+          <Grid
+            container
+            columnSpacing={SECTION_GRID.columnSpacing}
+            rowSpacing={SECTION_GRID.rowSpacing}
+          >
+            <Grid size={{ xs: 12, md: 6 }}>
+              {isEditing ? (
+                <Box>
+                  <TextField
+                    fullWidth
+                    label="Timeout (seconds)"
+                    type="number"
+                    value={draft.timeout_seconds}
+                    onChange={e =>
+                      setDraft(prev => ({
+                        ...prev,
+                        timeout_seconds: e.target.value,
+                      }))
+                    }
+                    placeholder="30"
+                    slotProps={{
+                      input: { inputProps: { min: 1 } },
+                    }}
+                  />
+                  <FormHelperText>
+                    Leave empty for the system default (30s for REST, 120s for
+                    SDK endpoints)
+                  </FormHelperText>
+                </Box>
+              ) : (
+                <ViewField
+                  label="Timeout"
+                  value={
+                    endpoint.timeout_seconds
+                      ? `${endpoint.timeout_seconds}s`
+                      : 'System default'
+                  }
+                />
+              )}
+            </Grid>
+          </Grid>
         )}
       </EditableSection>
     </Box>

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
@@ -52,6 +52,7 @@ export interface FormData {
   auth_token: string;
   request_headers: string;
   disable_tracing: boolean;
+  timeout_seconds: string;
 }
 
 const DEFAULT_REQ_BODY =
@@ -154,6 +155,7 @@ const EndpointForm = forwardRef<EndpointFormHandle, EndpointFormProps>(
       auth_token: '',
       request_headers: '{}',
       disable_tracing: false,
+      timeout_seconds: '',
     });
 
     // Set project_id from URL parameter, then fall back to active project cookie
@@ -368,6 +370,10 @@ const EndpointForm = forwardRef<EndpointFormHandle, EndpointFormProps>(
         if (formData.auth_token) {
           (endpointData as Record<string, unknown>).auth_token =
             formData.auth_token;
+        }
+        const parsedTimeout = parseInt(formData.timeout_seconds, 10);
+        if (!isNaN(parsedTimeout) && parsedTimeout > 0) {
+          endpointData.timeout_seconds = parsedTimeout;
         }
 
         const result = await createEndpoint(

--- a/apps/frontend/src/app/(protected)/endpoints/components/TabConnection.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/TabConnection.tsx
@@ -87,6 +87,26 @@ export default function TabConnection({
             isEditing
           />
         </Box>
+
+        <FormSectionDivider
+          headline="Timeout"
+          descriptiveText="How long to wait for a response before timing out."
+        />
+
+        <Box sx={{ mt: 2 }}>
+          <TextField
+            fullWidth
+            label="Timeout (seconds)"
+            type="number"
+            value={formData.timeout_seconds}
+            onChange={e => onChange('timeout_seconds', e.target.value)}
+            placeholder="30"
+            helperText="Leave empty for the system default (30s for REST, 120s for SDK endpoints)"
+            slotProps={{
+              input: { inputProps: { min: 1 } },
+            }}
+          />
+        </Box>
       </SectionCard>
     </Box>
   );

--- a/apps/frontend/src/app/(protected)/endpoints/components/__tests__/TabBasics.test.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/__tests__/TabBasics.test.tsx
@@ -20,6 +20,7 @@ const defaultFormData: FormData = {
   auth_token: '',
   request_headers: '{}',
   disable_tracing: false,
+  timeout_seconds: '',
 };
 
 const projects = [

--- a/apps/frontend/src/app/(protected)/endpoints/components/__tests__/TabHeaders.test.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/__tests__/TabHeaders.test.tsx
@@ -55,6 +55,7 @@ const defaultFormData: FormData = {
   auth_token: '',
   request_headers: '{}',
   disable_tracing: false,
+  timeout_seconds: '',
 };
 
 describe('TabConnection — auth token fields', () => {

--- a/apps/frontend/src/utils/api-client/interfaces/endpoint.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/endpoint.ts
@@ -25,6 +25,7 @@ export interface EndpointMetadata {
   last_error?: string;
   created_at?: string;
   last_registered?: string;
+  timeout_seconds?: number | null;
   [key: string]: unknown;
 }
 

--- a/apps/frontend/src/utils/api-client/interfaces/endpoint.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/endpoint.ts
@@ -53,6 +53,9 @@ export interface Endpoint {
   // Tracing control
   disable_tracing?: boolean;
 
+  // Invocation timeout in seconds (null/undefined = system default per connection type)
+  timeout_seconds?: number | null;
+
   project_id?: string;
   organization_id?: string;
 

--- a/sdk/src/rhesis/sdk/entities/endpoint.py
+++ b/sdk/src/rhesis/sdk/entities/endpoint.py
@@ -80,6 +80,9 @@ class Endpoint(BaseEntity):
     # Authentication - for the target API (not Rhesis API)
     auth_token: Optional[str] = None
 
+    # Invocation timeout in seconds. None means use the system default.
+    timeout_seconds: Optional[int] = None
+
     @handle_http_errors
     def invoke(
         self,

--- a/tests/backend/crud/test_endpoint_timeout_merge.py
+++ b/tests/backend/crud/test_endpoint_timeout_merge.py
@@ -1,21 +1,21 @@
-"""Tests for _merge_timeout_into_metadata in endpoint CRUD."""
+"""Tests for _set_metadata_timeout in endpoint CRUD."""
 
 from unittest.mock import Mock
 
-from rhesis.backend.app.crud.endpoint import _merge_timeout_into_metadata
+from rhesis.backend.app.crud.endpoint import _set_metadata_timeout
 
 
-class TestMergeTimeoutIntoMetadata:
+class TestSetMetadataTimeout:
     def test_sets_timeout_in_empty_metadata(self):
         ep = Mock()
         ep.endpoint_metadata = None
-        _merge_timeout_into_metadata(ep, 60)
+        _set_metadata_timeout(ep, 60)
         assert ep.endpoint_metadata == {"timeout_seconds": 60}
 
     def test_merges_without_overwriting_other_keys(self):
         ep = Mock()
         ep.endpoint_metadata = {"sdk_connection": {"function_name": "fn"}}
-        _merge_timeout_into_metadata(ep, 120)
+        _set_metadata_timeout(ep, 120)
         assert ep.endpoint_metadata == {
             "sdk_connection": {"function_name": "fn"},
             "timeout_seconds": 120,
@@ -24,11 +24,18 @@ class TestMergeTimeoutIntoMetadata:
     def test_overwrites_existing_timeout(self):
         ep = Mock()
         ep.endpoint_metadata = {"timeout_seconds": 30}
-        _merge_timeout_into_metadata(ep, 90)
+        _set_metadata_timeout(ep, 90)
         assert ep.endpoint_metadata == {"timeout_seconds": 90}
 
-    def test_none_timeout_is_noop(self):
+    def test_none_clears_timeout(self):
         ep = Mock()
-        ep.endpoint_metadata = {"timeout_seconds": 30}
-        _merge_timeout_into_metadata(ep, None)
-        assert ep.endpoint_metadata == {"timeout_seconds": 30}
+        ep.endpoint_metadata = {"timeout_seconds": 30, "sdk_connection": {"function_name": "fn"}}
+        _set_metadata_timeout(ep, None)
+        assert ep.endpoint_metadata == {"sdk_connection": {"function_name": "fn"}}
+        assert "timeout_seconds" not in ep.endpoint_metadata
+
+    def test_none_on_empty_metadata_is_noop(self):
+        ep = Mock()
+        ep.endpoint_metadata = None
+        _set_metadata_timeout(ep, None)
+        assert ep.endpoint_metadata == {}

--- a/tests/backend/crud/test_endpoint_timeout_merge.py
+++ b/tests/backend/crud/test_endpoint_timeout_merge.py
@@ -1,0 +1,34 @@
+"""Tests for _merge_timeout_into_metadata in endpoint CRUD."""
+
+from unittest.mock import Mock
+
+from rhesis.backend.app.crud.endpoint import _merge_timeout_into_metadata
+
+
+class TestMergeTimeoutIntoMetadata:
+    def test_sets_timeout_in_empty_metadata(self):
+        ep = Mock()
+        ep.endpoint_metadata = None
+        _merge_timeout_into_metadata(ep, 60)
+        assert ep.endpoint_metadata == {"timeout_seconds": 60}
+
+    def test_merges_without_overwriting_other_keys(self):
+        ep = Mock()
+        ep.endpoint_metadata = {"sdk_connection": {"function_name": "fn"}}
+        _merge_timeout_into_metadata(ep, 120)
+        assert ep.endpoint_metadata == {
+            "sdk_connection": {"function_name": "fn"},
+            "timeout_seconds": 120,
+        }
+
+    def test_overwrites_existing_timeout(self):
+        ep = Mock()
+        ep.endpoint_metadata = {"timeout_seconds": 30}
+        _merge_timeout_into_metadata(ep, 90)
+        assert ep.endpoint_metadata == {"timeout_seconds": 90}
+
+    def test_none_timeout_is_noop(self):
+        ep = Mock()
+        ep.endpoint_metadata = {"timeout_seconds": 30}
+        _merge_timeout_into_metadata(ep, None)
+        assert ep.endpoint_metadata == {"timeout_seconds": 30}

--- a/tests/backend/schemas/test_endpoint_timeout_validation.py
+++ b/tests/backend/schemas/test_endpoint_timeout_validation.py
@@ -1,0 +1,93 @@
+"""Tests for timeout_seconds validation on endpoint schemas."""
+
+import pytest
+from pydantic import ValidationError
+
+from rhesis.backend.app.schemas.endpoint import Endpoint, EndpointCreate, EndpointUpdate
+
+
+class TestTimeoutSecondsValidation:
+    """Validate timeout_seconds bounds on create/update schemas."""
+
+    def test_none_is_accepted(self):
+        data = EndpointCreate(
+            name="ep", connection_type="REST", timeout_seconds=None
+        )
+        assert data.timeout_seconds is None
+
+    def test_valid_value_accepted(self):
+        data = EndpointCreate(
+            name="ep", connection_type="REST", timeout_seconds=60
+        )
+        assert data.timeout_seconds == 60
+
+    def test_boundary_min(self):
+        data = EndpointCreate(
+            name="ep", connection_type="REST", timeout_seconds=1
+        )
+        assert data.timeout_seconds == 1
+
+    def test_boundary_max(self):
+        data = EndpointCreate(
+            name="ep", connection_type="REST", timeout_seconds=3600
+        )
+        assert data.timeout_seconds == 3600
+
+    def test_zero_rejected(self):
+        with pytest.raises(ValidationError, match="timeout_seconds must be between 1 and 3600"):
+            EndpointCreate(name="ep", connection_type="REST", timeout_seconds=0)
+
+    def test_negative_rejected(self):
+        with pytest.raises(ValidationError, match="timeout_seconds must be between 1 and 3600"):
+            EndpointCreate(name="ep", connection_type="REST", timeout_seconds=-5)
+
+    def test_over_max_rejected(self):
+        with pytest.raises(ValidationError, match="timeout_seconds must be between 1 and 3600"):
+            EndpointCreate(name="ep", connection_type="REST", timeout_seconds=3601)
+
+    def test_update_schema_validates_too(self):
+        with pytest.raises(ValidationError, match="timeout_seconds must be between 1 and 3600"):
+            EndpointUpdate(timeout_seconds=0)
+
+    def test_update_schema_accepts_valid(self):
+        data = EndpointUpdate(timeout_seconds=120)
+        assert data.timeout_seconds == 120
+
+
+class TestResponseSchemaExtractsTimeout:
+    """Validate model_validator on the response schema pulls timeout from metadata."""
+
+    _VALID_UUID = "a0000000-0000-4000-8000-000000000001"
+
+    def test_extracts_timeout_from_metadata_dict(self):
+        ep = Endpoint.model_validate(
+            {
+                "id": self._VALID_UUID,
+                "name": "ep",
+                "connection_type": "REST",
+                "endpoint_metadata": {"timeout_seconds": 45},
+            }
+        )
+        assert ep.timeout_seconds == 45
+
+    def test_explicit_field_wins_over_metadata(self):
+        ep = Endpoint.model_validate(
+            {
+                "id": self._VALID_UUID,
+                "name": "ep",
+                "connection_type": "REST",
+                "timeout_seconds": 90,
+                "endpoint_metadata": {"timeout_seconds": 45},
+            }
+        )
+        assert ep.timeout_seconds == 90
+
+    def test_no_metadata_returns_none(self):
+        ep = Endpoint.model_validate(
+            {
+                "id": self._VALID_UUID,
+                "name": "ep",
+                "connection_type": "REST",
+            }
+        )
+        assert ep.timeout_seconds is None

--- a/tests/backend/schemas/test_endpoint_timeout_validation.py
+++ b/tests/backend/schemas/test_endpoint_timeout_validation.py
@@ -3,7 +3,12 @@
 import pytest
 from pydantic import ValidationError
 
-from rhesis.backend.app.schemas.endpoint import Endpoint, EndpointCreate, EndpointUpdate
+from rhesis.backend.app.schemas.endpoint import (
+    Endpoint,
+    EndpointCreate,
+    EndpointMetadata,
+    EndpointUpdate,
+)
 
 
 class TestTimeoutSecondsValidation:
@@ -91,3 +96,77 @@ class TestResponseSchemaExtractsTimeout:
             }
         )
         assert ep.timeout_seconds is None
+
+
+class TestEndpointMetadataValidation:
+    """Validate EndpointMetadata model and its sub-models."""
+
+    def test_timeout_inside_metadata_validated(self):
+        """Invalid timeout_seconds inside endpoint_metadata is rejected."""
+        with pytest.raises(ValidationError, match="timeout_seconds must be between 1 and 3600"):
+            EndpointCreate(
+                name="ep",
+                connection_type="REST",
+                endpoint_metadata={"timeout_seconds": 5000},
+            )
+
+    def test_valid_timeout_inside_metadata(self):
+        ep = EndpointCreate(
+            name="ep",
+            connection_type="REST",
+            endpoint_metadata={"timeout_seconds": 120},
+        )
+        assert ep.endpoint_metadata.timeout_seconds == 120
+
+    def test_confidence_range_validated(self):
+        with pytest.raises(ValidationError, match="confidence must be between 0.0 and 1.0"):
+            EndpointCreate(
+                name="ep",
+                connection_type="REST",
+                endpoint_metadata={"mapping_info": {"confidence": 1.5}},
+            )
+
+    def test_valid_confidence(self):
+        ep = EndpointCreate(
+            name="ep",
+            connection_type="REST",
+            endpoint_metadata={"mapping_info": {"confidence": 0.85, "source": "auto_mapped"}},
+        )
+        assert ep.endpoint_metadata.mapping_info.confidence == 0.85
+
+    def test_extra_keys_preserved(self):
+        ep = EndpointCreate(
+            name="ep",
+            connection_type="REST",
+            endpoint_metadata={"custom_flag": True, "timeout_seconds": 30},
+        )
+        assert ep.endpoint_metadata.timeout_seconds == 30
+        assert ep.endpoint_metadata.model_dump()["custom_flag"] is True
+
+    def test_serialization_strips_none(self):
+        meta = EndpointMetadata(timeout_seconds=60)
+        dumped = meta.model_dump()
+        assert dumped == {"timeout_seconds": 60}
+        assert "sdk_connection" not in dumped
+
+    def test_nested_model_strips_none(self):
+        meta = EndpointMetadata(
+            sdk_connection={"function_name": "my_func"},
+        )
+        dumped = meta.model_dump()
+        assert dumped == {"sdk_connection": {"function_name": "my_func"}}
+        assert "project_id" not in dumped["sdk_connection"]
+
+    def test_full_metadata_round_trip(self):
+        raw = {
+            "sdk_connection": {"function_name": "test", "project_id": "abc"},
+            "function_schema": {"description": "A test func", "parameters": {"x": {"type": "str"}}},
+            "mapping_info": {"source": "auto_mapped", "confidence": 0.9},
+            "timeout_seconds": 60,
+        }
+        meta = EndpointMetadata.model_validate(raw)
+        dumped = meta.model_dump()
+        assert dumped["sdk_connection"]["function_name"] == "test"
+        assert dumped["function_schema"]["parameters"] == {"x": {"type": "str"}}
+        assert dumped["mapping_info"]["confidence"] == 0.9
+        assert dumped["timeout_seconds"] == 60

--- a/tests/backend/services/invokers/test_rest_invoker_timeout.py
+++ b/tests/backend/services/invokers/test_rest_invoker_timeout.py
@@ -1,0 +1,72 @@
+"""Tests for REST invoker timeout override from endpoint.timeout_seconds."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from rhesis.backend.app.models.endpoint import Endpoint
+from rhesis.backend.app.models.enums import EndpointAuthType, EndpointConnectionType
+from rhesis.backend.app.services.invokers.rest_invoker import RestEndpointInvoker
+
+
+def _mock_httpx_response(status_code=200, json_data=None, text="", reason_phrase="OK"):
+    resp = Mock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.reason_phrase = reason_phrase
+    resp.text = text or ""
+    resp.headers = {}
+    if json_data is not None:
+        resp.json.return_value = json_data
+    return resp
+
+
+def _make_endpoint(timeout_seconds_in_metadata=None):
+    meta = {}
+    if timeout_seconds_in_metadata is not None:
+        meta["timeout_seconds"] = timeout_seconds_in_metadata
+    return Endpoint(
+        id="ep-timeout",
+        name="Timeout EP",
+        connection_type=EndpointConnectionType.REST.value,
+        method="POST",
+        url="https://api.example.com/chat",
+        auth_type=EndpointAuthType.BEARER_TOKEN.value,
+        auth_token="tok",
+        request_mapping='{"msg": "{{ input }}"}',
+        response_mapping={"output": "$.answer"},
+        endpoint_metadata=meta or None,
+        project_id="00000000-0000-0000-0000-000000000001",
+    )
+
+
+class TestRestInvokerTimeout:
+    @pytest.mark.asyncio
+    async def test_custom_timeout_forwarded(self):
+        endpoint = _make_endpoint(timeout_seconds_in_metadata=90)
+        invoker = RestEndpointInvoker()
+        mock_resp = _mock_httpx_response(json_data={"answer": "ok"})
+
+        with patch.object(
+            invoker, "_async_request", new_callable=AsyncMock, return_value=mock_resp
+        ) as mock_req:
+            await invoker.invoke(
+                Mock(), endpoint, {"input": "hi"}, test_execution_context=None
+            )
+            _, call_kwargs = mock_req.call_args
+            assert call_kwargs.get("timeout") == 90.0
+
+    @pytest.mark.asyncio
+    async def test_no_timeout_uses_default(self):
+        endpoint = _make_endpoint(timeout_seconds_in_metadata=None)
+        invoker = RestEndpointInvoker()
+        mock_resp = _mock_httpx_response(json_data={"answer": "ok"})
+
+        with patch.object(
+            invoker, "_async_request", new_callable=AsyncMock, return_value=mock_resp
+        ) as mock_req:
+            await invoker.invoke(
+                Mock(), endpoint, {"input": "hi"}, test_execution_context=None
+            )
+            _, call_kwargs = mock_req.call_args
+            assert call_kwargs.get("timeout") is None

--- a/tests/backend/services/invokers/test_sdk_invoker_timeout.py
+++ b/tests/backend/services/invokers/test_sdk_invoker_timeout.py
@@ -1,0 +1,117 @@
+"""Tests for SDK invoker timeout override from endpoint.timeout_seconds."""
+
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import UUID
+
+import pytest
+
+from rhesis.backend.app.models.endpoint import Endpoint
+from rhesis.backend.app.models.enums import EndpointConnectionType
+from rhesis.backend.app.services.invokers.sdk_invoker import (
+    SDK_FUNCTION_TIMEOUT,
+    SdkEndpointInvoker,
+)
+
+TEST_PROJECT_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+def _sdk_endpoint(timeout_seconds_in_metadata=None):
+    meta = {
+        "sdk_connection": {
+            "function_name": "my_func",
+        }
+    }
+    if timeout_seconds_in_metadata is not None:
+        meta["timeout_seconds"] = timeout_seconds_in_metadata
+    return Endpoint(
+        id="ep-sdk-timeout",
+        name="SDK Timeout EP",
+        connection_type=EndpointConnectionType.SDK.value,
+        url="",
+        environment="development",
+        request_mapping={"input": "{{ input }}"},
+        response_mapping={"output": "$.output"},
+        endpoint_metadata=meta,
+        project_id=TEST_PROJECT_ID,
+        organization_id=TEST_PROJECT_ID,
+    )
+
+
+class TestSdkInvokerTimeout:
+    @pytest.mark.asyncio
+    async def test_custom_timeout_passed_to_rpc(self):
+        endpoint = _sdk_endpoint(timeout_seconds_in_metadata=180)
+        invoker = SdkEndpointInvoker()
+
+        rpc_result = {"output": "hello", "status": "ok"}
+
+        with (
+            patch.object(
+                invoker,
+                "_determine_invocation_context",
+                return_value=(True, "WORKER (RPC)"),
+            ),
+            patch.object(
+                invoker,
+                "_execute_via_rpc",
+                new_callable=AsyncMock,
+                return_value=rpc_result,
+            ) as mock_rpc,
+        ):
+            await invoker.invoke(
+                Mock(), endpoint, {"input": "hi"}, test_execution_context=None
+            )
+            call_kwargs = mock_rpc.call_args
+            assert call_kwargs.kwargs.get("timeout") == 180.0
+
+    @pytest.mark.asyncio
+    async def test_no_timeout_uses_sdk_default(self):
+        endpoint = _sdk_endpoint(timeout_seconds_in_metadata=None)
+        invoker = SdkEndpointInvoker()
+
+        rpc_result = {"output": "hello", "status": "ok"}
+
+        with (
+            patch.object(
+                invoker,
+                "_determine_invocation_context",
+                return_value=(True, "WORKER (RPC)"),
+            ),
+            patch.object(
+                invoker,
+                "_execute_via_rpc",
+                new_callable=AsyncMock,
+                return_value=rpc_result,
+            ) as mock_rpc,
+        ):
+            await invoker.invoke(
+                Mock(), endpoint, {"input": "hi"}, test_execution_context=None
+            )
+            call_kwargs = mock_rpc.call_args
+            assert call_kwargs.kwargs.get("timeout") == SDK_FUNCTION_TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_custom_timeout_passed_to_websocket(self):
+        endpoint = _sdk_endpoint(timeout_seconds_in_metadata=60)
+        invoker = SdkEndpointInvoker()
+
+        ws_result = {"output": "world", "status": "ok"}
+
+        with (
+            patch.object(
+                invoker,
+                "_determine_invocation_context",
+                return_value=(False, "BACKEND (direct WebSocket)"),
+            ),
+            patch.object(
+                invoker,
+                "_execute_via_websocket",
+                new_callable=AsyncMock,
+                return_value=ws_result,
+            ) as mock_ws,
+        ):
+            await invoker.invoke(
+                Mock(), endpoint, {"input": "hi"}, test_execution_context=None
+            )
+            call_kwargs = mock_ws.call_args
+            assert call_kwargs.kwargs.get("timeout") == 60.0

--- a/tests/sdk/entities/test_endpoint.py
+++ b/tests/sdk/entities/test_endpoint.py
@@ -309,3 +309,83 @@ class TestEndpointWriteOnlyFields:
         push_call = mock_request.call_args_list[-1]
         request_data = push_call.kwargs.get("json", {})
         assert "auth_token" not in request_data or request_data["auth_token"] is not None
+
+
+class TestEndpointTimeoutSeconds:
+    """Tests for timeout_seconds field on the SDK Endpoint entity."""
+
+    def test_timeout_seconds_defaults_to_none(self):
+        endpoint = Endpoint()
+        assert endpoint.timeout_seconds is None
+
+    def test_timeout_seconds_can_be_set(self):
+        endpoint = Endpoint(name="ep", timeout_seconds=90)
+        assert endpoint.timeout_seconds == 90
+
+    def test_to_dict_includes_timeout_seconds(self):
+        endpoint = Endpoint(name="ep", timeout_seconds=60)
+        data = endpoint.to_dict()
+        assert data["timeout_seconds"] == 60
+
+    def test_to_dict_excludes_none_timeout_seconds(self):
+        endpoint = Endpoint(name="ep", timeout_seconds=None)
+        data = endpoint.to_dict()
+        assert data["timeout_seconds"] is None
+
+    @patch("requests.request")
+    def test_push_sends_timeout_seconds(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "ep-1"}
+        mock_request.return_value = mock_response
+
+        endpoint = Endpoint(
+            name="ep",
+            connection_type=ConnectionType.REST,
+            project_id="proj-1",
+            timeout_seconds=120,
+        )
+        endpoint.push()
+
+        call_args = mock_request.call_args
+        request_data = call_args.kwargs.get("json", {})
+        assert request_data.get("timeout_seconds") == 120
+
+    @patch("requests.request")
+    def test_push_omits_none_timeout(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "ep-1"}
+        mock_request.return_value = mock_response
+
+        endpoint = Endpoint(
+            name="ep",
+            connection_type=ConnectionType.REST,
+            project_id="proj-1",
+            timeout_seconds=None,
+        )
+        endpoint.push()
+
+        call_args = mock_request.call_args
+        request_data = call_args.kwargs.get("json", {})
+        assert "timeout_seconds" not in request_data
+
+    @patch("requests.request")
+    def test_pull_picks_up_timeout_seconds(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "id": "ep-1",
+            "name": "ep",
+            "connection_type": "REST",
+            "timeout_seconds": 45,
+        }
+        mock_request.return_value = mock_response
+
+        endpoint = Endpoint(id="ep-1")
+        endpoint.pull()
+
+        assert endpoint.timeout_seconds == 45
+
+    def test_from_dict_picks_up_timeout_seconds(self):
+        endpoint = Endpoint.from_dict(
+            {"name": "ep", "connection_type": "REST", "timeout_seconds": 300}
+        )
+        assert endpoint.timeout_seconds == 300


### PR DESCRIPTION
## Summary

- Adds a configurable `timeout_seconds` setting to endpoints, stored in `endpoint_metadata` JSON (no DB migration)
- Exposed as a top-level API field with 1-3600s validation, respected by both REST (httpx per-request override) and SDK (RPC/WebSocket timeout) invokers
- Frontend: timeout field on both create and edit flows, with system-default fallback display
- SDK: `timeout_seconds` field on the `Endpoint` entity, included in push/pull round-trips

Fixes the issue where the hardcoded 30s timeout caused confusing failures during endpoint setup for slower endpoints.

## Test plan

- [x] 12 schema validation tests (bounds, edge cases, metadata extraction)
- [x] 4 CRUD merge helper tests (empty metadata, key preservation, overwrite, None no-op)
- [x] 2 REST invoker tests (custom timeout, default fallback)
- [x] 3 SDK invoker tests (RPC, WebSocket, default fallback)
- [x] 8 SDK entity tests (defaults, serialization, push/pull)
- [x] Ruff and TypeScript clean