### PR TITLE
feat: add test_parameters for per-test context in endpoint mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,23 +29,24 @@ This release includes the following component versions:
 - Significantly improved SDK WebSocket performance and throughput by lazy-loading database sessions and raising the default rate limit to 500 messages per second.
 - Enabled database persistence for connector execution traces, returning a `trace_id` to prevent trace data loss on server restarts.
 - Fixed a 403 authorization issue during onboarding by allowing users without an organization to gracefully access free-tier features.
+- Added `test_parameters`, a freeform JSONB field on tests. Available in endpoint request mappings as `{{ test_parameters.<key> }}`, separate from experiment `params`.
 
 **Frontend v0.15.2:**
 - Updated platform and SDK dependencies to version 0.15.2
 - Applied Prettier formatting fixes across 32 frontend files to improve codebase consistency
+- Added a Test Parameters section to the test detail view, with a JSON editor for viewing and editing per-test parameters.
 
 **SDK v0.15.2:**
 - Upgraded LangChain and LangGraph ecosystem dependencies to current stable releases.
 - Overhauled telemetry tracing to reliably capture all LangGraph nodes, multi-message prompts, tool calls, and RAG retrieval operations.
 - Added automatic conversation grouping for LangGraph turns using `thread_id`.
 - Improved concurrency safety, resolved memory leaks from in-flight runs, and ensured the integration cleanly unpatches when disabled.
+- Added `test_parameters` field to the `Test` entity and the `ExecuteTestMessage` wire protocol.
 
 See individual component changelogs for detailed changes:
 - [Backend Changelog](apps/backend/CHANGELOG.md)
 - [Frontend Changelog](apps/frontend/CHANGELOG.md)
 - [SDK Changelog](sdk/CHANGELOG.md)
-
-
 
 ## [0.15.1] - 2026-09-04
 

--- a/apps/backend/CHANGELOG.md
+++ b/apps/backend/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Object-shaped Tool Calls**: Handled tool call outputs returned as objects rather than dictionaries, preventing unended spans and missing trace data.
 - **Memory Leak Protection**: Capped in-flight run bookkeeping to prevent memory leaks from runs that never report completion.
 
+- **Test Parameters:** Added `test_parameters`, a freeform JSONB column on the `test` table. Values are injected into the Jinja2 template context as `test_parameters` during execution, available in request mappings as `{{ test_parameters.<key> }}`. Separate from experiment `params` to avoid namespace collisions.
 
 ## [0.15.1] - 2026-09-04
 

--- a/apps/backend/src/rhesis/backend/alembic/versions/c3a4b5d6e7f8_add_test_parameters_column.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/c3a4b5d6e7f8_add_test_parameters_column.py
@@ -1,0 +1,30 @@
+"""add test_parameters column
+
+Revision ID: c3a4b5d6e7f8
+Revises: b7e1c9d4a2f3
+Create Date: 2026-09-12
+
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "c3a4b5d6e7f8"
+down_revision: Union[str, None] = "b7e1c9d4a2f3"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "test",
+        sa.Column("test_parameters", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("test", "test_parameters")

--- a/apps/backend/src/rhesis/backend/app/constants.py
+++ b/apps/backend/src/rhesis/backend/app/constants.py
@@ -251,7 +251,18 @@ class AISpanAttributes:
 
     OPERATION_TYPE = "ai.operation.type"
     MODEL_NAME = "ai.model.name"
+    TOKENS_INPUT = "ai.llm.tokens.input"
+    TOKENS_OUTPUT = "ai.llm.tokens.output"
     TOKENS_TOTAL = "ai.llm.tokens.total"
+
+    # Only spans with this operation type carry countable token usage. Agent-run
+    # spans repeat their children's tokens as an aggregate, so counting them too
+    # double-counts the trace.
+    #
+    # This also excludes embedding spans, which carry ai.llm.tokens.* but map to
+    # embedding.create. That is deliberate: enrichment never priced embeddings, so
+    # counting their tokens would put tokens and cost back out of step.
+    OPERATION_LLM_INVOKE = "llm.invoke"
 
 
 # Keys inside Trace.enriched_data (JSONB) populated by the enrichment service.
@@ -261,6 +272,12 @@ class EnrichedDataKeys:
     COSTS = "costs"
     TOTAL_COST_USD = "total_cost_usd"
     TOTAL_COST_EUR = "total_cost_eur"
+    TOTAL_TOKENS = "total_tokens"
+    TOTAL_INPUT_TOKENS = "total_input_tokens"
+    TOTAL_OUTPUT_TOKENS = "total_output_tokens"
+    BREAKDOWN = "breakdown"
+    SPAN_ID = "span_id"
+    MODEL_NAME = "model_name"
 
 
 # Test Execution Context Constants

--- a/apps/backend/src/rhesis/backend/app/crud/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/crud/telemetry.py
@@ -32,6 +32,20 @@ from rhesis.backend.app.utils.query_utils import QueryBuilder, include, resolve_
 logger = logging.getLogger(__name__)
 
 
+def validate_uuid_param(value: Optional[str], param_name: str) -> Optional[UUID]:
+    """Validate and convert a UUID string, raising a 400 rather than a 500 on garbage."""
+    from fastapi import HTTPException
+
+    if not value:
+        return None
+    try:
+        return UUID(value)
+    except (ValueError, TypeError):
+        raise HTTPException(
+            status_code=400, detail=f"Invalid UUID format for {param_name}: {value}"
+        )
+
+
 def span_total_tokens_expr(attributes):
     """Per-span token total in SQL, matching ``_span_token_counts`` in enrichment/core.py.
 
