### PR TITLE
Declare cachetools for the chatbot

### DIFF
--- a/apps/chatbot/pyproject.toml
+++ b/apps/chatbot/pyproject.toml
@@ -11,6 +11,10 @@ dependencies = [
     "pydantic>=2.11.7",
     "python-dotenv>=1.2.2",
     "redis>=5.0.0",
+    # client.py imports TTLCache. It used to arrive transitively via google-auth,
+    # which the langchain upgrade in #2711 removed from this resolution, and the
+    # chatbot then crashed on boot with ModuleNotFoundError.
+    "cachetools>=6.2.1",
     "rhesis-sdk",
 ]
 

--- a/apps/chatbot/uv.lock
+++ b/apps/chatbot/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-09-01T14:43:14.421469Z"
+exclude-newer = "2026-09-05T10:58:49.287365Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -3489,6 +3489,7 @@ name = "rhesis-chatbot"
 version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "cachetools" },
     { name = "fastapi" },
     { name = "gunicorn" },
     { name = "pydantic" },
@@ -3506,6 +3507,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cachetools", specifier = ">=6.2.1" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "gunicorn", specifier = ">=21.2.0" },
     { name = "pydantic", specifier = ">=2.11.7" },


### PR DESCRIPTION
## Purpose

The dev deploy has failed since 10 September, including both nightly runs on `main`. The chatbot pod is in CrashLoopBackOff with 545 restarts, so ArgoCD reports the application Degraded and the deploy job times out waiting for health.

```
File "/app/apps/chatbot/client.py", line 16, in <module>
    from cachetools import TTLCache
ModuleNotFoundError: No module named 'cachetools'
```

`client.py` has imported `TTLCache` since #2065 in June, but the dependency was never declared. It arrived transitively through `google-auth`, so nothing noticed. The langchain and langgraph upgrade in #2711 changed this project's resolution, `google-auth` is no longer reachable from it, and nothing depends on `cachetools` any more, so uv stops installing it.

The lockfile diff of that upgrade shows exactly this: it removes the `google-auth` package block from `apps/chatbot/uv.lock` and with it the one line that pulled `cachetools` in.

| when | event |
| --- | --- |
| Sep 10, 03:16 | nightly deploy succeeds |
| Sep 10, 13:15 | #2711 merges |
| Sep 11, 03:11 | nightly deploy fails |
| Sep 12, 03:17 | nightly deploy fails again |

## What Changed

`cachetools` is declared in `apps/chatbot/pyproject.toml` and the lockfile relocked. Floor set to 6.2.1, the version already resolved.

## Additional Context

Worth a follow-up, not done here: nothing catches an undeclared import in these projects until a pod crashes in a cluster. A build-time import check of the app's entrypoints would have caught this at the point the upgrade landed.

## Testing

Installed from the updated lock and imported the module that was failing:

```bash
cd apps/chatbot
uv sync
uv run python -c 'import client'
```

The import succeeds. Before this change it raises ModuleNotFoundError, which is what the pod was doing on every restart.