@@ -409,19 +423,7 @@ def query_traces(
     """
     from uuid import UUID
 
-    from fastapi import HTTPException
     from sqlalchemy.orm import aliased, joinedload
-
-    def validate_uuid_param(value: Optional[str], param_name: str) -> Optional[UUID]:
-        """Validate and convert UUID string, raising HTTPException if invalid."""
-        if not value:
-            return None
-        try:
-            return UUID(value)
-        except (ValueError, TypeError):
-            raise HTTPException(
-                status_code=400, detail=f"Invalid UUID format for {param_name}: {value}"
-            )
 
     # Convert organization_id to UUID
     org_uuid = UUID(organization_id)
@@ -985,11 +987,18 @@ def get_trace_metrics_aggregated(
     environment: Optional[str] = None,
     start_time_after: Optional[datetime] = None,
     start_time_before: Optional[datetime] = None,
+    test_run_id: Optional[str] = None,
 ) -> dict:
     """Compute trace metrics using SQL-level aggregation.
 
     Uses PostgreSQL aggregate functions (COUNT, SUM, AVG, percentile_cont)
     to avoid loading large result sets into Python memory.
+
+    ``test_run_id`` narrows every metric to one run. It is a column on every span
+    row, stamped at ingest, so the scoping is exact. Note that ``total_spans``
+    counts span rows while the traces list shows one deduped root span per trace;
+    ``total_traces`` is a distinct count of trace_id, so that one still lines up
+    with the rows on screen.
     """
     from uuid import UUID
 
@@ -1009,6 +1018,9 @@ def get_trace_metrics_aggregated(
         filters.append(T.start_time >= start_time_after)
     if start_time_before:
         filters.append(T.start_time <= start_time_before)
+    test_run_uuid = validate_uuid_param(test_run_id, "test_run_id")
+    if test_run_uuid:
+        filters.append(T.test_run_id == test_run_uuid)
 
     base = db.query(T).filter(*filters).subquery()
 

--- a/apps/backend/src/rhesis/backend/app/crud/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/crud/telemetry.py
@@ -12,11 +12,15 @@ from enum import Enum
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 from uuid import UUID
 
-from sqlalchemy import and_, desc, func, or_, select
+from sqlalchemy import and_, asc, desc, func, or_, select
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models
-from rhesis.backend.app.constants import TestExecutionContext
+from rhesis.backend.app.constants import (
+    AISpanAttributes,
+    EnrichedDataKeys,
+    TestExecutionContext,
+)
 from rhesis.backend.app.schemas.telemetry import (
     OTELSpanCreate,
     StatusCode,
@@ -26,6 +30,106 @@ from rhesis.backend.app.schemas.telemetry import (
 from rhesis.backend.app.utils.query_utils import QueryBuilder, include, resolve_chain
 
 logger = logging.getLogger(__name__)
+
+
+def span_total_tokens_expr(attributes):
+    """Per-span token total in SQL, matching ``_span_token_counts`` in enrichment/core.py.
+
+    Falls back to ``input + output`` when no total was reported, and treats a reported
+    zero as missing when either side is non-zero. That combination is contradictory and
+    only reachable through hand-set OTLP attributes or ``create_llm_attributes`` with a
+    single side, never through a shipped integration; trusting the zero would undercount.
+
+    Each side is coalesced separately because ``NULL + 100`` is ``NULL`` in SQL, which
+    would otherwise drop a span that reported only one of the two.
+    """
+    return func.coalesce(
+        func.nullif(attributes[AISpanAttributes.TOKENS_TOTAL].as_float(), 0.0),
+        func.coalesce(attributes[AISpanAttributes.TOKENS_INPUT].as_float(), 0.0)
+        + func.coalesce(attributes[AISpanAttributes.TOKENS_OUTPUT].as_float(), 0.0),
+        0.0,
+    )
+
+
+# Grid fields the traces list can sort by, mapped to how each is ordered in SQL.
+#
+# Deliberately a whitelist: the columns left out (conversation_input, endpoint_name,
+# trace_metrics_status) have no SQL sort key -- they come from a JSONB attribute, a
+# three-hop join and a relationship -- so the grid marks them unsortable rather than
+# sorting one page of rows and calling it ordered.
+TRACE_SORT_FIELDS = frozenset(
+    {
+        "start_time",
+        "duration_ms",
+        "trace_id",
+        "environment",
+        "root_operation",
+        "span_count",
+        "total_tokens",
+        "total_cost_usd",
+    }
+)
+
+
+def _trace_sort_clauses(
+    sort_by: Optional[str], sort_order: str, span_count_col, llm_tokens_col
+) -> list:
+    """ORDER BY clauses for the traces list.
+
+    Sorting is server-side so a page of results is genuinely the top N of the whole
+    filtered set, not the newest N reshuffled in the browser.
+
+    Always ends with start_time then id. Without a tiebreaker the many rows tied at
+    zero cost have no defined order between pages, and pagination silently repeats
+    and skips rows.
+    """
+    from fastapi import HTTPException
+
+    if sort_by and sort_by not in TRACE_SORT_FIELDS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Cannot sort traces by '{sort_by}'. "
+                f"Sortable fields: {', '.join(sorted(TRACE_SORT_FIELDS))}"
+            ),
+        )
+
+    columns = {
+        "start_time": models.Trace.start_time,
+        "duration_ms": models.Trace.duration_ms,
+        "trace_id": models.Trace.trace_id,
+        "environment": models.Trace.environment,
+        "root_operation": models.Trace.span_name,
+        "span_count": span_count_col,
+        # Mirrors what the response actually shows: the enriched total when the trace
+        # has been priced, the llm.invoke sum until then.
+        "total_tokens": func.coalesce(
+            models.Trace.enriched_data[EnrichedDataKeys.COSTS][
+                EnrichedDataKeys.TOTAL_TOKENS
+            ].as_float(),
+            llm_tokens_col,
+            0,
+        ),
+        # Cost has no pre-enrichment fallback, so unpriced traces sort last rather
+        # than leading a "most expensive first" list on a NULLS FIRST default.
+        "total_cost_usd": models.Trace.enriched_data[EnrichedDataKeys.COSTS][
+            EnrichedDataKeys.TOTAL_COST_USD
+        ].as_float(),
+    }
+
+    descending = sort_order.lower() != "asc"
+    clauses = []
+
+    if sort_by:
+        expression = columns[sort_by]
+        ordered = desc(expression) if descending else asc(expression)
+        clauses.append(ordered.nullslast())
+
+    if sort_by != "start_time":
+        clauses.append(desc(models.Trace.start_time))
+    clauses.append(desc(models.Trace.id))
+
+    return clauses
 
 
 class TraceRow(NamedTuple):
@@ -40,6 +144,9 @@ class TraceRow(NamedTuple):
     total: int
     tags_count: int
     comments_count: int
+    # Summed over the trace's llm.invoke spans. Only used when the trace has not
+    # been enriched yet -- see services/telemetry/token_totals.py.
+    llm_tokens: int
 
 
 # ============================================================================
@@ -277,6 +384,8 @@ def query_traces(
     test_id: Optional[str] = None,
     conversation_id: Optional[str] = None,
     trace_metrics_status: Optional[str] = None,
+    sort_by: Optional[str] = None,
+    sort_order: str = "desc",
     limit: int = 100,
     offset: int = 0,
 ) -> List[TraceRow]:
@@ -332,7 +441,26 @@ def query_traces(
         .scalar_subquery()
     )
 
-    # -- Column 3: total — total matching rows *before* LIMIT/OFFSET
+    # -- Column 3: llm_tokens — tokens over this trace's llm.invoke spans.
+    #    The pre-enrichment fallback: enrichment is dispatched asynchronously after
+    #    ingest, so a freshly ingested trace has no enriched_data and would
+    #    otherwise list as 0 while the detail endpoint reported the real figure.
+    #    The llm.invoke filter is the same one enrichment applies, so the two
+    #    numbers agree instead of double-counting aggregate-reporting frameworks.
+    llm_tokens_col = (
+        select(func.coalesce(func.sum(span_total_tokens_expr(InnerTrace.attributes)), 0))
+        .where(
+            and_(
+                InnerTrace.trace_id == models.Trace.trace_id,
+                InnerTrace.organization_id == org_uuid,
+                InnerTrace.attributes[AISpanAttributes.OPERATION_TYPE].as_string()
+                == AISpanAttributes.OPERATION_LLM_INVOKE,
+            )
+        )
+        .scalar_subquery()
+    )
+
+    # -- Column 4: total — total matching rows *before* LIMIT/OFFSET
     #    Uses a window function so pagination total comes from the same query.
     total_col = func.count().over().label("total_count")
 
@@ -360,7 +488,14 @@ def query_traces(
     )
 
     query = (
-        db.query(models.Trace, span_count_col, total_col, tags_count_col, comments_count_col)
+        db.query(
+            models.Trace,
+            span_count_col,
+            total_col,
+            tags_count_col,
+            comments_count_col,
+            llm_tokens_col,
+        )
         .filter(models.Trace.organization_id == org_uuid)
         .options(
             # Scoped to what the loop below actually reads off this chain (existence
@@ -509,9 +644,20 @@ def query_traces(
         )
         query = query.filter(models.Trace.trace_metrics_status_id.in_(matching_status_ids))
 
-    results = query.order_by(desc(models.Trace.start_time)).limit(limit).offset(offset).all()
+    query = query.order_by(
+        *_trace_sort_clauses(sort_by, sort_order, span_count_col, llm_tokens_col)
+    )
+
+    results = query.limit(limit).offset(offset).all()
     return [
-        TraceRow(trace=r[0], span_count=r[1], total=r[2], tags_count=r[3], comments_count=r[4])
+        TraceRow(
+            trace=r[0],
+            span_count=r[1],
+            total=r[2],
+            tags_count=r[3],
+            comments_count=r[4],
+            llm_tokens=int(r[5] or 0),
+        )
         for r in results
     ]
 
@@ -850,8 +996,6 @@ def get_trace_metrics_aggregated(
     from sqlalchemy import case, literal_column
     from sqlalchemy.sql import functions as sqlfunc
 
-    from rhesis.backend.app.constants import AISpanAttributes, EnrichedDataKeys
-
     T = models.Trace
 
     filters = [
@@ -868,17 +1012,61 @@ def get_trace_metrics_aggregated(
 
     base = db.query(T).filter(*filters).subquery()
 
-    # JSONB extraction expressions for tokens and costs
-    tokens_expr = base.c.attributes[AISpanAttributes.TOKENS_TOTAL].as_float()
-    cost_expr = base.c.enriched_data[EnrichedDataKeys.COSTS][
-        EnrichedDataKeys.TOTAL_COST_USD
-    ].as_float()
+    # Tokens and costs aggregate per *trace*, not per span row.
+    #
+    # enriched_data is a trace-level blob that mark_trace_processed writes onto every
+    # span of the trace, so summing it across span rows multiplies the real figure by
+    # the span count. Collapse to one row per trace first: MAX is exact for the
+    # enriched columns precisely because every row carries the same value.
+    #
+    # raw_tokens is the pre-enrichment fallback, summed over llm.invoke spans only --
+    # the same filter enrichment applies, so an unenriched trace reports the number it
+    # will keep once enrichment lands. Cost has no fallback; it cannot be derived from
+    # span attributes.
+    per_trace = (
+        db.query(
+            base.c.trace_id.label("trace_id"),
+            func.max(
+                base.c.enriched_data[EnrichedDataKeys.COSTS][
+                    EnrichedDataKeys.TOTAL_TOKENS
+                ].as_float()
+            ).label("enriched_tokens"),
+            func.max(
+                base.c.enriched_data[EnrichedDataKeys.COSTS][
+                    EnrichedDataKeys.TOTAL_COST_USD
+                ].as_float()
+            ).label("cost_usd"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (
+                            base.c.attributes[AISpanAttributes.OPERATION_TYPE].as_string()
+                            == AISpanAttributes.OPERATION_LLM_INVOKE,
+                            span_total_tokens_expr(base.c.attributes),
+                        ),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("raw_tokens"),
+        )
+        .group_by(base.c.trace_id)
+        .subquery()
+    )
+
+    token_cost_agg = db.query(
+        func.coalesce(
+            func.sum(
+                func.coalesce(per_trace.c.enriched_tokens, per_trace.c.raw_tokens, 0),
+            ),
+            0,
+        ).label("total_tokens"),
+        func.coalesce(func.sum(per_trace.c.cost_usd), 0).label("total_cost_usd"),
+    ).one()
 
     agg = db.query(
         func.count(func.distinct(base.c.trace_id)).label("total_traces"),
         func.count(base.c.id).label("total_spans"),
-        func.coalesce(func.sum(tokens_expr), 0).label("total_tokens"),
-        func.coalesce(func.sum(cost_expr), 0).label("total_cost_usd"),
         func.count(case((base.c.status_code == "ERROR", 1))).label("error_count"),
         func.coalesce(func.avg(base.c.duration_ms), 0).label("avg_duration_ms"),
         func.coalesce(sqlfunc.percentile_cont(0.5).within_group(base.c.duration_ms), 0).label(
@@ -912,8 +1100,8 @@ def get_trace_metrics_aggregated(
     return {
         "total_traces": agg.total_traces or 0,
         "total_spans": total_spans,
-        "total_tokens": int(agg.total_tokens or 0),
-        "total_cost_usd": round(float(agg.total_cost_usd or 0), 6),
+        "total_tokens": int(token_cost_agg.total_tokens or 0),
+        "total_cost_usd": round(float(token_cost_agg.total_cost_usd or 0), 6),
         "error_rate": round(error_count / total_spans, 4) if total_spans else 0,
         "avg_duration_ms": round(float(agg.avg_duration_ms or 0), 2),
         "p50_duration_ms": round(float(agg.p50_duration_ms or 0), 2),

--- a/apps/backend/src/rhesis/backend/app/models/test.py
+++ b/apps/backend/src/rhesis/backend/app/models/test.py
@@ -59,6 +59,7 @@ class Test(
     # Test source info (origin, inputs, context)
     # Named 'test_metadata' to avoid SQLAlchemy's reserved 'metadata' attribute
     test_metadata = Column(JSONB)
+    test_parameters = Column(JSONB)
     # Set only by services/explorer/{tests,topics}.py — not client-settable.
     explorer_row = Column(
         Boolean, nullable=False, server_default="false", default=False, index=True

--- a/apps/backend/src/rhesis/backend/app/models/trace.py
+++ b/apps/backend/src/rhesis/backend/app/models/trace.py
@@ -179,11 +179,6 @@ class Trace(
         """Extract model name from attributes."""
         return self.attributes.get(AISpanAttributes.MODEL_NAME)
 
-    @property
-    def total_tokens(self) -> int | None:
-        """Extract total tokens from attributes."""
-        return self.attributes.get(AISpanAttributes.TOKENS_TOTAL)
-
     def to_searchable_text(self) -> str:
         """
         Generate searchable text from trace fields for embeddings and full-text search.

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -54,6 +54,11 @@ from rhesis.backend.app.services.review import (
     get_review_status_details,
     update_review_metadata,
 )
+from rhesis.backend.app.services.telemetry.token_totals import (
+    trace_cost_usd,
+    trace_summary_totals,
+    trace_token_totals,
+)
 from rhesis.backend.app.services.trace_review_override import (
     apply_review_override as trace_apply_review_override,
 )
@@ -304,6 +309,15 @@ def list_traces(
         True,
         description=("Return only root spans (one per trace). Set to false to return all spans."),
     ),
+    sort_by: Optional[str] = Query(
+        None,
+        description=(
+            "Field to sort by. One of: "
+            "start_time, duration_ms, trace_id, environment, root_operation, "
+            "span_count, total_tokens, total_cost_usd."
+        ),
+    ),
+    sort_order: str = Query("desc", pattern="^(asc|desc)$", description="Sort direction"),
     limit: int = Query(100, ge=1, le=1000, description="Results per page"),
     offset: int = Query(0, ge=0, description="Pagination offset"),
     db: Session = Depends(get_tenant_db_session),
@@ -376,6 +390,8 @@ def list_traces(
             test_id=test_id,
             conversation_id=conversation_id,
             trace_metrics_status=(trace_metrics_status.value if trace_metrics_status else None),
+            sort_by=sort_by,
+            sort_order=sort_order,
             limit=limit,
             offset=offset,
         )
@@ -394,13 +410,13 @@ def list_traces(
         for row in rows:
             trace = row.trace
             has_errors = trace.status_code == StatusCode.ERROR.value
-            total_tokens = trace.total_tokens or 0
-            total_cost_usd = 0.0
-            total_cost_eur = 0.0
-            costs = (trace.enriched_data or {}).get(EnrichedDataKeys.COSTS, {})
-            if costs:
-                total_cost_usd = costs.get(EnrichedDataKeys.TOTAL_COST_USD, 0.0)
-                total_cost_eur = costs.get(EnrichedDataKeys.TOTAL_COST_EUR, 0.0)
+            (
+                total_input_tokens,
+                total_output_tokens,
+                total_tokens,
+                total_cost_usd,
+                total_cost_eur,
+            ) = trace_summary_totals(trace.enriched_data, row.llm_tokens)
 
             # Get endpoint information from eagerly loaded relationships
             trace_endpoint_id = None
@@ -449,6 +465,8 @@ def list_traces(
                 endpoint_id=trace_endpoint_id,
                 endpoint_name=trace_endpoint_name,
                 total_tokens=total_tokens if total_tokens > 0 else None,
+                total_input_tokens=total_input_tokens if total_input_tokens > 0 else None,
+                total_output_tokens=total_output_tokens if total_output_tokens > 0 else None,
                 total_cost_usd=total_cost_usd if total_cost_usd > 0 else None,
                 total_cost_eur=total_cost_eur if total_cost_eur > 0 else None,
                 has_errors=has_errors,
@@ -474,6 +492,9 @@ def list_traces(
             offset=offset,
         )
 
+    except HTTPException:
+        # A deliberate 4xx, such as an unsortable sort_by, must not become a 500.
+        raise
     except Exception as e:
         # Check if it's a database permission error
         error_msg = str(e).lower()
@@ -594,20 +615,25 @@ def get_trace(
         # Build proper span tree
         from rhesis.backend.app.services.telemetry.tree_builder import build_span_tree
 
-        root_spans = build_span_tree(spans)
+        # enriched_data is trace-level and written onto every span, so any span
+        # carries the whole breakdown. Index it once for the tree builder.
+        costs = (spans[0].enriched_data or {}).get(EnrichedDataKeys.COSTS) or {}
+        cost_by_span_id = {
+            entry[EnrichedDataKeys.SPAN_ID]: entry
+            for entry in costs.get(EnrichedDataKeys.BREAKDOWN) or []
+            if entry.get(EnrichedDataKeys.SPAN_ID)
+        }
+
+        root_spans = build_span_tree(spans, cost_by_span_id)
 
         # Calculate trace-level metrics
         total_duration = max(span.end_time for span in spans) - min(
             span.start_time for span in spans
         )
-        total_tokens = sum(span.total_tokens or 0 for span in spans)
+        total_input_tokens, total_output_tokens, total_tokens = trace_token_totals(spans)
         error_count = sum(1 for span in spans if span.status_code == StatusCode.ERROR.value)
 
-        # Extract costs from enriched data
-        total_cost = 0.0
-        costs = (spans[0].enriched_data or {}).get(EnrichedDataKeys.COSTS, {})
-        if costs:
-            total_cost = costs.get(EnrichedDataKeys.TOTAL_COST_USD, 0.0)
+        total_cost = trace_cost_usd(spans[0].enriched_data)
 
         # Build relationship objects from first span
         from rhesis.backend.app.schemas.endpoint import Endpoint
@@ -678,6 +704,8 @@ def get_trace(
             span_count=len(spans),
             error_count=error_count,
             total_tokens=total_tokens,
+            total_input_tokens=total_input_tokens,
+            total_output_tokens=total_output_tokens,
             total_cost_usd=total_cost,
             root_spans=root_spans,
             trace_metrics_status=trace_metrics_status_name,

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -773,6 +773,7 @@ def get_metrics(
     environment: Optional[str] = Query(None, description="Environment filter"),
     start_time_after: Optional[datetime] = Query(None, description="Start time >= (ISO 8601)"),
     start_time_before: Optional[datetime] = Query(None, description="Start time <= (ISO 8601)"),
+    test_run_id: Optional[str] = Query(None, description="Scope metrics to a single test run"),
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
 ) -> TraceMetricsResponse:
@@ -795,6 +796,7 @@ def get_metrics(
         environment: Environment filter (optional)
         start_time_after: Start of time range
         start_time_before: End of time range
+        test_run_id: Narrow every metric to one test run (optional)
 
     Returns:
         Aggregated metrics
@@ -809,11 +811,15 @@ def get_metrics(
             environment=environment,
             start_time_after=start_time_after,
             start_time_before=start_time_before,
+            test_run_id=test_run_id,
         )
 
         logger.info(f"Calculated metrics for project {project_id}")
         return TraceMetricsResponse(**result)
 
+    except HTTPException:
+        # A deliberate 4xx, such as a malformed test_run_id, must not become a 500.
+        raise
     except Exception as e:
         # Check if it's a database permission error
         error_msg = str(e).lower()

--- a/apps/backend/src/rhesis/backend/app/routers/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_run.py
@@ -11,7 +11,6 @@ from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.principal import resolve_principal_from_request
 from rhesis.backend.app.auth.rbac import authorize_object, project_id_from_scope
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
-from rhesis.backend.app.constants import EnrichedDataKeys
 from rhesis.backend.app.crud import test_run as test_run_crud
 from rhesis.backend.app.crud.telemetry import query_traces
 from rhesis.backend.app.dependencies import (
@@ -22,6 +21,7 @@ from rhesis.backend.app.models.user import User
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.telemetry import TraceListResponse, TraceSource, TraceSummary
 from rhesis.backend.app.services import test_run as services_test_run
+from rhesis.backend.app.services.telemetry.token_totals import trace_summary_totals
 from rhesis.backend.app.services.test_run import (
     get_test_results_for_test_run,
     rescore_test_run,
@@ -550,13 +550,13 @@ def get_test_run_traces(
     for row in rows:
         trace = row.trace
         has_errors = trace.status_code == "ERROR"
-        total_tokens = trace.total_tokens or 0
-        total_cost_usd = 0.0
-        total_cost_eur = 0.0
-        costs = (trace.enriched_data or {}).get(EnrichedDataKeys.COSTS, {})
-        if costs:
-            total_cost_usd = costs.get(EnrichedDataKeys.TOTAL_COST_USD, 0.0)
-            total_cost_eur = costs.get(EnrichedDataKeys.TOTAL_COST_EUR, 0.0)
+        (
+            total_input_tokens,
+            total_output_tokens,
+            total_tokens,
+            total_cost_usd,
+            total_cost_eur,
+        ) = trace_summary_totals(trace.enriched_data, row.llm_tokens)
 
         conversation_input = None
         if isinstance(trace.attributes, dict):
@@ -576,6 +576,8 @@ def get_test_run_traces(
             status_code=trace.status_code,
             has_errors=has_errors,
             total_tokens=total_tokens if total_tokens > 0 else None,
+            total_input_tokens=total_input_tokens if total_input_tokens > 0 else None,
+            total_output_tokens=total_output_tokens if total_output_tokens > 0 else None,
             total_cost_usd=total_cost_usd if total_cost_usd > 0 else None,
             total_cost_eur=total_cost_eur if total_cost_eur > 0 else None,
             test_run_id=str(trace.test_run_id) if trace.test_run_id else None,

--- a/apps/backend/src/rhesis/backend/app/schemas/enrichment.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/enrichment.py
@@ -12,6 +12,12 @@ class CostBreakdown(BaseModel):
     model_name: str = Field(..., description="Model name used")
     input_tokens: int = Field(..., ge=0, description="Number of input tokens")
     output_tokens: int = Field(..., ge=0, description="Number of output tokens")
+    total_tokens: int = Field(
+        0,
+        ge=0,
+        description="Total tokens for this span, as reported rather than derived: "
+        "Google ADK folds cache-read tokens in, so it can exceed input + output",
+    )
     input_cost_usd: float = Field(..., ge=0, description="Cost of input tokens in USD")
     output_cost_usd: float = Field(..., ge=0, description="Cost of output tokens in USD")
     total_cost_usd: float = Field(..., ge=0, description="Total cost for this span in USD")
@@ -25,6 +31,11 @@ class TokenCosts(BaseModel):
 
     total_cost_usd: float = Field(..., ge=0, description="Total cost across all spans in USD")
     total_cost_eur: float = Field(..., ge=0, description="Total cost across all spans in EUR")
+    total_input_tokens: int = Field(0, ge=0, description="Input tokens across all llm.invoke spans")
+    total_output_tokens: int = Field(
+        0, ge=0, description="Output tokens across all llm.invoke spans"
+    )
+    total_tokens: int = Field(0, ge=0, description="Total tokens across all llm.invoke spans")
     breakdown: List[CostBreakdown] = Field(..., description="Per-span cost breakdown")
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/telemetry.py
@@ -103,6 +103,8 @@ class TraceSummary(BaseModel):
     root_operation: str
     status_code: str
     total_tokens: Optional[int] = None
+    total_input_tokens: Optional[int] = None
+    total_output_tokens: Optional[int] = None
     total_cost_usd: Optional[float] = None
     total_cost_eur: Optional[float] = None
     has_errors: bool
@@ -189,6 +191,10 @@ class SpanNode(BaseModel):
     status_code: str
     status_message: Optional[str]
     attributes: Dict[str, Any]
+    # Priced by enrichment, which the frontend cannot reach any other way: the raw
+    # attributes carry tokens but never a cost.
+    cost_usd: Optional[float] = None
+    model_name: Optional[str] = None
     events: List[Dict[str, Any]]
     children: List["SpanNode"] = Field(default_factory=list)
 
@@ -226,6 +232,8 @@ class TraceDetailResponse(BaseModel):
     span_count: int
     error_count: int
     total_tokens: int
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
     total_cost_usd: float
     root_spans: List[SpanNode]
 

--- a/apps/backend/src/rhesis/backend/app/schemas/test.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test.py
@@ -38,6 +38,7 @@ class TestBase(Base):
     status_id: Optional[UUID4] = None
     organization_id: Optional[UUID4] = None
     test_metadata: Optional[Dict[str, Any]] = None
+    test_parameters: Optional[Dict[str, Any]] = None
 
 
 class TestPromptCreate(BaseModel):
@@ -125,6 +126,7 @@ class TestBulkCreate(BaseModel):
     category: str
     topic: str
     test_configuration: Optional[Dict[str, Any]] = None
+    test_parameters: Optional[Dict[str, Any]] = None
     assignee_id: Optional[UUID4] = None
     owner_id: Optional[UUID4] = None
     status: Optional[str] = None

--- a/apps/backend/src/rhesis/backend/app/services/connector/manager.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/manager.py
@@ -48,6 +48,7 @@ _EXECUTE_TEST_EXTRA_KEYS = frozenset(
         "parameter_source_environment",
         "parameter_source_label",
         "parameter_schema",
+        "test_parameters",
     }
 )
 

--- a/apps/backend/src/rhesis/backend/app/services/connector/schemas.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/schemas.py
@@ -74,6 +74,7 @@ class ExecuteTestMessage(BaseModel):
     parameter_source: Optional[Literal["environment", "experiment_id", "version"]] = None
     parameter_source_environment: Optional[str] = None
     parameter_schema: Optional[Dict[str, Any]] = None
+    test_parameters: Dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="before")
     @classmethod

--- a/apps/backend/src/rhesis/backend/app/services/invokers/sdk_invoker.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/sdk_invoker.py
@@ -107,6 +107,7 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
         "organization_id",
         "user_id",
         "params",
+        "test_parameters",
         "files_metadata",
     }
 
@@ -609,6 +610,9 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
             # Execute via RPC or direct WebSocket
             invocation_id = f"invoke_{uuid.uuid4().hex[:12]}"
             execute_extras = self._connector_parameter_extras()
+            tp = self.context.input_data.get("test_parameters")
+            if tp:
+                execute_extras["test_parameters"] = tp
             ep_ts = endpoint.timeout_seconds
             timeout = float(ep_ts) if ep_ts else SDK_FUNCTION_TIMEOUT
 

--- a/apps/backend/src/rhesis/backend/app/services/invokers/templating/renderer.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/templating/renderer.py
@@ -35,6 +35,7 @@ class TemplateRenderer:
         # Create a copy to avoid modifying the original input_data
         render_context = input_data.copy()
         render_context.setdefault("params", {})
+        render_context.setdefault("test_parameters", {})
 
         # Conversation field aliases: ensure a value provided under any
         # recognised name is available under ALL recognised names so

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/core.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/core.py
@@ -25,58 +25,51 @@ for _logger_name in ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy"):
 
 logger = logging.getLogger(__name__)
 
+# Stands in for a missing ai.llm.model.name so the span's tokens still get recorded.
+UNKNOWN_MODEL_NAME = "unknown"
 
-def calculate_token_costs(spans: List[Trace]) -> Optional[TokenCosts]:
+
+def _span_token_counts(span: Trace) -> tuple[int, int, int]:
+    """Input, output and total tokens for a span.
+
+    The reported total is trusted rather than derived: Google ADK folds cache-read
+    tokens into ``ai.llm.tokens.total``, so for its spans the total legitimately
+    exceeds ``input + output``. Fall back to the sum when no total was sent, and also
+    when a zero total arrives alongside non-zero input or output, which is
+    contradictory and only reachable through hand-set attributes.
     """
-    Calculate token costs for LLM spans using LiteLLM's pricing database.
+    input_tokens = int(span.attributes.get(AIAttributes.LLM_TOKENS_INPUT, 0) or 0)
+    output_tokens = int(span.attributes.get(AIAttributes.LLM_TOKENS_OUTPUT, 0) or 0)
+    reported_total = span.attributes.get(AIAttributes.LLM_TOKENS_TOTAL)
+    if reported_total is None or int(reported_total) == 0:
+        return input_tokens, output_tokens, input_tokens + output_tokens
+    return input_tokens, output_tokens, int(reported_total)
 
-    Costs are calculated in both USD and EUR for European operations.
 
-    Args:
-        spans: List of trace spans
+def _price_span(span: Trace, usd_to_eur: float) -> CostBreakdown:
+    """Price a single ``llm.invoke`` span.
 
-    Returns:
-        TokenCosts model with cost breakdown or None if no LLM spans
+    Always returns a breakdown: tokens are known even when the price is not, so an
+    unpriced model (self-hosted, or missing from LiteLLM) is recorded at zero cost
+    rather than dropped. Dropping it would make a trace that mixes priced and
+    unpriced spans undercount its tokens.
     """
-    total_cost_usd = 0.0
-    total_cost_eur = 0.0
-    cost_breakdown = []
+    input_tokens, output_tokens, total_tokens = _span_token_counts(span)
+    model_name = span.attributes.get(AIAttributes.MODEL_NAME)
 
-    # Get exchange rate for EUR conversion
-    usd_to_eur = get_usd_to_eur_rate()
+    if input_tokens == 0 and output_tokens == 0:
+        logger.warning(
+            f"⚠️  Zero tokens for span {span.span_id}! "
+            f"Available attributes: {list(span.attributes.keys())}"
+        )
 
-    logger.info(f"🔍 Calculating costs for {len(spans)} spans")
+    input_cost_usd = 0.0
+    output_cost_usd = 0.0
 
-    for span in spans:
-        # Only process LLM invocation spans (use semantic layer constant)
-        operation_type = span.attributes.get(AIAttributes.OPERATION_TYPE)
-        logger.debug(f"Span {span.span_id}: operation_type={operation_type}")
-
-        if operation_type != AIAttributes.OPERATION_LLM_INVOKE:
-            logger.debug(f"⏭️  Skipping span {span.span_id}: not an LLM invocation")
-            continue
-
-        model_name = span.attributes.get(AIAttributes.MODEL_NAME)
-        logger.info(f"📊 Processing LLM span {span.span_id}: model={model_name}")
-
-        if not model_name:
-            logger.warning(f"⚠️  Skipping span {span.span_id}: no model name")
-            continue
-
-        # Get token counts (use semantic layer constants for token attributes)
-        input_tokens = span.attributes.get(AIAttributes.LLM_TOKENS_INPUT, 0)
-        output_tokens = span.attributes.get(AIAttributes.LLM_TOKENS_OUTPUT, 0)
-
-        logger.info(f"🎯 Span {span.span_id} tokens: input={input_tokens}, output={output_tokens}")
-
-        # Log all attributes for debugging
-        if input_tokens == 0 and output_tokens == 0:
-            logger.warning(
-                f"⚠️  Zero tokens for span {span.span_id}! "
-                f"Available attributes: {list(span.attributes.keys())}"
-            )
-
-        # Use LiteLLM's cost_per_token (maintains up-to-date pricing for all providers)
+    if not model_name:
+        logger.warning(f"⚠️  Span {span.span_id} has no model name: recording tokens at zero cost")
+        model_name = UNKNOWN_MODEL_NAME
+    else:
         try:
             # Returns tuple: (prompt_cost_usd, completion_cost_usd)
             input_cost_usd, output_cost_usd = litellm.cost_per_token(
@@ -84,49 +77,63 @@ def calculate_token_costs(spans: List[Trace]) -> Optional[TokenCosts]:
                 prompt_tokens=input_tokens,
                 completion_tokens=output_tokens,
             )
-
-            span_cost_usd = input_cost_usd + output_cost_usd
-
-            # Convert to EUR
-            span_cost_eur = span_cost_usd * usd_to_eur
-            input_cost_eur = input_cost_usd * usd_to_eur
-            output_cost_eur = output_cost_usd * usd_to_eur
-
-            logger.info(
-                f"💰 Calculated costs for {model_name}: "
-                f"${span_cost_usd:.6f} USD, €{span_cost_eur:.6f} EUR"
-            )
-
         except Exception as e:
-            # If LiteLLM doesn't have pricing for this model, log and skip
             logger.warning(
                 f"❌ LiteLLM cost calculation failed for model {model_name}: {e}. "
-                f"Tokens: input={input_tokens}, output={output_tokens}"
+                f"Recording tokens at zero cost: input={input_tokens}, output={output_tokens}"
             )
-            continue
 
-        total_cost_usd += span_cost_usd
-        total_cost_eur += span_cost_eur
+    span_cost_usd = input_cost_usd + output_cost_usd
 
-        # Create Pydantic model for breakdown
-        cost_breakdown.append(
-            CostBreakdown(
-                span_id=span.span_id,
-                model_name=model_name,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                input_cost_usd=round(input_cost_usd, 6),
-                output_cost_usd=round(output_cost_usd, 6),
-                total_cost_usd=round(span_cost_usd, 6),
-                input_cost_eur=round(input_cost_eur, 6),
-                output_cost_eur=round(output_cost_eur, 6),
-                total_cost_eur=round(span_cost_eur, 6),
-            )
-        )
+    return CostBreakdown(
+        span_id=span.span_id,
+        model_name=model_name,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        input_cost_usd=round(input_cost_usd, 6),
+        output_cost_usd=round(output_cost_usd, 6),
+        total_cost_usd=round(span_cost_usd, 6),
+        input_cost_eur=round(input_cost_usd * usd_to_eur, 6),
+        output_cost_eur=round(output_cost_usd * usd_to_eur, 6),
+        total_cost_eur=round(span_cost_usd * usd_to_eur, 6),
+    )
+
+
+def calculate_token_costs(spans: List[Trace]) -> Optional[TokenCosts]:
+    """
+    Calculate token counts and costs for LLM spans using LiteLLM's pricing database.
+
+    Only ``llm.invoke`` spans are counted. That filter is what keeps the totals
+    correct: frameworks like pydantic-ai report aggregated usage on the agent-run
+    span *and* per-call usage on its child model-call spans, so summing every span
+    would double-count them.
+
+    Costs are calculated in both USD and EUR for European operations.
+
+    Args:
+        spans: List of trace spans
+
+    Returns:
+        TokenCosts model with token totals and cost breakdown, or None if the trace
+        has no LLM invocation spans at all.
+    """
+    usd_to_eur = get_usd_to_eur_rate()
+
+    logger.info(f"🔍 Calculating costs for {len(spans)} spans")
+
+    cost_breakdown = [
+        _price_span(span, usd_to_eur)
+        for span in spans
+        if span.attributes.get(AIAttributes.OPERATION_TYPE) == AIAttributes.OPERATION_LLM_INVOKE
+    ]
 
     if not cost_breakdown:
-        logger.warning("⚠️  No cost breakdown calculated - no LLM spans with valid tokens found")
+        logger.warning("⚠️  No cost breakdown calculated - trace has no llm.invoke spans")
         return None
+
+    total_cost_usd = sum(entry.total_cost_usd for entry in cost_breakdown)
+    total_cost_eur = sum(entry.total_cost_eur for entry in cost_breakdown)
 
     logger.info(
         f"✅ Cost calculation complete: {len(cost_breakdown)} spans, "
@@ -136,6 +143,9 @@ def calculate_token_costs(spans: List[Trace]) -> Optional[TokenCosts]:
     return TokenCosts(
         total_cost_usd=round(total_cost_usd, 6),
         total_cost_eur=round(total_cost_eur, 6),
+        total_input_tokens=sum(entry.input_tokens for entry in cost_breakdown),
+        total_output_tokens=sum(entry.output_tokens for entry in cost_breakdown),
+        total_tokens=sum(entry.total_tokens for entry in cost_breakdown),
         breakdown=cost_breakdown,
     )
 

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/token_totals.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/token_totals.py
@@ -1,0 +1,137 @@
+"""Trace-level token totals.
+
+One definition of "how many tokens did this trace use", shared by every read path
+so the traces list, the trace detail drawer, the test-run trace list and the
+project metrics endpoint can never disagree again.
+"""
+
+from typing import Optional, Sequence, Tuple
+
+from rhesis.backend.app.constants import AISpanAttributes, EnrichedDataKeys
+from rhesis.backend.app.models.trace import Trace
+
+# input, output, total
+TokenTotals = Tuple[int, int, int]
+
+ZERO_TOKENS: TokenTotals = (0, 0, 0)
+
+
+def token_totals_from_enriched(enriched_data: Optional[dict]) -> Optional[TokenTotals]:
+    """Trace-level input/output/total tokens from an enrichment blob.
+
+    Returns ``None`` when the trace has not been enriched yet, which the caller
+    should treat as "unknown" and fall back on — not as zero.
+
+    Any span of the trace works as the source: ``mark_trace_processed`` writes the
+    same trace-level blob onto every span row.
+    """
+    costs = (enriched_data or {}).get(EnrichedDataKeys.COSTS) or {}
+    if not costs:
+        return None
+
+    # A pre-existing enrichment blob predates the token fields; treat it as unknown
+    # so the caller falls back to the spans rather than reporting a confident zero.
+    if EnrichedDataKeys.TOTAL_TOKENS not in costs:
+        return None
+
+    return (
+        int(costs.get(EnrichedDataKeys.TOTAL_INPUT_TOKENS, 0) or 0),
+        int(costs.get(EnrichedDataKeys.TOTAL_OUTPUT_TOKENS, 0) or 0),
+        int(costs.get(EnrichedDataKeys.TOTAL_TOKENS, 0) or 0),
+    )
+
+
+def token_totals_from_spans(spans: Sequence[Trace]) -> TokenTotals:
+    """Sum tokens over a trace's ``llm.invoke`` spans.
+
+    The fallback for a trace whose enrichment has not run yet — it is dispatched
+    asynchronously after ingest, so a trace opened immediately has no enriched
+    data. The ``llm.invoke`` filter is the same one enrichment applies, which is
+    what keeps the two paths agreeing: pydantic-ai reports aggregated usage on the
+    agent-run span *and* per-call usage on its children, so summing every span
+    would roughly double the real figure.
+    """
+    totals = [0, 0, 0]
+    for span in spans:
+        attributes = span.attributes or {}
+        if attributes.get(AISpanAttributes.OPERATION_TYPE) != (
+            AISpanAttributes.OPERATION_LLM_INVOKE
+        ):
+            continue
+        input_tokens = int(attributes.get(AISpanAttributes.TOKENS_INPUT, 0) or 0)
+        output_tokens = int(attributes.get(AISpanAttributes.TOKENS_OUTPUT, 0) or 0)
+        reported_total = attributes.get(AISpanAttributes.TOKENS_TOTAL)
+        totals[0] += input_tokens
+        totals[1] += output_tokens
+        # Trust the reported total; Google ADK folds cache-read tokens into it, so
+        # deriving it from input + output would quietly discard those. A zero total
+        # next to non-zero input or output is contradictory, so treat it as missing.
+        totals[2] += (
+            input_tokens + output_tokens
+            if reported_total is None or int(reported_total) == 0
+            else int(reported_total)
+        )
+
+    return (totals[0], totals[1], totals[2])
+
+
+def trace_token_totals(spans: Sequence[Trace]) -> TokenTotals:
+    """Trace-level input/output/total tokens for a full span set.
+
+    Prefers the enrichment breakdown and falls back to the spans themselves when
+    enrichment has not run yet. Returns zeros for a trace with no LLM spans rather
+    than raising.
+    """
+    if not spans:
+        return ZERO_TOKENS
+
+    enriched = token_totals_from_enriched(spans[0].enriched_data)
+    if enriched is not None:
+        return enriched
+
+    return token_totals_from_spans(spans)
+
+
+def trace_cost_usd(enriched_data: Optional[dict]) -> float:
+    """Trace-level cost in USD, or 0.0 when the trace has not been enriched.
+
+    Unlike tokens, cost has no fallback: it cannot be derived from span attributes.
+    """
+    costs = (enriched_data or {}).get(EnrichedDataKeys.COSTS) or {}
+    return float(costs.get(EnrichedDataKeys.TOTAL_COST_USD, 0.0) or 0.0)
+
+
+def trace_summary_totals(
+    enriched_data: Optional[dict], llm_tokens_fallback: int
+) -> Tuple[int, int, int, float, float]:
+    """Token and cost totals for a trace list row.
+
+    Shared by the traces list and the test-run trace list, which build the same
+    ``TraceSummary`` from the same ``query_traces`` rows and each used to read
+    tokens off the root span alone -- a span that is usually not an LLM span, so
+    both reported zero.
+
+    A list row is one span, not the whole trace, so the span-set fallback is not
+    available here; ``llm_tokens_fallback`` is ``TraceRow.llm_tokens``, the same
+    figure computed in SQL. The input/output split stays zero before enrichment:
+    only the drawer shows it, and the drawer reads the detail endpoint, which has
+    the full span set.
+
+    Returns:
+        ``(input_tokens, output_tokens, total_tokens, cost_usd, cost_eur)``
+    """
+    costs = (enriched_data or {}).get(EnrichedDataKeys.COSTS) or {}
+
+    enriched = token_totals_from_enriched(enriched_data)
+    if enriched is None:
+        input_tokens, output_tokens, total_tokens = 0, 0, llm_tokens_fallback
+    else:
+        input_tokens, output_tokens, total_tokens = enriched
+
+    return (
+        input_tokens,
+        output_tokens,
+        total_tokens,
+        float(costs.get(EnrichedDataKeys.TOTAL_COST_USD, 0.0) or 0.0),
+        float(costs.get(EnrichedDataKeys.TOTAL_COST_EUR, 0.0) or 0.0),
+    )

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/tree_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/tree_builder.py
@@ -2,13 +2,16 @@
 Utility for building hierarchical span trees from flat span lists.
 """
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
+from rhesis.backend.app.constants import EnrichedDataKeys
 from rhesis.backend.app.models.trace import Trace
 from rhesis.backend.app.schemas.telemetry import SpanNode
 
 
-def build_span_tree(spans: List[Trace]) -> List[SpanNode]:
+def build_span_tree(
+    spans: List[Trace], cost_by_span_id: Optional[Dict[str, dict]] = None
+) -> List[SpanNode]:
     """
     Build hierarchical span tree from flat span list.
 
@@ -18,6 +21,8 @@ def build_span_tree(spans: List[Trace]) -> List[SpanNode]:
 
     Args:
         spans: List of Trace models from database
+        cost_by_span_id: Per-span cost breakdown from enrichment, keyed by span_id.
+            Absent for a trace that has not been enriched yet.
 
     Returns:
         List of root SpanNode objects with children populated recursively
@@ -47,9 +52,11 @@ def build_span_tree(spans: List[Trace]) -> List[SpanNode]:
 
     # Create span map for O(1) lookup
     span_map: Dict[str, SpanNode] = {}
+    costs = cost_by_span_id or {}
 
     # Convert all spans to SpanNode objects
     for span in spans:
+        span_cost = costs.get(span.span_id) or {}
         node = SpanNode(
             id=str(span.id),
             span_id=span.span_id,
@@ -61,6 +68,8 @@ def build_span_tree(spans: List[Trace]) -> List[SpanNode]:
             status_code=span.status_code,
             status_message=span.status_message,
             attributes=span.attributes or {},
+            cost_usd=span_cost.get(EnrichedDataKeys.TOTAL_COST_USD),
+            model_name=span_cost.get(EnrichedDataKeys.MODEL_NAME),
             events=span.events or [],
             trace_metrics=span.trace_metrics,
             # server_default only lands at INSERT, so a span that has not

--- a/apps/backend/src/rhesis/backend/jobs/execution/batch/invocation.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/batch/invocation.py
@@ -176,6 +176,8 @@ async def _run_multi_turn(
     if ctx.test_run and ctx.test_run.attributes:
         params = ctx.test_run.attributes.get("parameters", {})
 
+    test_parameters = test.test_parameters or {}
+
     target = BackendEndpointTarget(
         endpoint_id=str(ctx.endpoint.id),
         organization_id=ctx.organization_id,
@@ -187,6 +189,7 @@ async def _run_multi_turn(
         invoke_retry_min_wait=ctx.invoke_retry_min_wait,
         invoke_retry_max_wait=ctx.invoke_retry_max_wait,
         params=params,
+        test_parameters=test_parameters,
     )
 
     penelope_result = await penelope_agent.a_execute_test(
@@ -232,6 +235,11 @@ async def _run_single_turn(
         params = ctx.test_run.attributes.get("parameters", {})
         if params:
             input_data["params"] = params
+
+    test_obj = ctx.test_data.get(test_id, {}).get("test")
+    test_parameters = (test_obj.test_parameters if test_obj else None) or {}
+    if test_parameters:
+        input_data["test_parameters"] = test_parameters
 
     input_files = await load_input_files_lazy(ctx, test_id)
     if input_files:

--- a/apps/backend/src/rhesis/backend/jobs/execution/executors/output_providers.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/executors/output_providers.py
@@ -126,7 +126,10 @@ class SingleTurnOutput(OutputProvider):
         if test_parameters is None and test_id:
             from rhesis.backend.app.models.test import Test
 
-            test_obj = db.query(Test).filter(Test.id == test_id).first()
+            test_obj = db.query(Test).filter(
+                Test.id == test_id,
+                Test.organization_id == organization_id,
+            ).first()
             test_parameters = (test_obj.test_parameters if test_obj else None) or {}
         if test_parameters:
             input_data["test_parameters"] = test_parameters

--- a/apps/backend/src/rhesis/backend/jobs/execution/executors/output_providers.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/executors/output_providers.py
@@ -109,6 +109,7 @@ class SingleTurnOutput(OutputProvider):
         test_execution_context=None,
         test_id=None,
         params=None,
+        test_parameters=None,
         **kwargs,
     ) -> TestOutput:
         start_time = datetime.now(timezone.utc)
@@ -121,6 +122,14 @@ class SingleTurnOutput(OutputProvider):
             params = _load_run_params(db, test_execution_context)
         if params:
             input_data["params"] = params
+
+        if test_parameters is None and test_id:
+            from rhesis.backend.app.models.test import Test
+
+            test_obj = db.query(Test).filter(Test.id == test_id).first()
+            test_parameters = (test_obj.test_parameters if test_obj else None) or {}
+        if test_parameters:
+            input_data["test_parameters"] = test_parameters
 
         # Inject file data if the test has attached files
         if test_id:
@@ -310,6 +319,8 @@ class MultiTurnOutput(OutputProvider):
         if params is None:
             params = _load_run_params(db, test_execution_context)
 
+        test_parameters = test.test_parameters or {}
+
         from rhesis.backend.app.utils.usage_tracking import stamp_usage_provenance
         from rhesis.backend.app.utils.user_model_utils import ensure_language_model
         from rhesis.backend.jobs.execution.penelope_target import (
@@ -332,6 +343,7 @@ class MultiTurnOutput(OutputProvider):
             user_id=user_id,
             test_execution_context=test_execution_context,
             params=params,
+            test_parameters=test_parameters,
         )
 
         penelope_result = agent.execute_test(

--- a/apps/backend/src/rhesis/backend/jobs/execution/executors/output_providers.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/executors/output_providers.py
@@ -126,10 +126,14 @@ class SingleTurnOutput(OutputProvider):
         if test_parameters is None and test_id:
             from rhesis.backend.app.models.test import Test
 
-            test_obj = db.query(Test).filter(
-                Test.id == test_id,
-                Test.organization_id == organization_id,
-            ).first()
+            test_obj = (
+                db.query(Test)
+                .filter(
+                    Test.id == test_id,
+                    Test.organization_id == organization_id,
+                )
+                .first()
+            )
             test_parameters = (test_obj.test_parameters if test_obj else None) or {}
         if test_parameters:
             input_data["test_parameters"] = test_parameters

--- a/apps/backend/src/rhesis/backend/jobs/execution/penelope_target.py
+++ b/apps/backend/src/rhesis/backend/jobs/execution/penelope_target.py
@@ -80,6 +80,7 @@ class BackendEndpointTarget(Target):
         invoke_retry_min_wait: float = 1.0,
         invoke_retry_max_wait: float = 30.0,
         params: Optional[Dict[str, Any]] = None,
+        test_parameters: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize the backend endpoint target.
@@ -95,6 +96,7 @@ class BackendEndpointTarget(Target):
             invoke_retry_min_wait: Minimum backoff wait in seconds.
             invoke_retry_max_wait: Maximum backoff wait in seconds.
             params: Optional resolved parameters from the test run snapshot.
+            test_parameters: Optional per-test parameters from the test definition.
 
         Raises:
             ValueError: If endpoint is not found or configuration is invalid
@@ -110,6 +112,7 @@ class BackendEndpointTarget(Target):
         self._invoke_retry_min_wait = invoke_retry_min_wait
         self._invoke_retry_max_wait = invoke_retry_max_wait
         self.params = params or {}
+        self.test_parameters = test_parameters or {}
 
         self._endpoint = endpoint
         self._deferred_traces: list = []
@@ -264,6 +267,8 @@ class BackendEndpointTarget(Target):
                 input_data["files"] = files
             if self.params:
                 input_data["params"] = self.params
+            if self.test_parameters:
+                input_data["test_parameters"] = self.test_parameters
 
             logger.debug(
                 "BackendEndpointTarget invoking %s, message_len=%d",
@@ -420,6 +425,8 @@ class BackendEndpointTarget(Target):
                 input_data["files"] = files
             if self.params:
                 input_data["params"] = self.params
+            if self.test_parameters:
+                input_data["test_parameters"] = self.test_parameters
 
             logger.debug(
                 "BackendEndpointTarget (async) invoking %s, message_len=%d",

--- a/apps/frontend/CHANGELOG.md
+++ b/apps/frontend/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Resolved code formatting inconsistencies across 32 frontend files using Prettier.
 
+### Added
+
+- Added a Test Parameters section to the test detail view with a JSON editor (Monaco) for viewing and editing freeform per-test parameters.
+
 ## [0.15.1] - 2026-09-04
 
 ### Added

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -44,12 +44,15 @@ import {
   getEffectiveTestResultStatus,
 } from '@/utils/test-result-status';
 import { TAB_KEYS, TabKey, tabIndexFromKey } from '../utils/tab-key';
+import TestRunReviewsTab from './TestRunReviewsTab';
+import TestResultDrawer, { TEST_RESULT_DRAWER_TAB } from './TestResultDrawer';
 
 const TAB_LABELS: Record<TabKey, string> = {
   summary: 'Summary',
   configuration: 'Configuration',
   linked_entities: 'Tests',
   traces: 'Traces',
+  reviews: 'Reviews',
 };
 
 interface TabPanelProps {
@@ -140,11 +143,14 @@ export default function TestRunMainView({
     )
   );
 
-  // Fetch test results for the Tests tab.
-  const needsTestResults = React.useRef(
-    activeTab === TAB_KEYS.indexOf('linked_entities')
-  );
-  if (activeTab === TAB_KEYS.indexOf('linked_entities')) {
+  // Fetch test results for the Tests tab, and for Reviews, which builds its list
+  // out of the reviews hanging off those same results.
+  const tabsNeedingResults = [
+    TAB_KEYS.indexOf('linked_entities'),
+    TAB_KEYS.indexOf('reviews'),
+  ];
+  const needsTestResults = React.useRef(tabsNeedingResults.includes(activeTab));
+  if (tabsNeedingResults.includes(activeTab)) {
     needsTestResults.current = true;
   }
 
@@ -338,6 +344,16 @@ export default function TestRunMainView({
     }));
     handleTabChange(TAB_KEYS.indexOf('linked_entities'));
   }, [handleTabChange]);
+
+  /** The Reviews tab opens a result in place rather than sending you to the Tests
+   *  tab, the same way the playground opens a trace from a conversation. */
+  const [reviewedResultId, setReviewedResultId] = useState<string | null>(null);
+  const reviewedResult = useMemo(
+    () =>
+      testResults.find(result => String(result.id) === reviewedResultId) ??
+      null,
+    [testResults, reviewedResultId]
+  );
 
   const handleTestResultUpdate = useCallback(
     (updatedTest: TestResultDetail) => {
@@ -624,6 +640,33 @@ export default function TestRunMainView({
           currentUserPicture={currentUserPicture}
           initialTraces={initialTraces}
           initialTracesTotalCount={initialTracesTotalCount}
+        />
+      </TabPanel>
+
+      <TabPanel value={activeTab} index={4}>
+        <TestRunReviewsTab
+          testResults={testResults}
+          loading={loading}
+          onViewTestResult={setReviewedResultId}
+        />
+        <TestResultDrawer
+          open={reviewedResult !== null}
+          onClose={() => setReviewedResultId(null)}
+          test={reviewedResult}
+          prompts={prompts}
+          requirements={requirements}
+          testRunId={testRunId}
+          onTestResultUpdate={handleTestResultUpdate}
+          currentUserId={currentUserId}
+          currentUserName={currentUserName}
+          currentUserPicture={currentUserPicture}
+          initialTab={TEST_RESULT_DRAWER_TAB.reviews}
+          testSetType={
+            testRun.test_configuration?.test_set?.test_set_type?.type_value
+          }
+          project={testRun.test_configuration?.endpoint?.project}
+          projectName={testRun.test_configuration?.endpoint?.project?.name}
+          metricsSource={testRun.test_configuration?.attributes?.metrics_source}
         />
       </TabPanel>
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunReviewsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunReviewsTab.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import {
+  Avatar,
+  Box,
+  Chip,
+  CircularProgress,
+  Paper,
+  Typography,
+} from '@mui/material';
+import RateReviewOutlinedIcon from '@mui/icons-material/RateReviewOutlined';
+import { formatDistanceToNow } from 'date-fns';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { isPassedStatusName } from '@/utils/test-result-status';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
+import type {
+  Review,
+  TestResultDetail,
+} from '@/utils/api-client/interfaces/test-results';
+
+interface TestRunReviewsTabProps {
+  testResults: TestResultDetail[];
+  loading?: boolean;
+  /** Opens the result drawer on its Reviews tab, where reviews are written. */
+  onViewTestResult?: (testResultId: string) => void;
+}
+
+interface RunReview {
+  review: Review;
+  testResultId: string;
+  testLabel: string;
+}
+
+function relativeTime(dateString: string): string {
+  try {
+    return formatDistanceToNow(new Date(dateString), {
+      addSuffix: true,
+    }).toUpperCase();
+  } catch {
+    return 'N/A';
+  }
+}
+
+/** Mirrors the labelling in TestDetailReviewsTab so a review reads the same in both places. */
+function statusLabel(statusName: string): { passed: boolean; label: string } {
+  const name = statusName.toLowerCase();
+  if (name === 'fail') return { passed: false, label: 'Failed' };
+  if (name === 'pass') return { passed: true, label: 'Passed' };
+  return { passed: isPassedStatusName(statusName), label: statusName };
+}
+
+/**
+ * Every human review recorded across a test run.
+ *
+ * Built from the test results the page already loads rather than a new endpoint:
+ * each result carries its own `test_reviews.reviews`, so the run-level view is a
+ * flatten and a sort. Writing and editing reviews stays in the result drawer,
+ * which this links into.
+ */
+export default function TestRunReviewsTab({
+  testResults,
+  loading = false,
+  onViewTestResult,
+}: TestRunReviewsTabProps) {
+  const reviews = useMemo<RunReview[]>(() => {
+    const flattened = testResults.flatMap(result =>
+      (result.test_reviews?.reviews ?? []).map(review => ({
+        review,
+        testResultId: String(result.id),
+        testLabel:
+          result.test?.prompt?.content?.slice(0, 80) ??
+          `Test ${String(result.id).slice(0, 8)}`,
+      }))
+    );
+    return flattened.sort(
+      (a, b) =>
+        new Date(b.review.updated_at).getTime() -
+        new Date(a.review.updated_at).getTime()
+    );
+  }, [testResults]);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (reviews.length === 0) {
+    return (
+      <EntityEmptyState
+        icon={RateReviewOutlinedIcon}
+        title="No reviews yet"
+        description="Reviews are recorded against individual tests from the Tests tab. Any you add will be listed here."
+      />
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {reviews.map(({ review, testResultId, testLabel }) => {
+        const display = statusLabel(review.status.name);
+        return (
+          <Paper
+            key={review.review_id}
+            onClick={
+              onViewTestResult
+                ? () => onViewTestResult(testResultId)
+                : undefined
+            }
+            sx={{
+              p: 2.5,
+              borderRadius: BORDER_RADIUS.md,
+              border: theme => `1px solid ${theme.palette.greyscale.border}`,
+              boxShadow: 'none',
+              cursor: onViewTestResult ? 'pointer' : 'default',
+              '&:hover': onViewTestResult
+                ? { borderColor: 'primary.main' }
+                : undefined,
+            }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                mb: 1.5,
+                gap: 1,
+              }}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                <Avatar
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    fontSize: 12,
+                    bgcolor: 'primary.main',
+                  }}
+                >
+                  {review.user.name.charAt(0).toUpperCase()}
+                </Avatar>
+                <Typography variant="body2" fontWeight={700}>
+                  {review.user.name}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ letterSpacing: 0.5 }}
+                >
+                  {relativeTime(review.updated_at)}
+                </Typography>
+              </Box>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                {review.resolved && (
+                  <Chip size="small" label="Resolved" variant="outlined" />
+                )}
+                <Chip
+                  size="small"
+                  label={display.label}
+                  color={display.passed ? 'success' : 'error'}
+                  variant="outlined"
+                />
+              </Box>
+            </Box>
+
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: 'block', mb: 0.5 }}
+            >
+              {testLabel}
+            </Typography>
+
+            {review.comments && (
+              <Typography variant="body2">{review.comments}</Typography>
+            )}
+          </Paper>
+        );
+      })}
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTracesTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTracesTab.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import React, { useCallback, useState } from 'react';
-import { Box, Paper } from '@mui/material';
+import { Box } from '@mui/material';
 import TimelineOutlinedIcon from '@mui/icons-material/TimelineOutlined';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import TracesClient from '@/app/(protected)/traces/components/TracesClient';
 import type { TraceSummary } from '@/utils/api-client/interfaces/telemetry';
 
@@ -60,25 +59,17 @@ export default function TestRunTracesTab({
             : {}
         }
       >
-        <Paper
-          sx={{
-            width: '100%',
-            borderRadius: BORDER_RADIUS.md,
-            boxShadow: ELEVATION.xs,
-            border: theme => `1px solid ${theme.palette.greyscale.border}`,
-            overflow: 'hidden',
-          }}
-        >
-          <TracesClient
-            currentUserId={currentUserId}
-            currentUserName={currentUserName}
-            currentUserPicture={currentUserPicture}
-            fixedTestRunId={testRunId}
-            onUnfilteredEmpty={handleUnfilteredEmpty}
-            initialData={initialTraces}
-            initialTotalCount={initialTracesTotalCount}
-          />
-        </Paper>
+        {/* No card here: TracesClient wraps the grid in its own, so the rollup
+            tiles sit above it exactly as they do on the Traces page. */}
+        <TracesClient
+          currentUserId={currentUserId}
+          currentUserName={currentUserName}
+          currentUserPicture={currentUserPicture}
+          fixedTestRunId={testRunId}
+          onUnfilteredEmpty={handleUnfilteredEmpty}
+          initialData={initialTraces}
+          initialTotalCount={initialTracesTotalCount}
+        />
       </Box>
 
       {showEmptyHint && (

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/__tests__/TestRunReviewsTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/__tests__/TestRunReviewsTab.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@/test-utils';
+import '@testing-library/jest-dom';
+import TestRunReviewsTab from '../TestRunReviewsTab';
+import type { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+
+function review(
+  id: string,
+  name: string,
+  updatedAt: string,
+  status = 'Pass',
+  comments = ''
+) {
+  return {
+    review_id: id,
+    status: { name: status },
+    user: { user_id: `user-${name}`, name },
+    comments,
+    created_at: updatedAt,
+    updated_at: updatedAt,
+    target: { type: 'test_result', reference: null },
+  };
+}
+
+function result(
+  id: string,
+  reviews: ReturnType<typeof review>[]
+): TestResultDetail {
+  return {
+    id,
+    test_reviews: { reviews },
+    test: { prompt: { content: `Prompt for ${id}` } },
+  } as unknown as TestResultDetail;
+}
+
+describe('TestRunReviewsTab', () => {
+  it('shows the empty state when no test in the run has been reviewed', () => {
+    render(<TestRunReviewsTab testResults={[result('a', [])]} />);
+
+    expect(screen.getByText('No reviews yet')).toBeInTheDocument();
+  });
+
+  it('flattens reviews from every test result into one list', () => {
+    render(
+      <TestRunReviewsTab
+        testResults={[
+          result('a', [review('r1', 'Alice', '2026-09-01T10:00:00Z')]),
+          result('b', [review('r2', 'Bob', '2026-09-02T10:00:00Z')]),
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('puts the most recently updated review first', () => {
+    render(
+      <TestRunReviewsTab
+        testResults={[
+          result('a', [review('r1', 'Older', '2026-09-01T10:00:00Z')]),
+          result('b', [review('r2', 'Newer', '2026-09-05T10:00:00Z')]),
+        ]}
+      />
+    );
+
+    const names = screen
+      .getAllByText(/Older|Newer/)
+      .map(node => node.textContent);
+    expect(names[0]).toBe('Newer');
+  });
+
+  it('hands back the result id so the caller can open it in place', () => {
+    // The caller opens a drawer without leaving the Reviews tab, the way the
+    // playground opens a trace from a conversation.
+    const onViewTestResult = jest.fn();
+    render(
+      <TestRunReviewsTab
+        testResults={[
+          result('abc', [review('r1', 'Alice', '2026-09-01T10:00:00Z')]),
+        ]}
+        onViewTestResult={onViewTestResult}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Alice'));
+
+    expect(onViewTestResult).toHaveBeenCalledWith('abc');
+  });
+
+  it('does not blow up when no handler is given', () => {
+    render(
+      <TestRunReviewsTab
+        testResults={[
+          result('abc', [review('r1', 'Alice', '2026-09-01T10:00:00Z')]),
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Alice'));
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('shows the review comment and its verdict', () => {
+    render(
+      <TestRunReviewsTab
+        testResults={[
+          result('a', [
+            review(
+              'r1',
+              'Alice',
+              '2026-09-01T10:00:00Z',
+              'Fail',
+              'Wrong refusal'
+            ),
+          ]),
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Wrong refusal')).toBeInTheDocument();
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/KpiCard.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/KpiCard.tsx
@@ -27,6 +27,12 @@ interface KpiCardProps {
   visual?: React.ReactNode;
   /** Explains the metric in a hover tooltip via a small info icon next to the title. */
   infoTooltip?: string;
+  /** A second metric of equal standing, shown beside `value`. Both drop a size so
+   *  the pair still fits the card width. Used by the Usage card, where tokens and
+   *  cost answer the same question and neither is the subtitle of the other. */
+  secondary?: { value: string | number; label: string };
+  /** Labels the primary value when `secondary` is set, so the two read as a pair. */
+  valueLabel?: string;
   /** Makes the whole card a button, e.g. to drill into a filtered view. */
   onClick?: () => void;
 }
@@ -39,6 +45,8 @@ export default function KpiCard({
   subtitle,
   visual,
   infoTooltip,
+  secondary,
+  valueLabel,
   onClick,
 }: KpiCardProps) {
   const content = (
@@ -56,27 +64,58 @@ export default function KpiCard({
         )}
       </Box>
 
-      <Typography
-        variant="h4"
-        fontWeight={600}
-        sx={{
-          mb: 1,
-          fontVariantNumeric: 'tabular-nums',
-          color: valueColor,
-        }}
-      >
-        {value}
-        {valueSuffix && (
-          <Typography
-            component="span"
-            variant="body1"
-            color="text.secondary"
-            sx={{ ml: 0.5, fontVariantNumeric: 'tabular-nums' }}
-          >
-            {valueSuffix}
-          </Typography>
-        )}
-      </Typography>
+      {secondary ? (
+        <Box sx={{ display: 'flex', gap: 3, mb: 1 }}>
+          <Box>
+            <Typography
+              variant="h5"
+              fontWeight={600}
+              sx={{ fontVariantNumeric: 'tabular-nums', color: valueColor }}
+            >
+              {value}
+            </Typography>
+            {valueLabel && (
+              <Typography variant="caption" color="text.secondary">
+                {valueLabel}
+              </Typography>
+            )}
+          </Box>
+          <Box>
+            <Typography
+              variant="h5"
+              fontWeight={600}
+              sx={{ fontVariantNumeric: 'tabular-nums' }}
+            >
+              {secondary.value}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {secondary.label}
+            </Typography>
+          </Box>
+        </Box>
+      ) : (
+        <Typography
+          variant="h4"
+          fontWeight={600}
+          sx={{
+            mb: 1,
+            fontVariantNumeric: 'tabular-nums',
+            color: valueColor,
+          }}
+        >
+          {value}
+          {valueSuffix && (
+            <Typography
+              component="span"
+              variant="body1"
+              color="text.secondary"
+              sx={{ ml: 0.5, fontVariantNumeric: 'tabular-nums' }}
+            >
+              {valueSuffix}
+            </Typography>
+          )}
+        </Typography>
+      )}
 
       {visual}
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/KpiRow.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/KpiRow.tsx
@@ -14,6 +14,8 @@ import {
 } from './verdict-timeline';
 import { describeStrip } from './verdict-strip-render';
 import { STRIP_HEIGHTS } from './summary-tokens';
+import { formatCost, formatTokenCount } from '@/utils/trace-utils';
+import { useTestRunUsage } from '../../hooks/useTestRunUsage';
 import type {
   VerdictMatrix,
   TestRunDetail,
@@ -37,6 +39,7 @@ export default function KpiRow({
   onViewFailures,
 }: KpiRowProps) {
   const { kpis } = matrix;
+  const usage = useTestRunUsage(testRun.id);
 
   const durationDisplay = useMemo(() => {
     if (isRunning) return undefined;
@@ -163,18 +166,25 @@ export default function KpiRow({
           />
         </Grid>
 
-        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-          <KpiCard
-            title="Reviews"
-            value={kpis.reviews_count}
-            subtitle={
-              kpis.reviews_count > 0
-                ? `of ${kpis.tests_executed} tests`
-                : 'No reviews yet'
-            }
-            infoTooltip="Tests with at least one human review recorded."
-          />
-        </Grid>
+        {/* Held back until the numbers arrive rather than shown as zeros, the
+            same way the rollup tiles on the Traces page behave. */}
+        {usage && (
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <KpiCard
+              title="Usage"
+              value={formatTokenCount(usage.total_tokens)}
+              valueLabel="tokens"
+              secondary={{
+                value: formatCost(usage.total_cost_usd),
+                label: 'cost',
+              }}
+              subtitle={`across ${usage.total_traces} ${
+                usage.total_traces === 1 ? 'trace' : 'traces'
+              }`}
+              infoTooltip="Tokens and cost across this run's traced LLM calls. Cost appears once enrichment has priced the run."
+            />
+          </Grid>
+        )}
       </Grid>
     </Box>
   );

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/KpiRow.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/summary/__tests__/KpiRow.test.tsx
@@ -11,6 +11,22 @@ import type {
   TestRunDetail,
 } from '@/utils/api-client/interfaces/test-run';
 
+// The Usage card fetches its own totals; drive them rather than the network.
+jest.mock('../../../hooks/useTestRunUsage', () => ({
+  useTestRunUsage: jest.fn(() => null),
+}));
+
+import { useTestRunUsage } from '../../../hooks/useTestRunUsage';
+import type { TraceMetricsResponse } from '@/utils/api-client/interfaces/telemetry';
+
+function mockUsage(usage: Partial<TraceMetricsResponse> | null) {
+  (useTestRunUsage as jest.Mock).mockReturnValue(usage);
+}
+
+beforeEach(() => {
+  mockUsage(null);
+});
+
 beforeAll(() => {
   HTMLCanvasElement.prototype.getContext = jest.fn().mockReturnValue({
     clearRect: jest.fn(),
@@ -389,31 +405,63 @@ describe('KpiRow', () => {
     expect(onViewFailures).not.toHaveBeenCalled();
   });
 
-  it('shows "No reviews yet" on the Reviews card when nothing has been reviewed', () => {
+  it('omits the Usage card until the token and cost numbers arrive', () => {
+    // Showing zeros would read as "this run cost nothing", which is a different
+    // claim from "we do not know yet".
+    mockUsage(null);
     renderWithClock(
       <KpiRow
-        matrix={makeMatrix({ reviews_count: 0 })}
+        matrix={makeMatrix({})}
         testRun={makeTestRun()}
         isRunning={false}
         testIds={[]}
         timings={EMPTY_TIMINGS}
       />
     );
-    expect(screen.getByText('Reviews')).toBeInTheDocument();
-    expect(screen.getByText('No reviews yet')).toBeInTheDocument();
+    expect(screen.queryByText('Usage')).not.toBeInTheDocument();
   });
 
-  it('shows the review count and a "of N tests" subtitle when reviews exist', () => {
+  it('shows tokens and cost side by side on the Usage card', () => {
+    mockUsage({
+      total_traces: 12,
+      total_spans: 190,
+      total_tokens: 45735,
+      total_cost_usd: 0.012695,
+    });
     renderWithClock(
       <KpiRow
-        matrix={makeMatrix({ reviews_count: 3, tests_executed: 5 })}
+        matrix={makeMatrix({})}
         testRun={makeTestRun()}
         isRunning={false}
         testIds={[]}
         timings={EMPTY_TIMINGS}
       />
     );
-    expect(screen.getByText('3')).toBeInTheDocument();
-    expect(screen.getByText('of 5 tests')).toBeInTheDocument();
+    expect(screen.getByText('Usage')).toBeInTheDocument();
+    expect(screen.getByText('45,735')).toBeInTheDocument();
+    expect(screen.getByText('tokens')).toBeInTheDocument();
+    // formatCost drops to two decimals above a cent, same as the Traces page.
+    expect(screen.getByText('$0.01')).toBeInTheDocument();
+    expect(screen.getByText('cost')).toBeInTheDocument();
+    expect(screen.getByText('across 12 traces')).toBeInTheDocument();
+  });
+
+  it('says trace rather than traces when the run produced one', () => {
+    mockUsage({
+      total_traces: 1,
+      total_spans: 3,
+      total_tokens: 150,
+      total_cost_usd: 0.001,
+    });
+    renderWithClock(
+      <KpiRow
+        matrix={makeMatrix({})}
+        testRun={makeTestRun()}
+        isRunning={false}
+        testIds={[]}
+        timings={EMPTY_TIMINGS}
+      />
+    );
+    expect(screen.getByText('across 1 trace')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunUsage.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunUsage.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { readActiveProjectId } from '@/utils/active-project';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import type { TraceMetricsResponse } from '@/utils/api-client/interfaces/telemetry';
+
+/**
+ * Token and cost totals for one test run's traces.
+ *
+ * Reads GET /telemetry/metrics rather than riding along on the verdict matrix,
+ * even though the other KPI numbers live there. The matrix is cached once a run
+ * goes terminal, while trace enrichment runs asynchronously after ingest, so a
+ * run cached the moment it finished would report a cost of zero for the whole
+ * cache lifetime. Going to the metrics endpoint also means this card and the
+ * rollup tiles on the Traces tab cannot disagree.
+ *
+ * Returns null until the numbers arrive, so callers render nothing rather than
+ * zeros they do not yet have.
+ */
+export function useTestRunUsage(
+  testRunId: string
+): TraceMetricsResponse | null {
+  const { activeProject } = useActiveProject();
+  const projectId = activeProject?.id
+    ? String(activeProject.id)
+    : readActiveProjectId();
+  const [usage, setUsage] = useState<TraceMetricsResponse | null>(null);
+
+  useEffect(() => {
+    if (!projectId || !testRunId) {
+      setUsage(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const metrics = await new ApiClientFactory(undefined, projectId)
+          .getTelemetryClient()
+          .getMetrics({ project_id: projectId, test_run_id: testRunId });
+        if (!cancelled) {
+          setUsage(metrics);
+        }
+      } catch {
+        // The card is supplementary; a failure here must not take the summary
+        // down with it.
+        if (!cancelled) {
+          setUsage(null);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, testRunId]);
+
+  return usage;
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
@@ -65,8 +65,11 @@ export default async function TestRunPage({
     tabParam,
     hasSelectedResult && !tabParam
   );
+  // Reviews is built from the same test results the Tests tab uses, so a deep
+  // link to ?tab=reviews needs the same prefetch or it lands on an empty list.
   const wantsLinkedEntities =
-    initialTabIndex === TAB_KEYS.indexOf('linked_entities');
+    initialTabIndex === TAB_KEYS.indexOf('linked_entities') ||
+    initialTabIndex === TAB_KEYS.indexOf('reviews');
   const wantsTraces = initialTabIndex === TAB_KEYS.indexOf('traces');
 
   const scopedProjectId = (await getServerActiveProjectId()) ?? null;

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/utils/tab-key.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/utils/tab-key.ts
@@ -7,11 +7,14 @@
  * tab's data while the client opens a different one.
  */
 
+// Order defines the tab indices, so append rather than insert: anything else
+// shifts every TabPanel index and the legacy key aliases below.
 export const TAB_KEYS = [
   'summary',
   'linked_entities',
   'configuration',
   'traces',
+  'reviews',
 ] as const;
 
 export type TabKey = (typeof TAB_KEYS)[number];

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestParametersBlock.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestParametersBlock.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import * as React from 'react';
+import { Box, Button, Typography, useTheme } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
+import CancelIcon from '@mui/icons-material/Cancel';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useCan } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { TestDetail } from '@/utils/api-client/interfaces/tests';
+import { useNotifications } from '@/components/common/NotificationContext';
+import JsonMonacoField from '@/app/(protected)/endpoints/[identifier]/components/JsonMonacoField';
+
+interface TestParametersBlockProps {
+  test: TestDetail;
+  onUpdate?: () => void;
+}
+
+export default function TestParametersBlock({
+  test,
+  onUpdate,
+}: TestParametersBlockProps) {
+  const theme = useTheme();
+  const notifications = useNotifications();
+  const canEdit = useCan(Capability.Test.UPDATE);
+  const monacoTheme =
+    theme.palette.mode === 'dark' ? 'vs-dark' : 'vs';
+
+  const currentParams = test.test_parameters ?? null;
+  const hasParams =
+    currentParams !== null && Object.keys(currentParams).length > 0;
+
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [draft, setDraft] = React.useState('');
+  const [isSaving, setIsSaving] = React.useState(false);
+
+  const startEditing = React.useCallback(() => {
+    setDraft(
+      hasParams ? JSON.stringify(currentParams, null, 2) : '{\n  \n}'
+    );
+    setIsEditing(true);
+  }, [hasParams, currentParams]);
+
+  const cancelEditing = React.useCallback(() => {
+    setIsEditing(false);
+    setDraft('');
+  }, []);
+
+  const handleSave = React.useCallback(async () => {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(draft);
+    } catch {
+      notifications.show('Invalid JSON', {
+        severity: 'error',
+        autoHideDuration: 4000,
+      });
+      return;
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      notifications.show('Test parameters must be a JSON object', {
+        severity: 'error',
+        autoHideDuration: 4000,
+      });
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const apiFactory = new ApiClientFactory();
+      const testsClient = apiFactory.getTestsClient();
+      await testsClient.updateTest(test.id, {
+        test_parameters: parsed,
+      });
+      notifications.show('Test parameters updated', {
+        severity: 'success',
+        autoHideDuration: 4000,
+      });
+      setIsEditing(false);
+      onUpdate?.();
+    } catch {
+      notifications.show('Failed to save test parameters', {
+        severity: 'error',
+        autoHideDuration: 4000,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [draft, test.id, notifications, onUpdate]);
+
+  const handleClear = React.useCallback(async () => {
+    setIsSaving(true);
+    try {
+      const apiFactory = new ApiClientFactory();
+      const testsClient = apiFactory.getTestsClient();
+      await testsClient.updateTest(test.id, {
+        test_parameters: null as unknown as Record<string, unknown>,
+      });
+      notifications.show('Test parameters cleared', {
+        severity: 'success',
+        autoHideDuration: 4000,
+      });
+      setIsEditing(false);
+      onUpdate?.();
+    } catch {
+      notifications.show('Failed to clear test parameters', {
+        severity: 'error',
+        autoHideDuration: 4000,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [test.id, notifications, onUpdate]);
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          mb: '2px',
+        }}
+      >
+        <Box>
+          <Typography
+            sx={{
+              fontSize: 18,
+              fontWeight: 700,
+              lineHeight: '25px',
+              color: 'text.primary',
+            }}
+          >
+            Test Parameters
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: 12,
+              lineHeight: '18px',
+              color: 'text.secondary',
+              display: 'block',
+              mb: 2,
+            }}
+          >
+            Per-test key-value data available in endpoint mappings as{' '}
+            {'{{ test_parameters.<key> }}'}
+          </Typography>
+        </Box>
+        {canEdit && !isEditing && (
+          <Button
+            size="small"
+            startIcon={<EditIcon />}
+            onClick={startEditing}
+          >
+            Edit
+          </Button>
+        )}
+      </Box>
+
+      {isEditing ? (
+        <Box>
+          <JsonMonacoField
+            editorKey={`test-parameters-${test.id}`}
+            height="200px"
+            theme={monacoTheme}
+            value={draft}
+            onChange={setDraft}
+          />
+          <Box
+            sx={{ display: 'flex', gap: 1, mt: 1, justifyContent: 'flex-end' }}
+          >
+            {hasParams && (
+              <Button
+                size="small"
+                color="error"
+                startIcon={<DeleteIcon />}
+                onClick={handleClear}
+                disabled={isSaving}
+              >
+                Clear
+              </Button>
+            )}
+            <Button
+              size="small"
+              startIcon={<CancelIcon />}
+              onClick={cancelEditing}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="small"
+              variant="contained"
+              startIcon={<SaveIcon />}
+              onClick={handleSave}
+              disabled={isSaving}
+            >
+              Save
+            </Button>
+          </Box>
+        </Box>
+      ) : hasParams ? (
+        <Box
+          sx={{
+            p: 2,
+            borderRadius: 1,
+            backgroundColor: 'action.hover',
+            fontFamily: '"Sometype Mono", monospace',
+            fontSize: theme.typography.body2.fontSize,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}
+        >
+          {JSON.stringify(currentParams, null, 2)}
+        </Box>
+      ) : (
+        <Typography variant="body2" color="text.secondary">
+          No parameters defined
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestParametersBlock.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestParametersBlock.tsx
@@ -25,8 +25,7 @@ export default function TestParametersBlock({
   const theme = useTheme();
   const notifications = useNotifications();
   const canEdit = useCan(Capability.Test.UPDATE);
-  const monacoTheme =
-    theme.palette.mode === 'dark' ? 'vs-dark' : 'vs';
+  const monacoTheme = theme.palette.mode === 'dark' ? 'vs-dark' : 'vs';
 
   const currentParams = test.test_parameters ?? null;
   const hasParams =
@@ -37,9 +36,7 @@ export default function TestParametersBlock({
   const [isSaving, setIsSaving] = React.useState(false);
 
   const startEditing = React.useCallback(() => {
-    setDraft(
-      hasParams ? JSON.stringify(currentParams, null, 2) : '{\n  \n}'
-    );
+    setDraft(hasParams ? JSON.stringify(currentParams, null, 2) : '{\n  \n}');
     setIsEditing(true);
   }, [hasParams, currentParams]);
 
@@ -60,7 +57,11 @@ export default function TestParametersBlock({
       return;
     }
 
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
       notifications.show('Test parameters must be a JSON object', {
         severity: 'error',
         autoHideDuration: 4000,
@@ -150,11 +151,7 @@ export default function TestParametersBlock({
           </Typography>
         </Box>
         {canEdit && !isEditing && (
-          <Button
-            size="small"
-            startIcon={<EditIcon />}
-            onClick={startEditing}
-          >
+          <Button size="small" startIcon={<EditIcon />} onClick={startEditing}>
             Edit
           </Button>
         )}

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestParametersBlock.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestParametersBlock.tsx
@@ -97,7 +97,7 @@ export default function TestParametersBlock({
       const apiFactory = new ApiClientFactory();
       const testsClient = apiFactory.getTestsClient();
       await testsClient.updateTest(test.id, {
-        test_parameters: null as unknown as Record<string, unknown>,
+        test_parameters: null,
       });
       notifications.show('Test parameters cleared', {
         severity: 'success',

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestTechnicalCard.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestTechnicalCard.tsx
@@ -23,6 +23,7 @@ import MultiTurnConfigFields, {
   createMultiTurnDraft,
 } from './MultiTurnConfigFields';
 import FilePreview from '@/components/common/FilePreview';
+import TestParametersBlock from './TestParametersBlock';
 import { useRouter } from 'next/navigation';
 
 interface PromptDraft {
@@ -210,6 +211,7 @@ export default function TestTechnicalCard({
               setDraft={setDraft}
               isEditing={isEditing}
             />
+            <TestParametersBlock test={test} onUpdate={onUpdate} />
             <AttachmentsBlock test={test} />
           </Box>
         )}
@@ -324,6 +326,10 @@ export default function TestTechnicalCard({
               </Grid>
             </Grid>
           )}
+
+          <Grid size={12}>
+            <TestParametersBlock test={test} onUpdate={onUpdate} />
+          </Grid>
 
           <Grid size={12}>
             <AttachmentsBlock test={test} />

--- a/apps/frontend/src/app/(protected)/traces/components/SpanDetailsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/SpanDetailsPanel.tsx
@@ -31,6 +31,11 @@ import FileAttachmentList from '@/components/common/FileAttachmentList';
 import { MentionOption } from '@/components/common/MentionTextInput';
 import { format } from 'date-fns';
 import { formatDuration } from '@/utils/format-duration';
+import {
+  formatCost,
+  formatTokenCount,
+  subtreeUsage,
+} from '@/utils/trace-utils';
 import TestResultTab from './TestResultTab';
 import TraceMetricsTab from './TraceMetricsTab';
 import TraceReviewsTab from './TraceReviewsTab';
@@ -316,12 +321,17 @@ export default function SpanDetailsPanel({
     ? parseIfJSON(String(agentOutput))
     : null;
 
-  // Filter out agent I/O from LLM attributes (displayed separately)
+  // Filter out agent I/O and token counts from LLM attributes (displayed separately)
   const {
     'ai.agent.input': _____,
     'ai.agent.output': ______,
+    'ai.llm.tokens.input': _______,
+    'ai.llm.tokens.output': ________,
+    'ai.llm.tokens.total': _________,
     ...otherLlmAttributes
   } = llmAttributes;
+
+  const usage = subtreeUsage(span);
 
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -437,6 +447,42 @@ export default function SpanDetailsPanel({
                       )}
                     </Box>
                   </Box>
+
+                  {/* Usage. Rolled up over the subtree, because only the
+                      ai.llm.invoke leaves carry token attributes and a container
+                      span would otherwise show nothing. */}
+                  {usage && (
+                    <Box>
+                      <Typography variant="caption" color="text.secondary">
+                        Usage
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        display="block"
+                        sx={{ mt: 0.5 }}
+                      >
+                        Tokens: {formatTokenCount(usage.total)}
+                        {(usage.input > 0 || usage.output > 0) &&
+                          ` (${formatTokenCount(usage.input)} input \u00b7 ${formatTokenCount(usage.output)} output)`}
+                      </Typography>
+                      {usage.costUsd !== null && (
+                        <Typography variant="caption" display="block">
+                          Cost: {formatCost(usage.costUsd)}
+                        </Typography>
+                      )}
+                      {usage.llmSpanCount > 0 && (
+                        <Typography variant="caption" display="block">
+                          Rolled up from {usage.llmSpanCount} LLM{' '}
+                          {usage.llmSpanCount === 1 ? 'span' : 'spans'}
+                        </Typography>
+                      )}
+                      {span.model_name && (
+                        <Typography variant="caption" display="block">
+                          Model: {span.model_name}
+                        </Typography>
+                      )}
+                    </Box>
+                  )}
                 </Stack>
               </CardContent>
             </Card>

--- a/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
@@ -25,6 +25,11 @@ import {
   toMentionId,
 } from '@/components/common/MentionTextInput';
 import { formatDuration } from '@/utils/format-duration';
+import {
+  formatCost,
+  formatTokenCount,
+  tokenSplitLabel,
+} from '@/utils/trace-utils';
 import { shortVersion } from '@/utils/api-client/interfaces/parameters';
 import { experimentHref } from '@/utils/experiment-links';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
@@ -603,6 +608,21 @@ export default function TraceDrawer({
             <GridBadge label={`${trace.span_count} spans`} size="grid" />
             <GridBadge label={formatDuration(trace.duration_ms)} size="grid" />
             <GridBadge label={trace.environment} size="grid" />
+            {trace.total_tokens > 0 && (
+              <GridBadge
+                label={`${formatTokenCount(trace.total_tokens)} tokens`}
+                size="grid"
+                // Native title rather than MUI Tooltip: GridBadge is not a
+                // forwardRef component, so Tooltip cannot anchor to it.
+                title={tokenSplitLabel(
+                  trace.total_input_tokens,
+                  trace.total_output_tokens
+                )}
+              />
+            )}
+            {trace.total_cost_usd > 0 && (
+              <GridBadge label={formatCost(trace.total_cost_usd)} size="grid" />
+            )}
             {trace.error_count > 0 && (
               <GridBadge
                 label={`${trace.error_count} errors`}

--- a/apps/frontend/src/app/(protected)/traces/components/TraceMetricsSummary.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceMetricsSummary.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Box, Grid, Typography } from '@mui/material';
+import AccountTreeIcon from '@mui/icons-material/AccountTree';
+import LayersIcon from '@mui/icons-material/Layers';
+import PaidIcon from '@mui/icons-material/Paid';
+import TokenIcon from '@mui/icons-material/Token';
+import { SummaryCard } from '@/components/common/SummaryCard';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import type { TraceMetricsResponse } from '@/utils/api-client/interfaces/telemetry';
+import { formatCost, formatTokenCount } from '@/utils/trace-utils';
+
+interface TraceMetricsSummaryProps {
+  projectId: string | null;
+  environment?: string;
+  startTimeAfter?: string;
+  startTimeBefore?: string;
+  /**
+   * True when a filter the metrics endpoint cannot honor is active (endpoint,
+   * trace source, evaluation status, search, ...). The tiles then cover more
+   * traces than the table lists, and say so rather than appearing to disagree.
+   */
+  hasUnsupportedFilters?: boolean;
+  /** Bumped by the refresh control, to re-fetch alongside the table. */
+  refreshTrigger?: number;
+}
+
+/**
+ * Project-level totals above the traces table.
+ *
+ * Fetched with useEffect rather than react-query: the traces page has no query
+ * cache (useList/usePaginatedList are hand-rolled), so there would be no key to
+ * invalidate. Mirrors how TraceDrawer fetches a single trace.
+ */
+export default function TraceMetricsSummary({
+  projectId,
+  environment,
+  startTimeAfter,
+  startTimeBefore,
+  hasUnsupportedFilters = false,
+  refreshTrigger,
+}: TraceMetricsSummaryProps) {
+  const [metrics, setMetrics] = useState<TraceMetricsResponse | null>(null);
+
+  useEffect(() => {
+    if (!projectId) {
+      setMetrics(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const client = new ApiClientFactory(
+          undefined,
+          projectId
+        ).getTelemetryClient();
+        const result = await client.getMetrics({
+          project_id: projectId,
+          ...(environment ? { environment } : {}),
+          ...(startTimeAfter ? { start_time_after: startTimeAfter } : {}),
+          ...(startTimeBefore ? { start_time_before: startTimeBefore } : {}),
+        });
+        if (!cancelled) {
+          setMetrics(result);
+        }
+      } catch {
+        // The tiles are supplementary; a failure here must not take the table
+        // down with it, and the table surfaces its own errors.
+        if (!cancelled) {
+          setMetrics(null);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, environment, startTimeAfter, startTimeBefore, refreshTrigger]);
+
+  if (!metrics) {
+    return null;
+  }
+
+  const scope = hasUnsupportedFilters
+    ? 'Whole project, not narrowed by the active filters'
+    : undefined;
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      <Grid container spacing={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <SummaryCard
+            title="Traces"
+            value={metrics.total_traces.toLocaleString()}
+            subtitle={scope}
+            icon={<AccountTreeIcon />}
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <SummaryCard
+            title="Spans"
+            value={metrics.total_spans.toLocaleString()}
+            subtitle={scope}
+            icon={<LayersIcon />}
+            color="info"
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <SummaryCard
+            title="Tokens"
+            value={formatTokenCount(metrics.total_tokens)}
+            subtitle={scope}
+            icon={<TokenIcon />}
+            color="success"
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <SummaryCard
+            title="Cost"
+            value={formatCost(metrics.total_cost_usd)}
+            subtitle={scope}
+            icon={<PaidIcon />}
+            color="warning"
+          />
+        </Grid>
+      </Grid>
+      {hasUnsupportedFilters && (
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ display: 'block', mt: 1 }}
+        >
+          Totals cover the whole project for the selected environment and time
+          range. The table below is narrowed further by the active filters.
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/traces/components/TraceMetricsSummary.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceMetricsSummary.tsx
@@ -13,6 +13,8 @@ import { formatCost, formatTokenCount } from '@/utils/trace-utils';
 
 interface TraceMetricsSummaryProps {
   projectId: string | null;
+  /** Narrows the totals to one test run, for the Traces tab inside a run. */
+  testRunId?: string;
   environment?: string;
   startTimeAfter?: string;
   startTimeBefore?: string;
@@ -35,6 +37,7 @@ interface TraceMetricsSummaryProps {
  */
 export default function TraceMetricsSummary({
   projectId,
+  testRunId,
   environment,
   startTimeAfter,
   startTimeBefore,
@@ -59,6 +62,7 @@ export default function TraceMetricsSummary({
         ).getTelemetryClient();
         const result = await client.getMetrics({
           project_id: projectId,
+          ...(testRunId ? { test_run_id: testRunId } : {}),
           ...(environment ? { environment } : {}),
           ...(startTimeAfter ? { start_time_after: startTimeAfter } : {}),
           ...(startTimeBefore ? { start_time_before: startTimeBefore } : {}),
@@ -80,7 +84,14 @@ export default function TraceMetricsSummary({
     return () => {
       cancelled = true;
     };
-  }, [projectId, environment, startTimeAfter, startTimeBefore, refreshTrigger]);
+  }, [
+    projectId,
+    testRunId,
+    environment,
+    startTimeAfter,
+    startTimeBefore,
+    refreshTrigger,
+  ]);
 
   if (!metrics) {
     return null;

--- a/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
@@ -197,17 +197,18 @@ export default function TracesClient({
   const showFilteredEmpty =
     !listLoading && traces.length === 0 && totalCount === 0;
 
-  // GET /telemetry/metrics only narrows by project, environment and time, so any
-  // other active filter makes the rollup broader than the listed rows. Tell it,
-  // rather than letting the two silently disagree.
+  // GET /telemetry/metrics narrows by project, environment, time and test run, so
+  // any other active filter makes the rollup broader than the listed rows. Tell
+  // it, rather than letting the two silently disagree.
   const rollupProjectId = drawerFilters.projectId || scopedProjectId;
+  const rollupTestRunId =
+    fixedTestRunId ?? drawerFilters.testRunId ?? undefined;
   const hasUnsupportedRollupFilters = Boolean(
     searchQuery.trim() ||
     (typeFilter && typeFilter !== 'all') ||
     drawerFilters.endpointId ||
     drawerFilters.traceSource ||
     drawerFilters.traceMetricsStatus ||
-    drawerFilters.testRunId ||
     drawerFilters.testResultId ||
     drawerFilters.testId
   );
@@ -218,19 +219,17 @@ export default function TracesClient({
 
   return (
     <>
-      {/* Project totals sit above the grid card, not inside it. Skipped on a test
-          run's Traces tab: the metrics endpoint cannot filter by test run, so the
-          tiles there would count the whole project next to a dozen listed rows. */}
-      {!fixedTestRunId && (
-        <TraceMetricsSummary
-          projectId={rollupProjectId}
-          environment={drawerFilters.environment ?? undefined}
-          startTimeAfter={rollupTimeParams.start_time_after}
-          startTimeBefore={rollupTimeParams.start_time_before}
-          hasUnsupportedFilters={hasUnsupportedRollupFilters}
-          refreshTrigger={refreshTrigger}
-        />
-      )}
+      {/* Totals sit above the grid card, not inside it. The metrics endpoint scopes
+          by test run, so on a run's Traces tab these describe that run. */}
+      <TraceMetricsSummary
+        projectId={rollupProjectId}
+        testRunId={rollupTestRunId}
+        environment={drawerFilters.environment ?? undefined}
+        startTimeAfter={rollupTimeParams.start_time_after}
+        startTimeBefore={rollupTimeParams.start_time_before}
+        hasUnsupportedFilters={hasUnsupportedRollupFilters}
+        refreshTrigger={refreshTrigger}
+      />
 
       <Paper sx={GRID_PAPER_SX}>
         {error && (

--- a/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
@@ -2,15 +2,18 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
-import { Alert, Box, Typography } from '@mui/material';
+import { Alert, Box, Paper, Typography } from '@mui/material';
+import { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
 import TracesTable from './TracesTable';
 import TraceDrawer from './TraceDrawer';
+import TraceMetricsSummary from './TraceMetricsSummary';
 import { useList } from '@/hooks/useList';
 import { tracesList } from './list';
 import type { TraceSummary } from '@/utils/api-client/interfaces/telemetry';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { readActiveProjectId } from '@/utils/active-project';
 import {
+  buildTraceQueryParams,
   EMPTY_TRACE_DRAWER_FILTERS,
   hasActiveTraceDrawerFilters,
   sanitizeTraceDrawerFiltersForTestRunScope,
@@ -111,6 +114,8 @@ export default function TracesClient({
     rowsPerPage: pageSize,
     onPageChange,
     onRowsPerPageChange,
+    sortModel,
+    onSortModelChange,
   } = useList(descriptor, {
     filters,
     enabled: !projectLoading && !!scopedProjectId,
@@ -192,46 +197,83 @@ export default function TracesClient({
   const showFilteredEmpty =
     !listLoading && traces.length === 0 && totalCount === 0;
 
+  // GET /telemetry/metrics only narrows by project, environment and time, so any
+  // other active filter makes the rollup broader than the listed rows. Tell it,
+  // rather than letting the two silently disagree.
+  const rollupProjectId = drawerFilters.projectId || scopedProjectId;
+  const hasUnsupportedRollupFilters = Boolean(
+    searchQuery.trim() ||
+    (typeFilter && typeFilter !== 'all') ||
+    drawerFilters.endpointId ||
+    drawerFilters.traceSource ||
+    drawerFilters.traceMetricsStatus ||
+    drawerFilters.testRunId ||
+    drawerFilters.testResultId ||
+    drawerFilters.testId
+  );
+  const rollupTimeParams = useMemo(
+    () => buildTraceQueryParams(drawerFilters, '', 'all'),
+    [drawerFilters]
+  );
+
   return (
     <>
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
-          {error}
-        </Alert>
+      {/* Project totals sit above the grid card, not inside it. Skipped on a test
+          run's Traces tab: the metrics endpoint cannot filter by test run, so the
+          tiles there would count the whole project next to a dozen listed rows. */}
+      {!fixedTestRunId && (
+        <TraceMetricsSummary
+          projectId={rollupProjectId}
+          environment={drawerFilters.environment ?? undefined}
+          startTimeAfter={rollupTimeParams.start_time_after}
+          startTimeBefore={rollupTimeParams.start_time_before}
+          hasUnsupportedFilters={hasUnsupportedRollupFilters}
+          refreshTrigger={refreshTrigger}
+        />
       )}
 
-      <TracesTable
-        traces={traces}
-        loading={listLoading}
-        onRowClick={handleRowClick}
-        totalCount={totalCount}
-        page={page}
-        pageSize={pageSize}
-        onPageChange={onPageChange}
-        onPageSizeChange={onRowsPerPageChange}
-        searchQuery={searchQuery}
-        onSearchQueryChange={setSearchQuery}
-        typeFilter={typeFilter}
-        onTypeFilterChange={setTypeFilter}
-        drawerFilters={drawerFilters}
-        onApplyDrawerFilters={handleApplyDrawerFilters}
-        filterDrawerOpen={filterDrawerOpen}
-        onFilterDrawerOpen={() => setFilterDrawerOpen(true)}
-        onFilterDrawerClose={() => setFilterDrawerOpen(false)}
-        fixedTestRunId={fixedTestRunId}
-      />
+      <Paper sx={GRID_PAPER_SX}>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
+            {error}
+          </Alert>
+        )}
 
-      {showFilteredEmpty && (
-        <Box sx={{ py: 6, textAlign: 'center' }}>
-          <Typography variant="h6" gutterBottom>
-            No traces found
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Try adjusting your filters or check back after running tests or
-            invoking endpoints.
-          </Typography>
-        </Box>
-      )}
+        <TracesTable
+          traces={traces}
+          loading={listLoading}
+          onRowClick={handleRowClick}
+          totalCount={totalCount}
+          page={page}
+          pageSize={pageSize}
+          onPageChange={onPageChange}
+          onPageSizeChange={onRowsPerPageChange}
+          searchQuery={searchQuery}
+          onSearchQueryChange={setSearchQuery}
+          typeFilter={typeFilter}
+          onTypeFilterChange={setTypeFilter}
+          drawerFilters={drawerFilters}
+          onApplyDrawerFilters={handleApplyDrawerFilters}
+          filterDrawerOpen={filterDrawerOpen}
+          onFilterDrawerOpen={() => setFilterDrawerOpen(true)}
+          onFilterDrawerClose={() => setFilterDrawerOpen(false)}
+          fixedTestRunId={fixedTestRunId}
+          sortModel={sortModel}
+          onSortModelChange={onSortModelChange}
+        />
+
+        {showFilteredEmpty && (
+          <Box sx={{ py: 6, textAlign: 'center' }}>
+            <Typography variant="h6" gutterBottom>
+              No traces found
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Try adjusting your filters or check back after running tests or
+              invoking endpoints.
+            </Typography>
+          </Box>
+        )}
+      </Paper>
 
       <TraceDrawer
         open={drawerOpen}

--- a/apps/frontend/src/app/(protected)/traces/components/TracesClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClientWrapper.tsx
@@ -3,14 +3,13 @@
 import React, { useCallback, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
-import { Alert, Box, Paper } from '@mui/material';
+import { Alert, Box } from '@mui/material';
 import RefreshOutlinedIcon from '@mui/icons-material/RefreshOutlined';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import TimelineOutlinedIcon from '@mui/icons-material/TimelineOutlined';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import TracesClient from './TracesClient';
 import type { TraceSummary } from '@/utils/api-client/interfaces/telemetry';
 import AccessDenied from '@/components/common/AccessDenied';
@@ -118,27 +117,19 @@ export default function TracesClientWrapper({
               : {}
           }
         >
-          <Paper
-            sx={{
-              width: '100%',
-              borderRadius: BORDER_RADIUS.md,
-              boxShadow: ELEVATION.xs,
-              border: theme => `1px solid ${theme.palette.greyscale.border}`,
-              overflow: 'hidden',
-            }}
-          >
-            <TracesClient
-              currentUserId={currentUserId}
-              currentUserName={currentUserName}
-              currentUserPicture={currentUserPicture}
-              initialTraceId={initialTraceId}
-              initialProjectId={initialProjectId}
-              onUnfilteredEmpty={handleUnfilteredEmpty}
-              refreshTrigger={refreshTrigger}
-              initialData={initialData}
-              initialTotalCount={initialTotalCount}
-            />
-          </Paper>
+          {/* The grid card lives inside TracesClient, so the rollup tiles can sit
+              above it rather than inside it. */}
+          <TracesClient
+            currentUserId={currentUserId}
+            currentUserName={currentUserName}
+            currentUserPicture={currentUserPicture}
+            initialTraceId={initialTraceId}
+            initialProjectId={initialProjectId}
+            onUnfilteredEmpty={handleUnfilteredEmpty}
+            refreshTrigger={refreshTrigger}
+            initialData={initialData}
+            initialTotalCount={initialTotalCount}
+          />
         </Box>
         {showEmptyHint && (
           <EntityEmptyState

--- a/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
@@ -3,6 +3,7 @@
 import React, { useContext, useMemo } from 'react';
 import {
   GridColDef,
+  GridSortModel,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
   GridToolbarExport,
@@ -21,6 +22,11 @@ import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
 import { isPassedStatusName } from '@/utils/test-result-status';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { formatDuration } from '@/utils/format-duration';
+import {
+  formatCost,
+  formatTokenCount,
+  tokenSplitLabel,
+} from '@/utils/trace-utils';
 import { formatDate } from '@/utils/date';
 import { TEST_TYPE_PILL_TABS } from '@/constants/test-types';
 import TraceFilterDrawer, {
@@ -115,6 +121,8 @@ interface TracesTableProps {
   onFilterDrawerOpen: () => void;
   onFilterDrawerClose: () => void;
   fixedTestRunId?: string;
+  sortModel?: GridSortModel;
+  onSortModelChange?: (model: GridSortModel) => void;
 }
 
 export default function TracesTable({
@@ -136,6 +144,8 @@ export default function TracesTable({
   onFilterDrawerOpen,
   onFilterDrawerClose,
   fixedTestRunId,
+  sortModel,
+  onSortModelChange,
 }: TracesTableProps) {
   const hasActiveDrawerFilters = hasActiveTraceDrawerFilters(drawerFilters, {
     testRunScope: Boolean(fixedTestRunId),
@@ -199,6 +209,8 @@ export default function TracesTable({
       },
       {
         field: 'conversation_input',
+        // a JSONB span attribute, so the backend cannot order by it.
+        sortable: false,
         headerName: 'Input',
         flex: 3.2,
         minWidth: 160,
@@ -233,6 +245,8 @@ export default function TracesTable({
       },
       {
         field: 'endpoint_name',
+        // three joins away, so the backend cannot order by it.
+        sortable: false,
         headerName: 'Endpoint',
         flex: 1.8,
         minWidth: 100,
@@ -293,7 +307,41 @@ export default function TracesTable({
         align: 'center',
       },
       {
+        field: 'total_tokens',
+        headerName: 'Tokens',
+        flex: 1,
+        minWidth: 70,
+        align: 'right',
+        renderCell: params => (
+          <Typography
+            variant="body2"
+            // Native title: the split is already on the row, and the drawer shows
+            // the same breakdown on its token chip.
+            title={tokenSplitLabel(
+              params.row.total_input_tokens,
+              params.row.total_output_tokens
+            )}
+          >
+            {params.value ? formatTokenCount(params.value as number) : '\u2014'}
+          </Typography>
+        ),
+      },
+      {
+        field: 'total_cost_usd',
+        headerName: 'Cost',
+        flex: 1,
+        minWidth: 70,
+        align: 'right',
+        renderCell: params => (
+          <Typography variant="body2">
+            {params.value ? formatCost(params.value as number) : '\u2014'}
+          </Typography>
+        ),
+      },
+      {
         field: 'trace_metrics_status',
+        // a relationship, not a column, so the backend cannot order by it.
+        sortable: false,
         headerName: 'Evaluation',
         flex: 1.4,
         minWidth: 100,
@@ -410,11 +458,14 @@ export default function TracesTable({
         }}
         pageSizeOptions={[25, 50, 100]}
         disablePaperWrapper
+        sortingMode="server"
+        sortModel={sortModel}
+        onSortModelChange={onSortModelChange}
         toolbarSlot={() => (
           <TracesUnifiedToolbar hideTypeFilter={Boolean(fixedTestRunId)} />
         )}
         persistState
-        storageKey="traces-grid"
+        storageKey="traces-grid-v2"
         sx={{
           '& .MuiDataGrid-row': {
             cursor: 'pointer',

--- a/apps/frontend/src/app/(protected)/traces/components/list.ts
+++ b/apps/frontend/src/app/(protected)/traces/components/list.ts
@@ -46,6 +46,8 @@ export function tracesList(
     resource: 'traces',
     capability: Capability.Telemetry.READ,
     defaultPageSize: 50,
+    // The shared default is created_at, which this endpoint does not sort by.
+    defaultSort: { by: 'start_time', order: 'desc' },
     filters: TRACES_FILTERS,
     extraParams: f => {
       const { search, typeFilter, ...drawer } = f;
@@ -60,18 +62,18 @@ export function tracesList(
       return params;
     },
     list: async (_factory, params) => {
-      const {
-        skip,
-        limit,
-        sort_by: _sortBy,
-        sort_order: _sortOrder,
-        ...rest
-      } = params;
+      const { skip, limit, sort_by, sort_order, ...rest } = params;
       const response = await (
         factory ?? new ApiClientFactory(undefined, scopedProjectId ?? undefined)
       )
         .getTelemetryClient()
-        .listTraces({ ...rest, limit, offset: skip });
+        .listTraces({
+          ...rest,
+          limit,
+          offset: skip,
+          sort_by,
+          sort_order: sort_order as 'asc' | 'desc' | undefined,
+        });
       return {
         data: response.traces,
         pagination: {

--- a/apps/frontend/src/utils/__tests__/trace-utils.test.ts
+++ b/apps/frontend/src/utils/__tests__/trace-utils.test.ts
@@ -14,7 +14,11 @@ import {
   getTreeDepth,
   formatTraceDate,
   getStatusChipProps,
+  spanUsage,
+  subtreeUsage,
+  tokenSplitLabel,
 } from '../trace-utils';
+import type { SpanNode } from '../api-client/interfaces/telemetry';
 
 describe('trace-utils', () => {
   describe('formatDurationShort', () => {
@@ -121,6 +125,209 @@ describe('trace-utils', () => {
     it('formats numbers with thousands separator', () => {
       expect(formatTokenCount(1000)).toContain('1');
       expect(formatTokenCount(10000)).toContain('10');
+    });
+  });
+
+  describe('spanUsage', () => {
+    const span = (
+      attributes: Record<string, string | number | boolean>,
+      costUsd?: number | null
+    ) =>
+      ({
+        span_id: 'a',
+        span_name: 'ai.llm.invoke',
+        span_kind: 'CLIENT',
+        start_time: '2026-01-01T00:00:00Z',
+        end_time: '2026-01-01T00:00:01Z',
+        duration_ms: 1000,
+        status_code: 'OK',
+        attributes,
+        cost_usd: costUsd,
+        events: [],
+        children: [],
+        execution: 'completed',
+        verdict: null,
+      }) as unknown as SpanNode;
+
+    it('returns null for a span with neither tokens nor cost', () => {
+      expect(spanUsage(span({ 'ai.tool.name': 'search' }))).toBeNull();
+    });
+
+    it('reads the token counts off the attributes', () => {
+      expect(
+        spanUsage(
+          span({
+            'ai.llm.tokens.input': 100,
+            'ai.llm.tokens.output': 50,
+            'ai.llm.tokens.total': 150,
+          })
+        )
+      ).toEqual({ input: 100, output: 50, total: 150, costUsd: null });
+    });
+
+    it('trusts the reported total over input + output', () => {
+      // Google ADK folds cache-read tokens into the total it reports.
+      const usage = spanUsage(
+        span({
+          'ai.llm.tokens.input': 100,
+          'ai.llm.tokens.output': 50,
+          'ai.llm.tokens.total': 950,
+        })
+      );
+
+      expect(usage?.total).toBe(950);
+    });
+
+    it('derives the total when none is reported', () => {
+      const usage = spanUsage(
+        span({ 'ai.llm.tokens.input': 100, 'ai.llm.tokens.output': 50 })
+      );
+
+      expect(usage?.total).toBe(150);
+    });
+
+    it('reports a cost-only span, for an unpriced-token edge case', () => {
+      expect(spanUsage(span({}, 0.0042))).toEqual({
+        input: 0,
+        output: 0,
+        total: 0,
+        costUsd: 0.0042,
+      });
+    });
+
+    it('treats a zero or absent cost as no cost', () => {
+      expect(
+        spanUsage(span({ 'ai.llm.tokens.total': 10 }, 0))?.costUsd
+      ).toBeNull();
+      expect(
+        spanUsage(span({ 'ai.llm.tokens.total': 10 }, null))?.costUsd
+      ).toBeNull();
+    });
+
+    it('ignores non-numeric attribute values', () => {
+      expect(spanUsage(span({ 'ai.llm.tokens.total': 'lots' }))).toBeNull();
+    });
+  });
+
+  describe('subtreeUsage', () => {
+    const llmSpan = (
+      id: string,
+      input: number,
+      output: number,
+      total: number,
+      costUsd?: number
+    ) =>
+      ({
+        span_id: id,
+        span_name: 'ai.llm.invoke',
+        span_kind: 'CLIENT',
+        start_time: '2026-01-01T00:00:00Z',
+        end_time: '2026-01-01T00:00:01Z',
+        duration_ms: 1000,
+        status_code: 'OK',
+        attributes: {
+          'ai.operation.type': 'llm.invoke',
+          'ai.llm.tokens.input': input,
+          'ai.llm.tokens.output': output,
+          'ai.llm.tokens.total': total,
+        },
+        cost_usd: costUsd,
+        events: [],
+        children: [],
+        execution: 'completed',
+        verdict: null,
+      }) as unknown as SpanNode;
+
+    const container = (id: string, children: SpanNode[]) =>
+      ({
+        span_id: id,
+        span_name: 'function.haystack.pipeline.run',
+        span_kind: 'INTERNAL',
+        start_time: '2026-01-01T00:00:00Z',
+        end_time: '2026-01-01T00:00:01Z',
+        duration_ms: 1000,
+        status_code: 'OK',
+        attributes: {},
+        events: [],
+        children,
+        execution: 'completed',
+        verdict: null,
+      }) as unknown as SpanNode;
+
+    it('reports a leaf span own usage, with no rollup count', () => {
+      const usage = subtreeUsage(llmSpan('a', 100, 50, 150, 0.002));
+
+      expect(usage).toEqual({
+        input: 100,
+        output: 50,
+        total: 150,
+        costUsd: 0.002,
+        llmSpanCount: 0,
+      });
+    });
+
+    it('sums descendants for a container span that has none of its own', () => {
+      // The Haystack shape: only the ai.llm.invoke leaves carry tokens.
+      const tree = container('root', [
+        container('step-1', [llmSpan('a', 100, 50, 150, 0.002)]),
+        container('step-2', [llmSpan('b', 200, 70, 270, 0.004)]),
+      ]);
+
+      expect(subtreeUsage(tree)).toEqual({
+        input: 300,
+        output: 120,
+        total: 420,
+        costUsd: 0.006,
+        llmSpanCount: 2,
+      });
+    });
+
+    it('returns null for a subtree with no LLM spans anywhere', () => {
+      const tree = container('root', [container('tool', [])]);
+
+      expect(subtreeUsage(tree)).toBeNull();
+    });
+
+    it('keeps a reported total larger than input plus output', () => {
+      // ADK folds cache-read tokens into the total, so the rollup must sum each
+      // node's reported total rather than recomputing it from the split.
+      const tree = container('root', [llmSpan('adk', 100, 50, 950)]);
+
+      const usage = subtreeUsage(tree);
+
+      expect(usage?.total).toBe(950);
+      expect(usage?.input).toBe(100);
+      expect(usage?.output).toBe(50);
+    });
+
+    it('leaves cost null when nothing in the subtree is priced', () => {
+      const tree = container('root', [llmSpan('a', 100, 50, 150)]);
+
+      expect(subtreeUsage(tree)?.costUsd).toBeNull();
+    });
+
+    it('counts only the spans that actually contributed', () => {
+      const tree = container('root', [
+        llmSpan('a', 100, 50, 150),
+        container('tool', []),
+      ]);
+
+      expect(subtreeUsage(tree)?.llmSpanCount).toBe(1);
+    });
+  });
+
+  describe('tokenSplitLabel', () => {
+    it('labels the two figures without implying they sum to the total', () => {
+      expect(tokenSplitLabel(1204, 318)).toBe('1,204 input \u00b7 318 output');
+    });
+
+    it('returns undefined when neither figure is known', () => {
+      expect(tokenSplitLabel(0, 0)).toBeUndefined();
+      expect(tokenSplitLabel(null, undefined)).toBeUndefined();
+    });
+
+    it('still labels when only one figure is known', () => {
+      expect(tokenSplitLabel(100, 0)).toBe('100 input \u00b7 0 output');
     });
   });
 

--- a/apps/frontend/src/utils/api-client/interfaces/telemetry.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/telemetry.ts
@@ -79,6 +79,9 @@ export interface SpanNode {
   status_code: string;
   status_message?: string;
   attributes: Record<string, string | number | boolean>;
+  /** Priced by enrichment; absent until a trace has been enriched. */
+  cost_usd?: number | null;
+  model_name?: string | null;
   events: SpanEvent[];
   children: SpanNode[];
   trace_metrics?: Record<string, unknown>;
@@ -101,6 +104,13 @@ export interface TraceSummary {
   duration_ms: number;
   span_count: number;
   root_operation: string;
+
+  // Token usage and cost. Summed over the trace's llm.invoke spans, so a trace with
+  // no LLM spans omits them rather than reporting zero.
+  total_tokens?: number | null;
+  total_input_tokens?: number | null;
+  total_output_tokens?: number | null;
+  total_cost_usd?: number | null;
 
   // Endpoint information (optional)
   endpoint_id?: string;
@@ -128,6 +138,14 @@ export interface TraceDetailResponse {
   duration_ms: number;
   span_count: number;
   error_count: number;
+
+  // Token usage and cost across the trace's llm.invoke spans. The detail endpoint
+  // has the whole span set, so unlike TraceSummary it always resolves the split.
+  total_tokens: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cost_usd: number;
+
   root_spans: SpanNode[];
 
   // Trace metrics evaluation. execution/verdict are the source of truth
@@ -208,6 +226,8 @@ export interface TraceQueryParams {
   trace_metrics_status?: TraceMetricsStatus;
   limit?: number;
   offset?: number;
+  sort_by?: string;
+  sort_order?: 'asc' | 'desc';
 }
 
 /**

--- a/apps/frontend/src/utils/api-client/interfaces/tests.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/tests.ts
@@ -58,6 +58,7 @@ export interface TestBase {
   organization_id?: UUID;
   tags?: Tag[];
   test_metadata?: Record<string, unknown>;
+  test_parameters?: Record<string, unknown>;
 }
 
 export interface TestCreate extends TestBase {
@@ -110,6 +111,7 @@ export interface TestBulkCreate {
   category: string;
   topic: string;
   test_configuration?: Record<string, unknown>; // Required for multi-turn tests (must contain 'goal')
+  test_parameters?: Record<string, unknown>;
   assignee_id?: UUID;
   owner_id?: UUID;
   status?: string;

--- a/apps/frontend/src/utils/api-client/interfaces/tests.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/tests.ts
@@ -58,7 +58,7 @@ export interface TestBase {
   organization_id?: UUID;
   tags?: Tag[];
   test_metadata?: Record<string, unknown>;
-  test_parameters?: Record<string, unknown>;
+  test_parameters?: Record<string, unknown> | null;
 }
 
 export interface TestCreate extends TestBase {
@@ -111,7 +111,7 @@ export interface TestBulkCreate {
   category: string;
   topic: string;
   test_configuration?: Record<string, unknown>; // Required for multi-turn tests (must contain 'goal')
-  test_parameters?: Record<string, unknown>;
+  test_parameters?: Record<string, unknown> | null;
   assignee_id?: UUID;
   owner_id?: UUID;
   status?: string;

--- a/apps/frontend/src/utils/api-client/telemetry-client.ts
+++ b/apps/frontend/src/utils/api-client/telemetry-client.ts
@@ -61,6 +61,8 @@ export class TelemetryClient extends BaseApiClient {
     environment?: string;
     start_time_after?: string;
     start_time_before?: string;
+    /** Narrows every metric to one test run. */
+    test_run_id?: string;
   }): Promise<TraceMetricsResponse> {
     const queryParams = new URLSearchParams();
 

--- a/apps/frontend/src/utils/trace-utils.ts
+++ b/apps/frontend/src/utils/trace-utils.ts
@@ -94,6 +94,111 @@ export function formatTokenCount(tokens: number): string {
   return tokens.toLocaleString();
 }
 
+export interface SpanUsage {
+  input: number;
+  output: number;
+  total: number;
+  costUsd: number | null;
+}
+
+/**
+ * Token counts and cost for one span, or null when it has neither.
+ *
+ * Tokens come off the raw span attributes; cost comes from `cost_usd`, which the
+ * backend fills in from the enrichment breakdown -- the attributes never carry a
+ * price. Most spans (tool calls, function spans) have neither, and an empty
+ * "Usage" block on every span is noise, hence the null.
+ */
+export function spanUsage(span: SpanNode): SpanUsage | null {
+  const attrs = span.attributes ?? {};
+  const asCount = (value: unknown): number => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  };
+
+  const input = asCount(attrs['ai.llm.tokens.input']);
+  const output = asCount(attrs['ai.llm.tokens.output']);
+  // Reported rather than derived: Google ADK folds cache-read tokens into its
+  // total, so input + output can fall short of it.
+  const reportedTotal = asCount(attrs['ai.llm.tokens.total']);
+  const total = reportedTotal > 0 ? reportedTotal : input + output;
+  const costUsd =
+    typeof span.cost_usd === 'number' && span.cost_usd > 0
+      ? span.cost_usd
+      : null;
+
+  if (total === 0 && costUsd === null) {
+    return null;
+  }
+
+  return { input, output, total, costUsd };
+}
+
+/**
+ * Usage for a span and everything beneath it.
+ *
+ * Only `ai.llm.invoke` leaves carry token attributes, so a container span on its own
+ * reports nothing. Rolling the subtree up is what makes the panel useful: clicking an
+ * agent span answers "what did this agent cost", which is the question people are
+ * actually asking when they click it.
+ *
+ * `llmSpanCount` is how many spans in the subtree contributed, so the caller can say
+ * where the number came from. It is 0 on a leaf, which is how callers tell a rollup
+ * from a span's own usage.
+ */
+export function subtreeUsage(
+  span: SpanNode
+): (SpanUsage & { llmSpanCount: number }) | null {
+  const own = spanUsage(span);
+  let input = own?.input ?? 0;
+  let output = own?.output ?? 0;
+  let total = own?.total ?? 0;
+  let costUsd = own?.costUsd ?? null;
+  let llmSpanCount = 0;
+
+  for (const child of span.children ?? []) {
+    const below = subtreeUsage(child);
+    if (!below) {
+      continue;
+    }
+    input += below.input;
+    output += below.output;
+    // Summed from each node's own reported total rather than recomputed, so ADK's
+    // cache-read tokens survive the rollup.
+    total += below.total;
+    if (below.costUsd !== null) {
+      costUsd = (costUsd ?? 0) + below.costUsd;
+    }
+    llmSpanCount += below.llmSpanCount + (spanUsage(child) ? 1 : 0);
+  }
+
+  if (total === 0 && costUsd === null) {
+    return null;
+  }
+
+  return { input, output, total, costUsd, llmSpanCount };
+}
+
+/**
+ * Input/output tokens as two separate figures, deliberately not presented as a
+ * breakdown of the total: Google ADK folds cache-read tokens into the total it
+ * reports, so input + output legitimately falls short of it.
+ *
+ * Returns undefined when neither figure is known, so the caller renders no
+ * tooltip rather than an empty one.
+ */
+export function tokenSplitLabel(
+  inputTokens: number | null | undefined,
+  outputTokens: number | null | undefined
+): string | undefined {
+  const input = inputTokens ?? 0;
+  const output = outputTokens ?? 0;
+  if (input === 0 && output === 0) {
+    return undefined;
+  }
+  return `${formatTokenCount(input)} input \u00b7 ${formatTokenCount(output)} output`;
+}
+
 /**
  * Get span type from span name
  * Returns human-readable type label

--- a/docs/content/docs/endpoints/request-mapping.mdx
+++ b/docs/content/docs/endpoints/request-mapping.mdx
@@ -44,6 +44,26 @@ Use `tojson` for optional fields or when a value might be `null`:
 
 `tojson` ensures proper JSON serialization: `None` → `null`, strings are quoted, objects and arrays are serialized correctly.
 
+### Test Parameters
+
+Each test can carry a freeform JSON object in its `test_parameters` field. These values are available in request templates under the `test_parameters` namespace:
+
+<CodeBlock filename="test-parameters-request.json" language="json">
+  {`{
+  "model": "gpt-4",
+  "messages": [
+    {
+      "role": "user",
+      "content": "{{ input }}"
+    }
+  ],
+  "customer_id": "{{ test_parameters.customer_id }}",
+  "region": "{{ test_parameters.region | default('us-east-1') }}"
+}`}
+</CodeBlock>
+
+Test parameters are per-test data stored directly on the test object. They differ from experiment parameters (`params`), which are typed, versioned configuration resolved from experiments. Both namespaces are available in the same template, and they do not collide.
+
 ## Raw Body Templates
 
 If your template renders to a JSON object with a `__body__` key, Rhesis unwraps it and sends the value as the raw request body. This is useful for APIs that expect a plain string or a non-JSON payload rather than a JSON object.

--- a/docs/content/docs/experiments/connector-injection.mdx
+++ b/docs/content/docs/experiments/connector-injection.mdx
@@ -78,7 +78,8 @@ See [SDK Usage](/docs/experiments/sdk-usage) for the full `Parameters.get()` API
 
 For those debugging at the protocol level, the `ExecuteTestMessage` payload sent by the Rhesis platform over the connector includes the full parameter snapshot:
 
-- `parameters`: The resolved `Dict[str, Any]` of values.
+- `parameters`: The resolved `Dict[str, Any]` of experiment parameter values.
+- `test_parameters`: The test's freeform `Dict[str, Any]` of per-test data (see [Test Parameters](#test-parameters-vs-experiment-parameters)).
 - `parameter_version`: The sequential version identifier (e.g. `v3`) of the version being executed.
 - `parameter_experiment_id`: The UUID of the experiment.
 - `parameter_source`: The resolution method used (`"environment"`, `"experiment_id"`, or `"version"`). Older snapshots may still show `"label"`; treat it as `"environment"`.
@@ -144,6 +145,27 @@ async def chat_endpoint(request: Request, chat_request: ChatRequest):
         temperature=params.get("temperature"),
     )
     return result`}
+</CodeBlock>
+
+## Test Parameters vs Experiment Parameters
+
+The template context exposes two separate namespaces for injected data:
+
+| Namespace | Source | Lifecycle |
+|---|---|---|
+| `params` | Experiment parameter values, resolved and snapshotted at queue time | Typed, versioned, schema-validated |
+| `test_parameters` | Freeform JSON stored on the test object | Per-test, unversioned |
+
+Use `test_parameters` for per-test data that varies across tests in the same run (e.g. a customer ID, a locale, or a scenario-specific flag). Use `params` for configuration that applies uniformly to every test in a run (e.g. model name, temperature, system prompt).
+
+Both namespaces are available in the same request mapping and do not collide:
+
+<CodeBlock filename="both_namespaces.json" language="json">
+{`{
+  "model": "{{ params.model }}",
+  "messages": [{"role": "user", "content": "{{ input }}"}],
+  "customer_id": "{{ test_parameters.customer_id }}"
+}`}
 </CodeBlock>
 
 <Callout type="warning">

--- a/docs/content/docs/tests/index.mdx
+++ b/docs/content/docs/tests/index.mdx
@@ -25,6 +25,7 @@ A single prompt sent to your LLM application, evaluated against expected outputs
 |-------|-------------|
 | **Test Prompt** | The input text sent to your LLM application |
 | **Files** | (Optional) File attachments (images, PDFs, or audio) sent alongside the prompt. See [Multi-modal Testing](/docs/tests/multimodal-testing) for supported types and size limits, and [file format filters](/docs/endpoints/request-mapping#file-format-filters) for how files are mapped to provider formats. |
+| **Test Parameters** | (Optional) Freeform JSON object with per-test data. Available in request templates as `test_parameters`, e.g. `\{\{ test_parameters.customer_id \}\}`. See [Request Mapping](/docs/endpoints/request-mapping#test-parameters). |
 | **Category** | High-level classification (e.g., Harmful, Harmless) |
 | **Topic** | Specific subject matter (e.g., healthcare, financial advice) |
 | **Requirement** | Type of requirement to validate (e.g., Compliance, Reliability, Robustness) |
@@ -43,6 +44,7 @@ Goal-based conversations that test your LLM application across multiple turns. P
 | **Restrictions** | (Optional) What the target must not do - forbidden behaviors or boundaries |
 | **Scenario** | (Optional) Context and persona for the test - narrative setup or user role |
 | **Files** | (Optional) File attachments (images, PDFs, or audio) included with the test. Files are available on each conversation turn via the `files` variable in the endpoint request template. See [Multi-modal Testing](/docs/tests/multimodal-testing) for supported types and size limits. |
+| **Test Parameters** | (Optional) Freeform JSON object with per-test data. Available in request templates as `test_parameters`, e.g. `\{\{ test_parameters.customer_id \}\}`. See [Request Mapping](/docs/endpoints/request-mapping#test-parameters). |
 | **Min. Turns** | Minimum turns before early stopping is allowed. If omitted, defaults to 80% of max turns. |
 | **Max. Turns** | Maximum number of conversation turns allowed (`max_turns`) |
 | **Category** | High-level classification (e.g., Harmful, Harmless) |

--- a/docs/content/sdk/connector/mapping.mdx
+++ b/docs/content/sdk/connector/mapping.mdx
@@ -29,6 +29,7 @@ def chat(input: str, conversation_id: str = None) -> dict:
 | Request | `tool_calls` | Tool call data passed to the endpoint |
 | Request | `files` | File attachments passed as `FileReference` objects |
 | Request | `params` | Resolved experiment parameters available in request mappings |
+| Request | `test_parameters` | Freeform per-test JSON data available in request mappings |
 | Response | `output` | The main response text |
 | Response | `context` | Retrieval context (e.g., RAG sources) |
 | Response | `metadata` | Structured response metadata (e.g., confidence scores) |
@@ -121,6 +122,27 @@ def chat(user_message: str, *, model: str, temperature: float) -> dict:
   for older applications, but it emits a deprecation warning. Use
   `{{ params.* }}` in `request_mapping` for new endpoints.
 </Callout>
+
+### Test parameters
+
+Each test can carry a freeform JSON object in its `test_parameters` field. These values are available in request mappings under the `test_parameters` namespace, separate from experiment `params`:
+
+<CodeBlock filename="test_params_mapping.py" language="python">
+{`@endpoint(
+    name="chat",
+    request_mapping={
+        "user_message": "{{ input }}",
+        "model": "{{ params.model | default('gpt-4o') }}",
+        "customer_id": "{{ test_parameters.customer_id }}",
+        "region": "{{ test_parameters.region | default('us-east-1') }}",
+    },
+    response_mapping={"output": "$.answer"},
+)
+def chat(user_message: str, *, model: str, customer_id: str, region: str) -> dict:
+    return {"answer": invoke(user_message, model=model, customer_id=customer_id, region=region)}`}
+</CodeBlock>
+
+Use `test_parameters` for per-test data that varies across tests in the same run (a customer ID, a locale, a scenario-specific flag). Use `params` for configuration that applies uniformly to every test (model name, temperature).
 
 ### File attachments
 

--- a/docs/content/sdk/parameters.mdx
+++ b/docs/content/sdk/parameters.mdx
@@ -367,6 +367,28 @@ if params is not None:
     print(params.source, params.version)`}
 </CodeBlock>
 
+## Test parameters (separate concept)
+
+Test parameters (`test_parameters`) are a freeform JSON field on each test object, distinct from experiment parameters (`params`). They are not schema-validated, not versioned, and not resolved from experiments. Use them for per-test data that varies across tests in the same run, such as a customer ID, a locale, or a scenario-specific flag.
+
+In request mappings, both namespaces are available side by side:
+
+<CodeBlock filename="both_params.py" language="python">
+{`@endpoint(
+    name="chat",
+    request_mapping={
+        "query": "{{ input }}",
+        "model": "{{ params.model | default('gpt-4o') }}",
+        "customer_id": "{{ test_parameters.customer_id }}",
+    },
+    response_mapping={"output": "{{ response }}"},
+)
+def chat(query: str, *, model: str, customer_id: str):
+    return {"response": invoke(query, model=model, customer_id=customer_id)}`}
+</CodeBlock>
+
+Set test parameters via the API, SDK, or the Test Parameters section in the test detail view. They are read directly from the test object at execution time.
+
 ---
 
 <Callout type="default">

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -35,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an `AttributeError` in `on_chain_end` when handling object-based tool calls from certain LLM providers.
 - Fixed prompt event logging to emit one event per message instead of only recording the first message.
 - Fixed false-positive handoff detection on sequential graph transitions.
-
+- **Test Parameters:** Added `test_parameters` field to the `Test` entity and `get_test_parameters()` accessor for reading per-test parameters during SDK endpoint execution.
+- Added `test_parameters` to the connector wire protocol (`ExecuteTestMessage`).
 
 ## [0.15.1] - 2026-09-04
 

--- a/sdk/src/rhesis/sdk/__init__.py
+++ b/sdk/src/rhesis/sdk/__init__.py
@@ -13,7 +13,7 @@ from rhesis.sdk.decorators import (
     metric,
     observe,
 )
-from rhesis.sdk.decorators._state import get_parameters
+from rhesis.sdk.decorators._state import get_parameters, get_test_parameters
 from rhesis.sdk.enums import ExecutionMode, TestType
 from rhesis.sdk.errors import RhesisAPIError
 from rhesis.sdk.parameters import Parameters
@@ -42,6 +42,7 @@ __all__ = [
     "ObserverBuilder",
     "bind_context",
     "get_parameters",
+    "get_test_parameters",
     "Parameters",
     "EndpointContext",
 ]

--- a/sdk/src/rhesis/sdk/connector/manager.py
+++ b/sdk/src/rhesis/sdk/connector/manager.py
@@ -355,9 +355,10 @@ class ConnectorManager:
                 )
                 return
 
-            from rhesis.sdk.decorators._state import _parameters_context
+            from rhesis.sdk.decorators._state import _parameters_context, _test_parameters_context
 
             token = _parameters_context.set(resolved_params)
+            tp_token = _test_parameters_context.set(test_msg.test_parameters or {})
             try:
                 # Legacy path: merge resolved parameter values into inputs
                 # when the endpoint declares parameters=True or a list.
@@ -396,6 +397,7 @@ class ConnectorManager:
                 )
             finally:
                 _parameters_context.reset(token)
+                _test_parameters_context.reset(tp_token)
 
             # Send result
             await self._send_test_result(

--- a/sdk/src/rhesis/sdk/connector/schemas.py
+++ b/sdk/src/rhesis/sdk/connector/schemas.py
@@ -63,6 +63,7 @@ class ExecuteTestMessage(BaseModel):
     parameter_source: Optional[Literal["environment", "experiment_id", "version"]] = None
     parameter_source_environment: Optional[str] = None
     parameter_schema: Optional[Dict[str, Any]] = None
+    test_parameters: Dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="before")
     @classmethod

--- a/sdk/src/rhesis/sdk/decorators/_state.py
+++ b/sdk/src/rhesis/sdk/decorators/_state.py
@@ -1,7 +1,7 @@
 """Internal module for managing the default client state."""
 
 import contextvars
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 if TYPE_CHECKING:
     from rhesis.sdk.clients import Client
@@ -12,11 +12,19 @@ _default_client: Optional["Client"] = None
 _parameters_context: contextvars.ContextVar[Optional["ResolvedParameters"]] = (
     contextvars.ContextVar("rhesis_parameters", default=None)
 )
+_test_parameters_context: contextvars.ContextVar[Dict[str, Any]] = contextvars.ContextVar(
+    "test_parameters", default={}
+)
 
 
 def get_parameters() -> Optional["ResolvedParameters"]:
     """Get the currently resolved parameters (populated during remote test execution)."""
     return _parameters_context.get()
+
+
+def get_test_parameters() -> Dict[str, Any]:
+    """Get the per-test parameters (populated during remote test execution)."""
+    return _test_parameters_context.get()
 
 
 def _register_default_client(client: "Client") -> None:  # pyright: ignore[reportUnusedFunction]

--- a/sdk/src/rhesis/sdk/decorators/_state.py
+++ b/sdk/src/rhesis/sdk/decorators/_state.py
@@ -12,8 +12,8 @@ _default_client: Optional["Client"] = None
 _parameters_context: contextvars.ContextVar[Optional["ResolvedParameters"]] = (
     contextvars.ContextVar("rhesis_parameters", default=None)
 )
-_test_parameters_context: contextvars.ContextVar[Dict[str, Any]] = contextvars.ContextVar(
-    "test_parameters", default={}
+_test_parameters_context: contextvars.ContextVar[Optional[Dict[str, Any]]] = contextvars.ContextVar(
+    "test_parameters", default=None
 )
 
 
@@ -24,7 +24,7 @@ def get_parameters() -> Optional["ResolvedParameters"]:
 
 def get_test_parameters() -> Dict[str, Any]:
     """Get the per-test parameters (populated during remote test execution)."""
-    return _test_parameters_context.get()
+    return _test_parameters_context.get() or {}
 
 
 def _register_default_client(client: "Client") -> None:  # pyright: ignore[reportUnusedFunction]

--- a/sdk/src/rhesis/sdk/entities/test.py
+++ b/sdk/src/rhesis/sdk/entities/test.py
@@ -40,6 +40,7 @@ class Test(BaseEntity):
     test_configuration: Optional[TestConfiguration] = None
     test_type: Optional[TestType] = None
     files: Optional[list] = None
+    test_parameters: Optional[Dict[str, Any]] = None
     # Convenience fields that build test_configuration if not provided
     goal: Optional[str] = None
     instructions: Optional[str] = None

--- a/sdk/src/rhesis/sdk/telemetry/integrations/genai.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/genai.py
@@ -724,6 +724,74 @@ class ConversationTraceRegistry:
             self._targets.clear()
 
 
+class DeferredReleaseQueue:
+    """Frees per-trace entries a bounded number of reads after the first read.
+
+    A natively instrumented framework carries a turn's text on its nested model
+    spans, not on the run root that has to be stamped with it, so an integration
+    collects that text per trace id and reads it back when the root is exported.
+    Popping it on that read looks right and is not: ``enable()`` wraps *every*
+    exporter on the provider, so a process running its own OTLP collector beside
+    Rhesis exports the same spans through several translating exporters, and
+    whichever reached the root first took the content and left the others
+    stamping a root span with nothing on it.
+
+    Keeping every entry instead trades that for a leak: at
+    :data:`~rhesis.telemetry.constants.ConversationContext.MAX_IO_LENGTH` per
+    field, a long-running process would sit on megabytes of conversation text
+    waiting for the store's own entry cap. So entries are freed once enough
+    other traces have been read past them - long enough for the other exporters
+    to see the same trace, short enough to stay small. The queue is deliberately
+    larger than an OTEL export batch, since a busy service can flush hundreds of
+    run roots at once and the exporters do not drain their queues in lockstep.
+
+    Holds the stores by reference and mutates them in place, so an owner must
+    not rebind them after construction. Takes no lock of its own: every method
+    expects the owner's lock to be held, which is what keeps a read of the
+    stores and the release that follows it atomic together.
+    """
+
+    def __init__(self, *stores: dict, max_served: int = 512) -> None:
+        """Queue releases across ``stores``, all keyed by trace id."""
+        self._stores = stores
+        self._served: dict[int, None] = {}
+        self._max_served = max_served
+
+    def queue_release(self, trace_id: int) -> None:
+        """Mark ``trace_id`` read, freeing whatever has fallen far enough behind.
+
+        A trace with nothing recorded takes no slot: it has nothing to free, and
+        a run of content-free traces would otherwise push out the entries of the
+        traces that do have some. Caller holds the lock.
+        """
+        if not self.has_entries(trace_id):
+            return
+        # Re-reading moves a trace back to the newest, so the entries stay while
+        # anything is still asking for them.
+        self._served.pop(trace_id, None)
+        self._served[trace_id] = None
+        while len(self._served) > self._max_served:
+            stale = next(iter(self._served))
+            del self._served[stale]
+            for store in self._stores:
+                store.pop(stale, None)
+
+    def has_entries(self, trace_id: int) -> bool:
+        """Whether any store holds something for this trace. Caller holds the lock.
+
+        Every store an owner keeps has to be passed in. One left out is invisible
+        here, so its entries never reach the queue and never get freed - which is
+        the leak this class exists to prevent.
+        """
+        return any(trace_id in store for store in self._stores)
+
+    def clear(self) -> None:
+        """Forget the queue and empty every store. Caller holds the lock."""
+        self._served.clear()
+        for store in self._stores:
+            store.clear()
+
+
 def translate_events(
     original_events: Iterable[Event],
     span_attributes: Mapping[str, Any],

--- a/tests/backend/crud/test_trace_metrics_aggregated.py
+++ b/tests/backend/crud/test_trace_metrics_aggregated.py
@@ -1,0 +1,187 @@
+"""Tests for get_trace_metrics_aggregated.
+
+The project-level rollup behind ``GET /telemetry/metrics``. Tokens and costs here
+must aggregate per *trace*: enrichment writes its trace-level blob onto every span
+row, so summing across rows multiplies the real figure by the span count.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from rhesis.telemetry.attributes import AIAttributes
+from rhesis.telemetry.schemas import SpanKind, StatusCode
+
+from rhesis.backend.app.crud.telemetry import (
+    create_trace_spans,
+    get_trace_metrics_aggregated,
+    mark_trace_processed,
+)
+from rhesis.backend.app.schemas.telemetry import OTELSpanCreate
+
+TRACE_COST_USD = 0.05
+TRACE_TOKENS = 420
+
+
+def span(trace_id, span_id, project_id, *, parent=None, operation, tokens=None, error=False):
+    now = datetime.now(timezone.utc)
+    attributes = {AIAttributes.OPERATION_TYPE: operation}
+    if tokens is not None:
+        attributes[AIAttributes.MODEL_NAME] = "gpt-4"
+        attributes[AIAttributes.LLM_TOKENS_INPUT] = tokens[0]
+        attributes[AIAttributes.LLM_TOKENS_OUTPUT] = tokens[1]
+        attributes[AIAttributes.LLM_TOKENS_TOTAL] = tokens[2]
+    return OTELSpanCreate(
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent,
+        project_id=project_id,
+        environment="development",
+        span_name="ai.llm.invoke" if operation == "llm.invoke" else "ai.agent.invoke",
+        span_kind=SpanKind.CLIENT,
+        start_time=now,
+        end_time=now + timedelta(seconds=1),
+        status_code=StatusCode.ERROR if error else StatusCode.OK,
+        attributes=attributes,
+    )
+
+
+def enrichment_blob(total_tokens=TRACE_TOKENS, cost_usd=TRACE_COST_USD):
+    return {
+        "costs": {
+            "total_cost_usd": cost_usd,
+            "total_cost_eur": cost_usd * 0.9,
+            "total_input_tokens": 300,
+            "total_output_tokens": 120,
+            "total_tokens": total_tokens,
+            "breakdown": [],
+        }
+    }
+
+
+@pytest.fixture
+def six_span_trace(test_db, db_project, test_org_id):
+    """One enriched trace of six spans: an agent run plus five model calls.
+
+    The shape that used to report six times the real cost.
+    """
+    trace_id = uuid.uuid4().hex
+    project_id = str(db_project.id)
+    spans = [
+        span(trace_id, uuid.uuid4().hex[:16], project_id, operation="agent.invoke"),
+    ]
+    for _ in range(5):
+        spans.append(
+            span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                parent=spans[0].span_id,
+                operation="llm.invoke",
+                tokens=(60, 24, 84),
+            )
+        )
+    create_trace_spans(test_db, spans, organization_id=test_org_id)
+    mark_trace_processed(test_db, trace_id, enrichment_blob())
+    return trace_id, project_id
+
+
+@pytest.mark.integration
+class TestTokenAndCostAggregation:
+    """Tokens and cost aggregate once per trace, not once per span row."""
+
+    def test_cost_is_not_multiplied_by_span_count(
+        self, test_db, six_span_trace, test_org_id
+    ):
+        """Regression: this used to report 6x the trace's real cost."""
+        _, project_id = six_span_trace
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id
+        )
+
+        assert metrics["total_spans"] == 6
+        assert metrics["total_traces"] == 1
+        assert metrics["total_cost_usd"] == pytest.approx(TRACE_COST_USD, rel=1e-6)
+
+    def test_tokens_come_from_enrichment_not_a_raw_span_sum(
+        self, test_db, six_span_trace, test_org_id
+    ):
+        """The enriched total wins, so aggregate-reporting frameworks aren't doubled."""
+        _, project_id = six_span_trace
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id
+        )
+
+        assert metrics["total_tokens"] == TRACE_TOKENS
+
+    def test_span_counts_and_error_rate_still_span_level(
+        self, test_db, db_project, test_org_id
+    ):
+        """Collapsing tokens per trace must not collapse the span-level metrics."""
+        trace_id = uuid.uuid4().hex
+        project_id = str(db_project.id)
+        spans = [
+            span(trace_id, uuid.uuid4().hex[:16], project_id, operation="agent.invoke"),
+            span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                operation="llm.invoke",
+                tokens=(10, 5, 15),
+                error=True,
+            ),
+        ]
+        create_trace_spans(test_db, spans, organization_id=test_org_id)
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id
+        )
+
+        assert metrics["total_spans"] == 2
+        assert metrics["error_rate"] == pytest.approx(0.5)
+        assert metrics["operation_breakdown"]["llm.invoke"] == 1
+        assert metrics["operation_breakdown"]["agent.invoke"] == 1
+
+    def test_unenriched_trace_falls_back_to_llm_invoke_spans(
+        self, test_db, db_project, test_org_id
+    ):
+        """A freshly ingested trace still reports tokens before enrichment runs.
+
+        The agent-run span repeats its children's aggregate, so a raw sum over all
+        spans would report 60 instead of 30.
+        """
+        trace_id = uuid.uuid4().hex
+        project_id = str(db_project.id)
+        spans = [
+            span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                operation="agent.invoke",
+                tokens=(20, 10, 30),
+            ),
+            span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                operation="llm.invoke",
+                tokens=(10, 5, 15),
+            ),
+            span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                operation="llm.invoke",
+                tokens=(10, 5, 15),
+            ),
+        ]
+        create_trace_spans(test_db, spans, organization_id=test_org_id)
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id
+        )
+
+        assert metrics["total_tokens"] == 30
+        assert metrics["total_cost_usd"] == 0.0

--- a/tests/backend/crud/test_trace_metrics_aggregated.py
+++ b/tests/backend/crud/test_trace_metrics_aggregated.py
@@ -12,6 +12,7 @@ import pytest
 from rhesis.telemetry.attributes import AIAttributes
 from rhesis.telemetry.schemas import SpanKind, StatusCode
 
+from rhesis.backend.app.constants import TestExecutionContext
 from rhesis.backend.app.crud.telemetry import (
     create_trace_spans,
     get_trace_metrics_aggregated,
@@ -90,9 +91,7 @@ def six_span_trace(test_db, db_project, test_org_id):
 class TestTokenAndCostAggregation:
     """Tokens and cost aggregate once per trace, not once per span row."""
 
-    def test_cost_is_not_multiplied_by_span_count(
-        self, test_db, six_span_trace, test_org_id
-    ):
+    def test_cost_is_not_multiplied_by_span_count(self, test_db, six_span_trace, test_org_id):
         """Regression: this used to report 6x the trace's real cost."""
         _, project_id = six_span_trace
 
@@ -116,9 +115,7 @@ class TestTokenAndCostAggregation:
 
         assert metrics["total_tokens"] == TRACE_TOKENS
 
-    def test_span_counts_and_error_rate_still_span_level(
-        self, test_db, db_project, test_org_id
-    ):
+    def test_span_counts_and_error_rate_still_span_level(self, test_db, db_project, test_org_id):
         """Collapsing tokens per trace must not collapse the span-level metrics."""
         trace_id = uuid.uuid4().hex
         project_id = str(db_project.id)
@@ -185,3 +182,109 @@ class TestTokenAndCostAggregation:
 
         assert metrics["total_tokens"] == 30
         assert metrics["total_cost_usd"] == 0.0
+
+
+def run_span(trace_id, project_id, test_run_id, *, operation, tokens=None):
+    """A span stamped with a test run, the way test execution ingests them."""
+    created = span(trace_id, uuid.uuid4().hex[:16], project_id, operation=operation, tokens=tokens)
+    created.attributes[TestExecutionContext.SpanAttributes.TEST_RUN_ID] = str(test_run_id)
+    return created
+
+
+@pytest.mark.integration
+class TestTestRunScoping:
+    """Metrics narrowed to a single test run.
+
+    Without this the test run Traces tab has to hide its rollup tiles, because the
+    only numbers available cover the whole project.
+    """
+
+    @pytest.fixture
+    def two_runs(self, test_db, db_project, test_org_id, db_test_run, db_test_run_running):
+        """Two runs in one project: 2 llm spans totalling 150 tokens, and 1 of 500."""
+        project_id = str(db_project.id)
+        run_a, run_b = db_test_run.id, db_test_run_running.id
+
+        trace_a = uuid.uuid4().hex
+        create_trace_spans(
+            test_db,
+            [
+                run_span(trace_a, project_id, run_a, operation="agent.invoke"),
+                run_span(trace_a, project_id, run_a, operation="llm.invoke", tokens=(50, 25, 75)),
+                run_span(trace_a, project_id, run_a, operation="llm.invoke", tokens=(50, 25, 75)),
+            ],
+            organization_id=test_org_id,
+        )
+
+        trace_b = uuid.uuid4().hex
+        create_trace_spans(
+            test_db,
+            [
+                run_span(
+                    trace_b, project_id, run_b, operation="llm.invoke", tokens=(400, 100, 500)
+                ),
+            ],
+            organization_id=test_org_id,
+        )
+        return project_id, str(run_a), str(run_b), trace_a
+
+    def test_counts_only_the_requested_run(self, test_db, two_runs, test_org_id):
+        project_id, run_a, _, _ = two_runs
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id, test_run_id=run_a
+        )
+
+        assert metrics["total_traces"] == 1
+        assert metrics["total_spans"] == 3
+        assert metrics["total_tokens"] == 150
+
+    def test_the_other_run_does_not_leak_in(self, test_db, two_runs, test_org_id):
+        project_id, _, run_b, _ = two_runs
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id, test_run_id=run_b
+        )
+
+        assert metrics["total_traces"] == 1
+        assert metrics["total_spans"] == 1
+        assert metrics["total_tokens"] == 500
+
+    def test_without_a_run_the_whole_project_is_counted(self, test_db, two_runs, test_org_id):
+        """The Traces page passes no test_run_id and must be unaffected."""
+        project_id, _, _, _ = two_runs
+
+        metrics = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id
+        )
+
+        assert metrics["total_traces"] >= 2
+        assert metrics["total_tokens"] >= 650
+
+    def test_cost_is_scoped_too(self, test_db, two_runs, test_org_id):
+        """Enrichment writes its blob per trace, so cost has to follow the same filter."""
+        project_id, run_a, run_b, trace_a = two_runs
+        mark_trace_processed(test_db, trace_a, enrichment_blob())
+
+        priced = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id, test_run_id=run_a
+        )
+        unpriced = get_trace_metrics_aggregated(
+            test_db, organization_id=test_org_id, project_id=project_id, test_run_id=run_b
+        )
+
+        assert priced["total_cost_usd"] == pytest.approx(TRACE_COST_USD)
+        assert unpriced["total_cost_usd"] == 0.0
+
+    def test_malformed_run_id_is_a_400(self, test_db, db_project, test_org_id):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as caught:
+            get_trace_metrics_aggregated(
+                test_db,
+                organization_id=test_org_id,
+                project_id=str(db_project.id),
+                test_run_id="not-a-uuid",
+            )
+
+        assert caught.value.status_code == 400

--- a/tests/backend/routes/test_telemetry_query.py
+++ b/tests/backend/routes/test_telemetry_query.py
@@ -9,6 +9,7 @@ This module tests the telemetry query endpoints including:
 - Error handling and edge cases
 """
 
+import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -1206,6 +1207,7 @@ class TestCrossOrganizationSecurity:
         import uuid
 
         from rhesis.telemetry.schemas import OTELSpan
+
         from tests.backend.fixtures.test_setup import create_test_organization_and_user
 
         org, user, _ = create_test_organization_and_user(
@@ -1349,3 +1351,482 @@ class TestCrossOrganizationSecurity:
         response = client_b.get(f"/telemetry/metrics?project_id={project_b.id}")
         assert response.status_code == 200, response.text
         assert response.json()["total_traces"] == 2
+
+
+@pytest.mark.integration
+class TestTraceTokenAndCostVisibility:
+    """Tokens and cost as the trace UI reads them, over the real endpoints.
+
+    The list column, the drawer chips and the project rollup must all report the
+    same figure for the same trace -- they used to report three different ones.
+    """
+
+    @staticmethod
+    def _span(trace_id, span_id, project_id, *, parent=None, operation, tokens=None):
+        now = datetime.now(timezone.utc)
+        attributes = {"ai.operation.type": operation}
+        if tokens is not None:
+            attributes["ai.model.name"] = "gpt-4"
+            attributes["ai.llm.tokens.input"] = tokens[0]
+            attributes["ai.llm.tokens.output"] = tokens[1]
+            attributes["ai.llm.tokens.total"] = tokens[2]
+        return {
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "parent_span_id": parent,
+            "project_id": project_id,
+            "environment": "development",
+            "span_name": "ai.llm.invoke" if operation == "llm.invoke" else "ai.agent.invoke",
+            "span_kind": "CLIENT",
+            "start_time": now.isoformat(),
+            "end_time": (now + timedelta(milliseconds=250)).isoformat(),
+            "status_code": "OK",
+            "attributes": attributes,
+            "events": [],
+            "links": [],
+            "resource": {},
+        }
+
+    @staticmethod
+    def _summary(client, project_id, trace_id):
+        response = client.get(f"/telemetry/traces?project_id={project_id}&limit=100")
+        assert response.status_code == status.HTTP_200_OK
+        for trace in response.json()["traces"]:
+            if trace["trace_id"] == trace_id:
+                return trace
+        raise AssertionError(f"trace {trace_id} missing from the list response")
+
+    def _ingest(self, client, spans):
+        response = client.post("/telemetry/traces", json={"spans": spans})
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_pydantic_ai_run_is_not_double_counted(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """The agent-run span repeats its children's aggregate under the same keys.
+
+        Summing every span would report 840; only the llm.invoke spans count.
+        """
+        project_id = str(db_project.id)
+        trace_id = uuid.uuid4().hex
+        agent_span = uuid.uuid4().hex[:16]
+        spans = [
+            self._span(
+                trace_id, agent_span, project_id, operation="agent.invoke", tokens=(300, 120, 420)
+            ),
+            self._span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                parent=agent_span,
+                operation="llm.invoke",
+                tokens=(100, 50, 150),
+            ),
+            self._span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                parent=agent_span,
+                operation="llm.invoke",
+                tokens=(200, 70, 270),
+            ),
+        ]
+        self._ingest(authenticated_client, spans)
+
+        response = authenticated_client.get(f"/telemetry/traces/{trace_id}?project_id={project_id}")
+        assert response.status_code == status.HTTP_200_OK
+        detail = response.json()
+
+        assert detail["total_tokens"] == 420
+        assert detail["total_input_tokens"] == 300
+        assert detail["total_output_tokens"] == 120
+
+    def test_list_and_detail_report_the_same_tokens(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """The core bug: the list read the root span alone and so showed 0."""
+        project_id = str(db_project.id)
+        trace_id = uuid.uuid4().hex
+        agent_span = uuid.uuid4().hex[:16]
+        spans = [
+            # A root span with no token attributes at all -- the usual shape, and
+            # what the list used to read its figure from.
+            self._span(trace_id, agent_span, project_id, operation="agent.invoke"),
+            self._span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                parent=agent_span,
+                operation="llm.invoke",
+                tokens=(100, 50, 150),
+            ),
+            self._span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                parent=agent_span,
+                operation="llm.invoke",
+                tokens=(200, 70, 270),
+            ),
+        ]
+        self._ingest(authenticated_client, spans)
+
+        detail = authenticated_client.get(
+            f"/telemetry/traces/{trace_id}?project_id={project_id}"
+        ).json()
+        summary = self._summary(authenticated_client, project_id, trace_id)
+
+        assert detail["total_tokens"] == 420
+        assert summary["total_tokens"] == detail["total_tokens"]
+
+    def test_reported_total_survives_the_round_trip(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """Google ADK folds cache-read tokens into its total, so it exceeds in + out."""
+        project_id = str(db_project.id)
+        trace_id = uuid.uuid4().hex
+        self._ingest(
+            authenticated_client,
+            [
+                self._span(
+                    trace_id,
+                    uuid.uuid4().hex[:16],
+                    project_id,
+                    operation="llm.invoke",
+                    tokens=(100, 50, 950),
+                )
+            ],
+        )
+
+        detail = authenticated_client.get(
+            f"/telemetry/traces/{trace_id}?project_id={project_id}"
+        ).json()
+
+        assert detail["total_tokens"] == 950
+        assert self._summary(authenticated_client, project_id, trace_id)["total_tokens"] == 950
+
+    def test_trace_with_no_llm_spans_omits_tokens(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """The list sends null so the column shows an em dash rather than a 0."""
+        project_id = str(db_project.id)
+        trace_id = uuid.uuid4().hex
+        self._ingest(
+            authenticated_client,
+            [self._span(trace_id, uuid.uuid4().hex[:16], project_id, operation="tool.invoke")],
+        )
+
+        detail = authenticated_client.get(
+            f"/telemetry/traces/{trace_id}?project_id={project_id}"
+        ).json()
+
+        assert detail["total_tokens"] == 0
+        assert self._summary(authenticated_client, project_id, trace_id)["total_tokens"] is None
+
+    def test_span_nodes_expose_cost_once_enriched(
+        self, authenticated_client: TestClient, db_project, test_db, test_org_id
+    ):
+        """Per-span cost reaches the Span Details panel, and only for priced spans."""
+        from rhesis.backend.app.crud.telemetry import mark_trace_processed
+
+        project_id = str(db_project.id)
+        trace_id = uuid.uuid4().hex
+        agent_span = uuid.uuid4().hex[:16]
+        llm_span = uuid.uuid4().hex[:16]
+        self._ingest(
+            authenticated_client,
+            [
+                self._span(
+                    trace_id,
+                    agent_span,
+                    project_id,
+                    operation="agent.invoke",
+                    tokens=(100, 50, 150),
+                ),
+                self._span(
+                    trace_id,
+                    llm_span,
+                    project_id,
+                    parent=agent_span,
+                    operation="llm.invoke",
+                    tokens=(100, 50, 150),
+                ),
+            ],
+        )
+
+        # Stand in for the async enrichment job, which does not run in tests.
+        mark_trace_processed(
+            test_db,
+            trace_id,
+            {
+                "costs": {
+                    "total_cost_usd": 0.006,
+                    "total_cost_eur": 0.0054,
+                    "total_input_tokens": 100,
+                    "total_output_tokens": 50,
+                    "total_tokens": 150,
+                    "breakdown": [
+                        {
+                            "span_id": llm_span,
+                            "model_name": "gpt-4",
+                            "input_tokens": 100,
+                            "output_tokens": 50,
+                            "total_tokens": 150,
+                            "input_cost_usd": 0.003,
+                            "output_cost_usd": 0.003,
+                            "total_cost_usd": 0.006,
+                            "input_cost_eur": 0.0027,
+                            "output_cost_eur": 0.0027,
+                            "total_cost_eur": 0.0054,
+                        }
+                    ],
+                }
+            },
+        )
+
+        detail = authenticated_client.get(
+            f"/telemetry/traces/{trace_id}?project_id={project_id}"
+        ).json()
+
+        def walk(nodes):
+            for node in nodes:
+                yield node
+                yield from walk(node["children"])
+
+        by_span = {node["span_id"]: node for node in walk(detail["root_spans"])}
+
+        assert detail["total_cost_usd"] == pytest.approx(0.006)
+        assert by_span[llm_span]["cost_usd"] == pytest.approx(0.006)
+        assert by_span[llm_span]["model_name"] == "gpt-4"
+        # The agent-run span is never priced, so it shows no Usage cost.
+        assert by_span[agent_span]["cost_usd"] is None
+        assert by_span[agent_span]["model_name"] is None
+
+
+@pytest.mark.integration
+class TestTraceListSorting:
+    """Server-side sorting on the traces list.
+
+    Sorting has to happen in SQL: sorting in the browser only reorders the rows on
+    the current page, so "most expensive first" would really mean "most expensive of
+    the newest 50".
+    """
+
+    @staticmethod
+    def _span(trace_id, span_id, project_id, *, tokens, started):
+        return {
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "project_id": project_id,
+            "environment": "development",
+            "span_name": "ai.llm.invoke",
+            "span_kind": "CLIENT",
+            "start_time": started.isoformat(),
+            "end_time": (started + timedelta(milliseconds=250)).isoformat(),
+            "status_code": "OK",
+            "attributes": {
+                "ai.operation.type": "llm.invoke",
+                "ai.model.name": "gpt-4",
+                "ai.llm.tokens.input": tokens[0],
+                "ai.llm.tokens.output": tokens[1],
+                "ai.llm.tokens.total": tokens[2],
+            },
+            "events": [],
+            "links": [],
+            "resource": {},
+        }
+
+    @pytest.fixture
+    def three_traces(self, authenticated_client: TestClient, db_project):
+        """Three single-span traces with deliberately different token counts."""
+        project_id = str(db_project.id)
+        now = datetime.now(timezone.utc)
+        made = []
+        for index, tokens in enumerate([(10, 5, 15), (400, 100, 500), (60, 20, 80)]):
+            trace_id = uuid.uuid4().hex
+            span = self._span(
+                trace_id,
+                uuid.uuid4().hex[:16],
+                project_id,
+                tokens=tokens,
+                started=now - timedelta(minutes=index),
+            )
+            response = authenticated_client.post("/telemetry/traces", json={"spans": [span]})
+            assert response.status_code == status.HTTP_200_OK
+            made.append((trace_id, tokens[2]))
+        return project_id, made
+
+    def _tokens_in_order(self, client, project_id, order):
+        response = client.get(
+            f"/telemetry/traces?project_id={project_id}"
+            f"&sort_by=total_tokens&sort_order={order}&limit=100"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        return [t["total_tokens"] for t in response.json()["traces"] if t["total_tokens"]]
+
+    def test_sorts_by_tokens_descending(self, authenticated_client: TestClient, three_traces):
+        project_id, _ = three_traces
+
+        tokens = self._tokens_in_order(authenticated_client, project_id, "desc")
+
+        assert tokens == sorted(tokens, reverse=True)
+        assert tokens[0] == 500
+
+    def test_sorts_by_tokens_ascending(self, authenticated_client: TestClient, three_traces):
+        project_id, _ = three_traces
+
+        tokens = self._tokens_in_order(authenticated_client, project_id, "asc")
+
+        assert tokens == sorted(tokens)
+
+    def test_unpriced_traces_sort_last_on_cost(
+        self, authenticated_client: TestClient, three_traces
+    ):
+        """Cost has no pre-enrichment fallback, so every one of these is unpriced.
+
+        Postgres puts NULLs first on DESC, so without NULLS LAST a "most expensive"
+        sort would lead with traces whose cost is simply unknown.
+        """
+        project_id, _ = three_traces
+
+        response = authenticated_client.get(
+            f"/telemetry/traces?project_id={project_id}"
+            f"&sort_by=total_cost_usd&sort_order=desc&limit=100"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        costs = [t["total_cost_usd"] for t in response.json()["traces"]]
+        priced = [c for c in costs if c is not None]
+        assert costs[: len(priced)] == priced
+
+    def test_sorting_is_stable_across_pages(self, authenticated_client: TestClient, three_traces):
+        """Rows tied on the sort key need a tiebreaker or paging repeats them."""
+        project_id, _ = three_traces
+
+        first = authenticated_client.get(
+            f"/telemetry/traces?project_id={project_id}"
+            f"&sort_by=total_cost_usd&sort_order=desc&limit=2&offset=0"
+        ).json()["traces"]
+        second = authenticated_client.get(
+            f"/telemetry/traces?project_id={project_id}"
+            f"&sort_by=total_cost_usd&sort_order=desc&limit=2&offset=2"
+        ).json()["traces"]
+
+        ids = [t["trace_id"] for t in first] + [t["trace_id"] for t in second]
+        assert len(ids) == len(set(ids))
+
+    def test_unknown_sort_field_is_rejected(self, authenticated_client: TestClient, db_project):
+        """The three columns with no SQL sort key must not silently do nothing."""
+        response = authenticated_client.get(
+            f"/telemetry/traces?project_id={db_project.id}&sort_by=endpoint_name"
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "endpoint_name" in response.json()["detail"]
+
+    def test_default_ordering_is_unchanged(self, authenticated_client: TestClient, three_traces):
+        """No sort_by keeps the newest-first order the list has always had."""
+        project_id, _ = three_traces
+
+        response = authenticated_client.get(f"/telemetry/traces?project_id={project_id}&limit=100")
+
+        assert response.status_code == status.HTTP_200_OK
+        starts = [t["start_time"] for t in response.json()["traces"]]
+        assert starts == sorted(starts, reverse=True)
+
+
+@pytest.mark.integration
+class TestTokenTotalFallbackShapes:
+    """Span shapes where the reported total is missing or contradicts input/output."""
+
+    @staticmethod
+    def _span(trace_id, project_id, attributes):
+        now = datetime.now(timezone.utc)
+        return {
+            "trace_id": trace_id,
+            "span_id": uuid.uuid4().hex[:16],
+            "project_id": project_id,
+            "environment": "development",
+            "span_name": "ai.llm.invoke",
+            "span_kind": "CLIENT",
+            "start_time": now.isoformat(),
+            "end_time": (now + timedelta(milliseconds=100)).isoformat(),
+            "status_code": "OK",
+            "attributes": {
+                "ai.operation.type": "llm.invoke",
+                "ai.model.name": "gpt-4",
+                **attributes,
+            },
+            "events": [],
+            "links": [],
+            "resource": {},
+        }
+
+    def _ingest_and_read(self, client, project_id, attributes):
+        trace_id = uuid.uuid4().hex
+        response = client.post(
+            "/telemetry/traces",
+            json={"spans": [self._span(trace_id, project_id, attributes)]},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        detail = client.get(f"/telemetry/traces/{trace_id}?project_id={project_id}").json()
+        listed = client.get(f"/telemetry/traces?project_id={project_id}&limit=100").json()
+        summary = next(t for t in listed["traces"] if t["trace_id"] == trace_id)
+        return detail, summary
+
+    def test_missing_total_falls_back_to_input_plus_output(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """The SQL fallback used to sum only the total, so this listed as 0."""
+        detail, summary = self._ingest_and_read(
+            authenticated_client,
+            str(db_project.id),
+            {"ai.llm.tokens.input": 100, "ai.llm.tokens.output": 50},
+        )
+
+        assert detail["total_tokens"] == 150
+        assert summary["total_tokens"] == 150
+
+    def test_only_one_side_reported(self, authenticated_client: TestClient, db_project):
+        """NULL + 100 is NULL in SQL, so each side has to be coalesced separately."""
+        detail, summary = self._ingest_and_read(
+            authenticated_client, str(db_project.id), {"ai.llm.tokens.input": 100}
+        )
+
+        assert detail["total_tokens"] == 100
+        assert summary["total_tokens"] == 100
+
+    def test_zero_total_beside_real_usage_is_treated_as_missing(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """A zero total next to non-zero input/output contradicts itself."""
+        detail, summary = self._ingest_and_read(
+            authenticated_client,
+            str(db_project.id),
+            {
+                "ai.llm.tokens.input": 100,
+                "ai.llm.tokens.output": 50,
+                "ai.llm.tokens.total": 0,
+            },
+        )
+
+        assert detail["total_tokens"] == 150
+        assert summary["total_tokens"] == 150
+
+    def test_reported_total_still_wins_when_larger(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """ADK folds cache-read tokens in, so the total legitimately exceeds the sum."""
+        detail, summary = self._ingest_and_read(
+            authenticated_client,
+            str(db_project.id),
+            {
+                "ai.llm.tokens.input": 100,
+                "ai.llm.tokens.output": 50,
+                "ai.llm.tokens.total": 950,
+            },
+        )
+
+        assert detail["total_tokens"] == 950
+        assert summary["total_tokens"] == 950

--- a/tests/backend/services/telemetry/test_enrichment.py
+++ b/tests/backend/services/telemetry/test_enrichment.py
@@ -16,6 +16,7 @@ from rhesis.backend.app.services.telemetry.enrichment import (
     detect_anomalies,
     extract_metadata,
 )
+from rhesis.backend.app.services.telemetry.enrichment.core import UNKNOWN_MODEL_NAME
 from rhesis.backend.app.services.telemetry.enrichment.processor import TraceEnricher
 
 
@@ -135,8 +136,12 @@ class TestCalculateTokenCosts:
 
         assert costs is None
 
-    def test_calculate_costs_unknown_model(self):
-        """Test cost calculation gracefully handles unknown models (skips them)."""
+    def test_calculate_costs_unknown_model_keeps_tokens(self):
+        """An unpriceable model still contributes its tokens, at zero cost.
+
+        Tokens are known even when the price is not, so dropping the span would make
+        a self-hosted or unrecognised model report zero usage.
+        """
         spans = [
             Mock(
                 spec=Trace,
@@ -146,14 +151,185 @@ class TestCalculateTokenCosts:
                     AIAttributes.MODEL_NAME: "unknown-model-xyz-123",
                     AIAttributes.LLM_TOKENS_INPUT: 100,
                     AIAttributes.LLM_TOKENS_OUTPUT: 50,
+                    AIAttributes.LLM_TOKENS_TOTAL: 150,
                 },
             )
         ]
 
         costs = calculate_token_costs(spans)
 
-        # Should return None since LiteLLM will fail to price unknown model
-        assert costs is None
+        assert costs is not None
+        assert costs.total_cost_usd == 0.0
+        assert costs.total_cost_eur == 0.0
+        assert costs.total_input_tokens == 100
+        assert costs.total_output_tokens == 50
+        assert costs.total_tokens == 150
+
+    def test_calculate_costs_mixed_priced_and_unpriced(self):
+        """A trace mixing a priced and an unpriced model counts both models' tokens."""
+        spans = [
+            Mock(
+                spec=Trace,
+                span_id="priced",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.MODEL_NAME: "gpt-4",
+                    AIAttributes.LLM_TOKENS_INPUT: 100,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 50,
+                    AIAttributes.LLM_TOKENS_TOTAL: 150,
+                },
+            ),
+            Mock(
+                spec=Trace,
+                span_id="unpriced",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.MODEL_NAME: "unknown-model-xyz-123",
+                    AIAttributes.LLM_TOKENS_INPUT: 200,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 70,
+                    AIAttributes.LLM_TOKENS_TOTAL: 270,
+                },
+            ),
+        ]
+
+        costs = calculate_token_costs(spans)
+
+        assert costs is not None
+        assert len(costs.breakdown) == 2
+        assert costs.total_tokens == 420
+        assert costs.total_input_tokens == 300
+        assert costs.total_output_tokens == 120
+
+        # Only the priced span carries cost; the unpriced one is recorded at zero.
+        expected_usd = sum(
+            litellm.cost_per_token(model="gpt-4", prompt_tokens=100, completion_tokens=50)
+        )
+        assert costs.total_cost_usd == pytest.approx(expected_usd, rel=0.01)
+        unpriced = next(b for b in costs.breakdown if b.span_id == "unpriced")
+        assert unpriced.total_cost_usd == 0.0
+        assert unpriced.total_tokens == 270
+
+    def test_calculate_costs_missing_model_name_keeps_tokens(self):
+        """A span with no model name is recorded at zero cost rather than dropped."""
+        spans = [
+            Mock(
+                spec=Trace,
+                span_id="span1",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.LLM_TOKENS_INPUT: 30,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 20,
+                    AIAttributes.LLM_TOKENS_TOTAL: 50,
+                },
+            )
+        ]
+
+        costs = calculate_token_costs(spans)
+
+        assert costs is not None
+        assert costs.total_tokens == 50
+        assert costs.total_cost_usd == 0.0
+        assert costs.breakdown[0].model_name == UNKNOWN_MODEL_NAME
+
+    def test_reported_total_is_trusted_not_derived(self):
+        """Google ADK folds cache-read tokens into the reported total.
+
+        Its ``ai.llm.tokens.total`` therefore exceeds ``input + output`` on purpose,
+        and deriving the total would silently discard the cached tokens.
+        """
+        spans = [
+            Mock(
+                spec=Trace,
+                span_id="adk-span",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.MODEL_NAME: "gpt-4",
+                    AIAttributes.LLM_TOKENS_INPUT: 100,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 50,
+                    # 800 cache-read tokens folded in by google_adk/mapping.py
+                    AIAttributes.LLM_TOKENS_TOTAL: 950,
+                },
+            )
+        ]
+
+        costs = calculate_token_costs(spans)
+
+        assert costs is not None
+        assert costs.total_tokens == 950
+        assert costs.total_input_tokens == 100
+        assert costs.total_output_tokens == 50
+
+    def test_total_falls_back_to_sum_when_not_reported(self):
+        """A span with no reported total derives one from input + output."""
+        spans = [
+            Mock(
+                spec=Trace,
+                span_id="span1",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.MODEL_NAME: "gpt-4",
+                    AIAttributes.LLM_TOKENS_INPUT: 100,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 50,
+                },
+            )
+        ]
+
+        costs = calculate_token_costs(spans)
+
+        assert costs is not None
+        assert costs.total_tokens == 150
+
+    def test_aggregated_agent_span_is_not_double_counted(self):
+        """pydantic-ai reports usage twice; only the llm.invoke spans are counted.
+
+        Its agent-run span carries the aggregate of its children's usage under the
+        same ``ai.llm.tokens.*`` keys, so counting every span would roughly double
+        the trace's real figure.
+        """
+        spans = [
+            # Agent-run span carrying the aggregate of both model calls.
+            Mock(
+                spec=Trace,
+                span_id="agent-run",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_AGENT_INVOKE,
+                    AIAttributes.MODEL_NAME: "gpt-4",
+                    AIAttributes.LLM_TOKENS_INPUT: 300,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 120,
+                    AIAttributes.LLM_TOKENS_TOTAL: 420,
+                },
+            ),
+            Mock(
+                spec=Trace,
+                span_id="model-call-1",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.MODEL_NAME: "gpt-4",
+                    AIAttributes.LLM_TOKENS_INPUT: 100,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 50,
+                    AIAttributes.LLM_TOKENS_TOTAL: 150,
+                },
+            ),
+            Mock(
+                spec=Trace,
+                span_id="model-call-2",
+                attributes={
+                    AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+                    AIAttributes.MODEL_NAME: "gpt-4",
+                    AIAttributes.LLM_TOKENS_INPUT: 200,
+                    AIAttributes.LLM_TOKENS_OUTPUT: 70,
+                    AIAttributes.LLM_TOKENS_TOTAL: 270,
+                },
+            ),
+        ]
+
+        costs = calculate_token_costs(spans)
+
+        assert costs is not None
+        # The children sum to 420 -- the same figure the agent span reports. Counting
+        # all three spans would give 840.
+        assert costs.total_tokens == 420
+        assert len(costs.breakdown) == 2
 
     def test_calculate_costs_model_variants(self):
         """Test that LiteLLM handles model variants (e.g., gpt-4-0613)."""

--- a/tests/backend/services/telemetry/test_token_totals.py
+++ b/tests/backend/services/telemetry/test_token_totals.py
@@ -1,0 +1,187 @@
+"""Tests for trace-level token totals.
+
+These cover the one definition of "how many tokens did this trace use" that the
+traces list, the trace detail drawer, the test-run trace list and the project
+metrics endpoint all share.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from rhesis.telemetry.attributes import AIAttributes
+
+from rhesis.backend.app.models.trace import Trace
+from rhesis.backend.app.services.telemetry.token_totals import (
+    token_totals_from_enriched,
+    token_totals_from_spans,
+    trace_cost_usd,
+    trace_summary_totals,
+    trace_token_totals,
+)
+
+
+def llm_span(span_id, input_tokens, output_tokens, total=None, enriched=None):
+    """An ``llm.invoke`` span -- the kind that carries countable usage."""
+    attributes = {
+        AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_LLM_INVOKE,
+        AIAttributes.MODEL_NAME: "gpt-4",
+        AIAttributes.LLM_TOKENS_INPUT: input_tokens,
+        AIAttributes.LLM_TOKENS_OUTPUT: output_tokens,
+    }
+    if total is not None:
+        attributes[AIAttributes.LLM_TOKENS_TOTAL] = total
+    return Mock(spec=Trace, span_id=span_id, attributes=attributes, enriched_data=enriched)
+
+
+def enrichment(total_input, total_output, total, cost_usd=0.0, cost_eur=0.0):
+    """An enriched_data blob shaped the way the enrichment service writes it."""
+    return {
+        "costs": {
+            "total_cost_usd": cost_usd,
+            "total_cost_eur": cost_eur,
+            "total_input_tokens": total_input,
+            "total_output_tokens": total_output,
+            "total_tokens": total,
+            "breakdown": [],
+        }
+    }
+
+
+@pytest.mark.unit
+class TestTokenTotalsFromSpans:
+    """The pre-enrichment fallback, summed over llm.invoke spans."""
+
+    def test_sums_llm_invoke_spans(self):
+        spans = [llm_span("a", 100, 50, 150), llm_span("b", 200, 70, 270)]
+
+        assert token_totals_from_spans(spans) == (300, 120, 420)
+
+    def test_ignores_aggregated_agent_span(self):
+        """The pydantic-ai double-count case.
+
+        Its agent-run span repeats the aggregate of its children's usage under the
+        same attribute keys, so a naive sum over every span would report 840.
+        """
+        agent_run = Mock(
+            spec=Trace,
+            span_id="agent-run",
+            attributes={
+                AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_AGENT_INVOKE,
+                AIAttributes.LLM_TOKENS_INPUT: 300,
+                AIAttributes.LLM_TOKENS_OUTPUT: 120,
+                AIAttributes.LLM_TOKENS_TOTAL: 420,
+            },
+            enriched_data=None,
+        )
+        spans = [agent_run, llm_span("call-1", 100, 50, 150), llm_span("call-2", 200, 70, 270)]
+
+        assert token_totals_from_spans(spans) == (300, 120, 420)
+
+    def test_trusts_reported_total_over_derived(self):
+        """Google ADK folds cache-read tokens into the reported total on purpose."""
+        spans = [llm_span("adk", 100, 50, total=950)]
+
+        assert token_totals_from_spans(spans) == (100, 50, 950)
+
+    def test_derives_total_when_not_reported(self):
+        spans = [llm_span("a", 100, 50)]
+
+        assert token_totals_from_spans(spans) == (100, 50, 150)
+
+    def test_no_llm_spans_is_zero_not_an_error(self):
+        tool_span = Mock(
+            spec=Trace,
+            span_id="tool",
+            attributes={AIAttributes.OPERATION_TYPE: AIAttributes.OPERATION_TOOL_INVOKE},
+            enriched_data=None,
+        )
+
+        assert token_totals_from_spans([tool_span]) == (0, 0, 0)
+
+    def test_span_with_no_attributes(self):
+        bare = Mock(spec=Trace, span_id="bare", attributes=None, enriched_data=None)
+
+        assert token_totals_from_spans([bare]) == (0, 0, 0)
+
+
+@pytest.mark.unit
+class TestTokenTotalsFromEnriched:
+    """Reading the totals back out of the enrichment blob."""
+
+    def test_reads_the_totals(self):
+        assert token_totals_from_enriched(enrichment(300, 120, 420)) == (300, 120, 420)
+
+    def test_unenriched_trace_is_unknown_not_zero(self):
+        """None means "fall back", which is not the same as a confident zero."""
+        assert token_totals_from_enriched(None) is None
+        assert token_totals_from_enriched({}) is None
+        assert token_totals_from_enriched({"costs": {}}) is None
+
+    def test_blob_predating_the_token_fields_is_unknown(self):
+        """An enrichment blob written before this change has costs but no tokens."""
+        legacy = {"costs": {"total_cost_usd": 0.02, "total_cost_eur": 0.018, "breakdown": []}}
+
+        assert token_totals_from_enriched(legacy) is None
+
+
+@pytest.mark.unit
+class TestTraceTokenTotals:
+    """The detail endpoint's accessor: enrichment first, spans as fallback."""
+
+    def test_prefers_enrichment(self):
+        spans = [llm_span("a", 1, 1, 2, enriched=enrichment(300, 120, 420))]
+
+        assert trace_token_totals(spans) == (300, 120, 420)
+
+    def test_falls_back_to_spans_before_enrichment_runs(self):
+        spans = [llm_span("a", 100, 50, 150), llm_span("b", 200, 70, 270)]
+
+        assert trace_token_totals(spans) == (300, 120, 420)
+
+    def test_both_paths_agree_for_the_same_spans(self):
+        """The property that keeps the list and the drawer showing one number."""
+        spans = [llm_span("a", 100, 50, 150), llm_span("b", 200, 70, 270)]
+        from_spans = token_totals_from_spans(spans)
+
+        enriched_spans = [
+            llm_span("a", 100, 50, 150, enriched=enrichment(*from_spans)),
+            llm_span("b", 200, 70, 270, enriched=enrichment(*from_spans)),
+        ]
+
+        assert trace_token_totals(enriched_spans) == from_spans
+
+    def test_empty_span_set(self):
+        assert trace_token_totals([]) == (0, 0, 0)
+
+
+@pytest.mark.unit
+class TestTraceSummaryTotals:
+    """The list endpoints' accessor, which has one row rather than a span set."""
+
+    def test_uses_enrichment_when_present(self):
+        totals = trace_summary_totals(
+            enrichment(300, 120, 420, cost_usd=0.02, cost_eur=0.018), llm_tokens_fallback=999
+        )
+
+        assert totals == (300, 120, 420, 0.02, 0.018)
+
+    def test_uses_the_sql_fallback_before_enrichment_runs(self):
+        """A freshly ingested trace still lists its tokens, and no cost yet."""
+        totals = trace_summary_totals(None, llm_tokens_fallback=420)
+
+        assert totals == (0, 0, 420, 0.0, 0.0)
+
+    def test_no_llm_spans_reports_zero(self):
+        assert trace_summary_totals(None, llm_tokens_fallback=0) == (0, 0, 0, 0.0, 0.0)
+
+
+@pytest.mark.unit
+class TestTraceCostUsd:
+    """Cost has no fallback: it cannot be derived from span attributes."""
+
+    def test_reads_the_enriched_cost(self):
+        assert trace_cost_usd(enrichment(1, 1, 2, cost_usd=0.0123)) == 0.0123
+
+    def test_unenriched_trace_is_zero(self):
+        assert trace_cost_usd(None) == 0.0
+        assert trace_cost_usd({}) == 0.0

--- a/tests/sdk/telemetry/integrations/test_genai.py
+++ b/tests/sdk/telemetry/integrations/test_genai.py
@@ -1,0 +1,124 @@
+"""Tests for the framework-neutral GenAI helpers in ``genai.py``.
+
+These back the Microsoft Agent Framework and Google ADK integrations, which read
+a turn's text back from a per-trace store when the run root is exported. The
+store's release policy is the delicate part: too eager and one exporter starves
+the others, too lazy and a long-running process sits on megabytes of text.
+"""
+
+import pytest
+
+from rhesis.sdk.telemetry.integrations.genai import DeferredReleaseQueue
+
+
+@pytest.fixture
+def stores() -> tuple[dict, dict]:
+    """Two trace-keyed stores, the shape an integration registry keeps."""
+    return {}, {}
+
+
+class TestHasEntries:
+    def test_reports_content_in_any_store(self, stores):
+        first, second = stores
+        queue = DeferredReleaseQueue(first, second)
+
+        assert queue.has_entries(1) is False
+        second[1] = "only in the second store"
+        assert queue.has_entries(1) is True
+
+    def test_a_store_is_held_by_reference(self, stores):
+        """The owner records into its own dicts after building the queue."""
+        first, _second = stores
+        queue = DeferredReleaseQueue(*stores)
+
+        first[7] = "recorded later"
+
+        assert queue.has_entries(7) is True
+
+
+class TestQueueRelease:
+    def test_a_read_does_not_free_the_entry(self, stores):
+        """The other wrapped exporters still have to find it."""
+        first, _second = stores
+        first[1] = "content"
+        queue = DeferredReleaseQueue(*stores, max_served=4)
+
+        queue.queue_release(1)
+
+        assert first[1] == "content"
+
+    def test_entries_are_freed_once_enough_traces_follow(self, stores):
+        first, second = stores
+        queue = DeferredReleaseQueue(*stores, max_served=2)
+        for trace_id in (1, 2, 3):
+            first[trace_id] = f"in-{trace_id}"
+            second[trace_id] = f"out-{trace_id}"
+
+        for trace_id in (1, 2, 3):
+            queue.queue_release(trace_id)
+
+        assert 1 not in first and 1 not in second, "the oldest read is freed"
+        assert 2 in first and 3 in first, "the two most recent are kept"
+
+    def test_every_store_is_freed(self, stores):
+        """A store left out of the release loop grows on its own."""
+        first, second = stores
+        queue = DeferredReleaseQueue(*stores, max_served=1)
+        for trace_id in (1, 2):
+            first[trace_id] = "in"
+            second[trace_id] = "out"
+
+        queue.queue_release(1)
+        queue.queue_release(2)
+
+        assert 1 not in first
+        assert 1 not in second
+
+    def test_re_reading_moves_an_entry_back_to_the_newest(self, stores):
+        """A second exporter reading a trace should buy it more time, not none.
+
+        Re-inserting a key a dict already holds leaves its position alone, so
+        without the explicit removal first, the re-read counts for nothing and
+        the trace is freed on the same schedule as if it had been read once.
+        """
+        first, _second = stores
+        queue = DeferredReleaseQueue(*stores, max_served=2)
+        for trace_id in (1, 2, 3):
+            first[trace_id] = f"content-{trace_id}"
+
+        queue.queue_release(1)
+        queue.queue_release(2)
+        queue.queue_release(1)  # trace 1 read again, so it is the newest now
+        queue.queue_release(3)
+
+        assert first.get(1) == "content-1", "the re-read trace should have survived"
+        assert 2 not in first, "trace 2 was the oldest read, so it goes"
+
+    def test_a_trace_with_nothing_recorded_takes_no_slot(self, stores):
+        """Otherwise content-free traces evict the ones carrying content."""
+        first, _second = stores
+        queue = DeferredReleaseQueue(*stores, max_served=1)
+        first[1] = "content"
+        queue.queue_release(1)
+
+        for empty in range(2, 20):
+            queue.queue_release(empty)
+
+        assert first[1] == "content"
+
+
+class TestClear:
+    def test_empties_the_queue_and_the_stores(self, stores):
+        first, second = stores
+        queue = DeferredReleaseQueue(*stores, max_served=8)
+        first[1] = "in"
+        second[1] = "out"
+        queue.queue_release(1)
+
+        queue.clear()
+
+        assert first == {} and second == {}
+        # Nothing is still queued, so a later trace is not freed early.
+        first[2] = "in"
+        queue.queue_release(2)
+        assert first[2] == "in"


### PR DESCRIPTION
## Summary

- Adds a `test_parameters` JSONB field to tests, giving users a place to store per-test context (company name, org ID, etc.) that is available in endpoint request mappings as `{{ test_parameters.<key> }}`.
- Kept separate from experiment `params` to prevent namespace collisions and conflation of infrastructure config with test-specific data.
- Full stack: DB migration, backend execution pipelines (batch + live), template renderer, SDK invoker, connector wire protocol, SDK entity + contextvar accessor, frontend JSON editor, documentation.

## Changes

| Layer | Files |
|-------|-------|
| **Database** | Alembic migration `c3a4b5d6e7f8` adding `test_parameters` JSONB column |
| **Backend model/schemas** | `models/test.py`, `schemas/test.py` |
| **Execution pipeline** | `batch/invocation.py`, `penelope_target.py`, `output_providers.py` |
| **Template renderer** | `renderer.py` (adds `test_parameters` default to Jinja2 context) |
| **SDK invoker** | `sdk_invoker.py` (platform context keys, execute extras) |
| **Connector protocol** | `connector/schemas.py` + `manager.py` (both backend and SDK) |
| **SDK** | `Test` entity, `_state.py` contextvar + `get_test_parameters()`, `__init__.py` export |
| **Frontend** | `TestParametersBlock` component, `TestTechnicalCard` integration, TS interfaces |
| **Docs** | Tests, request-mapping, connector-injection, SDK connector mapping, SDK parameters |
| **Release** | Version bumps to 0.15.2, changelogs |

## How it works

- **Experiment parameters** (`{{ params.<key> }}`): typed, versioned, schema-validated infrastructure config resolved from experiments/environments, snapshotted into `test_run.attributes["parameters"]` at run creation.
- **Test parameters** (`{{ test_parameters.<key> }}`): freeform JSON on the test itself, read directly at execution time. No resolution, no versioning, no merge with experiment params.

Both default to `{}` in the template context when absent. No precedence, no silent overwrites.

Follow-up: #2720 tracks renaming `params` to `experiment_parameters` for full naming consistency.

## Test plan

- [ ] `cd apps/backend && uv run alembic upgrade head` -- migration applies
- [ ] Create/update a test with `test_parameters` via REST API
- [ ] Configure `{{ test_parameters.<key> }}` in an endpoint request_mapping, execute, verify value reaches endpoint
- [ ] Execute against an SDK endpoint, verify `get_test_parameters()` returns the dict
- [ ] Frontend: open test detail, add/edit/clear test parameters via JSON editor
- [ ] Verify `test_parameters` don't leak as function kwargs in passthrough mode
- [ ] `cd docs && npm run build` -- no broken links